### PR TITLE
Document 2025-10-24 ChatGPT sync run

### DIFF
--- a/data/chatgpt/local/2025-10-24/local-conversation-1.json
+++ b/data/chatgpt/local/2025-10-24/local-conversation-1.json
@@ -1,0 +1,12 @@
+{
+  "conversations": [
+    {
+      "id": "conv-001",
+      "title": "Aggiornamento progetto",
+      "messages": [
+        {"role": "user", "content": "Qual è lo stato attuale del progetto?"},
+        {"role": "assistant", "content": "Il progetto è in fase di test e la release è prevista per venerdì."}
+      ]
+    }
+  ]
+}

--- a/data/chatgpt/local/2025-10-24/snapshot-20251024T021902Z-local-export.json
+++ b/data/chatgpt/local/2025-10-24/snapshot-20251024T021902Z-local-export.json
@@ -1,0 +1,22 @@
+{
+  "source": "export",
+  "original_path": "/workspace/Game/data/exports/local-conversation.json",
+  "stored_path": "/workspace/Game/data/chatgpt/local/2025-10-24/local-conversation-1.json",
+  "timestamp": "2025-10-24T02:19:02.766567+00:00",
+  "export_preview": [
+    {
+      "id": "conv-001",
+      "title": "Aggiornamento progetto",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Qual è lo stato attuale del progetto?"
+        },
+        {
+          "role": "assistant",
+          "content": "Il progetto è in fase di test e la release è prevista per venerdì."
+        }
+      ]
+    }
+  ]
+}

--- a/data/chatgpt/local/2025-10-24/snapshot-20251024T021902Z-local-export.metadata.json
+++ b/data/chatgpt/local/2025-10-24/snapshot-20251024T021902Z-local-export.metadata.json
@@ -1,0 +1,12 @@
+{
+  "created_at": "2025-10-24T02:19:02.767010+00:00",
+  "namespace": "local",
+  "suffix": "json",
+  "snapshot_path": "/workspace/Game/data/chatgpt/local/2025-10-24/snapshot-20251024T021902Z-local-export.json",
+  "source": "export",
+  "namespace_requested": "local",
+  "name": "local-export",
+  "export_file": "/workspace/Game/data/exports/local-conversation.json",
+  "stored_path": "/workspace/Game/data/chatgpt/local/2025-10-24/local-conversation-1.json",
+  "original_export": "/workspace/Game/data/exports/local-conversation.json"
+}

--- a/data/chatgpt/notes/2025-10-24/notes-conversation-1.json
+++ b/data/chatgpt/notes/2025-10-24/notes-conversation-1.json
@@ -1,0 +1,12 @@
+{
+  "conversations": [
+    {
+      "id": "notes-001",
+      "title": "Note quotidiane",
+      "messages": [
+        {"role": "user", "content": "Ricordami di pianificare il meeting di domani."},
+        {"role": "assistant", "content": "Ho aggiunto il meeting di domani alle 15:00 al tuo calendario."}
+      ]
+    }
+  ]
+}

--- a/data/chatgpt/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.json
+++ b/data/chatgpt/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.json
@@ -1,0 +1,22 @@
+{
+  "source": "export",
+  "original_path": "/workspace/Game/data/exports/notes-conversation.json",
+  "stored_path": "/workspace/Game/data/chatgpt/notes/2025-10-24/notes-conversation-1.json",
+  "timestamp": "2025-10-24T02:19:02.769776+00:00",
+  "export_preview": [
+    {
+      "id": "notes-001",
+      "title": "Note quotidiane",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Ricordami di pianificare il meeting di domani."
+        },
+        {
+          "role": "assistant",
+          "content": "Ho aggiunto il meeting di domani alle 15:00 al tuo calendario."
+        }
+      ]
+    }
+  ]
+}

--- a/data/chatgpt/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.metadata.json
+++ b/data/chatgpt/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.metadata.json
@@ -1,0 +1,12 @@
+{
+  "created_at": "2025-10-24T02:19:02.770085+00:00",
+  "namespace": "notes",
+  "suffix": "json",
+  "snapshot_path": "/workspace/Game/data/chatgpt/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.json",
+  "source": "export",
+  "namespace_requested": "notes",
+  "name": "local-notes",
+  "export_file": "/workspace/Game/data/exports/notes-conversation.json",
+  "stored_path": "/workspace/Game/data/chatgpt/notes/2025-10-24/notes-conversation-1.json",
+  "original_export": "/workspace/Game/data/exports/notes-conversation.json"
+}

--- a/docs/chatgpt_changes/local/2025-10-24/snapshot-20251024T021902Z-local-export.diff
+++ b/docs/chatgpt_changes/local/2025-10-24/snapshot-20251024T021902Z-local-export.diff
@@ -1,0 +1,13 @@
+--- /workspace/Game/data/chatgpt/local/2025-10-24/snapshot-20251024T021001Z-local-export.json
++++ data/chatgpt/local/2025-10-24/snapshot-20251024T021902Z-local-export.json
+@@ -15,8 +15,8 @@
+       "title": "Aggiornamento progetto"
+     }
+   ],
+   "original_path": "/workspace/Game/data/exports/local-conversation.json",
+   "source": "export",
+-  "stored_path": "/workspace/Game/data/chatgpt/local/2025-10-24/local-conversation.json",
+-  "timestamp": "2025-10-24T02:10:01.975222+00:00"
++  "stored_path": "/workspace/Game/data/chatgpt/local/2025-10-24/local-conversation-1.json",
++  "timestamp": "2025-10-24T02:19:02.766567+00:00"
+ }

--- a/docs/chatgpt_changes/local/2025-10-24/snapshot-20251024T021902Z-local-export.md
+++ b/docs/chatgpt_changes/local/2025-10-24/snapshot-20251024T021902Z-local-export.md
@@ -1,0 +1,28 @@
+# Report snapshot snapshot-20251024T021902Z-local-export
+
+- **Namespace:** local
+- **Data cartella:** 2025-10-24
+- **File snapshot:** `data/chatgpt/local/2025-10-24/snapshot-20251024T021902Z-local-export.json`
+- **File diff:** `docs/chatgpt_changes/local/2025-10-24/snapshot-20251024T021902Z-local-export.diff`
+- **Linee aggiunte:** 2
+- **Linee rimosse:** 2
+- **Origine:** export
+- **Fonte configurazione:** local-export
+- **Namespace configurato:** local
+- **Export salvato:** /workspace/Game/data/chatgpt/local/2025-10-24/local-conversation-1.json
+- **Export originale:** /workspace/Game/data/exports/local-conversation.json
+
+## Estratto diff
+    --- /workspace/Game/data/chatgpt/local/2025-10-24/snapshot-20251024T021001Z-local-export.json
+    +++ data/chatgpt/local/2025-10-24/snapshot-20251024T021902Z-local-export.json
+    @@ -15,8 +15,8 @@
+           "title": "Aggiornamento progetto"
+         }
+       ],
+       "original_path": "/workspace/Game/data/exports/local-conversation.json",
+       "source": "export",
+    -  "stored_path": "/workspace/Game/data/chatgpt/local/2025-10-24/local-conversation.json",
+    -  "timestamp": "2025-10-24T02:10:01.975222+00:00"
+    +  "stored_path": "/workspace/Game/data/chatgpt/local/2025-10-24/local-conversation-1.json",
+    +  "timestamp": "2025-10-24T02:19:02.766567+00:00"
+     }

--- a/docs/chatgpt_changes/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.diff
+++ b/docs/chatgpt_changes/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.diff
@@ -1,0 +1,13 @@
+--- /workspace/Game/data/chatgpt/notes/2025-10-24/snapshot-20251024T021001Z-daily-notes.json
++++ data/chatgpt/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.json
+@@ -15,8 +15,8 @@
+       "title": "Note quotidiane"
+     }
+   ],
+   "original_path": "/workspace/Game/data/exports/notes-conversation.json",
+   "source": "export",
+-  "stored_path": "/workspace/Game/data/chatgpt/notes/2025-10-24/notes-conversation.json",
+-  "timestamp": "2025-10-24T02:10:01.979840+00:00"
++  "stored_path": "/workspace/Game/data/chatgpt/notes/2025-10-24/notes-conversation-1.json",
++  "timestamp": "2025-10-24T02:19:02.769776+00:00"
+ }

--- a/docs/chatgpt_changes/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.md
+++ b/docs/chatgpt_changes/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.md
@@ -1,0 +1,28 @@
+# Report snapshot snapshot-20251024T021902Z-daily-notes
+
+- **Namespace:** notes
+- **Data cartella:** 2025-10-24
+- **File snapshot:** `data/chatgpt/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.json`
+- **File diff:** `docs/chatgpt_changes/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.diff`
+- **Linee aggiunte:** 2
+- **Linee rimosse:** 2
+- **Origine:** export
+- **Fonte configurazione:** local-notes
+- **Namespace configurato:** notes
+- **Export salvato:** /workspace/Game/data/chatgpt/notes/2025-10-24/notes-conversation-1.json
+- **Export originale:** /workspace/Game/data/exports/notes-conversation.json
+
+## Estratto diff
+    --- /workspace/Game/data/chatgpt/notes/2025-10-24/snapshot-20251024T021001Z-daily-notes.json
+    +++ data/chatgpt/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.json
+    @@ -15,8 +15,8 @@
+           "title": "Note quotidiane"
+         }
+       ],
+       "original_path": "/workspace/Game/data/exports/notes-conversation.json",
+       "source": "export",
+    -  "stored_path": "/workspace/Game/data/chatgpt/notes/2025-10-24/notes-conversation.json",
+    -  "timestamp": "2025-10-24T02:10:01.979840+00:00"
+    +  "stored_path": "/workspace/Game/data/chatgpt/notes/2025-10-24/notes-conversation-1.json",
+    +  "timestamp": "2025-10-24T02:19:02.769776+00:00"
+     }

--- a/docs/chatgpt_sync_status.md
+++ b/docs/chatgpt_sync_status.md
@@ -15,6 +15,15 @@ problemi riscontrati) dopo ogni modifica sostanziale al flusso di sincronizzazio
 
 ## Cronologia esecuzioni recenti
 
+### 2025-10-24 02:19 UTC
+- **Esito**: riuscito.
+- **Ambiente**: Ubuntu container, Python 3.11.12 (global), pip 25.2, `requests` 2.32.5, `PyYAML` 6.0.3.
+- **Fonti eseguite**:
+  - `local-export` → diff aggiornato in `docs/chatgpt_changes/local/2025-10-24/snapshot-20251024T021902Z-local-export.*`.
+  - `local-notes` → diff aggiornato in `docs/chatgpt_changes/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.*`.
+- **Credenziali/Proxy**: non richiesti (fonti locali; nessuna variabile impostata).
+- **Note**: installati/aggiornati `requests` e `PyYAML` globalmente; log riepilogativo archiviato in `logs/chatgpt_sync_last.json`. Nessun follow-up aperto.
+
 ### 2025-10-24 02:10 UTC
 - **Esito**: riuscito.
 - **Ambiente**: Ubuntu container, Node.js 22.19.0, npm 11.4.2, Python 3.11.12 (venv disattivato), pip 25.2, `requests` 2.32.3, `PyYAML` 6.0.2.

--- a/logs/chatgpt_sync.log
+++ b/logs/chatgpt_sync.log
@@ -182,3 +182,12 @@ FileNotFoundError: File di export non trovato: /workspace/Game/data/data/exports
 2025-10-24 02:10:01,980 - INFO - Snapshot salvato in data/chatgpt/notes/2025-10-24/snapshot-20251024T021001Z-daily-notes.json
 2025-10-24 02:10:01,983 - INFO - Diff scritto in docs/chatgpt_changes/notes/2025-10-24/snapshot-20251024T021001Z-daily-notes.diff
 2025-10-24 02:10:01,984 - INFO - Riepilogo scritto in logs/chatgpt_sync_last.json
+2025-10-24 02:19:02,765 - INFO - Processo fonte configurata 'local-export' (export)
+2025-10-24 02:19:02,766 - INFO - Export copiato in data/chatgpt/local/2025-10-24/local-conversation-1.json
+2025-10-24 02:19:02,767 - INFO - Snapshot salvato in data/chatgpt/local/2025-10-24/snapshot-20251024T021902Z-local-export.json
+2025-10-24 02:19:02,769 - INFO - Diff scritto in docs/chatgpt_changes/local/2025-10-24/snapshot-20251024T021902Z-local-export.diff
+2025-10-24 02:19:02,769 - INFO - Processo fonte configurata 'local-notes' (export)
+2025-10-24 02:19:02,769 - INFO - Export copiato in data/chatgpt/notes/2025-10-24/notes-conversation-1.json
+2025-10-24 02:19:02,770 - INFO - Snapshot salvato in data/chatgpt/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.json
+2025-10-24 02:19:02,771 - INFO - Diff scritto in docs/chatgpt_changes/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.diff
+2025-10-24 02:19:02,771 - INFO - Riepilogo scritto in logs/chatgpt_sync_last.json

--- a/logs/chatgpt_sync_last.json
+++ b/logs/chatgpt_sync_last.json
@@ -1,38 +1,38 @@
 {
-  "run_timestamp": "2025-10-24T02:10:01.983927+00:00",
+  "run_timestamp": "2025-10-24T02:19:02.771632+00:00",
   "config": "data/chatgpt_sources.yaml",
   "results": [
     {
-      "snapshot": "data/chatgpt/local/2025-10-24/snapshot-20251024T021001Z-local-export.json",
+      "snapshot": "data/chatgpt/local/2025-10-24/snapshot-20251024T021902Z-local-export.json",
       "metadata": {
         "source": "export",
         "namespace": "local",
         "namespace_requested": "local",
         "name": "local-export",
         "export_file": "/workspace/Game/data/exports/local-conversation.json",
-        "stored_path": "/workspace/Game/data/chatgpt/local/2025-10-24/local-conversation.json",
+        "stored_path": "/workspace/Game/data/chatgpt/local/2025-10-24/local-conversation-1.json",
         "original_export": "/workspace/Game/data/exports/local-conversation.json"
       },
       "diff": {
-        "diff": "docs/chatgpt_changes/local/2025-10-24/snapshot-20251024T021001Z-local-export.diff",
-        "summary": "docs/chatgpt_changes/local/2025-10-24/snapshot-20251024T021001Z-local-export.md"
+        "diff": "docs/chatgpt_changes/local/2025-10-24/snapshot-20251024T021902Z-local-export.diff",
+        "summary": "docs/chatgpt_changes/local/2025-10-24/snapshot-20251024T021902Z-local-export.md"
       },
       "name": "local-export"
     },
     {
-      "snapshot": "data/chatgpt/notes/2025-10-24/snapshot-20251024T021001Z-daily-notes.json",
+      "snapshot": "data/chatgpt/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.json",
       "metadata": {
         "source": "export",
         "namespace": "notes",
         "namespace_requested": "notes",
         "name": "local-notes",
         "export_file": "/workspace/Game/data/exports/notes-conversation.json",
-        "stored_path": "/workspace/Game/data/chatgpt/notes/2025-10-24/notes-conversation.json",
+        "stored_path": "/workspace/Game/data/chatgpt/notes/2025-10-24/notes-conversation-1.json",
         "original_export": "/workspace/Game/data/exports/notes-conversation.json"
       },
       "diff": {
-        "diff": "docs/chatgpt_changes/notes/2025-10-24/snapshot-20251024T021001Z-daily-notes.diff",
-        "summary": "docs/chatgpt_changes/notes/2025-10-24/snapshot-20251024T021001Z-daily-notes.md"
+        "diff": "docs/chatgpt_changes/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.diff",
+        "summary": "docs/chatgpt_changes/notes/2025-10-24/snapshot-20251024T021902Z-daily-notes.md"
       },
       "name": "local-notes"
     }


### PR DESCRIPTION
## Summary
- record the 2025-10-24 02:19 UTC synchronization in `docs/chatgpt_sync_status.md`, including dependency versions and credential status
- archive the generated exports, metadata, and diffs for the latest `local-export` and `local-notes` runs
- update the sync logs to reflect the new execution

## Testing
- python scripts/chatgpt_sync.py --config data/chatgpt_sources.yaml

------
https://chatgpt.com/codex/tasks/task_e_68fae1f039488332abc9ee065735a438