### PR TITLE
feat: add diagnostics and manual data fetching to control site

### DIFF
--- a/docs/test-interface/index.html
+++ b/docs/test-interface/index.html
@@ -22,6 +22,41 @@
     </header>
 
     <main>
+      <section id="control" class="panel">
+        <h2>Controllo dati &amp; Fetching</h2>
+        <div class="control-grid">
+          <article class="card control-card">
+            <h3>Test rapidi dei dataset</h3>
+            <p class="muted">
+              Esegui un controllo istantaneo dei pacchetti PI, telemetria e biomi per verificare che i dati caricati siano pronti per il playtest.
+            </p>
+            <button id="run-tests" type="button">Esegui test</button>
+            <ul id="test-results" class="test-results"></ul>
+          </article>
+          <article class="card control-card">
+            <h3>Fetching manuale</h3>
+            <p class="muted">
+              Inserisci l'URL di uno snapshot YAML/JSON (es. endpoint Drive/GitHub raw) per aggiornare rapidamente il database locale in sessione.
+            </p>
+            <form id="fetch-form" class="fetch-form">
+              <label for="fetch-url">Sorgente dati</label>
+              <input
+                id="fetch-url"
+                name="fetch-url"
+                type="url"
+                placeholder="https://example.com/packs.yaml"
+                autocomplete="off"
+              />
+              <div class="control-actions">
+                <button type="submit">Scarica &amp; applica</button>
+              </div>
+            </form>
+            <p id="fetch-status" class="status">In attesa di input…</p>
+            <pre id="fetch-preview" class="preview" aria-live="polite"></pre>
+          </article>
+        </div>
+      </section>
+
       <section id="overview" class="panel">
         <h2>Overview rapida</h2>
         <div class="stats-grid" id="overview-stats">

--- a/docs/test-interface/styles.css
+++ b/docs/test-interface/styles.css
@@ -71,6 +71,10 @@ main {
   margin: 0 auto;
 }
 
+.muted {
+  color: var(--muted);
+}
+
 .panel {
   background: var(--bg-panel);
   border: 1px solid var(--border);
@@ -165,6 +169,142 @@ main {
   border: 1px solid rgba(148, 163, 184, 0.2);
   padding: 1.1rem;
   min-height: 120px;
+}
+
+.control-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.control-card button,
+.control-actions button {
+  background: var(--accent);
+  border: none;
+  color: #0f172a;
+  font-weight: 600;
+  padding: 0.65rem 1.2rem;
+  border-radius: 0.85rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 25px rgba(56, 189, 248, 0.25);
+}
+
+.control-card button:hover,
+.control-actions button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 35px rgba(56, 189, 248, 0.3);
+}
+
+.fetch-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.fetch-form label {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.fetch-form input {
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.4);
+  color: var(--text);
+}
+
+.fetch-form input::placeholder {
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.control-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.status {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  font-size: 0.9rem;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--muted);
+}
+
+.status[data-status="loading"] {
+  color: var(--accent);
+}
+
+.status[data-status="success"] {
+  background: rgba(74, 222, 128, 0.12);
+  color: #4ade80;
+}
+
+.status[data-status="error"] {
+  background: rgba(248, 113, 113, 0.12);
+  color: #f87171;
+}
+
+.status[data-status="warning"] {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+}
+
+.preview {
+  margin-top: 1rem;
+  max-height: 260px;
+  overflow: auto;
+  padding: 1rem;
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+}
+
+.test-results {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.test-results li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: start;
+  padding: 0.75rem;
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.result-icon {
+  font-size: 1.1rem;
+}
+
+.result-label {
+  margin: 0;
+  font-weight: 600;
+}
+
+.result-message {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.result-ok {
+  border-color: rgba(74, 222, 128, 0.25);
+}
+
+.result-ko {
+  border-color: rgba(248, 113, 113, 0.25);
 }
 
 .card h3 {


### PR DESCRIPTION
## Summary
- add a control panel to the dashboard with quick data validation and a manual fetch form
- extend the front-end logic to execute integrity checks and merge fetched payloads into the current session
- polish the UI with styles for the new controls, status badges, and preview area

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68fa0cea3b908332ba0e960aa8cedb6c