### PR TITLE
Add snapshot diff script and document October 23 updates

### DIFF
--- a/data/chatgpt/2025-10-22/snapshot-20251022T180000Z.json
+++ b/data/chatgpt/2025-10-22/snapshot-20251022T180000Z.json
@@ -1,0 +1,7 @@
+{
+  "source": "api",
+  "model": "gpt-4o-mini",
+  "prompt": "Riassumi gli ultimi aggiornamenti di design",
+  "response": "## Aggiornamenti 2025-10-22\n- Evento Echo Drifters: infiltrazione in grotte risonanti con obiettivi stealth.\n- Risorsa Resonance Shards: usata per potenziare moduli sonar e aprire porte sigillate.\n- Telemetria VC: introdotto indice StressWave per monitorare picchi di difficoltà co-op.\n- Nidi itineranti: i clan sabbiosi possono spostare l'avamposto ogni tre turni di campagna.\n",
+  "timestamp": "2025-10-22T18:00:00+00:00"
+}

--- a/data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json
+++ b/data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json
@@ -1,0 +1,7 @@
+{
+  "source": "api",
+  "model": "gpt-4.1",
+  "prompt": "Riassumi gli ultimi aggiornamenti di design",
+  "response": "## Aggiornamenti 2025-10-23\n- Missione Skydock Siege: incursione verticale con obiettivi multi-livello e timer di evacuazione.\n- Reattori Aeon: nuova risorsa leggendaria per sbloccare abilità temporali nelle forme Armoniche.\n- StressWave aggiornato: aggiunto filtro SquadSync per isolare picchi generati da mismatch di ruoli.\n- Nidi itineranti: ora richiedono ancoraggi Resonance Shards per stabilizzare il trasferimento.\n- Protocollo di soccorso: introdotte chiamate di rinforzo NPG basate su telemetria in tempo reale.\n",
+  "timestamp": "2025-10-23T10:15:00+00:00"
+}

--- a/docs/Canvas/feature-updates.md
+++ b/docs/Canvas/feature-updates.md
@@ -3,12 +3,17 @@
 ## Nuove feature
 - **CLI Pack Rolling (TS/Python)** — Gli script `tools/ts/roll_pack` e `tools/py/roll_pack.py` permettono di simulare l'assegnazione dei pacchetti PI usando `data/packs.yaml`, mantenendo parità funzionale tra stack tecnologici.
 - **Generatore Encounter Python** — `tools/py/generate_encounter.py` sfrutta `data/biomes.yaml` per derivare difficoltà, affissi dinamici e adattamenti VC, utile per playtest veloci.
+- **Missione Skydock Siege** — Infiltrazione verticale con obiettivi multilivello, evacuazione cronometrata e coordinamento a quote diverse.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
+- **Reattori Aeon** — Risorsa leggendaria che abilita poteri temporali specifici per le Forme Armoniche.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
 
 ## Regole di gioco evidenziate
 - **Economia PI** — I costi e i massimali (`pi_shop.costs`/`caps`) definiscono la cadenza di progressione e i limiti per i pack iniziali.【F:data/packs.yaml†L1-L17】
 - **Bias per Forma** — Le tabelle `bias_d12` forniscono controllo sullo skew dei pacchetti in base al MBTI scelto, abilitando tuning mirato delle build iniziali.【F:data/packs.yaml†L18-L88】
 - **Adattamenti VC per Bioma** — I flag `vc_adapt` determinano come gli encounter scalano controlli, guardia, imboscate e burst secondo i segnali di telemetria della squadra.【F:data/biomes.yaml†L6-L13】
 - **Regole Ibride di Mating** — Le combinazioni in `hybrid_rules` chiariscono le fusioni locomozione/sensi quando due forme condividono caratteristiche uniche.【F:data/mating.yaml†L25-L32】
+- **Filtro SquadSync** — L'indice StressWave ora isola i picchi dovuti a mismatch di ruolo, supportando tuning mirato della difficoltà co-op.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
+- **Nidi itineranti con ancoraggi** — Gli spostamenti dei clan sabbiosi richiedono Resonance Shards per stabilizzare il trasferimento tra turni.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
+- **Protocollo di soccorso** — Nuove chiamate di rinforzo NPG basate su telemetria live per recuperare squadre in difficoltà.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
 
 ## Dati YAML aggiornati
 - **Biomi** — Ogni voce contiene difficoltà base, modificatori e affissi tematici (es. `savana`, `caverna`, `palude`).【F:data/biomes.yaml†L1-L5】

--- a/docs/chatgpt_changes/2025-10-23.diff
+++ b/docs/chatgpt_changes/2025-10-23.diff
@@ -1,0 +1,13 @@
+--- data/chatgpt/2025-10-22/snapshot-20251022T180000Z.json
++++ data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json
+@@ -1,7 +1,7 @@
+ {
+-  "model": "gpt-4o-mini",
++  "model": "gpt-4.1",
+   "prompt": "Riassumi gli ultimi aggiornamenti di design",
+-  "response": "## Aggiornamenti 2025-10-22\n- Evento Echo Drifters: infiltrazione in grotte risonanti con obiettivi stealth.\n- Risorsa Resonance Shards: usata per potenziare moduli sonar e aprire porte sigillate.\n- Telemetria VC: introdotto indice StressWave per monitorare picchi di difficoltà co-op.\n- Nidi itineranti: i clan sabbiosi possono spostare l'avamposto ogni tre turni di campagna.\n",
++  "response": "## Aggiornamenti 2025-10-23\n- Missione Skydock Siege: incursione verticale con obiettivi multi-livello e timer di evacuazione.\n- Reattori Aeon: nuova risorsa leggendaria per sbloccare abilità temporali nelle forme Armoniche.\n- StressWave aggiornato: aggiunto filtro SquadSync per isolare picchi generati da mismatch di ruoli.\n- Nidi itineranti: ora richiedono ancoraggi Resonance Shards per stabilizzare il trasferimento.\n- Protocollo di soccorso: introdotte chiamate di rinforzo NPG basate su telemetria in tempo reale.\n",
+   "source": "api",
+-  "timestamp": "2025-10-22T18:00:00+00:00"
++  "timestamp": "2025-10-23T10:15:00+00:00"
+ }

--- a/docs/chatgpt_changes/2025-10-23.md
+++ b/docs/chatgpt_changes/2025-10-23.md
@@ -1,0 +1,17 @@
+# Report ChatGPT — 23 ottobre 2025
+
+## Evidenze principali
+- **Missione Skydock Siege** introduce una struttura multi-livello con timer di evacuazione che richiede coordinamento verticale.
+  【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
+- **Reattori Aeon** aggiungono una risorsa leggendaria per abilità temporali dedicate alle Forme Armoniche.
+  【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
+- **Filtro SquadSync** estende l'indice StressWave isolando i picchi generati da mismatch di ruoli nella squadra.
+  【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
+- **Nidi itineranti** ora richiedono ancoraggi Resonance Shards per stabilizzare gli spostamenti tra turni.
+  【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
+- **Protocollo di soccorso** abilita chiamate di rinforzo NPG basate su telemetria live.
+  【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
+
+## Diff
+Il diff completo è stato generato con `scripts/chatgpt_compare.py` e salvato in
+`docs/chatgpt_changes/2025-10-23.diff` per consultazione rapida.

--- a/docs/piani/roadmap.md
+++ b/docs/piani/roadmap.md
@@ -7,9 +7,12 @@
 2. **Telemetria VC in game build**  
    - Integrare le finestre EMA (`ema_alpha`, `windows`) nel client per raccogliere dati reali.【F:data/telemetry.yaml†L1-L8】
    - Mappare gli indici VC ai trigger Enneagram per generare feedback contestuali.【F:data/telemetry.yaml†L9-L22】
-3. **Esperienze di Mating e Nido**  
+3. **Esperienze di Mating e Nido**
    - Estendere `compat_forme` alle restanti 14 forme e definire cross-formula per `base_scores`.【F:data/mating.yaml†L1-L12】
    - Prototipare ambienti interattivi per `dune_stalker` ed `echo_morph`, validando risorse e privacy.【F:data/mating.yaml†L13-L24】
+4. **Missioni verticali e supporto live**
+   - Preparare il playtest di "Skydock Siege" con obiettivi multilivello e timer di evacuazione.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
+   - Collegare Reattori Aeon, filtro SquadSync e protocolli di soccorso alla pipeline telemetrica co-op.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
 
 ## Prossimi passi
 - Documentare esempi di encounter generati (CLI Python) e associarli a test di difficoltà per ciascun bioma.【F:data/biomes.yaml†L1-L13】

--- a/scripts/chatgpt_compare.py
+++ b/scripts/chatgpt_compare.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Confronta uno snapshot ChatGPT con il precedente e genera un diff."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+SNAPSHOT_ROOT = Path("data/chatgpt")
+
+
+def collect_snapshots(root: Path = SNAPSHOT_ROOT) -> List[Path]:
+    """Restituisce la lista ordinata di tutti gli snapshot disponibili."""
+
+    if not root.exists():
+        return []
+    snapshots: List[Path] = []
+    for path in root.rglob("snapshot-*"):
+        if path.is_file():
+            snapshots.append(path)
+    return sorted(snapshots)
+
+
+def find_previous_snapshot(new_snapshot: Path, *, root: Path = SNAPSHOT_ROOT) -> Optional[Path]:
+    """Trova lo snapshot immediatamente precedente rispetto a ``new_snapshot``."""
+
+    new_snapshot = new_snapshot.resolve()
+    snapshots = collect_snapshots(root)
+    previous: Optional[Path] = None
+    for candidate in snapshots:
+        resolved = candidate.resolve()
+        if resolved == new_snapshot:
+            return previous
+        previous = resolved
+    return None
+
+
+def load_formatted_lines(path: Path) -> List[str]:
+    """Carica il contenuto e lo restituisce come lista di linee formattate."""
+
+    text = path.read_text(encoding="utf-8")
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return text.splitlines()
+
+    formatted = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+    return formatted.splitlines()
+
+
+def build_diff(previous: Path, current: Path, *, context: int = 3) -> Iterable[str]:
+    """Genera le linee di diff tra due snapshot."""
+
+    prev_lines = load_formatted_lines(previous)
+    curr_lines = load_formatted_lines(current)
+    prev_label = _display_name(previous)
+    curr_label = _display_name(current)
+    return difflib.unified_diff(
+        prev_lines,
+        curr_lines,
+        fromfile=prev_label,
+        tofile=curr_label,
+        n=context,
+        lineterm="",
+    )
+
+
+def _display_name(path: Path) -> str:
+    """Restituisce un nome leggibile (relativo alla cwd se possibile)."""
+
+    try:
+        return str(path.resolve().relative_to(Path.cwd()))
+    except ValueError:
+        return str(path)
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Confronta un nuovo snapshot con quello precedente salvato in data/chatgpt."
+        )
+    )
+    parser.add_argument("new_snapshot", type=Path, help="Percorso del nuovo snapshot")
+    parser.add_argument(
+        "--previous",
+        type=Path,
+        help="Percorso dello snapshot precedente (facoltativo)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="File di destinazione per il diff (se assente, stampa su stdout)",
+    )
+    parser.add_argument(
+        "--context",
+        type=int,
+        default=3,
+        help="Numero di linee di contesto per il diff unificato (default: 3)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    new_snapshot: Path = args.new_snapshot
+    if not new_snapshot.exists():
+        raise SystemExit(f"Snapshot non trovato: {new_snapshot}")
+
+    if args.previous:
+        previous_snapshot = args.previous
+    else:
+        previous_snapshot = find_previous_snapshot(new_snapshot)
+
+    if previous_snapshot is None:
+        raise SystemExit(
+            "Impossibile determinare lo snapshot precedente."
+            " Specificare --previous esplicitamente."
+        )
+
+    diff_lines = list(build_diff(previous_snapshot, new_snapshot, context=args.context))
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        output_text = "\n".join(diff_lines)
+        if diff_lines:
+            output_text += "\n"
+        args.output.write_text(output_text, encoding="utf-8")
+    else:
+        for line in diff_lines:
+            print(line)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/chatgpt_compare.py` to locate the previous ChatGPT snapshot and generate a unified diff for the latest file
- archive the 22/23 Oct 2025 snapshots together with the generated diff and a daily report under `docs/chatgpt_changes`
- extend feature highlights and the operational roadmap with the new mission, resource, telemetry filter, and rescue protocol notes

## Testing
- `python3 scripts/chatgpt_compare.py data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json --output docs/chatgpt_changes/2025-10-23.diff`


------
https://chatgpt.com/codex/tasks/task_e_68f9847116148332ac2b67a624f2060d