### PR TITLE
Expand playtest dashboard with playtest tooling

### DIFF
--- a/docs/test-interface/index.html
+++ b/docs/test-interface/index.html
@@ -85,15 +85,33 @@
       <section id="forms" class="panel">
         <div class="panel-header">
           <h2>Pacchetti PI &amp; Compatibilità per Forma</h2>
-          <label class="selector">
-            <span>Seleziona forma:</span>
-            <select id="form-selector" aria-label="Forma MBTI">
-              <option value="" selected>Scegli…</option>
-            </select>
-          </label>
+          <div class="selectors">
+            <label class="selector">
+              <span>Seleziona forma:</span>
+              <select id="form-selector" aria-label="Forma MBTI">
+                <option value="" selected>Scegli…</option>
+              </select>
+            </label>
+            <label class="selector search">
+              <span>Filtra:</span>
+              <input
+                id="form-filter"
+                type="search"
+                placeholder="Cerca forma o job…"
+                autocomplete="off"
+              />
+            </label>
+          </div>
         </div>
         <div id="form-details" class="content-placeholder">
           <p>Seleziona una forma per visualizzare combinazioni A/B/C, bias d12 e hook di collaborazione.</p>
+        </div>
+      </section>
+
+      <section id="pi-shop" class="panel">
+        <h2>Negozio PI &amp; Caps sessione</h2>
+        <div id="pi-shop-content" class="content-placeholder">
+          <p>In attesa di dati…</p>
         </div>
       </section>
 
@@ -115,6 +133,36 @@
         <h2>Biomi &amp; Mutazioni</h2>
         <div id="biomes-grid" class="content-placeholder">
           <p>In attesa di dati…</p>
+        </div>
+      </section>
+
+      <section id="playtest-tools" class="panel">
+        <h2>Strumenti rapidi per il playtest</h2>
+        <div class="tools-grid">
+          <article class="card tool-card">
+            <h3>Roll tabella d20</h3>
+            <p class="muted">Simula un tiro per la tabella random general e ottieni il pack consigliato.</p>
+            <button id="roll-d20" type="button">Tira d20</button>
+            <div id="roll-d20-result" class="result-block">
+              <p class="muted">In attesa del primo tiro…</p>
+            </div>
+          </article>
+          <article class="card tool-card">
+            <h3>Bias d12 della forma</h3>
+            <p class="muted">Seleziona prima una forma nella sezione dedicata, poi tira per ottenere il pack A/B/C.</p>
+            <button id="roll-bias" type="button" disabled>Tira d12</button>
+            <div id="bias-roll-result" class="result-block">
+              <p class="muted">Nessuna forma selezionata.</p>
+            </div>
+          </article>
+          <article class="card tool-card">
+            <h3>Generatore incontro bioma</h3>
+            <p class="muted">Crea uno scenario veloce con bioma, mutazioni e adattamenti VC suggeriti.</p>
+            <button id="generate-encounter" type="button">Genera incontro</button>
+            <div id="encounter-result" class="result-block">
+              <p class="muted">Premi "Genera" per ottenere un setup.</p>
+            </div>
+          </article>
         </div>
       </section>
     </main>

--- a/docs/test-interface/styles.css
+++ b/docs/test-interface/styles.css
@@ -104,6 +104,13 @@ main {
   margin-bottom: 1.5rem;
 }
 
+.selectors {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
 .selector {
   display: flex;
   gap: 0.75rem;
@@ -117,6 +124,27 @@ main {
   border: 1px solid var(--border);
   background: var(--bg-panel-light);
   color: var(--text);
+}
+
+.selector.search {
+  flex: 1 1 220px;
+}
+
+.selector.search span {
+  white-space: nowrap;
+}
+
+.selector.search input {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: var(--bg-panel-light);
+  color: var(--text);
+}
+
+.selector.search input::placeholder {
+  color: rgba(148, 163, 184, 0.7);
 }
 
 .stats-grid {
@@ -168,6 +196,12 @@ main {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
+.pi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
 .card {
   background: var(--bg-panel-light);
   border-radius: 1.1rem;
@@ -183,7 +217,8 @@ main {
 }
 
 .control-card button,
-.control-actions button {
+.control-actions button,
+.tool-card button {
   background: var(--accent);
   border: none;
   color: #0f172a;
@@ -196,7 +231,8 @@ main {
 }
 
 .control-card button:hover,
-.control-actions button:hover {
+.control-actions button:hover,
+.tool-card button:hover {
   transform: translateY(-1px);
   box-shadow: 0 16px 35px rgba(56, 189, 248, 0.3);
 }
@@ -350,6 +386,60 @@ main {
   font-size: 0.85rem;
 }
 
+.tools-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.result-block {
+  margin-top: 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.5);
+  padding: 0.85rem;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.result-block p {
+  margin: 0.25rem 0;
+}
+
+.result-block h4 {
+  margin: 0.75rem 0 0.5rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.result-block .pills {
+  margin-top: 0.5rem;
+}
+
+.result-block ul {
+  margin: 0.35rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.result-block ul li {
+  margin-bottom: 0.3rem;
+}
+
+.dice-roll {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.dice-pack {
+  font-weight: 600;
+}
+
+.pi-hint {
+  margin-top: 1.25rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
 .pill-group {
   margin-bottom: 1rem;
 }
@@ -442,5 +532,19 @@ footer {
   .panel-header {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .selectors {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .selector.search {
+    width: 100%;
+  }
+
+  .selector.search input {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- add form search, PI shop overview, and playtest tools panel to the Evo-Tactics dashboard
- implement d20 pack roller, form bias d12 helper, and biome encounter generator driven by YAML data
- surface PI shop costs/caps and extend dataset tests to cover the shop configuration

## Testing
- node -e "new Function(require('fs').readFileSync('docs/test-interface/app.js','utf8'))"

------
https://chatgpt.com/codex/tasks/task_e_68fad74f560c83328872efc1568300dc