### PR TITLE
Enrich MBTI compatibility profiles

### DIFF
--- a/data/mating.yaml
+++ b/data/mating.yaml
@@ -1,6 +1,341 @@
 compat_forme:  # Esempi — completare 16x16 nel design
-  ISTJ: {likes: [ISFJ, ESTJ, ENTJ, INTJ], neutrals: [ISTP, INTP, ESFJ], dislikes: [ENFP, ENTP], base_scores: {like: 4, neutral: 2, dislike: 1}}
-  ENFP: {likes: [ENFJ, ENTP, ISFP, ESFP], neutrals: [INTP, INFP, ESTP], dislikes: [ISTJ, ESTJ], base_scores: {like: 4, neutral: 2, dislike: 1}}
+  ISTJ:
+    archetype: "Custode metodico"
+    overview: >-
+      Archivista tattico della squadra: organizza scorte, cronologie e scenari
+      di fallback per tenere il gruppo in rotta anche nelle spedizioni più
+      lunghe.
+    likes: [ISFJ, ESTJ, ENTJ, INTJ]
+    neutrals: [ISTP, INTP, ESFJ]
+    dislikes: [ENFP, ENTP]
+    strengths:
+      - Rigore logistico instancabile
+      - Capacità di leggere pattern ripetitivi negli avversari
+      - Memoria di missione dettagliata
+    stress_triggers:
+      - Improvvisazioni senza verifica di sicurezza
+      - Perdita di inventario o equipaggiamento danneggiato
+      - Compagni che ignorano i protocolli concordati
+    collaboration_hooks:
+      - Affidargli ruoli di quarto uomo e auditing risorse
+      - Fornire dashboard numeriche aggiornate in tempo reale
+      - Offrire cicli di briefing/debriefing serrati
+    base_scores: {like: 4, neutral: 2, dislike: 1}
+  ISFJ:
+    archetype: "Guaritore protettivo"
+    overview: >-
+      Custode del morale e della salute: monitora pulsazioni sociali e fisiche,
+      garantendo che ogni missione mantenga il gruppo integro e motivato.
+    likes: [ESFJ, ESTJ, ISFP, ESFP]
+    neutrals: [INFJ, ISTJ, ENFJ]
+    dislikes: [ENTP, ENFP]
+    strengths:
+      - Lettura empatica delle micro-espressioni
+      - Preparazione anticipata di kit di supporto
+      - Pazienza nelle sequenze di cura prolungate
+    stress_triggers:
+      - Cinismo aperto verso i compagni feriti
+      - Decisioni aggressive che sacrificano il supporto
+      - Mancanza di tempo per preparare il terreno di recupero
+    collaboration_hooks:
+      - Pianificare rotazioni di guardia in coppia
+      - Condividere telemetria biologica dei membri
+      - Creare rituali di check-in emozionale dopo gli scontri
+    base_scores: {like: 4, neutral: 2, dislike: 1}
+  INFJ:
+    archetype: "Oracolo delle sinergie"
+    overview: >-
+      Visionario delle dinamiche a lungo termine: traccia linee di convergenza
+      tra motivazioni, timeline e pattern emotivi per orchestrare coesione.
+    likes: [ENFP, ENTP, INFP, ENFJ]
+    neutrals: [INTJ, ISFJ, ESFJ]
+    dislikes: [ESTP, ISTP]
+    strengths:
+      - Capacità di anticipare conflitti latenti
+      - Visione narrativa delle missioni e dei loro impatti
+      - Comunicazione diplomatica in situazioni tese
+    stress_triggers:
+      - Rumore e caos continuo che impediscono la riflessione
+      - Compagni che ignorano segnali emotivi evidenti
+      - Tattiche ciniche che sacrificano il significato del gruppo
+    collaboration_hooks:
+      - Coinvolgerlo nel definire mission statements
+      - Offrirgli spazio per sessioni strategiche a porte chiuse
+      - Sincronizzare briefing cross-team per ridurre malintesi
+    base_scores: {like: 4, neutral: 2, dislike: 1}
+  INTJ:
+    archetype: "Architetto delle strategie"
+    overview: >-
+      Maestro delle strutture a medio-lungo termine: costruisce matrici di
+      decisione per portare la squadra a vantaggi cumulativi e inevitabili.
+    likes: [ENTJ, ENTP, INFJ, INTP]
+    neutrals: [ISTJ, ENFJ, ESTJ]
+    dislikes: [ESFP, ENFP]
+    strengths:
+      - Pianificazione multi-fase con metriche chiare
+      - Capacità di sfruttare le debolezze sistemiche dei nemici
+      - Analisi fredda delle risorse e del rischio
+    stress_triggers:
+      - Variabili non monitorate che rompono il modello
+      - Interferenze emotive che distorcono la decisione
+      - Micro-management altrui sulle sue roadmap
+    collaboration_hooks:
+      - Assegnargli la gestione delle mappe strategiche
+      - Offrirgli accesso a data lake e replay delle sessioni
+      - Allineare OKR tattici con le sue milestone di dominio
+    base_scores: {like: 4, neutral: 2, dislike: 1}
+  ISTP:
+    archetype: "Tecnico reattivo"
+    overview: >-
+      Specialista delle soluzioni improvvisate: ripara, hackera e sperimenta in
+      tempo reale per mantenere gli strumenti della squadra al massimo.
+    likes: [ESTP, INTP, ISFP, ENTP]
+    neutrals: [ISTJ, ESTJ, ENFP]
+    dislikes: [ESFJ, ENFJ]
+    strengths:
+      - Diagnosi lampo dei guasti sul campo
+      - Precisione chirurgica in combattimenti ravvicinati
+      - Calma sotto pressione durante gli hack
+    stress_triggers:
+      - Routine rigide che ostacolano la sperimentazione
+      - Debrief interminabili senza output pratici
+      - Compagni che contestano ogni microdecisione
+    collaboration_hooks:
+      - Creare zone sicure per test rapidi
+      - Delegargli l'ottimizzazione di gadget e veicoli
+      - Fornire materiale grezzo da modificare a vista
+    base_scores: {like: 4, neutral: 2, dislike: 1}
+  ISFP:
+    archetype: "Artigiano empatico"
+    overview: >-
+      Curatore dell'estetica e del ritmo emozionale: costruisce esperienze
+      sensoriali che mantengono la squadra ispirata anche in ambienti ostili.
+    likes: [ESFP, INFP, ENFP, ISFJ]
+    neutrals: [ISTP, ESFJ, ENFJ]
+    dislikes: [ENTJ, ESTJ]
+    strengths:
+      - Capacità di improvvisare coperture creative
+      - Sensibilità verso il tono emotivo della squadra
+      - Mano ferma in micro-movimenti e crafting
+    stress_triggers:
+      - Critiche aspre alla sua estetica
+      - Forzature verso tattiche troppo meccaniche
+      - Mancanza di spazio personale in base operativa
+    collaboration_hooks:
+      - Coinvolgerlo nel design di basi e rifugi
+      - Assegnare compiti che richiedono tocco delicato
+      - Fornire playlist/ambienti sonori condivisi
+    base_scores: {like: 4, neutral: 2, dislike: 1}
+  INFP:
+    archetype: "Custode della fiamma"
+    overview: >-
+      Portavoce delle cause e dei valori del team: mantiene viva la motivazione
+      simbolica e guida i compagni verso scelte coerenti con l'identità comune.
+    likes: [ENFP, ENFJ, INTP, ISFP]
+    neutrals: [INFJ, ESFP, ISTP]
+    dislikes: [ESTJ, ENTJ]
+    strengths:
+      - Capacità di motivare con storytelling coinvolgente
+      - Resilienza morale di fronte alle sconfitte
+      - Intuizione nelle dinamiche interpersonali profonde
+    stress_triggers:
+      - Cinismo prolungato nel gruppo
+      - Decisioni tattiche che negano i valori condivisi
+      - Pressioni per risultati "a ogni costo"
+    collaboration_hooks:
+      - Affidargli la scrittura dei diari di missione
+      - Coinvolgerlo in negoziazioni con PNG idealisti
+      - Fornire tempi di decompressione creativa
+    base_scores: {like: 4, neutral: 2, dislike: 1}
+  INTP:
+    archetype: "Analista curioso"
+    overview: >-
+      Investigatore delle anomalie: ricerca pattern nascosti e crea prototipi
+      concettuali che sbloccano tattiche fuori dal comune.
+    likes: [ENTP, ENFP, INTJ, INFP]
+    neutrals: [ISTP, ESTP, ENFJ]
+    dislikes: [ESFJ, ESTJ]
+    strengths:
+      - Capacità di modellare sistemi complessi al volo
+      - Creatività nel combinare moduli tecnologici
+      - Attenzione ai dettagli durante la ricerca
+    stress_triggers:
+      - Task ripetitivi senza stimolo mentale
+      - Impazienza altrui verso le sue ipotesi
+      - Mancanza di dati grezzi da analizzare
+    collaboration_hooks:
+      - Offrire accesso libero a database e laboratori
+      - Pianificare sessioni di brainstorming strutturate
+      - Aggiungere spazi di debug condivisi alle basi
+    base_scores: {like: 4, neutral: 2, dislike: 1}
+  ESTP:
+    archetype: "Sprinter tattico"
+    overview: >-
+      Incursore che vive nel tempo reale: legge la scena, afferra opportunità e
+      smantella gli ostacoli prima che diventino minacce strutturate.
+    likes: [ESFP, ISTP, ENTP, ENFP]
+    neutrals: [ESTJ, ISFP, ENTJ]
+    dislikes: [INFJ, ISFJ]
+    strengths:
+      - Riflessi rapidi e improvvisazione atletica
+      - Capacità di testare limiti senza paralisi analitica
+      - Carisma sul campo che energizza i compagni
+    stress_triggers:
+      - Vincoli eccessivi imposti da piani rigidi
+      - Ritmo di missione lento e burocratico
+      - Critiche costanti sulla sua audacia
+    collaboration_hooks:
+      - Assegnargli incursioni e distrazioni ad alto rischio
+      - Fornire feedback immediati post-azione
+      - Creare canali di comunicazione rapidi dedicati
+    base_scores: {like: 4, neutral: 2, dislike: 1}
+  ESFP:
+    archetype: "Showrunner ribelle"
+    overview: >-
+      Maestro dell'energia di squadra: trasforma ogni missione in un evento
+      corale dove entusiasmo e ritmo mantengono alta l'attenzione.
+    likes: [ENFP, ISFP, ESTP, ESFJ]
+    neutrals: [ISFJ, ENFJ, ENTP]
+    dislikes: [INTJ, ISTJ]
+    strengths:
+      - Capacità di sollevare il morale in istanti critici
+      - Lettura rapida del pubblico e dei nemici
+      - Creatività nell'uso degli elementi scenici
+    stress_triggers:
+      - Critiche severe alla spontaneità
+      - Mansioni isolanti o monotone
+      - Atmosfere silenziose senza interazione
+    collaboration_hooks:
+      - Coinvolgerlo nella regia delle sequenze d'assalto
+      - Programmare feste/pause strutturate post-missione
+      - Fornire spazi per performance e training condivisi
+    base_scores: {like: 4, neutral: 2, dislike: 1}
+  ENFP:
+    archetype: "Catalizzatore visionario"
+    overview: >-
+      Esploratore di possibilità sociali e tattiche: accende connessioni inedite
+      tra persone, fazioni e strumenti per aprire nuove strade al gruppo.
+    likes: [ENFJ, ENTP, ISFP, ESFP]
+    neutrals: [INTP, INFP, ESTP]
+    dislikes: [ISTJ, ESTJ]
+    strengths:
+      - Networking istantaneo con PNG e fazioni
+      - Creatività nel combinare abilità del party
+      - Capacità di mantenere alto il morale con idee fresche
+    stress_triggers:
+      - Rigidità eccessiva nelle procedure
+      - Atmosfere di conflitto prolungato non risolto
+      - Limitazioni sulle sue proposte sperimentali
+    collaboration_hooks:
+      - Affidargli scouting diplomatico e alleanze flash
+      - Tenere lavagne di idee aperte per le sue intuizioni
+      - Pianificare iterazioni rapide con feedback giocosi
+    base_scores: {like: 4, neutral: 2, dislike: 1}
+  ENTP:
+    archetype: "Duellante concettuale"
+    overview: >-
+      Provocatore creativo che stressa sistemi e avversari con idee non
+      convenzionali, svelando scorciatoie tattiche e buchi logici.
+    likes: [ENTJ, ENFP, INTP, ENFJ]
+    neutrals: [INTJ, ESTP, ISFP]
+    dislikes: [ISFJ, ESFJ]
+    strengths:
+      - Pensiero divergente sotto pressione
+      - Capacità di ribaltare posizioni nemiche con parole o gadget
+      - Elasticità nell'apprendere nuovi tool
+    stress_triggers:
+      - Limitazioni rigide sul brainstorming
+      - Membri del team che prendono tutto sul personale
+      - Routine che impediscono il confronto dialettico
+    collaboration_hooks:
+      - Organizzare sessioni di design-thinking competitivo
+      - Assegnargli ruoli di infiltrazione verbale o tecnologica
+      - Fornirgli prototipi da stress-testare
+    base_scores: {like: 4, neutral: 2, dislike: 1}
+  ESTJ:
+    archetype: "Comandante operativo"
+    overview: >-
+      Coordinatore del ritmo di missione: definisce responsabilità, controlla
+      l'avanzamento e assicura che il piano venga eseguito con disciplina.
+    likes: [ISTJ, ESFJ, ENTJ, ESTP]
+    neutrals: [ISFJ, INTJ, ENFJ]
+    dislikes: [INFP, ISFP]
+    strengths:
+      - Leadership chiara e orientata ai risultati
+      - Capacità di ottimizzare catene logistiche
+      - Decisioni rapide in situazioni grigie
+    stress_triggers:
+      - Disorganizzazione cronica del gruppo
+      - Contestazioni dell'autorità senza alternative solide
+      - Ritardi dovuti a indecisione
+    collaboration_hooks:
+      - Affidargli la timeline del raid e le check-list
+      - Offrire strumenti per monitorare KPI in tempo reale
+      - Stabilire protocolli di escalation condivisi
+    base_scores: {like: 4, neutral: 2, dislike: 1}
+  ESFJ:
+    archetype: "Direttore del party"
+    overview: >-
+      Facilitatore sociale della squadra: organizza risorse, turni e rituali
+      comunitari per mantenere la coesione e l'efficienza.
+    likes: [ISFJ, ESTJ, ENFJ, ESFP]
+    neutrals: [ISTJ, ENFP, ISFP]
+    dislikes: [INTP, ISTP]
+    strengths:
+      - Capacità di coordinare simultaneamente molte esigenze
+      - Talento per creare routine condivise rassicuranti
+      - Empatia pratica nelle emergenze
+    stress_triggers:
+      - Mancanza di riconoscimento per il lavoro di supporto
+      - Membri che sabotano il clima di squadra
+      - Task prolungati in solitaria
+    collaboration_hooks:
+      - Delegare la gestione dei rifornimenti comuni
+      - Co-progettare eventi sociali post-missione
+      - Fornirle strumenti per monitorare il benessere del party
+    base_scores: {like: 4, neutral: 2, dislike: 1}
+  ENFJ:
+    archetype: "Conduttore ispirazionale"
+    overview: >-
+      Guida carismatica che intreccia obiettivi personali e collettivi,
+      traghettando il team verso visioni condivise.
+    likes: [INFJ, ENFP, ENTP, ESFJ]
+    neutrals: [INTJ, ISFJ, ISFP]
+    dislikes: [ISTP, ESTP]
+    strengths:
+      - Coaching motivazionale e sviluppo dei talenti
+      - Lettura rapida della disposizione del gruppo
+      - Capacità di mediare conflitti con empatia
+    stress_triggers:
+      - Resistenze passive e mancanza di feedback
+      - Atmosfere fredde senza spazio per il dialogo
+      - Obiettivi imposti senza narrativo condiviso
+    collaboration_hooks:
+      - Coinvolgerlo nella definizione delle relazioni con i PNG
+      - Creare cerimonie di riconoscimento periodiche
+      - Sincronizzare le sue sessioni di mentoring con i turni critici
+    base_scores: {like: 4, neutral: 2, dislike: 1}
+  ENTJ:
+    archetype: "Stratega imperioso"
+    overview: >-
+      Visionario orientato al risultato: orchestra risorse, alleanze e tempo
+      in modo spietatamente efficiente per raggiungere la vittoria.
+    likes: [INTJ, ENTP, ENFP, ESTJ]
+    neutrals: [ISTJ, ESTP, ENFJ]
+    dislikes: [ISFP, INFP]
+    strengths:
+      - Capacità di scalare piani e logistica rapidamente
+      - Decisioni decisive in condizioni di ambiguità
+      - Resistenza notevole allo stress competitivo
+    stress_triggers:
+      - Compagni che esitano nel dare feedback onesto
+      - Vincoli burocratici che rallentano l'esecuzione
+      - Mancanza di sfide proporzionate
+    collaboration_hooks:
+      - Affidargli negoziazioni ad alto rischio
+      - Allineare i piani di crescita con i suoi obiettivi ambiziosi
+      - Fornire indicatori di performance aggressivi
+    base_scores: {like: 4, neutral: 2, dislike: 1}
 compat_ennea:
   Coordinatore(2): {likes: ["assist","shield_share","revive"], dislike: ["abandon_ally","selfish_loot"]}
   Conquistatore(3): {likes: ["apex_kill","first_strike"], dislike: ["stall","retreat"]}

--- a/docs/checklist/milestones.md
+++ b/docs/checklist/milestones.md
@@ -5,7 +5,7 @@
 - [x] Pubblicati script CLI per roll pack e encounter (`tools/ts`, `tools/py`).
 
 ## In corso
-- [ ] Espandere `compat_forme` per coprire tutte le 16 forme MBTI.【F:data/mating.yaml†L1-L12】
+- [x] Espandere `compat_forme` per coprire tutte le 16 forme MBTI.【F:data/mating.yaml†L1-L32】
 - [ ] Validare le formule di telemetria con dati di playtest reali.【F:data/telemetry.yaml†L1-L25】
 - [ ] Creare esempi di encounter documentati per ciascun bioma.【F:data/biomes.yaml†L1-L13】
 


### PR DESCRIPTION
## Summary
- expand each MBTI entry in `compat_forme` with archetype, overview, strengths, stress triggers, and collaboration hooks
- keep the existing like/neutral/dislike pairings while deepening narrative context for the 16 archetypes

## Testing
- `python tools/py/validate_datasets.py data/mating.yaml` *(fails: missing PyYAML dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f98b6425588332be7a7f16622d62c6