### PR TITLE
Fix default data root for simulator in support hub

### DIFF
--- a/docs/site.js
+++ b/docs/site.js
@@ -82,10 +82,10 @@ function computeDataRoot(config = currentConfig) {
   }
   if (config.repo && config.branch) {
     return ensureTrailingSlash(
-      `https://raw.githubusercontent.com/${config.repo}/${config.branch}/docs/test-interface/`
+      `https://raw.githubusercontent.com/${config.repo}/${config.branch}/`
     );
   }
-  return "test-interface/";
+  return "";
 }
 
 function computeSimulatorUrl(config = currentConfig) {


### PR DESCRIPTION
## Summary
- add a navigation entry for the repository dashboards on the Evo-Tactics support hub
- highlight the existing test interface and automatic YAML fetch dashboards with dedicated cards
- ensure the simulator defaults to the repository root for its data source so bundled YAML loads correctly

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68fb9278a47c8332bd3c3b0b474eb0ee