### PR TITLE
feat: enable dashboard for online data hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,20 @@ python3 generate_encounter.py savana ../../data/biomes.yaml
 ```
 
 ## Interfaccia test & recap via web
-- Avvia un server locale dalla radice del progetto (`python3 -m http.server 8000`).
-- Apri `http://localhost:8000/docs/test-interface/` per una dashboard che riassume pacchetti PI,
-  telemetria VC, biomi e compatibilità delle forme.
-- Premi "Ricarica dati YAML" per aggiornare i contenuti dopo aver modificato i file in `data/`.
+- [Apri la dashboard](docs/test-interface/index.html) per consultare rapidamente pacchetti PI,
+  telemetria VC, biomi e compatibilità delle forme (funziona sia in locale sia online).
+- **Online subito (GitHub Pages)**: abilita la pubblicazione da `Settings → Pages → Build and
+  deployment → Deploy from a branch`, scegli `work` (o il branch desiderato) e la cartella `/docs/`.
+  L'URL diventa `https://<tuo-utente>.github.io/<repo>/test-interface/`, con fetch automatico degli
+  YAML via `raw`.
+- **Uso locale**: avvia un server dalla radice (`python3 -m http.server 8000`) e visita
+  `http://localhost:8000/docs/test-interface/` per lavorare offline.
+- Premi "Ricarica dati YAML" dopo aver modificato i file in `data/`, quindi "Esegui test" per i
+  controlli rapidi di integrità sui dataset caricati.
+- Per aggiornamenti al volo, incolla l'URL di uno snapshot YAML/JSON nel form "Fetching manuale" e
+  premi "Scarica & applica" per un merge immediato nel dataset di sessione. In hosting remoto puoi
+  forzare sorgenti alternative con `?data-root=<url-assoluto-o-root-relative>` e cambiare branch `raw`
+  con `?ref=<branch>`.
 
 ## Pubblicazione su GitHub
 ```bash

--- a/docs/test-interface/app.js
+++ b/docs/test-interface/app.js
@@ -1,16 +1,19 @@
 const DATA_SOURCES = [
-  { key: "packs", path: "../../data/packs.yaml" },
-  { key: "telemetry", path: "../../data/telemetry.yaml" },
-  { key: "biomes", path: "../../data/biomes.yaml" },
-  { key: "mating", path: "../../data/mating.yaml" }
+  { key: "packs", path: "data/packs.yaml" },
+  { key: "telemetry", path: "data/telemetry.yaml" },
+  { key: "biomes", path: "data/biomes.yaml" },
+  { key: "mating", path: "data/mating.yaml" }
 ];
 
 const state = {
   data: {},
-  loadedAt: null
+  loadedAt: null,
+  dataBase: null
 };
 
 const metricsElements = {};
+const controlElements = {};
+const infoElements = {};
 
 function setupDomReferences() {
   metricsElements.forms = document.querySelector('[data-metric="forms"]');
@@ -18,6 +21,15 @@ function setupDomReferences() {
   metricsElements.indices = document.querySelector('[data-metric="indices"]');
   metricsElements.biomes = document.querySelector('[data-metric="biomes"]');
   metricsElements.timestamp = document.getElementById("last-updated");
+
+  controlElements.runTests = document.getElementById("run-tests");
+  controlElements.testResults = document.getElementById("test-results");
+  controlElements.fetchForm = document.getElementById("fetch-form");
+  controlElements.fetchUrl = document.getElementById("fetch-url");
+  controlElements.fetchStatus = document.getElementById("fetch-status");
+  controlElements.fetchPreview = document.getElementById("fetch-preview");
+
+  infoElements.dataSource = document.getElementById("data-source");
 }
 
 async function loadYaml(path) {
@@ -30,26 +42,115 @@ async function loadYaml(path) {
 }
 
 async function loadAllData() {
+  if (!state.dataBase) {
+    state.dataBase = detectDataBase();
+    updateDataSourceHint();
+  }
+
   setTimestamp("Caricamento in corso…");
   try {
     const entries = await Promise.all(
       DATA_SOURCES.map(async (source) => {
-        const value = await loadYaml(source.path);
+        const url = resolveDataPath(source.path);
+        const value = await loadYaml(url);
         return [source.key, value];
       })
     );
     state.data = Object.fromEntries(entries);
     state.loadedAt = new Date();
-    updateOverview();
-    populateFormSelector();
-    renderRandomTable();
-    renderTelemetry();
-    renderBiomes();
-    setTimestamp(`Ultimo aggiornamento: ${state.loadedAt.toLocaleString()}`);
+    renderAll();
+    const sourceLabel = state.dataBase ? ` · sorgente dati: ${state.dataBase}` : "";
+    setTimestamp(`Ultimo aggiornamento: ${state.loadedAt.toLocaleString()}${sourceLabel}`);
   } catch (error) {
     console.error(error);
     setTimestamp(`Errore nel caricamento: ${error.message}`);
   }
+}
+
+function ensureTrailingSlash(value) {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function normalizeBase(value) {
+  if (!value) return null;
+
+  try {
+    const absolute = new URL(value, window.location.href);
+    return ensureTrailingSlash(absolute.toString());
+  } catch (error) {
+    console.warn("Impossibile normalizzare la sorgente dati", value, error);
+    return ensureTrailingSlash(value);
+  }
+}
+
+function detectDataBase() {
+  const params = new URLSearchParams(window.location.search);
+  const override = params.get("data-root");
+  if (override) {
+    return normalizeBase(override);
+  }
+
+  const metaOverride = document
+    .querySelector('meta[name="data-root"]')
+    ?.getAttribute("content");
+  if (metaOverride) {
+    return normalizeBase(metaOverride);
+  }
+
+  if (window.location.hostname.endsWith("github.io")) {
+    const owner = window.location.hostname.split(".")[0];
+    const pathParts = window.location.pathname.split("/").filter(Boolean);
+    const repo = pathParts.length > 0 ? pathParts[0] : "";
+    const branch = params.get("ref") ||
+      document
+        .querySelector('meta[name="data-branch"]')
+        ?.getAttribute("content") ||
+      "main";
+
+    if (owner && repo) {
+      return ensureTrailingSlash(
+        `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/`
+      );
+    }
+  }
+
+  if (window.location.origin.startsWith("http")) {
+    return ensureTrailingSlash(`${window.location.origin}/`);
+  }
+
+  return null;
+}
+
+function resolveDataPath(path) {
+  if (!state.dataBase) {
+    state.dataBase = detectDataBase();
+    updateDataSourceHint();
+  }
+
+  if (!state.dataBase) {
+    return path;
+  }
+
+  return new URL(path, state.dataBase).toString();
+}
+
+function updateDataSourceHint() {
+  if (!infoElements.dataSource) return;
+
+  if (!state.dataBase) {
+    infoElements.dataSource.textContent = "Sorgente dati: in rilevamento…";
+    return;
+  }
+
+  infoElements.dataSource.textContent = `Sorgente dati: ${state.dataBase}`;
+}
+
+function renderAll() {
+  updateOverview();
+  populateFormSelector();
+  renderRandomTable();
+  renderTelemetry();
+  renderBiomes();
 }
 
 function setTimestamp(text) {
@@ -92,9 +193,12 @@ function populateFormSelector() {
       selector.appendChild(option);
     });
 
-  selector.addEventListener("change", (event) => {
-    renderFormDetails(event.target.value);
-  });
+  if (!selector.dataset.listenerAttached) {
+    selector.addEventListener("change", (event) => {
+      renderFormDetails(event.target.value);
+    });
+    selector.dataset.listenerAttached = "true";
+  }
 }
 
 function renderFormDetails(formId) {
@@ -392,10 +496,264 @@ function renderListBlock(title, values) {
   `;
 }
 
+function setupControlPanel() {
+  if (controlElements.runTests) {
+    controlElements.runTests.addEventListener("click", runDataTests);
+  }
+
+  if (controlElements.fetchForm) {
+    controlElements.fetchForm.addEventListener("submit", handleFetchSubmit);
+  }
+}
+
+function runDataTests() {
+  if (!controlElements.testResults) return;
+
+  if (!state.loadedAt) {
+    renderTestResults([
+      {
+        passed: false,
+        label: "Dataset non caricati",
+        message: "Carica i dati prima di eseguire i test."
+      }
+    ]);
+    return;
+  }
+
+  const tests = [
+    {
+      id: "packs",
+      label: "Pacchetti PI caricati",
+      run: () => {
+        const packs = state.data.packs;
+        const formsCount = packs?.forms ? Object.keys(packs.forms).length : 0;
+        return {
+          passed: formsCount > 0,
+          message: formsCount
+            ? `${formsCount} forme disponibili`
+            : "Nessuna forma caricata"
+        };
+      }
+    },
+    {
+      id: "randomTable",
+      label: "Tabella random d20 valida",
+      run: () => {
+        const table = state.data.packs?.random_general_d20;
+        const isValid = Array.isArray(table) && table.every((row) => row.range && row.pack);
+        return {
+          passed: Boolean(isValid),
+          message: isValid
+            ? `${table.length} righe con range e pack`
+            : "Mancano range o pack nella tabella"
+        };
+      }
+    },
+    {
+      id: "telemetry",
+      label: "Indici VC presenti",
+      run: () => {
+        const indices = state.data.telemetry?.indices;
+        const count = indices ? Object.keys(indices).length : 0;
+        return {
+          passed: count > 0,
+          message: count
+            ? `${count} indici registrati`
+            : "Nessun indice configurato"
+        };
+      }
+    },
+    {
+      id: "biomes",
+      label: "Biomi definiti",
+      run: () => {
+        const biomes = state.data.biomes?.biomes;
+        const count = biomes ? Object.keys(biomes).length : 0;
+        return {
+          passed: count > 0,
+          message: count ? `${count} biomi disponibili` : "Nessun bioma trovato"
+        };
+      }
+    }
+  ];
+
+  const results = tests.map((test) => {
+    try {
+      return { ...test.run(), label: test.label };
+    } catch (error) {
+      return {
+        passed: false,
+        message: error.message,
+        label: test.label
+      };
+    }
+  });
+
+  renderTestResults(results);
+}
+
+function renderTestResults(results) {
+  const container = controlElements.testResults;
+  if (!container) return;
+
+  if (!results.length) {
+    container.innerHTML = "<li>Nessun test eseguito.</li>";
+    return;
+  }
+
+  container.innerHTML = results
+    .map((result) => {
+      const statusClass = result.passed ? "result-ok" : "result-ko";
+      const icon = result.passed ? "✅" : "⚠️";
+      return `
+        <li class="${statusClass}">
+          <span class="result-icon">${icon}</span>
+          <div>
+            <p class="result-label">${result.label}</p>
+            <p class="result-message">${result.message}</p>
+          </div>
+        </li>
+      `;
+    })
+    .join("");
+}
+
+async function handleFetchSubmit(event) {
+  event.preventDefault();
+  if (!controlElements.fetchUrl) return;
+
+  const url = controlElements.fetchUrl.value.trim();
+  if (!url) {
+    setFetchStatus("Specifica un URL da cui recuperare i dati.", "error");
+    return;
+  }
+
+  try {
+    setFetchStatus("Recupero in corso…", "loading");
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Richiesta fallita (${response.status})`);
+    }
+
+    const text = await response.text();
+    const payload = parseFetchedContent(url, text, response.headers.get("content-type"));
+    updateFetchPreview(payload);
+    const applied = applyFetchedData(payload);
+
+    if (applied.length > 0) {
+      setFetchStatus(
+        `Aggiornati i dataset: ${applied.join(", ")}.`,
+        "success"
+      );
+    } else {
+      setFetchStatus(
+        "Fetch riuscito ma nessun dataset riconosciuto da aggiornare.",
+        "warning"
+      );
+    }
+  } catch (error) {
+    console.error(error);
+    setFetchStatus(`Errore durante il fetch: ${error.message}`, "error");
+  }
+}
+
+function parseFetchedContent(url, text, contentType = "") {
+  const normalizedType = (contentType || "").toLowerCase();
+  const looksLikeYaml =
+    normalizedType.includes("yaml") ||
+    normalizedType.includes("yml") ||
+    url.endsWith(".yaml") ||
+    url.endsWith(".yml");
+
+  if (looksLikeYaml) {
+    return jsyaml.load(text);
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    try {
+      return jsyaml.load(text);
+    } catch (yamlError) {
+      throw new Error("Impossibile interpretare la risposta come JSON o YAML valido.");
+    }
+  }
+}
+
+function updateFetchPreview(payload) {
+  if (!controlElements.fetchPreview) return;
+  if (payload === undefined || payload === null) {
+    controlElements.fetchPreview.textContent = "(nessun contenuto)";
+    return;
+  }
+
+  try {
+    const formatted = JSON.stringify(payload, null, 2);
+    controlElements.fetchPreview.textContent = formatted;
+  } catch (error) {
+    controlElements.fetchPreview.textContent = String(payload);
+  }
+}
+
+function applyFetchedData(payload) {
+  if (!payload || typeof payload !== "object") {
+    return [];
+  }
+
+  const updatedKeys = [];
+
+  DATA_SOURCES.forEach((source) => {
+    if (Object.prototype.hasOwnProperty.call(payload, source.key)) {
+      state.data[source.key] = payload[source.key];
+      updatedKeys.push(source.key);
+    }
+  });
+
+  if (updatedKeys.length === 0) {
+    const detectedKey = detectDataKey(payload);
+    if (detectedKey) {
+      state.data[detectedKey] = payload;
+      updatedKeys.push(detectedKey);
+    }
+  }
+
+  if (updatedKeys.length > 0) {
+    state.loadedAt = new Date();
+    renderAll();
+    const sourceLabel = state.dataBase ? ` · sorgente dati: ${state.dataBase}` : "";
+    setTimestamp(
+      `Ultimo aggiornamento: ${state.loadedAt.toLocaleString()}${sourceLabel} (fetch manuale)`
+    );
+    if (controlElements.testResults && controlElements.testResults.childElementCount > 0) {
+      runDataTests();
+    }
+  }
+
+  return updatedKeys;
+}
+
+function detectDataKey(payload) {
+  if (!payload || typeof payload !== "object") return null;
+
+  if (payload.forms || payload.random_general_d20) return "packs";
+  if (payload.telemetry || payload.indices || payload.mbti_axes) return "telemetry";
+  if (payload.biomes || payload.vc_adapt || payload.mutations) return "biomes";
+  if (payload.compat_forme || payload.base_scores) return "mating";
+
+  return null;
+}
+
+function setFetchStatus(message, variant) {
+  if (!controlElements.fetchStatus) return;
+  controlElements.fetchStatus.textContent = message;
+  controlElements.fetchStatus.dataset.status = variant || "info";
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   setupDomReferences();
   document
     .getElementById("reload-data")
     .addEventListener("click", () => loadAllData());
+  setupControlPanel();
   loadAllData();
 });

--- a/docs/test-interface/index.html
+++ b/docs/test-interface/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Evo-Tactics · Interfaccia Test & Recap</title>
+    <meta name="data-branch" content="work" />
     <link rel="stylesheet" href="styles.css" />
     <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
     <script defer src="app.js"></script>
@@ -16,12 +17,48 @@
       </p>
       <button id="reload-data" type="button">Ricarica dati YAML</button>
       <p class="hint">
-        Suggerimento: apri questa pagina tramite un piccolo server locale (<code>python3 -m http.server</code>)
-        per permettere il fetch dei file YAML.
+        La pagina rileva automaticamente la sorgente dati: funzionerà sia su GitHub Pages (fetch <code>raw</code>)
+        sia in locale con un semplice server.
       </p>
+      <p id="data-source" class="hint secondary">Sorgente dati: in rilevamento…</p>
     </header>
 
     <main>
+      <section id="control" class="panel">
+        <h2>Controllo dati &amp; Fetching</h2>
+        <div class="control-grid">
+          <article class="card control-card">
+            <h3>Test rapidi dei dataset</h3>
+            <p class="muted">
+              Esegui un controllo istantaneo dei pacchetti PI, telemetria e biomi per verificare che i dati caricati siano pronti per il playtest.
+            </p>
+            <button id="run-tests" type="button">Esegui test</button>
+            <ul id="test-results" class="test-results"></ul>
+          </article>
+          <article class="card control-card">
+            <h3>Fetching manuale</h3>
+            <p class="muted">
+              Inserisci l'URL di uno snapshot YAML/JSON (es. endpoint Drive/GitHub raw) per aggiornare rapidamente il database locale in sessione.
+            </p>
+            <form id="fetch-form" class="fetch-form">
+              <label for="fetch-url">Sorgente dati</label>
+              <input
+                id="fetch-url"
+                name="fetch-url"
+                type="url"
+                placeholder="https://example.com/packs.yaml"
+                autocomplete="off"
+              />
+              <div class="control-actions">
+                <button type="submit">Scarica &amp; applica</button>
+              </div>
+            </form>
+            <p id="fetch-status" class="status">In attesa di input…</p>
+            <pre id="fetch-preview" class="preview" aria-live="polite"></pre>
+          </article>
+        </div>
+      </section>
+
       <section id="overview" class="panel">
         <h2>Overview rapida</h2>
         <div class="stats-grid" id="overview-stats">

--- a/docs/test-interface/styles.css
+++ b/docs/test-interface/styles.css
@@ -63,12 +63,21 @@ header h1 {
   color: var(--muted);
 }
 
+.hint.secondary {
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
 main {
   display: grid;
   gap: 2rem;
   padding: 0 1.5rem 4rem;
   max-width: 1200px;
   margin: 0 auto;
+}
+
+.muted {
+  color: var(--muted);
 }
 
 .panel {
@@ -165,6 +174,142 @@ main {
   border: 1px solid rgba(148, 163, 184, 0.2);
   padding: 1.1rem;
   min-height: 120px;
+}
+
+.control-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.control-card button,
+.control-actions button {
+  background: var(--accent);
+  border: none;
+  color: #0f172a;
+  font-weight: 600;
+  padding: 0.65rem 1.2rem;
+  border-radius: 0.85rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 25px rgba(56, 189, 248, 0.25);
+}
+
+.control-card button:hover,
+.control-actions button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 35px rgba(56, 189, 248, 0.3);
+}
+
+.fetch-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.fetch-form label {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.fetch-form input {
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.4);
+  color: var(--text);
+}
+
+.fetch-form input::placeholder {
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.control-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.status {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  font-size: 0.9rem;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--muted);
+}
+
+.status[data-status="loading"] {
+  color: var(--accent);
+}
+
+.status[data-status="success"] {
+  background: rgba(74, 222, 128, 0.12);
+  color: #4ade80;
+}
+
+.status[data-status="error"] {
+  background: rgba(248, 113, 113, 0.12);
+  color: #f87171;
+}
+
+.status[data-status="warning"] {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+}
+
+.preview {
+  margin-top: 1rem;
+  max-height: 260px;
+  overflow: auto;
+  padding: 1rem;
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+}
+
+.test-results {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.test-results li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: start;
+  padding: 0.75rem;
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.result-icon {
+  font-size: 1.1rem;
+}
+
+.result-label {
+  margin: 0;
+  font-weight: 600;
+}
+
+.result-message {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.result-ok {
+  border-color: rgba(74, 222, 128, 0.25);
+}
+
+.result-ko {
+  border-color: rgba(248, 113, 113, 0.25);
 }
 
 .card h3 {


### PR DESCRIPTION
## Summary
- auto-detect the YAML data source so the dashboard works both locally and on GitHub Pages
- surface the detected dataset URL in the UI and support branch or root overrides via query params
- document GitHub Pages activation and remote overrides in the main README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fa0cea3b908332ba0e960aa8cedb6c