### PR TITLE
Add deterministic seeding support to roll_pack CLI outputs

### DIFF
--- a/docs/checklist/project-setup-todo.md
+++ b/docs/checklist/project-setup-todo.md
@@ -24,8 +24,8 @@ ogni esecuzione importante, annotando data, esito e note operative.
 - [ ] Annotare gli esiti della validazione (OK/errori) in `docs/checklist/action-items.md` o in un log.
 
 ## 4. Verifica CLI
-- [ ] Eseguire `node dist/roll_pack.js <MBTI> <archetipo> ../../data/packs.yaml` (es. `ENTP invoker`).
-- [ ] Avviare `python roll_pack.py <MBTI> <archetipo> ../../data/packs.yaml` e confrontare i risultati.
+- [ ] Eseguire `node dist/roll_pack.js <MBTI> <archetipo> ../../data/packs.yaml --seed demo` (sostituire `demo` con un seed a scelta per output replicabili).
+- [ ] Avviare `python roll_pack.py <MBTI> <archetipo> ../../data/packs.yaml --seed demo` e verificare che l'output (chiavi `pack`, `combo`, `total_cost`, ecc.) coincida con la CLI TypeScript.
 - [ ] Generare encounter di prova: `python generate_encounter.py <bioma> ../../data/biomes.yaml` per
       ogni bioma disponibile, salvando gli output in `docs/examples/` o nella sezione encounter.
 - [ ] Documentare eventuali discrepanze CLI TS/Python e aprire issue se necessarie.

--- a/docs/examples/roll_pack_seed_demo.json
+++ b/docs/examples/roll_pack_seed_demo.json
@@ -1,0 +1,31 @@
+{
+  "command": "node dist/roll_pack.js ENTP invoker ../../data/packs.yaml --seed demo",
+  "python_command": "python tools/py/roll_pack.py ENTP invoker ../../data/packs.yaml --seed demo",
+  "inputs": {
+    "form": "ENTP",
+    "job": "invoker"
+  },
+  "pack": "A",
+  "combo": [
+    "job_ability",
+    "trait_T1"
+  ],
+  "total_cost": 7,
+  "cost_breakdown": [
+    {
+      "item": "job_ability",
+      "cost": 4
+    },
+    {
+      "item": "trait_T1",
+      "cost": 3
+    }
+  ],
+  "rolls": {
+    "d20": 19
+  },
+  "selection": {
+    "table": "BIAS_JOB",
+    "notes": "Vang: B/D; Skir: C/E; Ward: E/G; Art: A/F; Inv: A/J; Harv: D/J"
+  }
+}

--- a/tools/py/roll_pack.py
+++ b/tools/py/roll_pack.py
@@ -1,60 +1,176 @@
-import sys, random, yaml, json
+import json
+import os
+import sys
+from typing import Callable, Dict, List, Optional
 
-def in_range(val, r):
+import yaml
+
+
+def in_range(val: int, r: str) -> bool:
     if '-' in r:
-        a,b = map(int, r.split('-'))
+        a, b = map(int, r.split('-'))
         return a <= val <= b
     return val == int(r)
 
-def roll_pack(form, job, data_path='../../data/packs.yaml'):
+
+def hash_seed(seed: str) -> int:
+    h = 1779033703 ^ len(seed)
+    for ch in seed:
+        h = (h ^ ord(ch)) * 3432918353 & 0xFFFFFFFF
+        h = ((h << 13) | (h >> 19)) & 0xFFFFFFFF
+    normalized = h & 0xFFFFFFFF
+    return normalized or 0x6D2B79F5
+
+
+def mulberry32(seed: int) -> Callable[[], float]:
+    state = seed & 0xFFFFFFFF
+
+    def rng() -> float:
+        nonlocal state
+        state = (state + 0x6D2B79F5) & 0xFFFFFFFF
+        t = state
+        t = ((t ^ (t >> 15)) * (t | 1)) & 0xFFFFFFFF
+        t ^= ((t ^ (t >> 7)) * (t | 61) & 0xFFFFFFFF) + t
+        t &= 0xFFFFFFFF
+        return ((t ^ (t >> 14)) & 0xFFFFFFFF) / 4294967296
+
+    return rng
+
+
+def create_rng(seed: Optional[str]) -> Callable[[int], int]:
+    if seed:
+        base = mulberry32(hash_seed(seed))
+    else:
+        import random
+
+        base_random = random.random
+
+        def base() -> float:
+            return base_random()
+
+    def roll(sides: int) -> int:
+        return 1 + int(base() * sides)
+
+    return roll
+
+
+def cost_of(key: str, shop: Dict[str, int]) -> int:
+    if key.startswith('trait_T1'):
+        return shop['trait_T1']
+    if key.startswith('job_ability'):
+        return shop['job_ability']
+    if key == 'cap_pt':
+        return shop['cap_pt']
+    if key == 'guardia_situazionale':
+        return shop['guardia_situazionale']
+    if key == 'starter_bioma':
+        return shop['starter_bioma']
+    if key == 'sigillo_forma':
+        return shop['sigillo_forma']
+    if key == 'PE':
+        return 1
+    raise KeyError(f"Chiave sconosciuta: {key}")
+
+
+def roll_pack(form: str, job: str, data_path: str = '../../data/packs.yaml', seed: Optional[str] = None):
+    resolved_seed = seed if seed is not None else os.getenv('ROLL_PACK_SEED')
+
     with open(data_path, 'r', encoding='utf-8') as f:
         data = yaml.safe_load(f)
 
-    d20 = random.randint(1,20)
-    general = next(x for x in data['random_general_d20'] if in_range(d20, x['range']))
+    roll_die = create_rng(resolved_seed)
 
-    def choose_bias_form():
-        d12 = random.randint(1,12)
-        bias = data['forms'][form]['bias_d12']
-        packKey = next(k for k,r in bias.items() if in_range(d12, r))
-        return packKey, data['forms'][form][packKey]
+    d20 = roll_die(20)
+    general = next((x for x in data['random_general_d20'] if in_range(d20, x['range'])), None)
+    if not general:
+        raise ValueError(f'Tabella d20 non copre il lancio: {d20}')
+
+    d12_roll: Optional[int] = None
 
     if general['pack'] == 'BIAS_FORMA':
-        pack, combo = choose_bias_form()
+        form_data = data['forms'].get(form)
+        if not form_data:
+            raise ValueError(f'Forma sconosciuta: {form}')
+        d12_roll = roll_die(12)
+        bias = form_data.get('bias_d12', {})
+        pack_key = next((k for k, r in bias.items() if in_range(d12_roll, r)), None)
+        if pack_key is None:
+            raise ValueError(f'Bias d12 non copre il lancio: {d12_roll}')
+        pack = pack_key
+        combo = form_data[pack_key]
     elif general['pack'] == 'BIAS_JOB':
-        job_bias = {
-            'vanguard':['B','D'],'skirmisher':['C','E'],'warden':['E','G'],
-            'artificer':['A','F'],'invoker':['A','J'],'harvester':['D','J']
+        job_bias: Dict[str, List[str]] = {
+            'vanguard': ['B', 'D'],
+            'skirmisher': ['C', 'E'],
+            'warden': ['E', 'G'],
+            'artificer': ['A', 'F'],
+            'invoker': ['A', 'J'],
+            'harvester': ['D', 'J'],
         }
-        pref = job_bias.get(job.lower(), ['A','B'])
-        first = next(x for x in data['random_general_d20'] if x['pack'] in pref)
-        pack, combo = first['pack'], first['combo']
+        pref = job_bias.get(job.lower(), ['A', 'B'])
+        first = next((x for x in data['random_general_d20'] if x['pack'] in pref and x.get('combo')), None)
+        if not first:
+            raise ValueError(f'Bias lavoro non ha trovato un pacchetto valido per: {job}')
+        pack = first['pack']
+        combo = first['combo']
     elif general['pack'] == 'SCELTA':
-        first = next(x for x in data['random_general_d20'] if x['pack']=='A')
-        pack, combo = 'A', first['combo']
+        first = next((x for x in data['random_general_d20'] if x['pack'] == 'A' and x.get('combo')), None)
+        if not first:
+            raise ValueError('Pacchetto A non trovato per scelta manuale')
+        pack = 'A'
+        combo = first['combo']
     else:
-        pack, combo = general['pack'], general['combo']
+        combo = general.get('combo')
+        if combo is None:
+            raise ValueError(f"Combinazione mancante per il pacchetto {general['pack']}")
+        pack = general['pack']
 
-    shop = data['pi_shop']['costs']
-    def cost(key):
-        return (
-            shop['trait_T1'] if str(key).startswith('trait_T1') else
-            shop['job_ability'] if str(key).startswith('job_ability') else
-            shop['cap_pt'] if key=='cap_pt' else
-            shop['guardia_situazionale'] if key=='guardia_situazionale' else
-            shop['starter_bioma'] if key=='starter_bioma' else
-            shop['sigillo_forma'] if key=='sigillo_forma' else
-            1 if key=='PE' else 0
-        )
-    total = sum(cost(k) for k in combo)
-    assert total==7, f"Pacchetto {pack} = {total}"
-    assert combo.count('cap_pt')<=1
-    assert combo.count('starter_bioma')<=1
-    return {'d20': d20, 'pack': pack, 'combo': combo}
+    shop_costs: Dict[str, int] = data['pi_shop']['costs']
+    breakdown = [{'item': item, 'cost': cost_of(item, shop_costs)} for item in combo]
+    total = sum(entry['cost'] for entry in breakdown)
+    if total != 7:
+        raise ValueError(f'Pacchetto {pack} non somma a 7 (= {total})')
+    if combo.count('cap_pt') > 1:
+        raise ValueError('Cap PT > 1')
+    if combo.count('starter_bioma') > 1:
+        raise ValueError('Starter>1')
+
+    rolls = {'d20': d20}
+    if d12_roll is not None:
+        rolls['d12'] = d12_roll
+
+    return {
+        'inputs': {'form': form, 'job': job},
+        'pack': pack,
+        'combo': combo,
+        'total_cost': total,
+        'cost_breakdown': breakdown,
+        'rolls': rolls,
+        'selection': {'table': general['pack'], 'notes': general.get('notes')},
+    }
+
 
 if __name__ == '__main__':
-    form = sys.argv[1] if len(sys.argv)>1 else 'ENTP'
-    job = sys.argv[2] if len(sys.argv)>2 else 'invoker'
-    data_path = sys.argv[3] if len(sys.argv)>3 else '../../data/packs.yaml'
-    res = roll_pack(form, job, data_path)
-    print(json.dumps(res, ensure_ascii=False, indent=2))
+    args = sys.argv[1:]
+    seed_arg: Optional[str] = None
+    positional: List[str] = []
+
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == '--seed':
+            if i + 1 < len(args):
+                seed_arg = args[i + 1]
+                i += 1
+        elif arg.startswith('--seed='):
+            seed_arg = arg.split('=', 1)[1]
+        else:
+            positional.append(arg)
+        i += 1
+
+    form = positional[0] if len(positional) > 0 else 'ENTP'
+    job = positional[1] if len(positional) > 1 else 'invoker'
+    data_path = positional[2] if len(positional) > 2 else '../../data/packs.yaml'
+
+    result = roll_pack(form, job, data_path, seed_arg)
+    print(json.dumps(result, ensure_ascii=False, indent=2))

--- a/tools/ts/roll_pack.ts
+++ b/tools/ts/roll_pack.ts
@@ -20,18 +20,62 @@ interface FormDefinition {
 }
 
 interface Data {
-  pi_shop: any;
+  pi_shop: {
+    costs: Record<string, number>;
+  };
   random_general_d20: RandomGeneralEntry[];
   forms: Record<string, FormDefinition>;
 }
 
-function rollDie(sides: number): number { return 1 + Math.floor(Math.random() * sides); }
+type RandomFn = () => number;
+
 function inRange(val: number, r: string): boolean {
-  if (r.includes('-')) { const [a,b] = r.split('-').map(Number); return val>=a && val<=b; }
+  if (r.includes('-')) {
+    const [a, b] = r.split('-').map(Number);
+    return val >= a && val <= b;
+  }
   return val === Number(r);
 }
 
-const costOf = (key: string, shop: any): number => {
+const UINT32_MASK = 0xffffffff;
+
+const hashSeed = (seed: string): number => {
+  let h = 1779033703 ^ seed.length;
+  for (let i = 0; i < seed.length; i += 1) {
+    h = Math.imul(h ^ seed.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  const normalized = (h >>> 0) & UINT32_MASK;
+  return normalized === 0 ? 0x6d2b79f5 : normalized;
+};
+
+const mulberry32 = (seed: number): RandomFn => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= Math.imul(t ^ (t >>> 7), t | 61) + t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const createRandom = (seed?: string | null): RandomFn => {
+  if (!seed) return () => Math.random();
+  return mulberry32(hashSeed(seed));
+};
+
+const resolveSeed = (seed?: string): string | undefined => {
+  if (seed) return seed;
+  if (typeof process !== 'undefined' && process?.env?.ROLL_PACK_SEED) {
+    return process.env.ROLL_PACK_SEED;
+  }
+  return undefined;
+};
+
+const rollDie = (rng: RandomFn, sides: number): number => 1 + Math.floor(rng() * sides);
+
+const costOf = (key: string, shop: Record<string, number>): number => {
   if (key.startsWith('trait_T1')) return shop.trait_T1;
   if (key.startsWith('job_ability')) return shop.job_ability;
   if (key === 'cap_pt') return shop.cap_pt;
@@ -39,55 +83,106 @@ const costOf = (key: string, shop: any): number => {
   if (key === 'starter_bioma') return shop.starter_bioma;
   if (key === 'sigillo_forma') return shop.sigillo_forma;
   if (key === 'PE') return 1;
-  throw new Error('Chiave sconosciuta: '+key);
+  throw new Error('Chiave sconosciuta: ' + key);
 };
 
-export function roll_pack(form: string, job: string, dataPath='../../data/packs.yaml') {
+type RollPackOptions = {
+  seed?: string;
+};
+
+export function roll_pack(
+  form: string,
+  job: string,
+  dataPath = '../../data/packs.yaml',
+  seedOrOptions?: string | RollPackOptions,
+) {
   const raw = readFileSync(dataPath, 'utf8');
   const data = yaml.load(raw) as Data;
-  const d20 = rollDie(20);
-  const general = data.random_general_d20.find(x => inRange(d20, x.range));
-  if (!general) throw new Error('Tabella d20 non copre il lancio: '+d20);
 
+  const resolvedSeed = typeof seedOrOptions === 'string'
+    ? seedOrOptions
+    : seedOrOptions?.seed;
+
+  const rng = createRandom(resolveSeed(resolvedSeed));
+
+  const d20 = rollDie(rng, 20);
+  const general = data.random_general_d20.find((x) => inRange(d20, x.range));
+  if (!general) throw new Error('Tabella d20 non copre il lancio: ' + d20);
+
+  let d12: number | undefined;
   let pick: { pack: string; combo: string[] };
 
   if (general.pack === 'BIAS_FORMA') {
-    const d12 = rollDie(12);
-    const bias = data.forms[form]?.bias_d12;
-    if (!bias) throw new Error('Forma sconosciuta: '+form);
-    const entry = (Object.entries(bias) as [FormPackKey, Range][]).find(([_, r]) => inRange(d12, r));
-    if (!entry) throw new Error('Bias d12 non copre il lancio: '+d12);
+    d12 = rollDie(rng, 12);
+    const formData = data.forms[form];
+    const bias = formData?.bias_d12;
+    if (!bias) throw new Error('Forma sconosciuta: ' + form);
+    const entry = (Object.entries(bias) as [FormPackKey, Range][])
+      .find(([, r]) => inRange(d12!, r));
+    if (!entry) throw new Error('Bias d12 non copre il lancio: ' + d12);
     const [packKey] = entry; // A|B|C
-    pick = { pack: packKey, combo: data.forms[form][packKey] };
+    pick = { pack: packKey, combo: formData[packKey] };
   } else if (general.pack === 'BIAS_JOB') {
     const jobBias: Record<string, string[]> = {
-      vanguard: ['B','D'], skirmisher: ['C','E'], warden: ['E','G'],
-      artificer: ['A','F'], invoker: ['A','J'], harvester: ['D','J']
+      vanguard: ['B', 'D'],
+      skirmisher: ['C', 'E'],
+      warden: ['E', 'G'],
+      artificer: ['A', 'F'],
+      invoker: ['A', 'J'],
+      harvester: ['D', 'J'],
     };
-    const pref = jobBias[job.toLowerCase()] || ['A','B'];
-    const first = data.random_general_d20.find(x => pref.includes(x.pack));
-    pick = { pack: first!.pack, combo: first!.combo! };
+    const pref = jobBias[job.toLowerCase()] || ['A', 'B'];
+    const first = data.random_general_d20.find((x) => pref.includes(x.pack));
+    if (!first || !first.combo) {
+      throw new Error('Bias lavoro non ha trovato un pacchetto valido per: ' + job);
+    }
+    pick = { pack: first.pack, combo: first.combo };
   } else if (general.pack === 'SCELTA') {
-    const first = data.random_general_d20.find(x=>x.pack==='A')!;
-    pick = { pack: 'A', combo: first.combo! };
+    const first = data.random_general_d20.find((x) => x.pack === 'A');
+    if (!first || !first.combo) throw new Error('Pacchetto A non trovato per scelta manuale');
+    pick = { pack: 'A', combo: first.combo };
   } else {
-    pick = { pack: general.pack, combo: general.combo! };
+    if (!general.combo) throw new Error('Combinazione mancante per il pacchetto ' + general.pack);
+    pick = { pack: general.pack, combo: general.combo };
   }
 
-  // VALIDAZIONE
-  const total = pick.combo.reduce((s,k)=> s+costOf(k, data.pi_shop.costs), 0);
-  if (total !== 7) throw new Error(`Pacchetto ${pick.pack} non somma a 7 (=${total})`);
-  const capPt = pick.combo.filter(x=>x==='cap_pt').length; if (capPt>1) throw new Error('Cap PT > 1');
-  const starters = pick.combo.filter(x=>x==='starter_bioma').length; if (starters>1) throw new Error('Starter>1');
+  const breakdown = pick.combo.map((item) => ({ item, cost: costOf(item, data.pi_shop.costs) }));
+  const total = breakdown.reduce((sum, entry) => sum + entry.cost, 0);
+  if (total !== 7) throw new Error(`Pacchetto ${pick.pack} non somma a 7 (= ${total})`);
+  if (pick.combo.filter((x) => x === 'cap_pt').length > 1) throw new Error('Cap PT > 1');
+  if (pick.combo.filter((x) => x === 'starter_bioma').length > 1) throw new Error('Starter>1');
 
-  return { d20, pick };
+  const rolls: { d20: number; d12?: number } = { d20 };
+  if (typeof d12 === 'number') rolls.d12 = d12;
+
+  return {
+    inputs: { form, job },
+    pack: pick.pack,
+    combo: pick.combo,
+    total_cost: total,
+    cost_breakdown: breakdown,
+    rolls,
+    selection: { table: general.pack, notes: general.notes ?? null },
+  };
 }
 
 // CLI
 if (process.argv[1] && process.argv[1].includes('roll_pack')) {
-  const form = process.argv[2] || 'ENTP';
-  const job = process.argv[3] || 'invoker';
-  const dataPath = process.argv[4] || '../../data/packs.yaml';
-  const res = roll_pack(form, job, dataPath);
+  const argv = process.argv.slice(2);
+  let seed: string | undefined;
+  const positional: string[] = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--seed') {
+      seed = argv[i + 1];
+      i += 1;
+    } else if (arg.startsWith('--seed=')) {
+      seed = arg.split('=')[1];
+    } else {
+      positional.push(arg);
+    }
+  }
+  const [form = 'ENTP', job = 'invoker', dataPath = '../../data/packs.yaml'] = positional;
+  const res = roll_pack(form, job, dataPath, seed);
   console.log(JSON.stringify(res, null, 2));
 }


### PR DESCRIPTION
## Summary
- share a seeded Mulberry32 RNG between the TypeScript and Python roll_pack implementations and expose consistent JSON fields
- validate cost breakdowns from data/packs.yaml while surfacing selection metadata and CLI seed options in both tools
- document the new seedable workflow and add a reproducible output snapshot under docs/examples

## Testing
- npm run build
- node dist/roll_pack.js ENTP invoker ../../data/packs.yaml --seed demo
- python tools/py/roll_pack.py ENTP invoker ../../data/packs.yaml --seed demo

------
https://chatgpt.com/codex/tasks/task_e_68fad6df496c83328635a00343c39106