### PR TITLE
Add dashboard shortcuts to support hub

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,37 +2,255 @@
 <html lang="it">
   <head>
     <meta charset="utf-8" />
-    <title>Evo-Tactics · Dashboard test</title>
-    <meta http-equiv="refresh" content="0; url=test-interface/" />
-    <link rel="canonical" href="test-interface/" />
-    <style>
-      body {
-        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 100vh;
-        margin: 0;
-        background: #0d1117;
-        color: #f0f6fc;
-      }
-      main {
-        text-align: center;
-        max-width: 480px;
-      }
-      a {
-        color: #58a6ff;
-      }
-    </style>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Evo-Tactics · Support Hub</title>
+    <meta
+      name="description"
+      content="Centro di supporto per il progetto Evo-Tactics: stato aggiornamenti, test di simulazioni e link rapidi alla documentazione."
+    />
+    <link rel="stylesheet" href="site.css" />
+    <script type="module" src="site.js" defer></script>
   </head>
   <body>
-    <main>
-      <h1>Evo-Tactics · Interfaccia Test &amp; Recap</h1>
-      <p>Reindirizzamento automatico all'interfaccia di test…</p>
-      <p>
-        Se il browser non reindirizza automaticamente, clicca qui:
-        <a href="test-interface/">Apri l'interfaccia</a>.
-      </p>
+    <header class="hero">
+      <div class="hero__inner">
+        <div class="hero__content">
+          <p class="hero__tagline">Supporto produzione</p>
+          <h1>Centro di Controllo Evo-Tactics</h1>
+          <p class="hero__description">
+            Un'unica plancia per seguire lo sviluppo del sistema, monitorare gli aggiornamenti
+            GitHub e provare rapidamente le nuove feature caricate sui branch di lavoro.
+          </p>
+          <div class="hero__actions">
+            <button type="button" class="button" id="hero-open-simulator">Apri il simulatore</button>
+            <a class="button button--secondary" href="40-ROADMAP.md">Roadmap</a>
+            <a class="button button--ghost" href="00-INDEX.md">Indice documentazione</a>
+          </div>
+        </div>
+        <aside class="hero__meta" aria-live="polite">
+          <div class="meta-card">
+            <span class="meta-card__label">Ultimo aggiornamento</span>
+            <strong class="meta-card__value" id="last-activity">In caricamento…</strong>
+          </div>
+          <div class="meta-card">
+            <span class="meta-card__label">Branch monitorata</span>
+            <strong class="meta-card__value" id="active-branch">—</strong>
+          </div>
+          <div class="meta-card">
+            <span class="meta-card__label">Feed changelog</span>
+            <strong class="meta-card__value" id="changelog-status">In caricamento…</strong>
+          </div>
+        </aside>
+      </div>
+      <nav class="hero__nav" aria-label="Navigazione principale">
+        <a href="#overview">Panoramica</a>
+        <a href="#updates">Aggiornamenti</a>
+        <a href="#simulator">Simulazioni</a>
+        <a href="#dashboards">Dashboard</a>
+        <a href="#resources">Risorse</a>
+      </nav>
+    </header>
+    <main class="layout">
+      <section id="overview" class="section">
+        <div class="section__header">
+          <h2>Panoramica</h2>
+          <p>
+            Organizza attività e verifiche del progetto da un'unica schermata. Salva le impostazioni
+            preferite per il repository GitHub e apri il simulatore con la base dati corretta in
+            pochi click.
+          </p>
+        </div>
+        <div class="grid grid--quick">
+          <article class="card">
+            <h3>Monitoraggio continuo</h3>
+            <p>
+              Il feed degli ultimi commit si aggiorna automaticamente usando le API GitHub.
+              Imposta l'organizzazione e il branch da tenere sotto osservazione e resta sempre
+              allineato.
+            </p>
+            <ul>
+              <li>Storico in tempo reale degli ultimi push</li>
+              <li>Indicazione immediata del branch attivo</li>
+              <li>Segnalazione errori in caso di rate limit</li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>Gestione dati simulatore</h3>
+            <p>
+              Seleziona il branch o una base dati personalizzata per provare pack e tabelle
+              aggiornate all'ultimo commit. L'URL viene salvato e riutilizzato per caricamenti
+              successivi.
+            </p>
+            <ul>
+              <li>Compatibile con sorgenti <code>raw.githubusercontent.com</code></li>
+              <li>Anteprima del percorso attivo</li>
+              <li>Supporto parametri <code>ref</code> e <code>data-root</code></li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>Documentazione integrata</h3>
+            <p>
+              Collegamenti rapidi ai documenti chiave: roadmap, checklist di produzione e log di
+              manutenzione restano sempre a portata di mano.
+            </p>
+            <ul>
+              <li>Accesso immediato al changelog</li>
+              <li>Indice completo dei capitoli di design</li>
+              <li>Riferimenti a procedure e tool interni</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+      <section id="updates" class="section section--split">
+        <div class="section__header">
+          <h2>Aggiornamenti</h2>
+          <p>
+            Consulta il changelog ufficiale e l'attività del repository per preparare review,
+            release e sessioni di playtest.
+          </p>
+        </div>
+        <div class="split">
+          <article class="card card--list" aria-live="polite">
+            <div class="card__header">
+              <h3>Changelog progetto</h3>
+              <button type="button" class="button button--ghost" id="refresh-changelog">Aggiorna</button>
+            </div>
+            <div id="changelog-feed" class="feed feed--changelog">
+              <p class="placeholder">Caricamento del changelog in corso…</p>
+            </div>
+          </article>
+          <article class="card card--list" aria-live="polite">
+            <div class="card__header">
+              <h3>Attività repository</h3>
+              <button type="button" class="button button--ghost" id="refresh-activity">Aggiorna</button>
+            </div>
+            <div id="activity-feed" class="feed feed--activity">
+              <p class="placeholder">Configura il repository per iniziare il monitoraggio.</p>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section id="simulator" class="section">
+        <div class="section__header">
+          <h2>Simulazioni &amp; test</h2>
+          <p>
+            Avvia l'interfaccia di prova direttamente da qui. Personalizza la sorgente dati per
+            verificare feature in anteprima oppure usa la configurazione di default del branch.
+          </p>
+        </div>
+        <div class="grid grid--two">
+          <article class="card">
+            <h3>Configurazione sorgenti</h3>
+            <form id="config-form" class="form">
+              <label for="repo-input">Repository GitHub</label>
+              <input id="repo-input" name="repo" type="text" autocomplete="off" placeholder="organizzazione/progetto" />
+              <label for="branch-input">Branch o ref</label>
+              <input id="branch-input" name="branch" type="text" autocomplete="off" placeholder="main" />
+              <label for="data-root-input">Base dati personalizzata (opzionale)</label>
+              <input
+                id="data-root-input"
+                name="dataRoot"
+                type="url"
+                autocomplete="off"
+                placeholder="https://raw.githubusercontent.com/organizzazione/progetto/branch/docs/test-interface/"
+              />
+              <p class="form__hint">
+                Lascia vuoto per usare automaticamente il percorso raw del branch selezionato.
+              </p>
+              <button type="submit" class="button">Salva configurazione</button>
+            </form>
+            <div class="stack">
+              <div class="stack__row">
+                <span class="stack__label">Data root attiva:</span>
+                <a id="data-root-preview" href="test-interface/" target="_blank" rel="noreferrer">test-interface/</a>
+              </div>
+              <div class="stack__row">
+                <span class="stack__label">URL simulatore:</span>
+                <a id="simulator-link" href="test-interface/" target="_blank" rel="noreferrer">test-interface/</a>
+              </div>
+            </div>
+            <div class="form__actions">
+              <button type="button" class="button button--secondary" id="open-simulator">Apri in nuova scheda</button>
+              <button type="button" class="button button--ghost" id="reset-config">Ripristina automatico</button>
+            </div>
+          </article>
+          <article class="card card--frame">
+            <h3>Anteprima interfaccia</h3>
+            <iframe
+              id="simulator-frame"
+              title="Interfaccia di test Evo-Tactics"
+              src="test-interface/"
+              loading="lazy"
+              referrerpolicy="no-referrer"
+              sandbox="allow-scripts allow-same-origin allow-forms"
+            ></iframe>
+          </article>
+        </div>
+      </section>
+      <section id="dashboards" class="section">
+        <div class="section__header">
+          <h2>Dashboard dedicate</h2>
+          <p>
+            Accedi rapidamente alle plance esistenti nel repository per verificare dataset YAML,
+            monitorare i playtest e seguire gli snapshot storici del progetto.
+          </p>
+        </div>
+        <div class="grid grid--resources">
+          <article class="card card--link">
+            <h3>Interfaccia Test &amp; Recap</h3>
+            <p>
+              Dashboard principale con riepiloghi MBTI, telemetria VC, negozio PI e strumenti di
+              fetch manuale dei dataset.
+            </p>
+            <a href="test-interface/index.html" class="button button--ghost">Apri dashboard</a>
+          </article>
+          <article class="card card--link">
+            <h3>Fetch automatico YAML</h3>
+            <p>
+              Pannello dedicato che scarica e valida tutti i file YAML dalla cartella
+              <code>data/</code> in modo automatico, segnalando errori di parsing o HTTP.
+            </p>
+            <a href="test-interface/auto-fetch.html" class="button button--ghost">Avvia fetch</a>
+          </article>
+        </div>
+      </section>
+      <section id="resources" class="section">
+        <div class="section__header">
+          <h2>Risorse utili</h2>
+          <p>
+            Collegamenti rapidi ai documenti di progetto: linee guida, checklist operative e report
+            di manutenzione.
+          </p>
+        </div>
+        <div class="grid grid--resources">
+          <article class="card card--link">
+            <h3>Checklist produzione</h3>
+            <p>Verifica gli step da completare prima di ogni release.</p>
+            <a href="checklist/action-items.md" class="button button--ghost">Apri checklist</a>
+          </article>
+          <article class="card card--link">
+            <h3>Registro manutenzione tool</h3>
+            <p>Storico delle operazioni effettuate sugli strumenti interni.</p>
+            <a href="tool_run_report.md" class="button button--ghost">Visualizza log</a>
+          </article>
+          <article class="card card--link">
+            <h3>Telemetria &amp; metriche</h3>
+            <p>Analisi dettagliata in <code>24-TELEMETRIA_VC.md</code> e dataset correlati.</p>
+            <a href="24-TELEMETRIA_VC.md" class="button button--ghost">Apri documento</a>
+          </article>
+          <article class="card card--link">
+            <h3>Documentazione UI</h3>
+            <p>Specifiche dell'interfaccia televisiva e componenti di identità visiva.</p>
+            <a href="30-UI_TV_IDENTITA.md" class="button button--ghost">Consulta specifiche</a>
+          </article>
+        </div>
+      </section>
     </main>
+    <footer class="footer">
+      <p>
+        Evo-Tactics · Centro di controllo sperimentale. Per feedback o suggerimenti apri una issue
+        su GitHub dopo aver sincronizzato i dati da questa dashboard.
+      </p>
+    </footer>
   </body>
 </html>

--- a/docs/site.css
+++ b/docs/site.css
@@ -1,0 +1,493 @@
+:root {
+  color-scheme: dark;
+  --bg: #05070b;
+  --surface: rgba(22, 27, 34, 0.75);
+  --surface-strong: rgba(13, 17, 23, 0.9);
+  --border: rgba(110, 118, 129, 0.3);
+  --border-strong: rgba(110, 118, 129, 0.6);
+  --accent: #58a6ff;
+  --accent-strong: #388bfd;
+  --accent-muted: rgba(88, 166, 255, 0.1);
+  --text: #f0f6fc;
+  --text-muted: #8b949e;
+  --shadow: 0 24px 60px rgba(2, 6, 23, 0.65);
+  --radius: 20px;
+  --transition: 200ms ease;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(88, 166, 255, 0.15), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(191, 90, 242, 0.1), transparent 50%), var(--bg);
+  color: var(--text);
+  min-height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+}
+
+.hero {
+  padding: 48px 5vw 24px;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: -120px;
+  background: radial-gradient(circle at 20% 20%, rgba(88, 166, 255, 0.35), transparent 60%),
+    radial-gradient(circle at 80% 0%, rgba(191, 90, 242, 0.25), transparent 55%);
+  filter: blur(40px);
+  opacity: 0.7;
+  z-index: 0;
+}
+
+.hero__inner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 32px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.hero__content {
+  max-width: 620px;
+}
+
+.hero__tagline {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin: 0 0 12px;
+}
+
+.hero__description {
+  color: var(--text-muted);
+  max-width: 520px;
+  line-height: 1.6;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.button {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 10px 20px;
+  background: linear-gradient(120deg, rgba(88, 166, 255, 0.85), rgba(56, 139, 253, 0.95));
+  color: #010409;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition), filter var(--transition);
+  box-shadow: 0 14px 30px rgba(56, 139, 253, 0.35);
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.button--secondary {
+  background: transparent;
+  color: var(--accent);
+  border-color: var(--accent-strong);
+  box-shadow: inset 0 0 0 1px rgba(88, 166, 255, 0.4);
+}
+
+.button--ghost {
+  background: rgba(88, 166, 255, 0.12);
+  color: var(--accent);
+  border-color: rgba(88, 166, 255, 0.2);
+  box-shadow: none;
+}
+
+.button--secondary:hover,
+.button--ghost:hover,
+.button--secondary:focus-visible,
+.button--ghost:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(88, 166, 255, 0.18);
+}
+
+.hero__meta {
+  display: grid;
+  gap: 16px;
+  min-width: 240px;
+}
+
+.meta-card {
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 18px 20px;
+  backdrop-filter: blur(12px);
+  box-shadow: var(--shadow);
+}
+
+.meta-card__label {
+  display: block;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.meta-card__value {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.hero__nav {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  gap: 16px;
+  margin-top: 32px;
+  flex-wrap: wrap;
+}
+
+.hero__nav a {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(240, 246, 252, 0.08);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  transition: background var(--transition), color var(--transition);
+}
+
+.hero__nav a:hover,
+.hero__nav a:focus-visible {
+  background: rgba(88, 166, 255, 0.18);
+  color: var(--text);
+}
+
+.layout {
+  flex: 1;
+  padding: 24px 5vw 80px;
+}
+
+.section {
+  margin-bottom: 72px;
+}
+
+.section__header {
+  max-width: 760px;
+  margin-bottom: 32px;
+}
+
+.section__header h2 {
+  margin: 0 0 12px;
+  font-size: 2rem;
+}
+
+.section__header p {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.grid {
+  display: grid;
+  gap: 24px;
+}
+
+.grid--quick {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.grid--two {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: stretch;
+}
+
+.grid--resources {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 28px;
+  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.card p {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.card ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-muted);
+  display: grid;
+  gap: 6px;
+}
+
+.card--list {
+  gap: 0;
+  padding: 24px;
+}
+
+.card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.feed {
+  display: grid;
+  gap: 16px;
+  max-height: 420px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.feed::-webkit-scrollbar {
+  width: 8px;
+}
+
+.feed::-webkit-scrollbar-thumb {
+  background: rgba(88, 166, 255, 0.25);
+  border-radius: 999px;
+}
+
+.feed__item {
+  border: 1px solid rgba(88, 166, 255, 0.12);
+  border-radius: 16px;
+  padding: 16px;
+  background: rgba(15, 20, 28, 0.7);
+  display: grid;
+  gap: 10px;
+}
+
+.feed__item h4 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.feed__item time {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.feed__item ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.feed__item p {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.feed__item a {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.placeholder {
+  margin: 0;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.form {
+  display: grid;
+  gap: 12px;
+}
+
+.form label {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.form input {
+  background: rgba(15, 20, 28, 0.85);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px 14px;
+  color: var(--text);
+  font-size: 0.95rem;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.form input:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(88, 166, 255, 0.2);
+}
+
+.form__hint {
+  margin: -4px 0 0;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.form__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.stack {
+  margin-top: 24px;
+  border: 1px dashed var(--border);
+  border-radius: 16px;
+  padding: 16px;
+  display: grid;
+  gap: 10px;
+  background: rgba(88, 166, 255, 0.05);
+}
+
+.stack__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.stack__label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.card--frame {
+  gap: 16px;
+}
+
+.card--frame iframe {
+  width: 100%;
+  min-height: 520px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: rgba(15, 20, 28, 0.6);
+}
+
+.section--split .split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.card--link {
+  gap: 18px;
+  text-align: left;
+}
+
+.card--link .button {
+  align-self: flex-start;
+}
+
+.footer {
+  padding: 32px 5vw 40px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  background: rgba(2, 6, 23, 0.7);
+  border-top: 1px solid rgba(88, 166, 255, 0.12);
+}
+
+.footer p {
+  margin: 0;
+  max-width: 720px;
+}
+
+@media (max-width: 960px) {
+  .hero__inner {
+    flex-direction: column;
+  }
+
+  .hero__meta {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+
+  .hero__content {
+    max-width: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: 32px 5vw 16px;
+  }
+
+  .layout {
+    padding: 24px 5vw 60px;
+  }
+
+  .card {
+    padding: 22px;
+  }
+
+  .card--list {
+    padding: 20px;
+  }
+
+  .card--frame iframe {
+    min-height: 420px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/docs/site.js
+++ b/docs/site.js
@@ -1,0 +1,452 @@
+const STORAGE_KEY = "evo-support-hub-config";
+
+const elements = {
+  repoInput: document.getElementById("repo-input"),
+  branchInput: document.getElementById("branch-input"),
+  dataRootInput: document.getElementById("data-root-input"),
+  configForm: document.getElementById("config-form"),
+  resetButton: document.getElementById("reset-config"),
+  openButton: document.getElementById("open-simulator"),
+  heroOpenButton: document.getElementById("hero-open-simulator"),
+  simulatorFrame: document.getElementById("simulator-frame"),
+  simulatorLink: document.getElementById("simulator-link"),
+  dataRootPreview: document.getElementById("data-root-preview"),
+  refreshActivity: document.getElementById("refresh-activity"),
+  refreshChangelog: document.getElementById("refresh-changelog"),
+  activityFeed: document.getElementById("activity-feed"),
+  changelogFeed: document.getElementById("changelog-feed"),
+  lastActivity: document.getElementById("last-activity"),
+  activeBranch: document.getElementById("active-branch"),
+  changelogStatus: document.getElementById("changelog-status"),
+};
+
+const defaultConfig = {
+  repo: detectDefaultRepo(),
+  branch: "main",
+  dataRoot: "",
+};
+
+let currentConfig = loadConfig();
+
+function detectDefaultRepo() {
+  try {
+    if (window.location.hostname.endsWith("github.io")) {
+      const [owner] = window.location.hostname.split(".");
+      const [repo] = window.location.pathname.split("/").filter(Boolean);
+      if (owner && repo) {
+        return `${owner}/${repo}`;
+      }
+    }
+  } catch (error) {
+    console.warn("Impossibile rilevare repository di default", error);
+  }
+  return "";
+}
+
+function loadConfig() {
+  try {
+    const saved = window.localStorage?.getItem(STORAGE_KEY);
+    if (saved) {
+      return { ...defaultConfig, ...JSON.parse(saved) };
+    }
+  } catch (error) {
+    console.warn("Impossibile leggere la configurazione salvata", error);
+  }
+  return { ...defaultConfig };
+}
+
+function saveConfig(config) {
+  try {
+    window.localStorage?.setItem(STORAGE_KEY, JSON.stringify(config));
+  } catch (error) {
+    console.warn("Impossibile salvare la configurazione", error);
+  }
+}
+
+function sanitizeRepo(value) {
+  if (!value) return "";
+  return value
+    .trim()
+    .replace(/^https?:\/\/github.com\//i, "")
+    .replace(/\.git$/i, "");
+}
+
+function ensureTrailingSlash(value) {
+  if (!value) return value;
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function computeDataRoot(config = currentConfig) {
+  if (config.dataRoot) {
+    return ensureTrailingSlash(config.dataRoot.trim());
+  }
+  if (config.repo && config.branch) {
+    return ensureTrailingSlash(
+      `https://raw.githubusercontent.com/${config.repo}/${config.branch}/docs/test-interface/`
+    );
+  }
+  return "test-interface/";
+}
+
+function computeSimulatorUrl(config = currentConfig) {
+  let baseReference = window.location.href;
+  try {
+    if (window.location.origin && window.location.origin !== "null") {
+      baseReference = window.location.origin + window.location.pathname;
+    }
+  } catch (error) {
+    console.warn("Impossibile calcolare la base di riferimento", error);
+  }
+
+  const url = new URL("test-interface/", baseReference);
+  const params = new URLSearchParams();
+  const dataRoot = computeDataRoot(config);
+  if (dataRoot) {
+    params.set("data-root", dataRoot);
+  }
+  if (config.branch) {
+    params.set("ref", config.branch);
+  }
+  url.search = params.toString();
+  return url.toString();
+}
+
+function updateSimulatorPreview() {
+  const dataRoot = computeDataRoot();
+  const simulatorUrl = computeSimulatorUrl();
+
+  if (elements.dataRootPreview) {
+    elements.dataRootPreview.textContent = dataRoot;
+    elements.dataRootPreview.href = dataRoot.startsWith("http") ? dataRoot : simulatorUrl;
+  }
+
+  if (elements.simulatorLink) {
+    elements.simulatorLink.textContent = simulatorUrl;
+    elements.simulatorLink.href = simulatorUrl;
+  }
+
+  if (elements.simulatorFrame) {
+    elements.simulatorFrame.src = simulatorUrl;
+  }
+}
+
+function populateForm() {
+  if (elements.repoInput) {
+    elements.repoInput.value = currentConfig.repo;
+  }
+  if (elements.branchInput) {
+    elements.branchInput.value = currentConfig.branch;
+  }
+  if (elements.dataRootInput) {
+    elements.dataRootInput.value = currentConfig.dataRoot;
+  }
+}
+
+function formatDate(value) {
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return date.toLocaleString("it-IT", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+  } catch (error) {
+    console.warn("Impossibile formattare la data", value, error);
+    return value;
+  }
+}
+
+function setActivityPlaceholder(message) {
+  if (elements.activityFeed) {
+    elements.activityFeed.innerHTML = `<p class="placeholder">${message}</p>`;
+  }
+}
+
+function renderActivity(commits = []) {
+  if (!elements.activityFeed) return;
+  if (!commits.length) {
+    setActivityPlaceholder("Nessun commit recente trovato per la configurazione selezionata.");
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  commits.forEach((commit) => {
+    const item = document.createElement("article");
+    item.className = "feed__item";
+
+    const title = document.createElement("h4");
+    title.textContent = commit.title;
+
+    const meta = document.createElement("div");
+    meta.className = "feed__meta";
+
+    const author = document.createElement("span");
+    author.textContent = commit.author;
+    author.style.color = "var(--text-muted)";
+
+    const time = document.createElement("time");
+    time.dateTime = commit.date;
+    time.textContent = formatDate(commit.date);
+
+    meta.append(author, document.createTextNode(" • "), time);
+
+    const link = document.createElement("a");
+    link.href = commit.url;
+    link.target = "_blank";
+    link.rel = "noreferrer";
+    link.textContent = `Apri ${commit.sha.slice(0, 7)}`;
+
+    item.append(title, meta, link);
+    fragment.appendChild(item);
+  });
+
+  elements.activityFeed.innerHTML = "";
+  elements.activityFeed.appendChild(fragment);
+}
+
+async function loadActivity() {
+  if (!currentConfig.repo) {
+    setActivityPlaceholder("Configura il repository per iniziare il monitoraggio.");
+    if (elements.lastActivity) {
+      elements.lastActivity.textContent = "Configurazione richiesta";
+    }
+    return;
+  }
+
+  setActivityPlaceholder("Recupero dati da GitHub…");
+
+  try {
+    const url = new URL(`https://api.github.com/repos/${currentConfig.repo}/commits`);
+    url.searchParams.set("per_page", "5");
+    if (currentConfig.branch) {
+      url.searchParams.set("sha", currentConfig.branch);
+    }
+
+    const response = await fetch(url.toString(), {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub API ha risposto con stato ${response.status}`);
+    }
+
+    const commits = await response.json();
+    if (!Array.isArray(commits)) {
+      throw new Error("Formato inatteso della risposta GitHub");
+    }
+
+    const simplified = commits.map((entry) => ({
+      title: entry.commit?.message?.split("\n")[0] ?? "Commit senza titolo",
+      author: entry.commit?.author?.name ?? "Autore sconosciuto",
+      date: entry.commit?.author?.date ?? new Date().toISOString(),
+      url: entry.html_url ?? `https://github.com/${currentConfig.repo}`,
+      sha: entry.sha ?? "",
+    }));
+
+    renderActivity(simplified);
+
+    const latest = simplified[0];
+    if (latest && elements.lastActivity) {
+      elements.lastActivity.textContent = formatDate(latest.date);
+    }
+  } catch (error) {
+    console.error(error);
+    setActivityPlaceholder(
+      "Impossibile caricare i commit. Verifica la connessione o il rate limit delle API GitHub."
+    );
+    if (elements.lastActivity) {
+      elements.lastActivity.textContent = "Errore nel caricamento";
+    }
+  }
+}
+
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function renderMarkdownBlock(markdown) {
+  const lines = markdown.trim().split(/\r?\n/);
+  const html = [];
+  let inList = false;
+
+  lines.forEach((line) => {
+    if (line.startsWith("### ")) {
+      if (inList) {
+        html.push("</ul>");
+        inList = false;
+      }
+      html.push(`<h4>${escapeHtml(line.slice(4).trim())}</h4>`);
+      return;
+    }
+
+    if (line.startsWith("- ")) {
+      if (!inList) {
+        html.push("<ul>");
+        inList = true;
+      }
+      html.push(`<li>${escapeHtml(line.slice(2).trim())}</li>`);
+      return;
+    }
+
+    if (!line.trim()) {
+      return;
+    }
+
+    if (inList) {
+      html.push("</ul>");
+      inList = false;
+    }
+
+    html.push(`<p>${escapeHtml(line.trim())}</p>`);
+  });
+
+  if (inList) {
+    html.push("</ul>");
+  }
+
+  return html.join("");
+}
+
+function renderChangelog(sections) {
+  if (!elements.changelogFeed) return;
+  if (!sections.length) {
+    elements.changelogFeed.innerHTML =
+      '<p class="placeholder">Nessuna voce di changelog disponibile.</p>';
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  sections.forEach((section) => {
+    const item = document.createElement("article");
+    item.className = "feed__item";
+
+    const title = document.createElement("h4");
+    title.textContent = section.title;
+
+    const content = document.createElement("div");
+    content.innerHTML = renderMarkdownBlock(section.body);
+
+    item.append(title, content);
+    fragment.appendChild(item);
+  });
+
+  elements.changelogFeed.innerHTML = "";
+  elements.changelogFeed.appendChild(fragment);
+}
+
+async function loadChangelog() {
+  if (elements.changelogStatus) {
+    elements.changelogStatus.textContent = "Aggiornamento in corso…";
+  }
+  if (elements.changelogFeed) {
+    elements.changelogFeed.innerHTML = '<p class="placeholder">Caricamento…</p>';
+  }
+
+  try {
+    const response = await fetch("changelog.md?cache=" + Date.now());
+    if (!response.ok) {
+      throw new Error(`Impossibile recuperare il changelog (${response.status})`);
+    }
+
+    const text = await response.text();
+    const rawSections = text.split(/^##\s+/m).slice(1);
+    const sections = rawSections.slice(0, 3).map((block) => {
+      const [titleLine, ...rest] = block.split(/\r?\n/);
+      return {
+        title: titleLine.trim(),
+        body: rest.join("\n").trim(),
+      };
+    });
+
+    renderChangelog(sections);
+    if (elements.changelogStatus) {
+      elements.changelogStatus.textContent = sections[0]
+        ? sections[0].title
+        : "Nessun dato";
+    }
+  } catch (error) {
+    console.error(error);
+    if (elements.changelogFeed) {
+      elements.changelogFeed.innerHTML =
+        '<p class="placeholder">Errore durante il caricamento del changelog.</p>';
+    }
+    if (elements.changelogStatus) {
+      elements.changelogStatus.textContent = "Errore";
+    }
+  }
+}
+
+function applyConfig(config) {
+  const nextConfig = {
+    ...defaultConfig,
+    ...currentConfig,
+    ...config,
+  };
+
+  if (!nextConfig.branch) {
+    nextConfig.branch = defaultConfig.branch;
+  }
+
+  currentConfig = nextConfig;
+
+  populateForm();
+  updateSimulatorPreview();
+  if (elements.activeBranch) {
+    elements.activeBranch.textContent = currentConfig.branch || "—";
+  }
+  saveConfig(currentConfig);
+  loadActivity();
+}
+
+function resetConfig() {
+  applyConfig({ ...defaultConfig });
+}
+
+function setupEvents() {
+  elements.configForm?.addEventListener("submit", (event) => {
+    event.preventDefault();
+    applyConfig({
+      repo: sanitizeRepo(elements.repoInput?.value || ""),
+      branch: (elements.branchInput?.value || "main").trim(),
+      dataRoot: (elements.dataRootInput?.value || "").trim(),
+    });
+  });
+
+  elements.resetButton?.addEventListener("click", () => {
+    resetConfig();
+  });
+
+  const openSimulator = () => {
+    const simulatorUrl = computeSimulatorUrl();
+    window.open(simulatorUrl, "_blank", "noopener");
+  };
+
+  elements.openButton?.addEventListener("click", openSimulator);
+  elements.heroOpenButton?.addEventListener("click", openSimulator);
+
+  elements.refreshActivity?.addEventListener("click", () => {
+    loadActivity();
+  });
+
+  elements.refreshChangelog?.addEventListener("click", () => {
+    loadChangelog();
+  });
+}
+
+function init() {
+  populateForm();
+  updateSimulatorPreview();
+  if (elements.activeBranch) {
+    elements.activeBranch.textContent = currentConfig.branch || "—";
+  }
+  setupEvents();
+  loadChangelog();
+  loadActivity();
+}
+
+init();


### PR DESCRIPTION
## Summary
- add a navigation entry for the repository dashboards on the Evo-Tactics support hub
- highlight the existing test interface and automatic YAML fetch dashboards with dedicated cards

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fb86b456a48332aba43bed7e233ff9