### PR TITLE
Install python requirements in deploy workflow

### DIFF
--- a/.github/workflows/deploy-test-interface.yml
+++ b/.github/workflows/deploy-test-interface.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install Python test dependencies
-        run: pip install pytest
+        run: pip install -r tools/py/requirements.txt
 
       - name: Run Python tests
         run: PYTHONPATH=tools/py pytest


### PR DESCRIPTION
## Summary
- install the Python test requirements in the deploy workflow so PYTHONPATH tests can import their dependencies

## Testing
- not run (CI only change)


------
https://chatgpt.com/codex/tasks/task_e_68fb926f557483328f1bd56cd8ba33fb