### PR TITLE
Add redirect landing page for test interface

### DIFF
--- a/docs/.nojekyll
+++ b/docs/.nojekyll
@@ -1,0 +1,1 @@
+# Prevent GitHub Pages from using Jekyll

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <title>Evo-Tactics · Dashboard test</title>
+    <meta http-equiv="refresh" content="0; url=test-interface/" />
+    <link rel="canonical" href="test-interface/" />
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        margin: 0;
+        background: #0d1117;
+        color: #f0f6fc;
+      }
+      main {
+        text-align: center;
+        max-width: 480px;
+      }
+      a {
+        color: #58a6ff;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Evo-Tactics · Interfaccia Test &amp; Recap</h1>
+      <p>Reindirizzamento automatico all'interfaccia di test…</p>
+      <p>
+        Se il browser non reindirizza automaticamente, clicca qui:
+        <a href="test-interface/">Apri l'interfaccia</a>.
+      </p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a docs/index.html landing page that redirects to the test interface
- add a .nojekyll marker so GitHub Pages serves static assets without processing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa6fd131648332bcaf010168156a7b