### PR TITLE
Add species validation tooling and UI summary card

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
         working-directory: tools/ts
         run: node dist/roll_pack.js ENTP invoker ../../data/packs.yaml
 
+      - name: Validate Species (TS)
+        working-directory: tools/ts
+        run: |
+          npm ci
+          npm run validate:species
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -41,6 +47,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --requirement requirements.txt
+
+      - name: Validate Species (Python)
+        working-directory: tools/py
+        run: |
+          python3 validate_species.py ../../data/species.yaml
 
       - name: Run Python validation script
         working-directory: tools/py

--- a/data/species.yaml
+++ b/data/species.yaml
@@ -1,0 +1,64 @@
+catalog:
+  slots:
+    locomotion:
+      burrower:
+        name: Burrower
+        effects:
+          resistances:
+            res:
+              sand: 1
+    metabolism:
+      sand_digest:
+        name: Sand Digestor
+        effects:
+          resistances:
+            res:
+              sand: 1
+    offense:
+      sand_claws:
+        name: Sand Claws
+        effects: {}
+    defense:
+      heat_scales:
+        name: Heat Scales
+        effects:
+          resistances:
+            res:
+              heat: 1
+    senses:
+      echolocation:
+        name: Echolocation
+        effects:
+          resistances:
+            res:
+              sonic: 1
+  synergies:
+    - id: echo_backstab
+      name: Echo Backstab
+      when_all:
+        - senses.echolocation
+        - offense.sand_claws
+
+global_rules:
+  morph_budget:
+    default_weight_budget: 12
+  stacking_caps:
+    res_cap_per_type: 2
+    dr_cap_per_type: 1
+  counters_reference:
+    - counter: ultrasound_ping
+      counters:
+        - echolocation
+
+species:
+  - id: dune_stalker
+    display_name: Dune Stalker
+    estimated_weight: 11
+    weight_budget: 12
+    default_parts:
+      locomotion: burrower
+      metabolism: sand_digest
+      offense: [sand_claws]
+      defense: [heat_scales]
+      senses: [echolocation]
+    synergy_hints: [echo_backstab]

--- a/docs/test-interface/components/SpeciesSummaryCard.tsx
+++ b/docs/test-interface/components/SpeciesSummaryCard.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+
+type UISpecies = {
+  id: string;
+  name: string;
+  budget: string;
+  over_budget: boolean;
+  active_synergies: string[];
+  known_counters: string[];
+  warnings: string[];
+};
+
+export function SpeciesSummaryCard({ s }: { s: UISpecies }) {
+  return (
+    <div className={`card ${s.over_budget ? "card--danger" : "card--ok"}`}>
+      <div className="row">
+        <h3>{s.name}</h3>
+        <span className="pill">Budget: {s.budget}</span>
+        {s.over_budget && <span className="pill pill--warn">OVER BUDGET</span>}
+      </div>
+
+      <div className="row">
+        <div className="col">
+          <strong>Sinergie attive</strong>
+          <ul>
+            {s.active_synergies.length ? (
+              s.active_synergies.map((x) => <li key={x}>{x}</li>)
+            ) : (
+              <li>—</li>
+            )}
+          </ul>
+        </div>
+        <div className="col">
+          <strong>Counter noti</strong>
+          <ul>
+            {s.known_counters.length ? (
+              s.known_counters.map((x) => <li key={x}>{x}</li>)
+            ) : (
+              <li>—</li>
+            )}
+          </ul>
+        </div>
+      </div>
+
+      {s.warnings.length > 0 && (
+        <div className="warnings">
+          <strong>Warning</strong>
+          <ul>
+            {s.warnings.map((w, i) => (
+              <li key={i}>{w}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="actions">
+        <button
+          disabled={s.over_budget}
+          title={s.over_budget ? "Rientra nel budget per salvare" : "Salva"}
+        >
+          Salva Specie
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export type { UISpecies };

--- a/tools/py/validate_species.py
+++ b/tools/py/validate_species.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+import sys
+import json
+import yaml
+import argparse
+from collections import defaultdict
+
+
+def load_yaml(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def collect_catalog(spec):
+    slots = spec["catalog"]["slots"]
+    by_slot = {slot: set(parts.keys()) for slot, parts in slots.items()}
+    synmap = {s["id"]: s for s in spec.get("catalog", {}).get("synergies", [])}
+    return by_slot, synmap
+
+
+def get_caps(spec):
+    caps = spec.get("global_rules", {}).get("stacking_caps", {})
+    res_cap = caps.get("res_cap_per_type", 2)
+    dr_cap = caps.get("dr_cap_per_type", 1) if "dr_cap_per_type" in caps else 1
+    return res_cap, dr_cap
+
+
+def gather_chosen_parts(dp):
+    chosen = set()
+    for slot in ["locomotion", "metabolism"]:
+        if dp.get(slot):
+            chosen.add(f"{slot}.{dp[slot]}")
+    for slot in ["offense", "defense", "senses"]:
+        for pid in dp.get(slot, []) or []:
+            chosen.add(f"{slot}.{pid}")
+    return chosen
+
+
+def resolve_part(spec, slot, pid):
+    return spec["catalog"]["slots"][slot].get(pid)
+
+
+def accumulate_resistances(spec, dp):
+    res_sum, vuln_sum, dr_sum = defaultdict(int), defaultdict(int), defaultdict(int)
+
+    def acc(slot, pid):
+        part = resolve_part(spec, slot, pid)
+        if not part:
+            return
+        eff = part.get("effects", {})
+        r = eff.get("resistances", {})
+        for t, v in (r.get("res") or {}).items():
+            res_sum[t] += int(v)
+        for t, v in (r.get("vuln") or {}).items():
+            vuln_sum[t] += int(v)
+        for t, v in (r.get("dr") or {}).items():
+            dr_sum[t] += int(v)
+
+    for s in ["locomotion", "metabolism"]:
+        if dp.get(s):
+            acc(s, dp[s])
+    for s in ["offense", "defense", "senses"]:
+        for pid in dp.get(s, []) or []:
+            acc(s, pid)
+    return dict(res_sum), dict(vuln_sum), dict(dr_sum)
+
+
+def compute_active_synergies(spec, chosen_set):
+    active = []
+    for syn in spec.get("catalog", {}).get("synergies", []):
+        reqs = set(syn.get("when_all", []))
+        if all(req in chosen_set for req in reqs):
+            active.append(syn["id"])
+    return active
+
+
+def compute_known_counters(spec, chosen_set):
+    out = []
+    for item in spec.get("global_rules", {}).get("counters_reference", []):
+        ctr_parts = item.get("counters", [])
+        hit = any(
+            any(k.endswith("." + c) or c in k for k in chosen_set) for c in ctr_parts
+        )
+        if hit:
+            out.append(item["counter"])
+    return out
+
+
+def validate(path):
+    spec = load_yaml(path)
+    by_slot, synmap = collect_catalog(spec)
+    res_cap, dr_cap = get_caps(spec)
+
+    report = {"file": path, "species": [], "errors": 0, "warnings": 0}
+    for sp in spec.get("species", []):
+        sid = sp["id"]
+        dp = sp.get("default_parts", {})
+        errors, warnings = [], []
+
+        est = sp.get("estimated_weight", 0)
+        bud = sp.get("weight_budget", spec["global_rules"]["morph_budget"]["default_weight_budget"])
+        over_budget = est > bud
+        if over_budget:
+            warnings.append(f"estimated_weight {est} exceeds budget {bud}")
+
+        for slot in ["locomotion", "metabolism"]:
+            pid = dp.get(slot)
+            if pid and pid not in by_slot.get(slot, set()):
+                errors.append(f"missing part: {slot}.{pid}")
+        for slot in ["offense", "defense", "senses"]:
+            for pid in dp.get(slot, []) or []:
+                if pid not in by_slot.get(slot, set()):
+                    errors.append(f"missing part: {slot}.{pid}")
+
+        for syn in sp.get("synergy_hints", []) or []:
+            if syn not in synmap:
+                warnings.append(f"synergy hint '{syn}' not in catalog.synergies")
+
+        res_sum, vuln_sum, dr_sum = accumulate_resistances(spec, dp)
+        for t, v in res_sum.items():
+            if v > res_cap:
+                warnings.append(f"res cap exceeded: {t}={v} > {res_cap}")
+        for t, v in dr_sum.items():
+            if v > dr_cap:
+                warnings.append(f"dr cap exceeded: {t}={v} > {dr_cap}")
+
+        chosen_set = gather_chosen_parts(dp)
+        active_syn = compute_active_synergies(spec, chosen_set)
+        known_counters = compute_known_counters(spec, chosen_set)
+
+        report["species"].append(
+            {
+                "id": sid,
+                "display_name": sp.get("display_name", sid),
+                "budget": {"used": est, "max": bud, "over_budget": over_budget},
+                "parts_ok": len([e for e in errors if e.startswith("missing part")]) == 0,
+                "active_synergies": active_syn,
+                "synergy_hints": sp.get("synergy_hints", []),
+                "known_counters": known_counters,
+                "res_summary": res_sum,
+                "vuln_summary": vuln_sum,
+                "dr_summary": dr_sum,
+                "warnings": warnings,
+                "errors": errors,
+            }
+        )
+        report["errors"] += len(errors)
+        report["warnings"] += len(warnings)
+
+    report["ui_summary"] = [
+        {
+            "id": s["id"],
+            "name": s["display_name"],
+            "budget": f'{s["budget"]["used"]}/{s["budget"]["max"]}',
+            "over_budget": s["budget"]["over_budget"],
+            "active_synergies": s["active_synergies"],
+            "known_counters": s["known_counters"],
+            "warnings": s["warnings"],
+        }
+        for s in report["species"]
+    ]
+
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0 if report["errors"] == 0 else 1
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("path", nargs="?", default="data/species.yaml")
+    args = ap.parse_args()
+    sys.exit(validate(args.path))

--- a/tools/ts/package.json
+++ b/tools/ts/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "node dist/roll_pack.js ENTP invoker ../../data/packs.yaml",
-    "test": "npm run build --silent && node --test \"dist/tests/**/*.test.js\""
+    "test": "npm run build --silent && node --test \"dist/tests/**/*.test.js\"",
+    "validate:species": "npm run build && node dist/validate_species.js ../../data/species.yaml"
   },
   "dependencies": {
     "js-yaml": "^4.1.0"

--- a/tools/ts/validate_species.ts
+++ b/tools/ts/validate_species.ts
@@ -1,0 +1,173 @@
+import fs from "fs";
+import yaml from "js-yaml";
+
+type Dict<T = any> = { [k: string]: T };
+
+function loadYaml(path: string): any {
+  return yaml.load(fs.readFileSync(path, "utf8")) as any;
+}
+
+function collectCatalog(spec: any) {
+  const slots = spec.catalog.slots;
+  const bySlot: Dict<Set<string>> = {};
+  Object.keys(slots).forEach((s) => (bySlot[s] = new Set(Object.keys(slots[s]))));
+  const synMap: Dict = {};
+  (spec.catalog.synergies || []).forEach((s: any) => (synMap[s.id] = s));
+  return { bySlot, synMap };
+}
+
+function getCaps(spec: any) {
+  const caps = spec.global_rules?.stacking_caps || {};
+  return {
+    resCap: caps.res_cap_per_type ?? 2,
+    drCap: caps.dr_cap_per_type ?? 1,
+  };
+}
+
+function gatherChosen(dp: any): Set<string> {
+  const out = new Set<string>();
+  ["locomotion", "metabolism"].forEach((sl) => {
+    if (dp[sl]) out.add(`${sl}.${dp[sl]}`);
+  });
+  ["offense", "defense", "senses"].forEach((sl) =>
+    (dp[sl] || []).forEach((p: string) => out.add(`${sl}.${p}`))
+  );
+  return out;
+}
+
+function resolvePart(spec: any, slot: string, pid: string) {
+  return spec.catalog.slots[slot]?.[pid] ?? null;
+}
+
+function accumulateRes(spec: any, dp: any) {
+  const res: Dict<number> = {};
+  const vuln: Dict<number> = {};
+  const dr: Dict<number> = {};
+
+  const acc = (slot: string, pid: string) => {
+    const part = resolvePart(spec, slot, pid);
+    if (!part) return;
+    const eff = part.effects || {};
+    const ro = eff.resistances || {};
+    Object.entries(ro.res || {}).forEach(([t, v]: any) => {
+      res[t] = (res[t] || 0) + Number(v);
+    });
+    Object.entries(ro.vuln || {}).forEach(([t, v]: any) => {
+      vuln[t] = (vuln[t] || 0) + Number(v);
+    });
+    Object.entries(ro.dr || {}).forEach(([t, v]: any) => {
+      dr[t] = (dr[t] || 0) + Number(v);
+    });
+  };
+
+  ["locomotion", "metabolism"].forEach((s) => {
+    if (dp[s]) acc(s, dp[s]);
+  });
+  ["offense", "defense", "senses"].forEach((s) =>
+    (dp[s] || []).forEach((p: string) => acc(s, p))
+  );
+
+  return { res, vuln, dr };
+}
+
+function computeActiveSynergies(spec: any, chosen: Set<string>): string[] {
+  const out: string[] = [];
+  (spec.catalog.synergies || []).forEach((syn: any) => {
+    const reqs: string[] = syn.when_all || [];
+    if (reqs.every((r) => chosen.has(r))) out.push(syn.id);
+  });
+  return out;
+}
+
+function computeKnownCounters(spec: any, chosen: Set<string>): string[] {
+  const out: string[] = [];
+  (spec.global_rules?.counters_reference || []).forEach((item: any) => {
+    const hit = (item.counters || []).some((c: string) => {
+      for (const k of Array.from(chosen)) {
+        if (k.endsWith("." + c) || k.includes(c)) return true;
+      }
+      return false;
+    });
+    if (hit) out.push(item.counter);
+  });
+  return out;
+}
+
+function validate(path: string) {
+  const spec = loadYaml(path);
+  const { bySlot, synMap } = collectCatalog(spec);
+  const { resCap, drCap } = getCaps(spec);
+
+  const report: any = { file: path, species: [], errors: 0, warnings: 0 };
+
+  (spec.species || []).forEach((sp: any) => {
+    const sid = sp.id;
+    const dp = sp.default_parts || {};
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    const est = sp.estimated_weight ?? 0;
+    const bud = sp.weight_budget ?? spec.global_rules.morph_budget.default_weight_budget;
+    const over_budget = est > bud;
+    if (over_budget) warnings.push(`estimated_weight ${est} exceeds budget ${bud}`);
+
+    ["locomotion", "metabolism"].forEach((sl) => {
+      const pid = dp[sl];
+      if (pid && !bySlot[sl]?.has(pid)) errors.push(`missing part: ${sl}.${pid}`);
+    });
+    ["offense", "defense", "senses"].forEach((sl) => {
+      (dp[sl] || []).forEach((pid: string) => {
+        if (!bySlot[sl]?.has(pid)) errors.push(`missing part: ${sl}.${pid}`);
+      });
+    });
+
+    (sp.synergy_hints || []).forEach((syn: string) => {
+      if (!synMap[syn]) warnings.push(`synergy hint '${syn}' not in catalog.synergies`);
+    });
+
+    const { res, vuln, dr } = accumulateRes(spec, dp);
+    Object.entries(res).forEach(([t, v]: any) => {
+      if ((v as number) > resCap) warnings.push(`res cap exceeded: ${t}=${v} > ${resCap}`);
+    });
+    Object.entries(dr).forEach(([t, v]: any) => {
+      if ((v as number) > drCap) warnings.push(`dr cap exceeded: ${t}=${v} > ${drCap}`);
+    });
+
+    const chosen = gatherChosen(dp);
+    const activeSyn = computeActiveSynergies(spec, chosen);
+    const knownCounters = computeKnownCounters(spec, chosen);
+
+    report.species.push({
+      id: sid,
+      display_name: sp.display_name || sid,
+      budget: { used: est, max: bud, over_budget },
+      parts_ok: errors.filter((e) => e.startsWith("missing part")).length === 0,
+      active_synergies: activeSyn,
+      synergy_hints: sp.synergy_hints || [],
+      known_counters: knownCounters,
+      res_summary: res,
+      vuln_summary: vuln,
+      dr_summary: dr,
+      warnings,
+      errors,
+    });
+    report.errors += errors.length;
+    report.warnings += warnings.length;
+  });
+
+  report.ui_summary = report.species.map((s: any) => ({
+    id: s.id,
+    name: s.display_name,
+    budget: `${s.budget.used}/${s.budget.max}`,
+    over_budget: s.budget.over_budget,
+    active_synergies: s.active_synergies,
+    known_counters: s.known_counters,
+    warnings: s.warnings,
+  }));
+
+  console.log(JSON.stringify(report, null, 2));
+  process.exit(report.errors === 0 ? 0 : 1);
+}
+
+const pathArg = process.argv[2] || "../../data/species.yaml";
+validate(pathArg);


### PR DESCRIPTION
## Summary
- add Python and TypeScript validators that produce UI-friendly species summaries
- seed the repository with a sample species catalog and expose the validators via CI
- add a React TV widget to display budget, synergies, counters, and warnings

## Testing
- python3 tools/py/validate_species.py data/species.yaml
- (cd tools/ts && npm run validate:species)


------
https://chatgpt.com/codex/tasks/task_e_68fb5177dd3083328f0b7a67f3af8f6c