### PR TITLE
Fix undefined result merges for auto-fetch status updates

### DIFF
--- a/docs/test-interface/auto-fetch.js
+++ b/docs/test-interface/auto-fetch.js
@@ -179,8 +179,10 @@ function updateResultStatus(key, status, message, details) {
     body.classList.toggle("muted", status !== "error");
   }
 
+  const previous = autoState.results.get(key) || {};
+
   autoState.results.set(key, {
-    ...autoState.results.get(key),
+    ...previous,
     status,
     message,
     ...details,


### PR DESCRIPTION
## Summary
- guard the result status merge with a default empty object to avoid spreading undefined entries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fae1fa38b88332bb286868e8e6a909