### PR TITLE
Add configurable ChatGPT sync automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,12 @@ git push -u origin main
 - Carica lo **zip** generato da ChatGPT su Drive (o estrai e carica la cartella).
 - (Opzionale) Usa lo script `scripts/driveSync.gs` come **Apps Script** su una cartella Drive per trasformare alcuni YAML in Google Sheet.
 
+## Sincronizzazione contenuti ChatGPT
+- Configura le fonti da monitorare in `data/chatgpt_sources.yaml` (URL del progetto, canvas esportati, ecc.).
+- Installa le dipendenze Python richieste (`pip install requests pyyaml` se non già presenti).
+- Esegui `python3 scripts/chatgpt_sync.py --config data/chatgpt_sources.yaml` per scaricare gli snapshot giornalieri.
+- Controlla i diff generati in `docs/chatgpt_changes/<namespace>/<data>/` e il riepilogo in `logs/chatgpt_sync_last.json`.
+- Aggiorna `docs/chatgpt_sync_status.md` con note operative e credenziali aggiornate.
+
 ## Licenza
 MIT — vedi `LICENSE`.

--- a/data/chatgpt_sources.yaml
+++ b/data/chatgpt_sources.yaml
@@ -1,0 +1,21 @@
+# Elenco delle fonti ChatGPT da sincronizzare automaticamente.
+# Copia questo file e personalizza URL, header e percorsi locali.
+# È possibile elencare più sorgenti (canvas, project, esport manuali).
+
+sources:
+  - name: "project-overview"
+    mode: "web"
+    namespace: "project"  # Verrà trasformato automaticamente in uno slug
+    label: "project"
+    url: "https://chatgpt.com/g/.../project"
+    method: "GET"
+    headers:
+      # Cookie: "__Secure-next-auth.session-token=..."
+      # User-Agent: "Mozilla/5.0 ..."
+    # body: "{}"
+
+  - name: "canvas-export"
+    mode: "export"
+    namespace: "canvas"
+    label: "canvas"
+    path: "exports/canvas-latest.json"

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,5 +13,7 @@ Questi file sono scheletri collegati ai **Canvas** già creati in ChatGPT. Copia
 - `Canvas/` — Note rapide estratte dai canvas principali, più callout su nuove feature e regole aggiornate.
 - `piani/` — Roadmap sintetica e milestone evolutive, con riferimenti ai dataset YAML da aggiornare.
 - `checklist/` — Tracker stato avanzamento con caselle di controllo per le milestone chiave.
+- `chatgpt_changes/` — Diff e report generati automaticamente dagli snapshot giornalieri.
+- `chatgpt_sync_status.md` — Log operativo delle sincronizzazioni.
 
 Aggiorna queste sezioni quando importi nuovi estratti dai Canvas o modifichi i dataset di gioco.

--- a/docs/chatgpt_sync_status.md
+++ b/docs/chatgpt_sync_status.md
@@ -1,0 +1,14 @@
+# Stato sincronizzazione ChatGPT
+
+Questo file riepiloga l'ultima esecuzione degli script di sincronizzazione.
+
+- Script principale: `scripts/chatgpt_sync.py`
+- Configurazione di esempio: `data/chatgpt_sources.yaml`
+- Riepilogo ultima esecuzione: `logs/chatgpt_sync_last.json`
+- Diff generati: `docs/chatgpt_changes/<namespace>/<YYYY-MM-DD>/`
+
+> Nota: i valori `namespace` vengono convertiti automaticamente in *slug*
+(es. `Canvas Principale` → `canvas-principale`) prima di creare le cartelle.
+
+Aggiorna questo file con note operative (es. nuove fonti, credenziali aggiornate,
+problemi riscontrati) dopo ogni modifica sostanziale al flusso di sincronizzazione.

--- a/scripts/chatgpt_sync.py
+++ b/scripts/chatgpt_sync.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Utility per sincronizzare conversazioni ChatGPT.
 
-Lo script può interrogare l'API di OpenAI per salvare un'istantanea di una
-conversazione o importare un export manuale. Ogni istantanea viene salvata in una
-cartella datata all'interno di ``data/chatgpt``. Gli errori sono registrati nel
+Lo script può interrogare l'API di OpenAI, importare un export manuale o
+scaricare una pagina web (ad esempio il progetto condiviso su chatgpt.com).
+Ogni istantanea viene salvata in una cartella datata all'interno di
+``data/chatgpt`` con metadati e diff automatici. Gli errori sono registrati nel
 file ``logs/chatgpt_sync.log``.
 """
 
@@ -11,17 +12,22 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import difflib
 import json
 import logging
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 SNAPSHOT_ROOT = Path("data/chatgpt")
 LOG_FILE = Path("logs/chatgpt_sync.log")
 DEFAULT_MODEL = "gpt-4o-mini"
+SUMMARY_FILE = Path("logs/chatgpt_sync_last.json")
+
+Payload = Union[Dict[str, Any], str, bytes]
 
 
 def setup_logging() -> None:
@@ -46,39 +52,84 @@ def setup_logging() -> None:
     logger.addHandler(stream_handler)
 
 
-def ensure_snapshot_dir(date: Optional[dt.date] = None) -> Path:
+def ensure_snapshot_dir(
+    namespace: Optional[str] = None, date: Optional[dt.date] = None
+) -> Path:
     """Return the directory where the snapshot should be stored."""
 
     if date is None:
         date = dt.date.today()
-    snapshot_dir = SNAPSHOT_ROOT / date.isoformat()
+
+    base_dir = SNAPSHOT_ROOT
+    if namespace:
+        base_dir = base_dir / slugify(namespace)
+
+    snapshot_dir = base_dir / date.isoformat()
     snapshot_dir.mkdir(parents=True, exist_ok=True)
     return snapshot_dir
 
 
-def save_snapshot(data: Dict[str, Any], suffix: str = "json") -> Path:
-    """Save the snapshot data as JSON in the dated directory."""
+def slugify(value: str) -> str:
+    """Create a filesystem-friendly slug from ``value``."""
 
-    snapshot_dir = ensure_snapshot_dir()
+    slug = re.sub(r"[^a-zA-Z0-9-_]+", "-", value.strip())
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug.lower()
+
+
+def save_snapshot(
+    data: Payload,
+    suffix: str = "json",
+    *,
+    namespace: Optional[str] = None,
+    label: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Path:
+    """Save the snapshot data in the dated directory."""
+
+    snapshot_dir = ensure_snapshot_dir(namespace)
     timestamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    snapshot_path = snapshot_dir / f"snapshot-{timestamp}.{suffix}"
-    if suffix == "json":
+    base_name = f"snapshot-{timestamp}"
+    if label:
+        base_name = f"{base_name}-{slugify(label)}"
+    snapshot_path = snapshot_dir / f"{base_name}.{suffix}"
+
+    if isinstance(data, bytes):
+        snapshot_path.write_bytes(data)
+    elif isinstance(data, str):
+        snapshot_path.write_text(data, encoding="utf-8")
+    elif isinstance(data, dict):
         snapshot_path.write_text(
             json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
         )
     else:
-        raise ValueError(f"Formato non supportato: {suffix}")
+        raise ValueError(f"Formato non supportato per il salvataggio: {type(data)!r}")
+
+    meta_payload: Dict[str, Any] = {
+        "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "namespace": namespace,
+        "suffix": suffix,
+        "snapshot_path": str(snapshot_path.resolve()),
+    }
+    if metadata:
+        meta_payload.update(metadata)
+
+    metadata_path = snapshot_path.parent / f"{snapshot_path.stem}.metadata.json"
+    metadata_path.write_text(
+        json.dumps(meta_payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
     logging.info("Snapshot salvato in %s", snapshot_path)
     return snapshot_path
 
 
-def copy_export_file(source: Path) -> Path:
+def copy_export_file(source: Path, *, namespace: Optional[str] = None) -> Path:
     """Copy the export file into the dated snapshot directory."""
 
     if not source.exists():
         raise FileNotFoundError(f"File di export non trovato: {source}")
 
-    snapshot_dir = ensure_snapshot_dir()
+    snapshot_dir = ensure_snapshot_dir(namespace)
     destination = snapshot_dir / source.name
     counter = 1
     while destination.exists():
@@ -132,10 +183,10 @@ def fetch_from_api(prompt: str, model: str = DEFAULT_MODEL) -> Dict[str, Any]:
     return snapshot
 
 
-def import_export(export_file: Path) -> Dict[str, Any]:
+def import_export(export_file: Path, *, namespace: Optional[str] = None) -> Dict[str, Any]:
     """Import data from a manual ChatGPT export file."""
 
-    copied_path = copy_export_file(export_file)
+    copied_path = copy_export_file(export_file, namespace=namespace)
     snapshot = {
         "source": "export",
         "original_path": str(export_file.resolve()),
@@ -154,13 +205,194 @@ def import_export(export_file: Path) -> Dict[str, Any]:
     return snapshot
 
 
+def fetch_from_web(
+    url: str,
+    *,
+    method: str = "GET",
+    headers: Optional[Dict[str, str]] = None,
+    body: Optional[str] = None,
+    timeout: int = 60,
+) -> Tuple[str, Dict[str, Any]]:
+    """Download a web page and return the text plus metadata."""
+
+    try:
+        import requests  # type: ignore
+    except ImportError as exc:  # pragma: no cover - dipende dall'ambiente
+        raise RuntimeError(
+            "Libreria 'requests' non installata. Eseguire 'pip install requests'."
+        ) from exc
+
+    response = requests.request(
+        method.upper(), url, headers=headers, data=body, timeout=timeout
+    )
+    response.raise_for_status()
+    metadata = {
+        "source": "web",
+        "url": url,
+        "status_code": response.status_code,
+        "headers": dict(response.headers),
+    }
+    return response.text, metadata
+
+
+def _parse_header(header: str) -> Tuple[str, str]:
+    if ":" not in header:
+        raise ValueError(
+            "Le intestazioni devono essere nel formato 'Nome: Valore'. Ricevuto: %s"
+            % header
+        )
+    name, value = header.split(":", 1)
+    return name.strip(), value.strip()
+
+
+def _load_lines(path: Path) -> List[str]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return text.splitlines()
+    formatted = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+    return formatted.splitlines()
+
+
+def _collect_snapshot_files(namespace: Optional[str] = None) -> List[Path]:
+    base_dir = SNAPSHOT_ROOT
+    if namespace:
+        base_dir = base_dir / namespace
+    if not base_dir.exists():
+        return []
+    snapshots: List[Path] = []
+    for path in base_dir.rglob("snapshot-*"):
+        if path.is_file() and not path.name.endswith("metadata.json"):
+            snapshots.append(path)
+    return sorted(snapshots, key=lambda p: str(p))
+
+
+def _detect_namespace(snapshot: Path) -> Optional[str]:
+    try:
+        rel = snapshot.resolve().relative_to(SNAPSHOT_ROOT.resolve())
+    except ValueError:
+        return None
+    parts = rel.parts
+    if not parts:
+        return None
+    first = parts[0]
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", first):
+        return None
+    return first
+
+
+def find_previous_snapshot(
+    new_snapshot: Path, *, namespace: Optional[str] = None
+) -> Optional[Path]:
+    """Find the previous snapshot within the same namespace."""
+
+    if namespace is None:
+        namespace = _detect_namespace(new_snapshot)
+
+    snapshots = _collect_snapshot_files(namespace)
+    previous: Optional[Path] = None
+    for candidate in snapshots:
+        if candidate.resolve() == new_snapshot.resolve():
+            return previous
+        previous = candidate.resolve()
+    return None
+
+
+def build_diff(previous: Path, current: Path, *, context: int = 3) -> Iterable[str]:
+    prev_lines = _load_lines(previous)
+    curr_lines = _load_lines(current)
+    return difflib.unified_diff(
+        prev_lines,
+        curr_lines,
+        fromfile=str(previous),
+        tofile=str(current),
+        n=context,
+        lineterm="",
+    )
+
+
+def write_diff_report(
+    new_snapshot: Path,
+    *,
+    namespace: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Path]]:
+    previous = find_previous_snapshot(new_snapshot, namespace=namespace)
+    if previous is None:
+        logging.info(
+            "Nessuno snapshot precedente trovato per %s: skip diff", new_snapshot
+        )
+        return None
+
+    namespace = namespace or _detect_namespace(new_snapshot)
+    diff_lines = list(build_diff(previous, new_snapshot, context=5))
+
+    date_folder = new_snapshot.parent.name
+    report_dir = Path("docs/chatgpt_changes")
+    if namespace:
+        report_dir = report_dir / namespace
+    report_dir = report_dir / date_folder
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    diff_path = report_dir / f"{new_snapshot.stem}.diff"
+    diff_text = "\n".join(diff_lines)
+    if diff_text:
+        diff_text += "\n"
+    diff_path.write_text(diff_text, encoding="utf-8")
+
+    added = sum(1 for line in diff_lines if line.startswith("+") and not line.startswith("+++"))
+    removed = sum(1 for line in diff_lines if line.startswith("-") and not line.startswith("---"))
+    summary_lines = [
+        f"# Report snapshot {new_snapshot.stem}",
+        "",
+        f"- **Namespace:** {namespace or 'default'}",
+        f"- **Data cartella:** {date_folder}",
+        f"- **File snapshot:** `{new_snapshot}`",
+        f"- **File diff:** `{diff_path}`",
+        f"- **Linee aggiunte:** {added}",
+        f"- **Linee rimosse:** {removed}",
+    ]
+    if metadata:
+        summary_lines.append("- **Origine:** %s" % metadata.get("source", "n/d"))
+        if metadata.get("url"):
+            summary_lines.append(f"- **URL:** {metadata['url']}")
+        if metadata.get("name"):
+            summary_lines.append(f"- **Fonte configurazione:** {metadata['name']}")
+        if metadata.get("namespace_requested"):
+            summary_lines.append(
+                f"- **Namespace configurato:** {metadata['namespace_requested']}"
+            )
+        if metadata.get("model"):
+            summary_lines.append(f"- **Modello:** {metadata['model']}")
+        if metadata.get("stored_path"):
+            summary_lines.append(f"- **Export salvato:** {metadata['stored_path']}")
+        if metadata.get("original_export"):
+            summary_lines.append(
+                f"- **Export originale:** {metadata['original_export']}"
+            )
+
+    if diff_lines:
+        summary_lines.append("\n## Estratto diff")
+        summary_lines.extend("    " + line for line in diff_lines[:40])
+        if len(diff_lines) > 40:
+            summary_lines.append("    ...")
+    else:
+        summary_lines.append("\n_Nessuna differenza rispetto allo snapshot precedente._")
+
+    summary_path = report_dir / f"{new_snapshot.stem}.md"
+    summary_path.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
+
+    logging.info("Diff scritto in %s", diff_path)
+    return {"diff": diff_path, "summary": summary_path}
+
+
 def parse_arguments(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Sincronizza conversazioni ChatGPT")
     parser.add_argument(
         "--source",
-        choices=("api", "export"),
-        required=True,
-        help="Fonte dei dati: 'api' per interrogare OpenAI oppure 'export' per importare un file",
+        choices=("api", "export", "web"),
+        help="Fonte dei dati: 'api', 'export' o 'web'",
     )
     parser.add_argument(
         "--prompt",
@@ -176,7 +408,235 @@ def parse_arguments(argv: Optional[list[str]] = None) -> argparse.Namespace:
         type=Path,
         help="Percorso del file di export da importare quando la sorgente è 'export'",
     )
+    parser.add_argument(
+        "--namespace",
+        help="Sottocartella opzionale dentro data/chatgpt dove salvare lo snapshot",
+    )
+    parser.add_argument(
+        "--label",
+        help="Etichetta da includere nel nome del file dello snapshot",
+    )
+    parser.add_argument(
+        "--url",
+        help="URL da scaricare quando la sorgente è 'web'",
+    )
+    parser.add_argument(
+        "--method",
+        default="GET",
+        help="Metodo HTTP da usare per la sorgente 'web' (default: GET)",
+    )
+    parser.add_argument(
+        "--header",
+        action="append",
+        default=[],
+        help="Header HTTP aggiuntivi per la sorgente 'web' (formato 'Nome: Valore')",
+    )
+    parser.add_argument(
+        "--body",
+        help="Body opzionale per la richiesta HTTP (solo sorgente 'web')",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        help="File di configurazione (YAML/JSON) con più fonti da sincronizzare",
+    )
+    parser.add_argument(
+        "--summary-file",
+        type=Path,
+        default=SUMMARY_FILE,
+        help="File JSON dove salvare il riepilogo dell'ultima sincronizzazione",
+    )
+    parser.add_argument(
+        "--skip-diff",
+        action="store_true",
+        help="Non generare i diff automatici dopo il download",
+    )
     return parser.parse_args(argv)
+
+
+def _load_config(path: Path) -> Dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        try:
+            import yaml  # type: ignore
+        except ImportError as exc:  # pragma: no cover - dipende dall'ambiente
+            raise RuntimeError(
+                "Libreria 'pyyaml' non installata. Eseguire 'pip install pyyaml'."
+            ) from exc
+        return yaml.safe_load(text) or {}
+    return json.loads(text)
+
+
+def _resolve_export_path(value: str, base_dir: Path) -> Path:
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        candidate = (base_dir / candidate).resolve()
+    return candidate
+
+
+def process_single_source(
+    *,
+    source: str,
+    namespace: Optional[str],
+    label: Optional[str],
+    prompt: Optional[str],
+    model: str,
+    export_file: Optional[Path],
+    url: Optional[str],
+    method: str,
+    headers: Dict[str, str],
+    body: Optional[str],
+    skip_diff: bool,
+    extra_metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    namespace_slug = slugify(namespace) if namespace else None
+    metadata: Dict[str, Any] = {"source": source, "namespace": namespace_slug}
+    if namespace:
+        metadata["namespace_requested"] = namespace
+    if extra_metadata:
+        metadata.update(extra_metadata)
+
+    if source == "api":
+        if not prompt:
+            raise ValueError("È necessario fornire un --prompt per la sorgente 'api'.")
+        metadata.update({"model": model, "prompt": prompt})
+        snapshot = fetch_from_api(prompt, model)
+        snapshot_path = save_snapshot(
+            snapshot,
+            suffix="json",
+            namespace=namespace_slug,
+            label=label,
+            metadata=metadata,
+        )
+    elif source == "export":
+        if not export_file:
+            raise ValueError(
+                "È necessario fornire --export-file quando la sorgente è 'export'."
+            )
+        metadata.update({"export_file": str(export_file.resolve())})
+        snapshot_info = import_export(export_file, namespace=namespace_slug)
+        if "stored_path" in snapshot_info:
+            metadata["stored_path"] = snapshot_info.get("stored_path")
+        if "original_path" in snapshot_info:
+            metadata["original_export"] = snapshot_info.get("original_path")
+        snapshot_path = save_snapshot(
+            snapshot_info,
+            suffix="json",
+            namespace=namespace_slug,
+            label=label,
+            metadata=metadata,
+        )
+    elif source == "web":
+        if not url:
+            raise ValueError("È necessario fornire --url quando la sorgente è 'web'.")
+        metadata.update({"url": url, "method": method})
+        text, extra_meta = fetch_from_web(
+            url, method=method, headers=headers, body=body
+        )
+        metadata.update(extra_meta)
+        if body:
+            metadata["body_length"] = len(body)
+        snapshot_path = save_snapshot(
+            text,
+            suffix="html",
+            namespace=namespace_slug,
+            label=label or "page",
+            metadata=metadata,
+        )
+    else:  # pragma: no cover - argparse garantisce i valori
+        raise ValueError(f"Sorgente non supportata: {source}")
+
+    diff_paths: Optional[Dict[str, Path]] = None
+    if not skip_diff:
+        diff_paths = write_diff_report(
+            snapshot_path, namespace=namespace_slug, metadata=metadata
+        )
+
+    return {
+        "snapshot": str(snapshot_path),
+        "metadata": metadata,
+        "diff": {k: str(v) for k, v in diff_paths.items()} if diff_paths else None,
+    }
+
+
+def process_config(
+    config_path: Path, *, summary_file: Path, skip_diff: bool
+) -> List[Dict[str, Any]]:
+    config = _load_config(config_path)
+    sources = config.get("sources")
+    if not sources:
+        raise ValueError("Il file di configurazione non contiene la chiave 'sources'.")
+
+    base_dir = config_path.parent.resolve()
+    results: List[Dict[str, Any]] = []
+
+    for entry in sources:
+        name = entry.get("name") or entry.get("id") or "source"
+        mode = entry.get("mode") or entry.get("source")
+        if not mode:
+            raise ValueError(f"Voce di configurazione senza 'mode': {entry}")
+        namespace = entry.get("namespace")
+        label = entry.get("label") or name
+        prompt = entry.get("prompt")
+        model = entry.get("model", DEFAULT_MODEL)
+        export_path = entry.get("path") or entry.get("export_file")
+        url = entry.get("url")
+        method = entry.get("method", "GET")
+        headers_data = entry.get("headers") or {}
+        body = entry.get("body")
+
+        headers: Dict[str, str]
+        if isinstance(headers_data, dict):
+            headers = {str(k): str(v) for k, v in headers_data.items()}
+        elif isinstance(headers_data, list):
+            headers = {}
+            for header in headers_data:
+                key, value = _parse_header(header)
+                headers[key] = value
+        else:
+            raise ValueError(
+                f"Formato di headers non supportato per la fonte '{name}': {headers_data!r}"
+            )
+
+        export_file = None
+        if export_path:
+            export_file = _resolve_export_path(str(export_path), base_dir)
+
+        logging.info("Processo fonte configurata '%s' (%s)", name, mode)
+        result = process_single_source(
+            source=mode,
+            namespace=namespace,
+            label=label,
+            prompt=prompt,
+            model=model,
+            export_file=export_file,
+            url=url,
+            method=method,
+            headers=headers,
+            body=body,
+            skip_diff=skip_diff,
+            extra_metadata={"name": name},
+        )
+        result["name"] = name
+        results.append(result)
+
+    record_summary(results, summary_file, config_path=config_path)
+    return results
+
+
+def record_summary(
+    results: List[Dict[str, Any]], summary_file: Path, *, config_path: Optional[Path] = None
+) -> None:
+    summary_file.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "run_timestamp": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "config": str(config_path) if config_path else None,
+        "results": results,
+    }
+    summary_file.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    logging.info("Riepilogo scritto in %s", summary_file)
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -184,20 +644,29 @@ def main(argv: Optional[list[str]] = None) -> int:
     args = parse_arguments(argv)
 
     try:
-        if args.source == "api":
-            if not args.prompt:
-                raise ValueError("È necessario fornire un --prompt per la sorgente 'api'.")
-            snapshot = fetch_from_api(args.prompt, args.model)
-            save_snapshot(snapshot)
-        elif args.source == "export":
-            if not args.export_file:
+        if args.config:
+            process_config(args.config, summary_file=args.summary_file, skip_diff=args.skip_diff)
+        else:
+            if not args.source:
                 raise ValueError(
-                    "È necessario fornire --export-file quando la sorgente è 'export'."
+                    "Specificare --source oppure fornire un file di configurazione con --config."
                 )
-            snapshot = import_export(args.export_file)
-            save_snapshot(snapshot)
-        else:  # pragma: no cover - case non raggiungibile con argparse
-            raise ValueError(f"Sorgente non supportata: {args.source}")
+
+            headers = {name: value for name, value in map(_parse_header, args.header)}
+            result = process_single_source(
+                source=args.source,
+                namespace=args.namespace,
+                label=args.label,
+                prompt=args.prompt,
+                model=args.model,
+                export_file=args.export_file,
+                url=args.url,
+                method=args.method,
+                headers=headers,
+                body=args.body,
+                skip_diff=args.skip_diff,
+            )
+            record_summary([result], args.summary_file)
     except Exception as exc:
         logging.exception("Errore durante la sincronizzazione: %s", exc)
         return 1


### PR DESCRIPTION
## Summary
- extend the ChatGPT sync utility with configurable sources, web scraping support, metadata files, and automatic diff/report generation
- update the diff helper to work with namespaced snapshot directories and expose namespace filtering on the CLI
- document the workflow and ship sample configuration/status files for daily snapshot automation

## Testing
- python -m compileall scripts/chatgpt_sync.py scripts/chatgpt_compare.py

------
https://chatgpt.com/codex/tasks/task_e_68f97b69e0ac83328d402896c173dd32