### PR TITLE
feat: add web recap test interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ python3 roll_pack.py ENTP invoker ../../data/packs.yaml
 python3 generate_encounter.py savana ../../data/biomes.yaml
 ```
 
+## Interfaccia test & recap via web
+- Avvia un server locale dalla radice del progetto (`python3 -m http.server 8000`).
+- Apri `http://localhost:8000/docs/test-interface/` per una dashboard che riassume pacchetti PI,
+  telemetria VC, biomi e compatibilità delle forme.
+- Premi "Ricarica dati YAML" per aggiornare i contenuti dopo aver modificato i file in `data/`.
+
 ## Pubblicazione su GitHub
 ```bash
 cd /path/alla/cartella/evo-tactics

--- a/docs/test-interface/app.js
+++ b/docs/test-interface/app.js
@@ -1,0 +1,401 @@
+const DATA_SOURCES = [
+  { key: "packs", path: "../../data/packs.yaml" },
+  { key: "telemetry", path: "../../data/telemetry.yaml" },
+  { key: "biomes", path: "../../data/biomes.yaml" },
+  { key: "mating", path: "../../data/mating.yaml" }
+];
+
+const state = {
+  data: {},
+  loadedAt: null
+};
+
+const metricsElements = {};
+
+function setupDomReferences() {
+  metricsElements.forms = document.querySelector('[data-metric="forms"]');
+  metricsElements.random = document.querySelector('[data-metric="random"]');
+  metricsElements.indices = document.querySelector('[data-metric="indices"]');
+  metricsElements.biomes = document.querySelector('[data-metric="biomes"]');
+  metricsElements.timestamp = document.getElementById("last-updated");
+}
+
+async function loadYaml(path) {
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`Impossibile caricare ${path} (${response.status})`);
+  }
+  const text = await response.text();
+  return jsyaml.load(text);
+}
+
+async function loadAllData() {
+  setTimestamp("Caricamento in corso…");
+  try {
+    const entries = await Promise.all(
+      DATA_SOURCES.map(async (source) => {
+        const value = await loadYaml(source.path);
+        return [source.key, value];
+      })
+    );
+    state.data = Object.fromEntries(entries);
+    state.loadedAt = new Date();
+    updateOverview();
+    populateFormSelector();
+    renderRandomTable();
+    renderTelemetry();
+    renderBiomes();
+    setTimestamp(`Ultimo aggiornamento: ${state.loadedAt.toLocaleString()}`);
+  } catch (error) {
+    console.error(error);
+    setTimestamp(`Errore nel caricamento: ${error.message}`);
+  }
+}
+
+function setTimestamp(text) {
+  if (metricsElements.timestamp) {
+    metricsElements.timestamp.textContent = text;
+  }
+}
+
+function updateOverview() {
+  const packs = state.data.packs || {};
+  const forms = packs.forms ? Object.keys(packs.forms) : [];
+  const randomTable = Array.isArray(packs.random_general_d20)
+    ? packs.random_general_d20.length
+    : 0;
+  const indices = state.data.telemetry?.indices
+    ? Object.keys(state.data.telemetry.indices).length
+    : 0;
+  const biomeCount = state.data.biomes?.biomes
+    ? Object.keys(state.data.biomes.biomes).length
+    : 0;
+
+  if (metricsElements.forms) metricsElements.forms.textContent = forms.length;
+  if (metricsElements.random) metricsElements.random.textContent = randomTable;
+  if (metricsElements.indices) metricsElements.indices.textContent = indices;
+  if (metricsElements.biomes) metricsElements.biomes.textContent = biomeCount;
+}
+
+function populateFormSelector() {
+  const selector = document.getElementById("form-selector");
+  if (!selector) return;
+
+  const forms = state.data.packs?.forms ? Object.keys(state.data.packs.forms) : [];
+  selector.innerHTML = '<option value="">Scegli…</option>';
+  forms
+    .sort()
+    .forEach((formId) => {
+      const option = document.createElement("option");
+      option.value = formId;
+      option.textContent = formId;
+      selector.appendChild(option);
+    });
+
+  selector.addEventListener("change", (event) => {
+    renderFormDetails(event.target.value);
+  });
+}
+
+function renderFormDetails(formId) {
+  const container = document.getElementById("form-details");
+  if (!container) return;
+
+  if (!formId) {
+    container.innerHTML =
+      "<p>Seleziona una forma per visualizzare combinazioni A/B/C, bias d12 e hook di collaborazione.</p>";
+    return;
+  }
+
+  const packData = state.data.packs?.forms?.[formId];
+  const compatibility = state.data.mating?.compat_forme?.[formId];
+
+  if (!packData) {
+    container.innerHTML = `<p>Nessun dato trovato per la forma <strong>${formId}</strong>.</p>`;
+    return;
+  }
+
+  const packSections = ["A", "B", "C"].map((slot) => {
+    const entries = Array.isArray(packData[slot]) ? packData[slot] : [];
+    const listItems = entries
+      .map((entry) => `<li>${formatEntry(entry)}</li>`)
+      .join("");
+    return `
+      <article class="card pack-card">
+        <h3>Pack ${slot}</h3>
+        <ul>${listItems || "<li>—</li>"}</ul>
+      </article>
+    `;
+  });
+
+  const biasEntries = packData.bias_d12
+    ? Object.entries(packData.bias_d12)
+        .map(([pack, range]) => `<li><strong>${pack}</strong>: ${range}</li>`)
+        .join("")
+    : "";
+
+  let compatibilityHtml = "";
+  if (compatibility) {
+    compatibilityHtml = `
+      <article class="card persona">
+        <h3>${compatibility.archetype || "Archetipo"}</h3>
+        <p class="overview">${compatibility.overview || ""}</p>
+        <div class="pill-groups">
+          ${renderPillGroup("Affinità", compatibility.likes)}
+          ${renderPillGroup("Neutrali", compatibility.neutrals)}
+          ${renderPillGroup("Attriti", compatibility.dislikes)}
+        </div>
+      </article>
+      <article class="card persona-details">
+        ${renderListBlock("Punti di forza", compatibility.strengths)}
+        ${renderListBlock("Trigger di stress", compatibility.stress_triggers)}
+        ${renderListBlock("Hook di collaborazione", compatibility.collaboration_hooks)}
+        <p class="scores">Base scores → like: ${compatibility.base_scores?.like ?? "-"}, neutral: ${compatibility.base_scores?.neutral ?? "-"}, dislike: ${compatibility.base_scores?.dislike ?? "-"}</p>
+      </article>
+    `;
+  }
+
+  container.innerHTML = `
+    <div class="cards pack-grid">
+      ${packSections.join("")}
+      <article class="card bias-card">
+        <h3>Bias d12</h3>
+        <ul>${biasEntries || "<li>—</li>"}</ul>
+      </article>
+    </div>
+    <div class="cards persona-grid">
+      ${
+        compatibilityHtml ||
+        '<article class="card"><p>Nessun dato di compatibilità disponibile per questa forma.</p></article>'
+      }
+    </div>
+  `;
+}
+
+function renderRandomTable() {
+  const container = document.getElementById("random-list");
+  if (!container) return;
+
+  const table = state.data.packs?.random_general_d20;
+  if (!Array.isArray(table) || table.length === 0) {
+    container.innerHTML = "<p>Nessuna combinazione trovata.</p>";
+    return;
+  }
+
+  const rows = table
+    .map((entry) => {
+      const combo = Array.isArray(entry.combo)
+        ? `<ul class="inline-list">${entry.combo
+            .map((item) => `<li>${formatEntry(item)}</li>`)
+            .join("")}</ul>`
+        : "—";
+      return `
+        <tr>
+          <td>${entry.range || "—"}</td>
+          <td>${entry.pack || "—"}</td>
+          <td>${combo}</td>
+          <td>${entry.notes || ""}</td>
+        </tr>
+      `;
+    })
+    .join("");
+
+  container.innerHTML = `
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>Range</th>
+            <th>Pack</th>
+            <th>Combo</th>
+            <th>Note</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+  `;
+}
+
+function renderTelemetry() {
+  const container = document.getElementById("telemetry-content");
+  if (!container) return;
+
+  const telemetry = state.data.telemetry;
+  if (!telemetry) {
+    container.innerHTML = "<p>Nessun dato disponibile.</p>";
+    return;
+  }
+
+  const telemetrySettings = telemetry.telemetry || {};
+  const windows = telemetrySettings.windows || {};
+  const indices = telemetry.indices || {};
+  const axes = telemetry.mbti_axes || {};
+  const ennea = telemetry.ennea_themes || [];
+  const economy = telemetry.pe_economy || {};
+
+  const indicesHtml = Object.entries(indices)
+    .map(
+      ([name, weights]) => `
+        <li>
+          <strong>${name}</strong>
+          <ul>${Object.entries(weights)
+            .map(([metric, value]) => `<li>${metric}: <span>${value}</span></li>`)
+            .join("")}</ul>
+        </li>
+      `
+    )
+    .join("");
+
+  const axesHtml = Object.entries(axes)
+    .map(([axis, details]) => `<li><strong>${axis}</strong>: ${details.formula}</li>`)
+    .join("");
+
+  const enneaHtml = ennea
+    .map((entry) => `<li><strong>${entry.id}</strong> — ${entry.when}</li>`)
+    .join("");
+
+  const economyHtml = Object.entries(economy)
+    .map(([key, value]) => `<li><strong>${key}</strong>: ${formatEntry(value)}</li>`)
+    .join("");
+
+  container.innerHTML = `
+    <div class="telemetry-grid">
+      <article class="card">
+        <h3>Finestra EMA</h3>
+        <p><strong>Alpha:</strong> ${telemetrySettings.ema_alpha ?? "—"}</p>
+        <p><strong>Debounce:</strong> ${telemetrySettings.debounce_ms ?? "—"} ms</p>
+        <p><strong>Idle threshold:</strong> ${telemetrySettings.idle_threshold_s ?? "—"} s</p>
+        <p><strong>Normalizzazione:</strong> ${telemetrySettings.normalization || "—"}</p>
+        <h4>Windows</h4>
+        <ul>${Object.entries(windows)
+          .map(([key, value]) => `<li>${key}: ${formatEntry(value)}</li>`)
+          .join("")}</ul>
+      </article>
+      <article class="card">
+        <h3>Indici VC</h3>
+        <ul class="nested-list">${indicesHtml}</ul>
+      </article>
+      <article class="card">
+        <h3>Assi MBTI</h3>
+        <ul>${axesHtml}</ul>
+      </article>
+      <article class="card">
+        <h3>Temi Enneagramma</h3>
+        <ul>${enneaHtml}</ul>
+      </article>
+      <article class="card">
+        <h3>Economia PE</h3>
+        <ul>${economyHtml}</ul>
+      </article>
+    </div>
+  `;
+}
+
+function renderBiomes() {
+  const container = document.getElementById("biomes-grid");
+  if (!container) return;
+
+  const biomesData = state.data.biomes;
+  if (!biomesData) {
+    container.innerHTML = "<p>Nessun dato disponibile.</p>";
+    return;
+  }
+
+  const biomes = biomesData.biomes || {};
+  const biomeCards = Object.entries(biomes)
+    .map(([name, details]) => {
+      return `
+        <article class="card biome-card">
+          <h3>${name}</h3>
+          <p><strong>Diff. base:</strong> ${details.diff_base ?? "—"}</p>
+          <p><strong>Mod. bioma:</strong> ${details.mod_biome ?? "—"}</p>
+          <h4>Affissi</h4>
+          <ul>${Array.isArray(details.affixes)
+            ? details.affixes.map((affix) => `<li>${affix}</li>`).join("")
+            : "<li>—</li>"}</ul>
+        </article>
+      `;
+    })
+    .join("");
+
+  const vcAdapt = biomesData.vc_adapt || {};
+  const vcHtml = Object.entries(vcAdapt)
+    .map(
+      ([key, value]) => `<li><strong>${key}</strong>: ${formatEntry(value)}</li>`
+    )
+    .join("");
+
+  const mutations = biomesData.mutations || {};
+  const mutationHtml = Object.entries(mutations)
+    .map(([key, value]) => `<li><strong>${key}</strong>: ${formatEntry(value)}</li>`)
+    .join("");
+
+  const frequencies = biomesData.frequencies || {};
+  const freqHtml = Object.entries(frequencies)
+    .map(([key, value]) => `<li><strong>${key}</strong>: ${formatEntry(value)}</li>`)
+    .join("");
+
+  container.innerHTML = `
+    <div class="biome-grid">
+      ${biomeCards}
+    </div>
+    <div class="cards biome-details">
+      <article class="card">
+        <h3>VC Adapt</h3>
+        <ul>${vcHtml}</ul>
+      </article>
+      <article class="card">
+        <h3>Mutazioni</h3>
+        <ul>${mutationHtml}</ul>
+      </article>
+      <article class="card">
+        <h3>Frequenze</h3>
+        <ul>${freqHtml}</ul>
+      </article>
+    </div>
+  `;
+}
+
+function formatEntry(entry) {
+  if (entry == null) return "—";
+  if (typeof entry === "string" || typeof entry === "number") return entry;
+  if (Array.isArray(entry)) {
+    return `<ul>${entry.map((item) => `<li>${formatEntry(item)}</li>`).join("")}</ul>`;
+  }
+  if (typeof entry === "object") {
+    return Object.entries(entry)
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(", ");
+  }
+  return String(entry);
+}
+
+function renderPillGroup(title, values) {
+  if (!Array.isArray(values) || values.length === 0) return "";
+  const pills = values.map((value) => `<span class="pill">${value}</span>`).join("");
+  return `
+    <div class="pill-group">
+      <h4>${title}</h4>
+      <div class="pills">${pills}</div>
+    </div>
+  `;
+}
+
+function renderListBlock(title, values) {
+  if (!Array.isArray(values) || values.length === 0) return "";
+  return `
+    <div class="list-block">
+      <h4>${title}</h4>
+      <ul>${values.map((value) => `<li>${value}</li>`).join("")}</ul>
+    </div>
+  `;
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  setupDomReferences();
+  document
+    .getElementById("reload-data")
+    .addEventListener("click", () => loadAllData());
+  loadAllData();
+});

--- a/docs/test-interface/index.html
+++ b/docs/test-interface/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Evo-Tactics · Interfaccia Test & Recap</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
+    <script defer src="app.js"></script>
+  </head>
+  <body>
+    <header>
+      <h1>Evo-Tactics · Interfaccia Test &amp; Recap</h1>
+      <p class="tagline">
+        Dashboard rapida per ispezionare pacchetti PI, telemetria VC e accoppiamenti MBTI.
+      </p>
+      <button id="reload-data" type="button">Ricarica dati YAML</button>
+      <p class="hint">
+        Suggerimento: apri questa pagina tramite un piccolo server locale (<code>python3 -m http.server</code>)
+        per permettere il fetch dei file YAML.
+      </p>
+    </header>
+
+    <main>
+      <section id="overview" class="panel">
+        <h2>Overview rapida</h2>
+        <div class="stats-grid" id="overview-stats">
+          <article>
+            <h3>Forme MBTI coperte</h3>
+            <p class="metric" data-metric="forms">—</p>
+          </article>
+          <article>
+            <h3>Combinazioni random d20</h3>
+            <p class="metric" data-metric="random">—</p>
+          </article>
+          <article>
+            <h3>Indici VC monitorati</h3>
+            <p class="metric" data-metric="indices">—</p>
+          </article>
+          <article>
+            <h3>Biomi attivi</h3>
+            <p class="metric" data-metric="biomes">—</p>
+          </article>
+        </div>
+        <p class="timestamp" id="last-updated">Dati non caricati.</p>
+      </section>
+
+      <section id="forms" class="panel">
+        <div class="panel-header">
+          <h2>Pacchetti PI &amp; Compatibilità per Forma</h2>
+          <label class="selector">
+            <span>Seleziona forma:</span>
+            <select id="form-selector" aria-label="Forma MBTI">
+              <option value="" selected>Scegli…</option>
+            </select>
+          </label>
+        </div>
+        <div id="form-details" class="content-placeholder">
+          <p>Seleziona una forma per visualizzare combinazioni A/B/C, bias d12 e hook di collaborazione.</p>
+        </div>
+      </section>
+
+      <section id="random-table" class="panel">
+        <h2>Tabella Random General d20</h2>
+        <div id="random-list" class="content-placeholder">
+          <p>In attesa di dati…</p>
+        </div>
+      </section>
+
+      <section id="telemetry" class="panel">
+        <h2>Telemetria VC</h2>
+        <div id="telemetry-content" class="content-placeholder">
+          <p>In attesa di dati…</p>
+        </div>
+      </section>
+
+      <section id="biomes" class="panel">
+        <h2>Biomi &amp; Mutazioni</h2>
+        <div id="biomes-grid" class="content-placeholder">
+          <p>In attesa di dati…</p>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        Dati sorgente: <code>data/*.yaml</code>. Aggiorna gli YAML, poi premi
+        <strong>Ricarica</strong> per validare rapidamente i contenuti durante il playtest.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/docs/test-interface/styles.css
+++ b/docs/test-interface/styles.css
@@ -1,0 +1,301 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --bg-panel: rgba(15, 23, 42, 0.75);
+  --bg-panel-light: rgba(30, 41, 59, 0.6);
+  --text: #e2e8f0;
+  --accent: #38bdf8;
+  --accent-soft: rgba(56, 189, 248, 0.2);
+  --border: rgba(148, 163, 184, 0.3);
+  --muted: #94a3b8;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(160deg, #0f172a 0%, #1e293b 55%, #020617 100%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+header,
+footer {
+  text-align: center;
+  padding: 2.5rem 1.5rem 1.5rem;
+  background: transparent;
+}
+
+header h1 {
+  margin-bottom: 0.5rem;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+}
+
+.tagline {
+  margin: 0 auto 1.5rem;
+  max-width: 60ch;
+  color: var(--muted);
+}
+
+#reload-data {
+  background: var(--accent);
+  border: none;
+  color: #0f172a;
+  font-weight: 600;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  cursor: pointer;
+  box-shadow: 0 10px 30px rgba(56, 189, 248, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+#reload-data:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 40px rgba(56, 189, 248, 0.35);
+}
+
+.hint {
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+main {
+  display: grid;
+  gap: 2rem;
+  padding: 0 1.5rem 4rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.panel {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(12px);
+}
+
+.panel h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.6rem;
+}
+
+.panel-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.selector {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  font-size: 0.95rem;
+}
+
+.selector select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: var(--bg-panel-light);
+  color: var(--text);
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.stats-grid article {
+  background: var(--bg-panel-light);
+  border-radius: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  text-align: center;
+}
+
+.metric {
+  font-size: 2rem;
+  margin: 0.25rem 0 0;
+  font-weight: 700;
+}
+
+.timestamp {
+  margin-top: 1.5rem;
+  color: var(--muted);
+}
+
+.cards {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.pack-grid {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.persona-grid {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.biome-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.biome-details {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  background: var(--bg-panel-light);
+  border-radius: 1.1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1.1rem;
+  min-height: 120px;
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.card h4 {
+  margin-bottom: 0.5rem;
+  color: var(--muted);
+}
+
+.card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--muted);
+}
+
+.card ul li {
+  margin-bottom: 0.35rem;
+}
+
+.inline-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.75rem;
+}
+
+.inline-list li {
+  background: rgba(56, 189, 248, 0.08);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.pill-group {
+  margin-bottom: 1rem;
+}
+
+.pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pill {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-weight: 600;
+}
+
+.list-block ul {
+  color: var(--text);
+}
+
+.overview {
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.scores {
+  margin-top: 1.25rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  border-spacing: 0;
+  font-size: 0.95rem;
+}
+
+table th,
+table td {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.75rem 0.5rem;
+  text-align: left;
+}
+
+table th {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+table tbody tr:hover {
+  background: rgba(148, 163, 184, 0.1);
+}
+
+.nested-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.nested-list > li {
+  margin-bottom: 0.75rem;
+}
+
+.nested-list > li > ul {
+  margin-top: 0.5rem;
+  padding-left: 1.2rem;
+}
+
+footer {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  header,
+  footer {
+    padding: 2rem 1rem 1rem;
+  }
+
+  .panel {
+    padding: 1.25rem;
+  }
+
+  .panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static dashboard under docs/test-interface that loads YAML data for packs, telemetry, biomes, and mating
- implement JavaScript logic to fetch and render summaries, selectors, and tables for quick playtest validation
- document how to open the recap interface from the repository README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f997494b5083328554fba11a91a7c7