### PR TITLE
Add canvas notes and planning trackers

### DIFF
--- a/docs/Canvas/feature-updates.md
+++ b/docs/Canvas/feature-updates.md
@@ -1,0 +1,16 @@
+# Canvas — Aggiornamenti Rapidi
+
+## Nuove feature
+- **CLI Pack Rolling (TS/Python)** — Gli script `tools/ts/roll_pack` e `tools/py/roll_pack.py` permettono di simulare l'assegnazione dei pacchetti PI usando `data/packs.yaml`, mantenendo parità funzionale tra stack tecnologici.
+- **Generatore Encounter Python** — `tools/py/generate_encounter.py` sfrutta `data/biomes.yaml` per derivare difficoltà, affissi dinamici e adattamenti VC, utile per playtest veloci.
+
+## Regole di gioco evidenziate
+- **Economia PI** — I costi e i massimali (`pi_shop.costs`/`caps`) definiscono la cadenza di progressione e i limiti per i pack iniziali.【F:data/packs.yaml†L1-L17】
+- **Bias per Forma** — Le tabelle `bias_d12` forniscono controllo sullo skew dei pacchetti in base al MBTI scelto, abilitando tuning mirato delle build iniziali.【F:data/packs.yaml†L18-L88】
+- **Adattamenti VC per Bioma** — I flag `vc_adapt` determinano come gli encounter scalano controlli, guardia, imboscate e burst secondo i segnali di telemetria della squadra.【F:data/biomes.yaml†L6-L13】
+- **Regole Ibride di Mating** — Le combinazioni in `hybrid_rules` chiariscono le fusioni locomozione/sensi quando due forme condividono caratteristiche uniche.【F:data/mating.yaml†L25-L32】
+
+## Dati YAML aggiornati
+- **Biomi** — Ogni voce contiene difficoltà base, modificatori e affissi tematici (es. `savana`, `caverna`, `palude`).【F:data/biomes.yaml†L1-L5】
+- **Telemetria VC** — Le finestre EMA, gli indici VC e le formule MBTI/Ennea supportano il nuovo layer di analytics live per sessioni co-op.【F:data/telemetry.yaml†L1-L25】
+- **Standard di Nido** — I profili `dune_stalker` ed `echo_morph` specificano ambiente, struttura e risorse, fungendo da baseline per la progressione narrativa di clan.【F:data/mating.yaml†L13-L24】

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,11 @@ Questi file sono scheletri collegati ai **Canvas** già creati in ChatGPT. Copia
 - `PI-Pacchetti-Forme.md` — 16 Forme, 7 PI, pacchetti A/B/C, tabelle d20/d12 (Canvas B).
 - `SistemaNPG-PF-Mutazioni.md` — NPG reattivi, PF, mutazioni T0/T1/T2, fusioni (Canvas C).
 - `Mating-Reclutamento-Nido.md` — Attrazione, Affinità/Fiducia, standard di nido, eredità (Canvas D).
+
+## Sottocartelle operative
+
+- `Canvas/` — Note rapide estratte dai canvas principali, più callout su nuove feature e regole aggiornate.
+- `piani/` — Roadmap sintetica e milestone evolutive, con riferimenti ai dataset YAML da aggiornare.
+- `checklist/` — Tracker stato avanzamento con caselle di controllo per le milestone chiave.
+
+Aggiorna queste sezioni quando importi nuovi estratti dai Canvas o modifichi i dataset di gioco.

--- a/docs/checklist/milestones.md
+++ b/docs/checklist/milestones.md
@@ -1,0 +1,14 @@
+# Checklist Milestone
+
+## Setup iniziale
+- [x] Caricati dataset YAML di base (biomi, pacchetti PI, mating, telemetria).【F:data/biomes.yaml†L1-L17】【F:data/packs.yaml†L1-L88】【F:data/mating.yaml†L1-L32】【F:data/telemetry.yaml†L1-L29】
+- [x] Pubblicati script CLI per roll pack e encounter (`tools/ts`, `tools/py`).
+
+## In corso
+- [ ] Espandere `compat_forme` per coprire tutte le 16 forme MBTI.【F:data/mating.yaml†L1-L12】
+- [ ] Validare le formule di telemetria con dati di playtest reali.【F:data/telemetry.yaml†L1-L25】
+- [ ] Creare esempi di encounter documentati per ciascun bioma.【F:data/biomes.yaml†L1-L13】
+
+## Completare prossimamente
+- [ ] Collegare esport automatizzato dei log VC a Google Sheet (`scripts/driveSync.gs`).
+- [ ] Aggiornare i Canvas principali con note sulle nuove feature CLI.

--- a/docs/piani/roadmap.md
+++ b/docs/piani/roadmap.md
@@ -1,0 +1,17 @@
+# Roadmap Operativa
+
+## Milestone attive
+1. **Bilanciare pacchetti PI tra Forme**  
+   - Validare il bias `random_general_d20` rispetto alle nuove combinazioni `bias_d12` per evitare inflazione di PE.【F:data/packs.yaml†L5-L88】
+   - Sincronizzare i costi `pi_shop` con la curva PE definita in `telemetry.pe_economy`.【F:data/packs.yaml†L1-L4】【F:data/telemetry.yaml†L23-L29】
+2. **Telemetria VC in game build**  
+   - Integrare le finestre EMA (`ema_alpha`, `windows`) nel client per raccogliere dati reali.【F:data/telemetry.yaml†L1-L8】
+   - Mappare gli indici VC ai trigger Enneagram per generare feedback contestuali.【F:data/telemetry.yaml†L9-L22】
+3. **Esperienze di Mating e Nido**  
+   - Estendere `compat_forme` alle restanti 14 forme e definire cross-formula per `base_scores`.【F:data/mating.yaml†L1-L12】
+   - Prototipare ambienti interattivi per `dune_stalker` ed `echo_morph`, validando risorse e privacy.【F:data/mating.yaml†L13-L24】
+
+## Prossimi passi
+- Documentare esempi di encounter generati (CLI Python) e associarli a test di difficoltà per ciascun bioma.【F:data/biomes.yaml†L1-L13】
+- Creare script di migrazione per esportare `telemetry` su Google Sheet via `scripts/driveSync.gs`.
+- Aggiornare i canvas principali con screenshot e note del playtest VC.


### PR DESCRIPTION
## Summary
- add a Canvas summary file that highlights recent features, rule references, and YAML data anchors
- create planning and checklist documents to track roadmap items and milestone progress
- update the docs index to point to the new Canvas, planning, and checklist folders

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f9802f62588332bc9f98f9c44e7d1c