### PR TITLE
Add shared Canvas links to sync configuration

### DIFF
--- a/data/chatgpt_sources.yaml
+++ b/data/chatgpt_sources.yaml
@@ -14,6 +14,46 @@ sources:
       # User-Agent: "Mozilla/5.0 ..."
     # body: "{}"
 
+  - name: "canvas-shared-68f97441"
+    mode: "web"
+    namespace: "canvas"
+    label: "canvas-68f97441"
+    url: "https://chatgpt.com/canvas/shared/68f974415ffc819197067147e9d6009e"
+    method: "GET"
+    headers:
+      # Cookie: "__Secure-next-auth.session-token=..."
+      # User-Agent: "Mozilla/5.0 ..."
+
+  - name: "canvas-shared-68f99565"
+    mode: "web"
+    namespace: "canvas"
+    label: "canvas-68f99565"
+    url: "https://chatgpt.com/canvas/shared/68f9956583848191b90cf13d97019904"
+    method: "GET"
+    headers:
+      # Cookie: "__Secure-next-auth.session-token=..."
+      # User-Agent: "Mozilla/5.0 ..."
+
+  - name: "canvas-shared-68f9957c"
+    mode: "web"
+    namespace: "canvas"
+    label: "canvas-68f9957c"
+    url: "https://chatgpt.com/canvas/shared/68f9957c20e8819195854b4fb88706c2"
+    method: "GET"
+    headers:
+      # Cookie: "__Secure-next-auth.session-token=..."
+      # User-Agent: "Mozilla/5.0 ..."
+
+  - name: "canvas-shared-68f99591"
+    mode: "web"
+    namespace: "canvas"
+    label: "canvas-68f99591"
+    url: "https://chatgpt.com/canvas/shared/68f99591e91481919c7948b0cf51091c"
+    method: "GET"
+    headers:
+      # Cookie: "__Secure-next-auth.session-token=..."
+      # User-Agent: "Mozilla/5.0 ..."
+
   - name: "canvas-export"
     mode: "export"
     namespace: "canvas"

--- a/logs/chatgpt_sync.log
+++ b/logs/chatgpt_sync.log
@@ -1,0 +1,79 @@
+2025-10-23 02:47:04,714 - INFO - Processo fonte configurata 'project-overview' (web)
+2025-10-23 02:47:04,715 - ERROR - Errore durante la sincronizzazione: Libreria 'requests' non installata. Eseguire 'pip install requests'.
+Traceback (most recent call last):
+  File "/workspace/Game/scripts/chatgpt_sync.py", line 219, in fetch_from_web
+    import requests  # type: ignore
+    ^^^^^^^^^^^^^^^
+ModuleNotFoundError: No module named 'requests'
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/workspace/Game/scripts/chatgpt_sync.py", line 648, in main
+    process_config(args.config, summary_file=args.summary_file, skip_diff=args.skip_diff)
+  File "/workspace/Game/scripts/chatgpt_sync.py", line 606, in process_config
+    result = process_single_source(
+             ^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/Game/scripts/chatgpt_sync.py", line 533, in process_single_source
+    text, extra_meta = fetch_from_web(
+                       ^^^^^^^^^^^^^^^
+  File "/workspace/Game/scripts/chatgpt_sync.py", line 221, in fetch_from_web
+    raise RuntimeError(
+RuntimeError: Libreria 'requests' non installata. Eseguire 'pip install requests'.
+2025-10-23 02:47:18,383 - INFO - Processo fonte configurata 'project-overview' (web)
+2025-10-23 02:47:18,640 - ERROR - Errore durante la sincronizzazione: HTTPSConnectionPool(host='chatgpt.com', port=443): Max retries exceeded with url: /g/.../project (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden')))
+Traceback (most recent call last):
+  File "/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/urllib3/connectionpool.py", line 773, in urlopen
+    self._prepare_proxy(conn)
+  File "/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/urllib3/connectionpool.py", line 1042, in _prepare_proxy
+    conn.connect()
+  File "/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/urllib3/connection.py", line 770, in connect
+    self._tunnel()
+  File "/root/.pyenv/versions/3.11.12/lib/python3.11/http/client.py", line 943, in _tunnel
+    raise OSError(f"Tunnel connection failed: {code} {message.strip()}")
+OSError: Tunnel connection failed: 403 Forbidden
+
+The above exception was the direct cause of the following exception:
+
+urllib3.exceptions.ProxyError: ('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/requests/adapters.py", line 644, in send
+    resp = conn.urlopen(
+           ^^^^^^^^^^^^^
+  File "/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/urllib3/connectionpool.py", line 841, in urlopen
+    retries = retries.increment(
+              ^^^^^^^^^^^^^^^^^^
+  File "/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/urllib3/util/retry.py", line 519, in increment
+    raise MaxRetryError(_pool, url, reason) from reason  # type: ignore[arg-type]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='chatgpt.com', port=443): Max retries exceeded with url: /g/.../project (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden')))
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/workspace/Game/scripts/chatgpt_sync.py", line 648, in main
+    process_config(args.config, summary_file=args.summary_file, skip_diff=args.skip_diff)
+  File "/workspace/Game/scripts/chatgpt_sync.py", line 606, in process_config
+    result = process_single_source(
+             ^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/Game/scripts/chatgpt_sync.py", line 533, in process_single_source
+    text, extra_meta = fetch_from_web(
+                       ^^^^^^^^^^^^^^^
+  File "/workspace/Game/scripts/chatgpt_sync.py", line 225, in fetch_from_web
+    response = requests.request(
+               ^^^^^^^^^^^^^^^^^
+  File "/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/requests/api.py", line 59, in request
+    return session.request(method=method, url=url, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/requests/sessions.py", line 589, in request
+    resp = self.send(prep, **send_kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/requests/sessions.py", line 703, in send
+    r = adapter.send(request, **kwargs)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/requests/adapters.py", line 671, in send
+    raise ProxyError(e, request=request)
+requests.exceptions.ProxyError: HTTPSConnectionPool(host='chatgpt.com', port=443): Max retries exceeded with url: /g/.../project (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden')))


### PR DESCRIPTION
## Summary
- add the four provided shared Canvas URLs to `data/chatgpt_sources.yaml`
- capture the latest `chatgpt_sync.py` run output in `logs/chatgpt_sync.log`, including the current network limitation

## Testing
- `python3 scripts/chatgpt_sync.py --config data/chatgpt_sources.yaml` *(fails: network access to chatgpt.com blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f993fb25908332a4904bb77eb0964f