### PR TITLE
Fix npm test glob for compiled TS tests

### DIFF
--- a/tools/ts/package.json
+++ b/tools/ts/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "node dist/roll_pack.js ENTP invoker ../../data/packs.yaml",
-    "test": "npm run build --silent && node --test \"dist/tests/**/*.test.js\"",
+    "test": "npm run build --silent && node --test dist/tests/**/*.test.js",
     "validate:species": "npm run build && node dist/validate_species.js ../../data/species.yaml"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- update the TypeScript test script to rely on shell globbing instead of a quoted pattern
- ensure the built JavaScript test files are found by Node's test runner on GitHub Actions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fb91e815588332a75a6b3b3a52940f