### PR TITLE
Add compatibility profile for neutral form

### DIFF
--- a/.github/workflows/deploy-test-interface.yml
+++ b/.github/workflows/deploy-test-interface.yml
@@ -22,6 +22,35 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: tools/ts/package-lock.json
+
+      - name: Install Node.js dependencies
+        working-directory: tools/ts
+        run: npm ci
+
+      - name: Run TypeScript tests
+        working-directory: tools/ts
+        run: npm test
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python test dependencies
+        run: pip install pytest
+
+      - name: Run Python tests
+        run: PYTHONPATH=tools/py pytest
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
       - name: Prepare static site
         run: |
           rm -rf dist

--- a/README.md
+++ b/README.md
@@ -54,10 +54,13 @@ python3 generate_encounter.py savana
 ## Interfaccia test & recap via web
 - [Apri la dashboard](docs/test-interface/index.html) per consultare rapidamente pacchetti PI,
   telemetria VC, biomi e compatibilità delle forme (funziona sia in locale sia online).
-- **Online subito (GitHub Pages)**: abilita la pubblicazione da `Settings → Pages → Build and
-  deployment → Deploy from a branch`, scegli `work` (o il branch desiderato) e la cartella `/docs/`.
-  L'URL diventa `https://<tuo-utente>.github.io/<repo>/test-interface/`, con fetch automatico degli
-  YAML via `raw`.
+- **Online automatico (GitHub Pages)**: il workflow [`deploy-test-interface`](.github/workflows/deploy-test-interface.yml)
+  pubblica in modo continuativo i contenuti della dashboard e i dataset YAML ad ogni push su `main`.
+  Dopo aver abilitato *una sola volta* GitHub Pages (`Settings → Pages → Build and deployment → GitHub Actions`),
+  il sito sarà sempre raggiungibile da `https://<tuo-utente>.github.io/<repo>/test-interface/` (o dal dominio
+  personalizzato) con fetch automatico degli YAML direttamente dal branch indicato. Prima del deploy il workflow
+  lancia le suite di test TypeScript (`npm test` in `tools/ts`) e Python (`PYTHONPATH=tools/py pytest`) per garantire
+  che la dashboard rifletta dati validi e CLI funzionanti.
 - **Uso locale**: avvia un server dalla radice (`python3 -m http.server 8000`) e visita
   `http://localhost:8000/docs/test-interface/` per lavorare offline.
 - Premi "Ricarica dati YAML" dopo aver modificato i file in `data/`, quindi "Esegui test" per i

--- a/data/mating.yaml
+++ b/data/mating.yaml
@@ -336,6 +336,28 @@ compat_forme:  # Esempi — completare 16x16 nel design
       - Allineare i piani di crescita con i suoi obiettivi ambiziosi
       - Fornire indicatori di performance aggressivi
     base_scores: {like: 4, neutral: 2, dislike: 1}
+  NEUTRA:
+    archetype: "Forma modulare"
+    overview: >-
+      Profilo di default per i test: bilancia i pacchetti senza preferenze
+      marcate, utile come base neutra e come placeholder durante la
+      creazione di nuove forme o per sessioni introduttive.
+    likes: [ISTJ, ENTP, ENFP]
+    neutrals: [ISFJ, ESTJ, INTP, ENFJ]
+    dislikes: [ISTP, ESTP]
+    strengths:
+      - Adattabilità immediata ai pacchetti standard
+      - Facilità nel seguire istruzioni e protocolli condivisi
+      - Ottimo banco di prova per bilanciare nuovi moduli
+    stress_triggers:
+      - Sovraccarico di specializzazioni contrastanti
+      - Squadre che cambiano focus senza briefing
+      - Pressioni per assumere ruoli estremi
+    collaboration_hooks:
+      - Usarla per testare configurazioni non classificate
+      - Affidarle ruoli di supporto generico o di backup
+      - Condividerle metriche chiare per valutare le iterazioni
+    base_scores: {like: 3, neutral: 2, dislike: 1}
 compat_ennea:
   Coordinatore(2): {likes: ["assist","shield_share","revive"], dislike: ["abandon_ally","selfish_loot"]}
   Conquistatore(3): {likes: ["apex_kill","first_strike"], dislike: ["stall","retreat"]}

--- a/docs/test-interface/index.html
+++ b/docs/test-interface/index.html
@@ -10,23 +10,86 @@
     <script defer src="app.js"></script>
   </head>
   <body>
-    <header>
-      <h1>Evo-Tactics · Interfaccia Test &amp; Recap</h1>
-      <p class="tagline">
-        Dashboard rapida per ispezionare pacchetti PI, telemetria VC e accoppiamenti MBTI.
-      </p>
-      <nav class="utility-nav" aria-label="Navigazione secondaria">
-        <a href="auto-fetch.html">Apri il fetch automatico YAML</a>
+    <header class="site-hero">
+      <div class="hero-content">
+        <p class="hero-kicker">Mission Control · Evo-Tactics</p>
+        <h1>Interfaccia Test &amp; Recap per il progetto di gioco</h1>
+        <p class="tagline">
+          Un'unica plancia per seguire forme MBTI, telemetria VC, negozio PI e biomi mutanti durante il playtest.
+          Tutto è pensato per raccontare l'identità del progetto e accelerare le sessioni sul campo.
+        </p>
+        <div class="hero-actions">
+          <button id="reload-data" type="button">Ricarica dati YAML</button>
+          <a class="pill-link" href="auto-fetch.html">Fetch automatico</a>
+          <a class="pill-link" href="../01-VISIONE.md" target="_blank" rel="noopener">Visione del progetto</a>
+        </div>
+        <p class="hint">
+          La pagina rileva automaticamente la sorgente dati: funzionerà sia su GitHub Pages (fetch <code>raw</code>)
+          sia in locale con un semplice server.
+        </p>
+        <p id="data-source" class="hint secondary">Sorgente dati: in rilevamento…</p>
+      </div>
+      <nav class="primary-nav" aria-label="Navigazione principale">
+        <ul>
+          <li><a href="#control">Controllo dati</a></li>
+          <li><a href="#overview">Overview</a></li>
+          <li><a href="#forms">Forme MBTI</a></li>
+          <li><a href="#pi-shop">Negozio PI</a></li>
+          <li><a href="#random-table">Tabella d20</a></li>
+          <li><a href="#telemetry">Telemetria</a></li>
+          <li><a href="#biomes">Biomi</a></li>
+          <li><a href="#species">Specie</a></li>
+          <li><a href="#playtest-tools">Playtest</a></li>
+        </ul>
       </nav>
-      <button id="reload-data" type="button">Ricarica dati YAML</button>
-      <p class="hint">
-        La pagina rileva automaticamente la sorgente dati: funzionerà sia su GitHub Pages (fetch <code>raw</code>)
-        sia in locale con un semplice server.
-      </p>
-      <p id="data-source" class="hint secondary">Sorgente dati: in rilevamento…</p>
     </header>
 
     <main>
+      <section id="project-overview" class="panel project-lore">
+        <div class="panel-header">
+          <h2>DNA del progetto</h2>
+          <p class="muted">Estratto da visione, pilastri e sistema tattico di Evo-Tactics.</p>
+        </div>
+        <div class="lore-grid">
+          <article class="lore-card">
+            <h3>Visione &amp; tono</h3>
+            <p>
+              Evo-Tactics racconta cellule di team specializzate che affrontano ecosistemi instabili con adattamenti
+              evolutivi. La plancia mette al centro lettura rapida, intelligenza collettiva e un tono techno-biologico.
+            </p>
+            <ul>
+              <li>Squadre ibride, half-scientist half-explorer.</li>
+              <li>Temi di adattamento ed evoluzione continua.</li>
+              <li>Playtest guidato da dati, telemetria e story beats.</li>
+            </ul>
+          </article>
+          <article class="lore-card">
+            <h3>Pilastri tattici</h3>
+            <p>
+              Dal <em>Sistema Tattico</em>: slot PI, hook collaborativi e bias di forma guidano ogni decisione durante la
+              sessione. Questa dashboard rende immediata la consultazione di pacchetti A/B/C e interazioni VC.
+            </p>
+            <ul>
+              <li>Gestione delle forme tramite pacchetti PI.</li>
+              <li>Caps e rarità sempre a portata di mano.</li>
+              <li>Integrazione con telemetria VC e random table.</li>
+            </ul>
+          </article>
+          <article class="lore-card">
+            <h3>Focus playtest</h3>
+            <p>
+              Ogni iterazione punta a stressare loop di missione, incontri bioma e compatibilità MBTI. Qui trovi strumenti
+              rapidi per roll, generazione incontri e monitoraggio dei dati caricati.
+            </p>
+            <ul>
+              <li>Controlli rapidi sui dataset YAML.</li>
+              <li>Riepilogo sinergie bioma e mutazioni.</li>
+              <li>Spotlight su specie e combinazioni slot.</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
       <section id="control" class="panel">
         <h2>Controllo dati &amp; Fetching</h2>
         <div class="control-grid">
@@ -80,6 +143,14 @@
           <article>
             <h3>Biomi attivi</h3>
             <p class="metric" data-metric="biomes">—</p>
+          </article>
+          <article>
+            <h3>Moduli specie catalogati</h3>
+            <p class="metric" data-metric="species-slots">—</p>
+          </article>
+          <article>
+            <h3>Trigger sinergici</h3>
+            <p class="metric" data-metric="species-synergies">—</p>
           </article>
         </div>
         <p class="timestamp" id="last-updated">Dati non caricati.</p>
@@ -135,6 +206,16 @@
       <section id="biomes" class="panel">
         <h2>Biomi &amp; Mutazioni</h2>
         <div id="biomes-grid" class="content-placeholder">
+          <p>In attesa di dati…</p>
+        </div>
+      </section>
+
+      <section id="species" class="panel">
+        <div class="panel-header">
+          <h2>Specie sintetiche &amp; sinergie slot</h2>
+          <p class="muted">Panoramica veloce su catalogo slot, moduli e trigger combinati dal file <code>species.yaml</code>.</p>
+        </div>
+        <div id="species-showcase" class="content-placeholder">
           <p>In attesa di dati…</p>
         </div>
       </section>

--- a/docs/test-interface/styles.css
+++ b/docs/test-interface/styles.css
@@ -1,13 +1,15 @@
 :root {
   color-scheme: light dark;
-  --bg: #0f172a;
-  --bg-panel: rgba(15, 23, 42, 0.75);
+  --bg: #0b1120;
+  --bg-panel: rgba(13, 23, 42, 0.85);
   --bg-panel-light: rgba(30, 41, 59, 0.6);
   --text: #e2e8f0;
   --accent: #38bdf8;
+  --accent-secondary: #f97316;
   --accent-soft: rgba(56, 189, 248, 0.2);
-  --border: rgba(148, 163, 184, 0.3);
+  --border: rgba(148, 163, 184, 0.32);
   --muted: #94a3b8;
+  --glow: rgba(56, 189, 248, 0.35);
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
@@ -17,9 +19,125 @@
 
 body {
   margin: 0;
-  background: linear-gradient(160deg, #0f172a 0%, #1e293b 55%, #020617 100%);
+  background: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.12), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(249, 115, 22, 0.18), transparent 50%),
+    linear-gradient(160deg, #0b1120 0%, #111c30 45%, #020617 100%);
   color: var(--text);
   min-height: 100vh;
+}
+
+.site-hero {
+  padding: clamp(3rem, 5vw, 5rem) 1.5rem 2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.site-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 15% 15%, rgba(56, 189, 248, 0.22), transparent 60%),
+    radial-gradient(circle at 80% 10%, rgba(249, 115, 22, 0.15), transparent 55%);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.hero-content {
+  position: relative;
+  max-width: 840px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.hero-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.75rem;
+  color: var(--accent);
+  margin-bottom: 1rem;
+}
+
+.hero-content h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2.25rem, 4vw, 3.25rem);
+  text-wrap: balance;
+}
+
+.hero-actions {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin: 2rem auto 0;
+}
+
+.hero-actions button {
+  font-size: 1rem;
+  padding: 0.85rem 1.75rem;
+}
+
+.pill-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  color: var(--text);
+  text-decoration: none;
+  background: rgba(15, 23, 42, 0.65);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.45);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pill-link::after {
+  content: "↗";
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.pill-link:hover {
+  transform: translateY(-1px);
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.6);
+}
+
+.primary-nav {
+  position: relative;
+  margin: clamp(2.5rem, 5vw, 4rem) auto 0;
+  padding: 0 1.5rem;
+}
+
+.primary-nav ul {
+  list-style: none;
+  margin: 0 auto;
+  padding: 0.85rem 1.25rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+  max-width: 960px;
+  border-radius: 999px;
+  backdrop-filter: blur(16px);
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+}
+
+.primary-nav a {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.9rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.primary-nav a:hover,
+.primary-nav a:focus {
+  color: var(--text);
+  background: rgba(56, 189, 248, 0.15);
 }
 
 header,
@@ -78,6 +196,59 @@ main {
 
 .muted {
   color: var(--muted);
+}
+
+.project-lore {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.12), rgba(56, 189, 248, 0))
+      border-box,
+    var(--bg-panel) padding-box;
+  border: 1px solid rgba(56, 189, 248, 0.35);
+}
+
+.project-lore .panel-header {
+  align-items: flex-start;
+}
+
+.lore-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.lore-card {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1.1rem;
+  padding: 1.35rem;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.35);
+}
+
+.lore-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.lore-card p {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  color: var(--muted);
+}
+
+.lore-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.lore-card li {
+  margin-bottom: 0.35rem;
+}
+
+.content-placeholder {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  padding: 1.5rem;
 }
 
 .panel {
@@ -400,6 +571,159 @@ main {
   padding: 0.85rem;
   font-size: 0.95rem;
   line-height: 1.5;
+}
+
+#species-showcase {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.species-overview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.species-metric {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.35);
+}
+
+.species-metric span {
+  display: block;
+}
+
+.species-metric .label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.species-metric .value {
+  margin-top: 0.5rem;
+  font-size: 1.85rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.species-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+}
+
+.species-card {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 1.1rem;
+  padding: 1.1rem;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.species-rules {
+  background: rgba(56, 189, 248, 0.1);
+  border-color: rgba(56, 189, 248, 0.35);
+}
+
+.species-rules li {
+  background: rgba(15, 23, 42, 0.6);
+  border-color: rgba(56, 189, 248, 0.28);
+}
+
+.species-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.species-card .slot-meta {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.species-card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.species-card li {
+  padding: 0.55rem 0.65rem;
+  border-radius: 0.75rem;
+  background: rgba(56, 189, 248, 0.08);
+  border: 1px solid rgba(56, 189, 248, 0.18);
+  color: rgba(224, 242, 254, 0.95);
+  font-size: 0.9rem;
+}
+
+.species-card li.muted {
+  background: rgba(15, 23, 42, 0.6);
+  border-color: rgba(148, 163, 184, 0.25);
+  color: var(--muted);
+}
+
+.species-card li strong {
+  display: block;
+  font-size: 0.95rem;
+  color: rgba(241, 245, 249, 0.95);
+}
+
+.species-card li span {
+  display: block;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.85);
+  margin-top: 0.25rem;
+}
+
+.species-synergies {
+  background: rgba(249, 115, 22, 0.12);
+  border: 1px solid rgba(249, 115, 22, 0.35);
+  border-radius: 1.1rem;
+  padding: 1.25rem;
+}
+
+.species-synergies h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  color: rgba(255, 247, 237, 0.95);
+}
+
+.species-synergies ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.species-synergies li {
+  display: grid;
+  gap: 0.35rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid rgba(249, 115, 22, 0.25);
+}
+
+.species-synergies li:last-child {
+  border-bottom: none;
+}
+
+.species-synergies .trigger {
+  font-size: 0.8rem;
+  color: rgba(249, 250, 251, 0.85);
+}
+
+.species-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: var(--muted);
 }
 
 .result-block p {


### PR DESCRIPTION
## Summary
- add the missing NEUTRA form entry to the compatibility tables so dashboard tests cover every pack profile

## Testing
- PYTHONPATH=tools/py pytest
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fb7bb1c7c4833283278cb6d108e61d