### PR TITLE
Add auto-fetch page for YAML datasets

### DIFF
--- a/docs/test-interface/auto-fetch.html
+++ b/docs/test-interface/auto-fetch.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Evo-Tactics · Fetch automatico YAML</title>
+    <meta name="data-branch" content="work" />
+    <link rel="stylesheet" href="styles.css" />
+    <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
+    <script defer src="auto-fetch.js"></script>
+  </head>
+  <body class="auto-fetch">
+    <header>
+      <h1>Fetch automatico degli YAML</h1>
+      <p class="tagline">
+        Carica e verifica automaticamente tutti i dataset YAML pubblicati nella cartella <code>data/</code>,
+        con rilevamento della sorgente dati su GitHub Pages o server locale.
+      </p>
+      <nav class="utility-nav" aria-label="Navigazione secondaria">
+        <a href="index.html">⟵ Torna alla dashboard</a>
+      </nav>
+      <p id="auto-data-source" class="hint secondary">Sorgente dati: in rilevamento…</p>
+    </header>
+
+    <main>
+      <section class="panel">
+        <div class="panel-header">
+          <h2>Stato caricamento YAML</h2>
+          <button id="auto-reload" type="button">Ricarica ora</button>
+        </div>
+        <p id="auto-global-status" class="status" data-status="idle">In attesa di avvio…</p>
+        <ul id="auto-results" class="data-results" aria-live="polite"></ul>
+      </section>
+
+      <section class="panel">
+        <h2>Dettaglio ultimo caricamento</h2>
+        <article class="card">
+          <h3>Preview contenuti</h3>
+          <p class="muted">
+            Seleziona una voce dall'elenco per ispezionare la preview dell'ultimo fetch effettuato.
+          </p>
+          <div id="auto-preview" class="preview" aria-live="polite">Nessun dataset selezionato.</div>
+        </article>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        La pagina avvia il download degli YAML automaticamente e notifica eventuali errori HTTP o di parsing.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/docs/test-interface/auto-fetch.js
+++ b/docs/test-interface/auto-fetch.js
@@ -1,0 +1,329 @@
+const DATA_SOURCES = [
+  { key: "packs", label: "Packs", path: "data/packs.yaml" },
+  { key: "telemetry", label: "Telemetry", path: "data/telemetry.yaml" },
+  { key: "biomes", label: "Biomi", path: "data/biomes.yaml" },
+  { key: "mating", label: "Mating", path: "data/mating.yaml" },
+];
+
+const autoState = {
+  dataBase: null,
+  results: new Map(),
+  selectedKey: null,
+};
+
+const autoElements = {};
+
+function setupAutoDom() {
+  autoElements.dataSource = document.getElementById("auto-data-source");
+  autoElements.globalStatus = document.getElementById("auto-global-status");
+  autoElements.results = document.getElementById("auto-results");
+  autoElements.preview = document.getElementById("auto-preview");
+  autoElements.reload = document.getElementById("auto-reload");
+}
+
+function ensureTrailingSlash(value) {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function normalizeBase(value) {
+  if (!value) return null;
+
+  try {
+    const absolute = new URL(value, window.location.href);
+    return ensureTrailingSlash(absolute.toString());
+  } catch (error) {
+    console.warn("Impossibile normalizzare la sorgente dati", value, error);
+    return ensureTrailingSlash(value);
+  }
+}
+
+function detectDataBase() {
+  const params = new URLSearchParams(window.location.search);
+  const override = params.get("data-root");
+  if (override) {
+    return normalizeBase(override);
+  }
+
+  const metaOverride = document
+    .querySelector('meta[name="data-root"]')
+    ?.getAttribute("content");
+  if (metaOverride) {
+    return normalizeBase(metaOverride);
+  }
+
+  if (window.location.hostname.endsWith("github.io")) {
+    const owner = window.location.hostname.split(".")[0];
+    const pathParts = window.location.pathname.split("/").filter(Boolean);
+    const repo = pathParts.length > 0 ? pathParts[0] : "";
+    const branch =
+      params.get("ref") ||
+      document.querySelector('meta[name="data-branch"]')?.getAttribute("content") ||
+      "main";
+
+    if (owner && repo) {
+      return ensureTrailingSlash(
+        `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/`
+      );
+    }
+  }
+
+  if (window.location.origin.startsWith("http")) {
+    return ensureTrailingSlash(`${window.location.origin}/`);
+  }
+
+  return null;
+}
+
+function resolveDataPath(path) {
+  if (!autoState.dataBase) {
+    autoState.dataBase = detectDataBase();
+    updateDataSourceHint();
+  }
+
+  if (!autoState.dataBase) {
+    return path;
+  }
+
+  return new URL(path, autoState.dataBase).toString();
+}
+
+function updateDataSourceHint() {
+  if (!autoElements.dataSource) return;
+
+  if (!autoState.dataBase) {
+    autoElements.dataSource.textContent = "Sorgente dati: in rilevamento…";
+    return;
+  }
+
+  autoElements.dataSource.textContent = `Sorgente dati: ${autoState.dataBase}`;
+}
+
+function updateGlobalStatus(status, message) {
+  if (!autoElements.globalStatus) return;
+  autoElements.globalStatus.dataset.status = status;
+  autoElements.globalStatus.textContent = message;
+}
+
+function createResultItem(source) {
+  const item = document.createElement("li");
+  item.className = "data-result";
+  item.dataset.key = source.key;
+
+  const header = document.createElement("div");
+  header.className = "data-result-header";
+
+  const title = document.createElement("h3");
+  title.textContent = `${source.label} (${source.path})`;
+  header.appendChild(title);
+
+  const badge = document.createElement("span");
+  badge.className = "data-badge";
+  badge.textContent = "In attesa";
+  header.appendChild(badge);
+
+  const body = document.createElement("p");
+  body.className = "data-message muted";
+  body.textContent = "In attesa di fetch…";
+
+  item.appendChild(header);
+  item.appendChild(body);
+
+  item.addEventListener("click", () => {
+    selectResult(source.key);
+  });
+
+  return item;
+}
+
+function renderResultsShell() {
+  if (!autoElements.results) return;
+
+  autoElements.results.innerHTML = "";
+  DATA_SOURCES.forEach((source) => {
+    const item = createResultItem(source);
+    autoElements.results.appendChild(item);
+  });
+}
+
+function selectResult(key) {
+  autoState.selectedKey = key;
+  autoElements.results
+    ?.querySelectorAll(".data-result")
+    .forEach((element) => {
+      element.classList.toggle("is-selected", element.dataset.key === key);
+    });
+
+  const result = autoState.results.get(key);
+  if (!result) {
+    autoElements.preview.textContent = "Nessun dataset selezionato.";
+    return;
+  }
+
+  autoElements.preview.textContent = result.preview || "(Nessuna preview disponibile)";
+}
+
+function updateResultStatus(key, status, message, details) {
+  const item = autoElements.results?.querySelector(`.data-result[data-key="${key}"]`);
+  if (!item) return;
+
+  const badge = item.querySelector(".data-badge");
+  const body = item.querySelector(".data-message");
+
+  item.dataset.status = status;
+  if (badge) {
+    badge.dataset.status = status;
+    badge.textContent = statusLabel(status);
+  }
+  if (body) {
+    body.textContent = message;
+    body.classList.toggle("muted", status !== "error");
+  }
+
+  autoState.results.set(key, {
+    ...autoState.results.get(key),
+    status,
+    message,
+    ...details,
+  });
+
+  if (autoState.selectedKey === key) {
+    selectResult(key);
+  }
+}
+
+function statusLabel(status) {
+  switch (status) {
+    case "success":
+      return "OK";
+    case "error":
+      return "Errore";
+    case "loading":
+      return "Caricamento";
+    default:
+      return "In attesa";
+  }
+}
+
+function summariseData(value) {
+  if (value == null) return "Dataset vuoto";
+  if (Array.isArray(value)) {
+    return `Array con ${value.length} elementi`;
+  }
+  if (typeof value === "object") {
+    const keys = Object.keys(value);
+    return `Oggetto con ${keys.length} chiavi`;
+  }
+  return `Valore ${typeof value}`;
+}
+
+function buildPreview(text, parsed) {
+  if (text && text.trim().length < 800) {
+    return text.trim();
+  }
+
+  try {
+    const snippet = JSON.stringify(parsed, null, 2);
+    if (snippet.length <= 1000) {
+      return snippet;
+    }
+    return `${snippet.slice(0, 1000)}\n…`;
+  } catch (error) {
+    return text ? `${text.slice(0, 1000)}\n…` : "";
+  }
+}
+
+async function fetchSource(source) {
+  const url = resolveDataPath(source.path);
+  updateResultStatus(
+    source.key,
+    "loading",
+    `Download da ${url}`,
+    { preview: "Caricamento…" }
+  );
+
+  const response = await fetch(url, { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText}`);
+  }
+
+  const text = await response.text();
+  let parsed;
+  try {
+    parsed = jsyaml.load(text);
+  } catch (error) {
+    throw new Error(`Errore parsing YAML: ${error.message}`);
+  }
+
+  const summary = summariseData(parsed);
+  const preview = buildPreview(text, parsed);
+
+  autoState.results.set(source.key, {
+    status: "success",
+    message: summary,
+    preview,
+    url,
+  });
+
+  updateResultStatus(source.key, "success", summary, { preview, url });
+}
+
+async function runAutoFetch() {
+  if (!autoElements.results) return;
+
+  autoState.dataBase = detectDataBase();
+  updateDataSourceHint();
+  autoState.results.clear();
+  autoState.selectedKey = null;
+  renderResultsShell();
+
+  updateGlobalStatus("loading", "Caricamento YAML in corso…");
+
+  const outcomes = await Promise.allSettled(
+    DATA_SOURCES.map(async (source) => {
+      try {
+        await fetchSource(source);
+        return { key: source.key, status: "success" };
+      } catch (error) {
+        console.error(`Errore nel fetch di ${source.path}`, error);
+        autoState.results.set(source.key, {
+          status: "error",
+          message: error.message,
+          preview: error.stack,
+        });
+        updateResultStatus(source.key, "error", error.message, {
+          preview: error.stack,
+        });
+        return { key: source.key, status: "error" };
+      }
+    })
+  );
+
+  const hasError = outcomes.some((outcome) => outcome.value?.status === "error");
+  if (hasError) {
+    updateGlobalStatus("error", "Caricamento completato con errori. Controlla i dettagli sopra.");
+  } else {
+    updateGlobalStatus("success", "Caricamento completato con successo.");
+  }
+
+  if (!autoState.selectedKey && autoState.results.size > 0) {
+    const firstKey = DATA_SOURCES[0]?.key;
+    if (firstKey) {
+      selectResult(firstKey);
+    }
+  }
+}
+
+function setupEventListeners() {
+  if (autoElements.reload) {
+    autoElements.reload.addEventListener("click", () => {
+      runAutoFetch();
+    });
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  setupAutoDom();
+  setupEventListeners();
+  renderResultsShell();
+  runAutoFetch();
+});

--- a/docs/test-interface/index.html
+++ b/docs/test-interface/index.html
@@ -15,6 +15,9 @@
       <p class="tagline">
         Dashboard rapida per ispezionare pacchetti PI, telemetria VC e accoppiamenti MBTI.
       </p>
+      <nav class="utility-nav" aria-label="Navigazione secondaria">
+        <a href="auto-fetch.html">Apri il fetch automatico YAML</a>
+      </nav>
       <button id="reload-data" type="button">Ricarica dati YAML</button>
       <p class="hint">
         La pagina rileva automaticamente la sorgente dati: funzionerà sia su GitHub Pages (fetch <code>raw</code>)

--- a/docs/test-interface/styles.css
+++ b/docs/test-interface/styles.css
@@ -548,3 +548,123 @@ footer {
     width: 100%;
   }
 }
+
+.utility-nav {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin: 1rem 0 0;
+  flex-wrap: wrap;
+}
+
+.utility-nav a {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.utility-nav a:hover {
+  background: rgba(56, 189, 248, 0.2);
+  transform: translateY(-1px);
+}
+
+#auto-reload {
+  background: var(--accent);
+  border: none;
+  color: #0f172a;
+  font-weight: 600;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  cursor: pointer;
+  box-shadow: 0 12px 25px rgba(56, 189, 248, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+#auto-reload:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 35px rgba(56, 189, 248, 0.3);
+}
+
+.data-results {
+  list-style: none;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.data-result {
+  padding: 1rem 1.1rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.data-result:hover {
+  transform: translateY(-1px);
+  border-color: rgba(56, 189, 248, 0.4);
+}
+
+.data-result.is-selected {
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 15px 35px rgba(56, 189, 248, 0.2);
+}
+
+.data-result-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.data-result h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.data-badge {
+  font-size: 0.8rem;
+  font-weight: 700;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.data-badge[data-status="success"] {
+  background: rgba(74, 222, 128, 0.15);
+  color: #4ade80;
+}
+
+.data-badge[data-status="error"] {
+  background: rgba(248, 113, 113, 0.18);
+  color: #f87171;
+}
+
+.data-badge[data-status="loading"] {
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--accent);
+}
+
+.data-message {
+  margin: 0.75rem 0 0;
+  font-size: 0.95rem;
+}
+
+.auto-fetch main {
+  max-width: 960px;
+}
+
+.auto-fetch .preview {
+  min-height: 160px;
+}


### PR DESCRIPTION
## Summary
- add a dedicated page that automatically downloads all YAML datasets and shows their status
- reuse the existing styling with a shared navigation link from the dashboard
- provide a reload action, status badges, and a preview panel for the fetched data

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fada481f188332a03d0057123daba8