### PR TITLE
feat: support external auto fetch sources and investigative CLI

### DIFF
--- a/data/auto_external_sources.yaml
+++ b/data/auto_external_sources.yaml
@@ -1,0 +1,20 @@
+# Manifest di sorgenti addizionali per il fetch automatico.
+# Ogni voce può indicare pagine web, wiki, canvas condivisi o documenti JSON.
+sources:
+  - key: "project-wiki"
+    label: "Wiki di progetto"
+    url: "https://en.wikipedia.org/wiki/Game_design"
+    format: "html"
+    description: "Pagina wiki esterna utilizzata come riferimento di design."
+
+  - key: "shared-canvas"
+    label: "Canvas condiviso ChatGPT"
+    url: "https://chatgpt.com/canvas/shared/68f9956583848191b90cf13d97019904"
+    format: "html"
+    description: "Canvas collaborativo aggiornato con obiettivi e milestone."
+
+  - key: "roadmap-notes"
+    label: "Note roadmap JSON"
+    url: "https://raw.githubusercontent.com/githubtraining/hellogitworld/master/helloworld.json"
+    format: "json"
+    description: "Esempio di payload JSON remoto per testare il merge automatico."

--- a/docs/test-interface/auto-fetch.html
+++ b/docs/test-interface/auto-fetch.html
@@ -15,6 +15,7 @@
       <p class="tagline">
         Carica e verifica automaticamente tutti i dataset YAML pubblicati nella cartella <code>data/</code>,
         con rilevamento della sorgente dati su GitHub Pages o server locale.
+        Il manifest dedicato abilita anche il fetch di pagine web, wiki e canvas collaborativi esterni.
       </p>
       <nav class="utility-nav" aria-label="Navigazione secondaria">
         <a href="index.html">⟵ Torna alla dashboard</a>

--- a/docs/test-interface/index.html
+++ b/docs/test-interface/index.html
@@ -120,7 +120,16 @@
               </div>
             </form>
             <p id="fetch-status" class="status">In attesa di input…</p>
-            <pre id="fetch-preview" class="preview" aria-live="polite"></pre>
+            <div id="fetch-preview" class="preview">
+              <p id="fetch-preview-empty" class="preview-empty" aria-live="polite">
+                (nessun contenuto)
+              </p>
+              <div id="fetch-preview-body" class="preview-body" hidden>
+                <div id="fetch-preview-tabs" class="preview-tabs" role="tablist" aria-label="Sezioni dataset"></div>
+                <pre id="fetch-preview-content" class="preview-content" aria-live="polite"></pre>
+                <div id="fetch-preview-pagination" class="preview-pagination"></div>
+              </div>
+            </div>
           </article>
         </div>
       </section>

--- a/docs/test-interface/styles.css
+++ b/docs/test-interface/styles.css
@@ -477,6 +477,119 @@ main {
   white-space: pre-wrap;
 }
 
+#fetch-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: none;
+  overflow: visible;
+  white-space: normal;
+}
+
+.preview-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.preview-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.75);
+  font-style: italic;
+}
+
+.preview-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.preview-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.preview-tab:hover {
+  border-color: rgba(148, 163, 184, 0.5);
+  color: var(--text);
+}
+
+.preview-tab.active {
+  background: rgba(56, 189, 248, 0.16);
+  border-color: rgba(56, 189, 248, 0.45);
+  color: #38bdf8;
+}
+
+.preview-tab-count {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+}
+
+#fetch-preview .preview-content {
+  margin: 0;
+  max-height: 220px;
+  overflow: auto;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.35);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+.preview-pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.preview-page-btn {
+  padding: 0.4rem 0.9rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.5);
+  color: var(--text);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.preview-page-btn:hover:not(:disabled) {
+  background: rgba(56, 189, 248, 0.16);
+  border-color: rgba(56, 189, 248, 0.45);
+  color: #38bdf8;
+}
+
+.preview-page-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.preview-page-info {
+  flex: 1 1 auto;
+  text-align: center;
+}
+
 .test-results {
   list-style: none;
   margin: 1rem 0 0;

--- a/tests/test_investigate_sources.py
+++ b/tests/test_investigate_sources.py
@@ -1,0 +1,107 @@
+"""Test per lo strumento di indagine dei contenuti ausiliari."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import zipfile
+from pathlib import Path
+
+from pypdf import PdfWriter
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TOOLS_PY = PROJECT_ROOT / "tools" / "py"
+if str(TOOLS_PY) not in sys.path:
+    sys.path.insert(0, str(TOOLS_PY))
+
+from investigate_sources import collect_investigation, render_report  # noqa: E402
+
+
+def _create_docx(path: Path, text: str) -> None:
+    document_xml = f"""<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
+<w:document xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\">
+  <w:body>
+    <w:p><w:r><w:t>{text}</w:t></w:r></w:p>
+  </w:body>
+</w:document>
+"""
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(
+            "[Content_Types].xml",
+            """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">
+  <Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>
+  <Default Extension=\"xml\" ContentType=\"application/xml\"/>
+  <Override PartName=\"/word/document.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml\"/>
+</Types>
+""",
+        )
+        archive.writestr(
+            "_rels/.rels",
+            """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">
+  <Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"word/document.xml\"/>
+</Relationships>
+""",
+        )
+        archive.writestr("word/_rels/document.xml.rels", """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"/>
+""")
+        archive.writestr("word/document.xml", document_xml)
+
+
+def _create_pdf(path: Path) -> None:
+    writer = PdfWriter()
+    writer.add_blank_page(width=200, height=200)
+    with path.open("wb") as handle:
+        writer.write(handle)
+
+
+def test_collect_investigation_handles_formats(tmp_path: Path) -> None:
+    json_path = tmp_path / "packs.json"
+    json_path.write_text(json.dumps({"pack": {"name": "Alpha"}, "note": "Bioma"}))
+
+    md_path = tmp_path / "notes.md"
+    md_path.write_text("# Canvas\nTelemetria pack VC")
+
+    docx_path = tmp_path / "report.docx"
+    _create_docx(docx_path, "Mutazioni e telemetria in analisi")
+
+    pdf_path = tmp_path / "brief.pdf"
+    _create_pdf(pdf_path)
+
+    zip_path = tmp_path / "bundle.zip"
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        archive.writestr("inner.json", json.dumps({"canvas": "Shared board"}))
+        archive.writestr("inner.md", "# Canvas Notes\nPack VC")
+
+    targets = [json_path, md_path, docx_path, pdf_path, zip_path]
+    results = collect_investigation(targets, recursive=False, max_preview=200)
+
+    results_map = {Path(result.path).name: result for result in results}
+    assert "packs.json" in results_map
+    assert "notes.md" in results_map
+    assert "report.docx" in results_map
+    assert "brief.pdf" in results_map
+    assert "bundle.zip" in results_map
+
+    assert "pack" in results_map["packs.json"].keywords
+    assert results_map["notes.md"].type == "markdown"
+    assert results_map["report.docx"].type == "docx"
+    assert results_map["brief.pdf"].summary.startswith("Documento PDF")
+
+    zip_result = results_map["bundle.zip"]
+    assert zip_result.children is not None
+    child_types = {child.type for child in zip_result.children}
+    assert "json" in child_types
+    assert "markdown" in child_types
+
+    buffer = io.StringIO()
+    render_report(results, json_output=False, stream=buffer)
+    assert "packs.json" in buffer.getvalue()
+
+    buffer = io.StringIO()
+    render_report(results, json_output=True, stream=buffer)
+    payload = json.loads(buffer.getvalue())
+    assert any(entry["type"] == "zip" for entry in payload)

--- a/tests/test_tools_modules.py
+++ b/tests/test_tools_modules.py
@@ -27,6 +27,7 @@ def test_game_cli_exports_commands() -> None:
         "roll-pack",
         "generate-encounter",
         "validate-datasets",
+        "investigate",
     }
 
 

--- a/tools/py/investigate_sources.py
+++ b/tools/py/investigate_sources.py
@@ -1,0 +1,430 @@
+"""Utility per ispezionare file di appunti e supporto al progetto di gioco."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import re
+import sys
+import textwrap
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+import yaml
+
+KEYWORDS = {
+    "biome",
+    "bioma",
+    "canvas",
+    "encounter",
+    "mating",
+    "mutazioni",
+    "pack",
+    "pi shop",
+    "telemetria",
+    "telemetry",
+    "vc",
+}
+
+TEXT_EXTENSIONS = {".md", ".markdown"}
+STRUCTURED_EXTENSIONS = {".json", ".yaml", ".yml"}
+DOCUMENT_EXTENSIONS = {".doc", ".docx"}
+PDF_EXTENSIONS = {".pdf"}
+ARCHIVE_EXTENSIONS = {".zip"}
+SUPPORTED_EXTENSIONS = (
+    TEXT_EXTENSIONS
+    | STRUCTURED_EXTENSIONS
+    | DOCUMENT_EXTENSIONS
+    | PDF_EXTENSIONS
+    | ARCHIVE_EXTENSIONS
+)
+
+
+@dataclass
+class InvestigationResult:
+    path: str
+    type: str
+    summary: str
+    preview: str
+    keywords: Sequence[str]
+    size_bytes: int
+    children: Optional[List["InvestigationResult"]] = None
+    notes: Optional[str] = None
+
+
+def detect_keywords(text: str) -> List[str]:
+    lowered = text.lower()
+    hits = sorted({keyword for keyword in KEYWORDS if keyword in lowered})
+    return hits
+
+
+def shrink_text(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return f"{value[:limit]}\n…"
+
+
+def summarise_mapping(data: object) -> str:
+    if isinstance(data, dict):
+        keys = list(data.keys())
+        head = ", ".join(keys[:5])
+        if len(keys) > 5:
+            head = f"{head}, …"
+        return f"Oggetto con {len(keys)} chiavi: {head or '—'}"
+    if isinstance(data, list):
+        return f"Lista con {len(data)} elementi"
+    return f"Valore {type(data).__name__}"
+
+
+def load_structured_payload(text: str, suffix: str) -> tuple[object, str]:
+    if suffix in {".yaml", ".yml"}:
+        try:
+            data = yaml.safe_load(text)
+        except yaml.YAMLError as error:
+            raise ValueError(f"YAML non valido: {error}") from error
+        return data if data is not None else {}, "yaml"
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"JSON non valido: {error}") from error
+    return data, "json"
+
+
+def analyse_structured(path: Path, text: str, *, max_preview: int) -> InvestigationResult:
+    data, label = load_structured_payload(text, path.suffix.lower())
+    if label == "json":
+        preview_source = json.dumps(data, ensure_ascii=False, indent=2)
+    else:
+        preview_source = text.strip() or yaml.safe_dump(
+            data, allow_unicode=True, sort_keys=False
+        )
+
+    preview = shrink_text(preview_source, max_preview)
+    keywords = detect_keywords(preview)
+    summary = summarise_mapping(data)
+    return InvestigationResult(
+        path=str(path),
+        type=label,
+        summary=summary,
+        preview=preview or "(contenuto vuoto)",
+        keywords=keywords,
+        size_bytes=len(text.encode("utf-8")),
+    )
+
+
+def analyse_markdown(path: Path, text: str, *, max_preview: int) -> InvestigationResult:
+    headings = len(re.findall(r"^#{1,6}\\s+", text, flags=re.MULTILINE))
+    words = len(re.findall(r"\\w+", text))
+    summary = f"Markdown con {words} parole e {headings} heading"
+    preview = shrink_text(text.strip(), max_preview)
+    keywords = detect_keywords(text)
+    return InvestigationResult(
+        path=str(path),
+        type="markdown",
+        summary=summary,
+        preview=preview or "(contenuto vuoto)",
+        keywords=keywords,
+        size_bytes=len(text.encode("utf-8")),
+    )
+
+
+def extract_docx_text(stream: io.BufferedIOBase) -> str:
+    import xml.etree.ElementTree as ET
+
+    with zipfile.ZipFile(stream) as archive:
+        document_xml = archive.read("word/document.xml")
+    root = ET.fromstring(document_xml)
+    namespace = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
+    texts = [
+        node.text
+        for node in root.iterfind(f".//{namespace}t")
+        if node.text and node.text.strip()
+    ]
+    return " ".join(texts)
+
+
+def analyse_docx(path: Path, *, max_preview: int) -> InvestigationResult:
+    with path.open("rb") as handle:
+        text = extract_docx_text(handle)
+    summary = f"Documento DOCX con circa {len(text.split())} parole"
+    preview = shrink_text(text.strip(), max_preview) or "(contenuto vuoto)"
+    keywords = detect_keywords(text)
+    return InvestigationResult(
+        path=str(path),
+        type="docx",
+        summary=summary,
+        preview=preview,
+        keywords=keywords,
+        size_bytes=path.stat().st_size,
+    )
+
+
+def analyse_doc(path: Path, *, max_preview: int) -> InvestigationResult:
+    return InvestigationResult(
+        path=str(path),
+        type="doc",
+        summary="File DOC legacy non supportato (convertire in DOCX per l'analisi)",
+        preview="",
+        keywords=[],
+        size_bytes=path.stat().st_size,
+        notes="Convertire il documento in formato DOCX per ottenere il testo.",
+    )
+
+
+def extract_pdf_text(stream: io.BufferedIOBase) -> tuple[str, int]:
+    try:
+        from pypdf import PdfReader
+    except ImportError as error:  # pragma: no cover - dipende dall'ambiente
+        raise RuntimeError(
+            "Libreria 'pypdf' non installata. Aggiungerla alle dipendenze per analizzare i PDF."
+        ) from error
+
+    reader = PdfReader(stream)
+    texts = []
+    for page in reader.pages:
+        snippet = page.extract_text() or ""
+        texts.append(snippet.strip())
+    combined = "\n".join(filter(None, texts))
+    return combined, len(reader.pages)
+
+
+def analyse_pdf(path: Path, *, max_preview: int) -> InvestigationResult:
+    with path.open("rb") as handle:
+        text, page_count = extract_pdf_text(handle)
+    summary = f"Documento PDF con {page_count} pagine"
+    preview = shrink_text(text.strip(), max_preview) or "(contenuto vuoto)"
+    keywords = detect_keywords(text)
+    return InvestigationResult(
+        path=str(path),
+        type="pdf",
+        summary=summary,
+        preview=preview,
+        keywords=keywords,
+        size_bytes=path.stat().st_size,
+    )
+
+
+def analyse_embedded_file(name: str, data: bytes, *, max_preview: int) -> Optional[InvestigationResult]:
+    suffix = Path(name).suffix.lower()
+    if suffix in STRUCTURED_EXTENSIONS:
+        text = data.decode("utf-8", errors="replace")
+        return analyse_structured(Path(name), text, max_preview=max_preview)
+    if suffix in TEXT_EXTENSIONS:
+        text = data.decode("utf-8", errors="replace")
+        return analyse_markdown(Path(name), text, max_preview=max_preview)
+    return None
+
+
+def analyse_zip(path: Path, *, max_preview: int) -> InvestigationResult:
+    entries: List[str] = []
+    children: List[InvestigationResult] = []
+    with zipfile.ZipFile(path) as archive:
+        for info in archive.infolist():
+            if info.is_dir():
+                continue
+            entries.append(f"{info.filename} ({info.file_size} B)")
+            with archive.open(info) as handle:
+                data = handle.read()
+            try:
+                child = analyse_embedded_file(
+                    info.filename, data, max_preview=max_preview
+                )
+            except Exception as error:
+                children.append(
+                    InvestigationResult(
+                        path=str(Path(path.name) / info.filename),
+                        type="error",
+                        summary=f"Errore estrazione: {error}",
+                        preview="",
+                        keywords=[],
+                        size_bytes=len(data),
+                    )
+                )
+            else:
+                if child:
+                    children.append(child)
+    listing = "\n".join(entries[:10])
+    if len(entries) > 10:
+        listing = f"{listing}\n…"
+    summary = f"Archivio ZIP con {len(entries)} file, {len(children)} analizzati"
+    keywords = detect_keywords("\n".join([listing] + [child.preview for child in children]))
+    preview = shrink_text(listing or "(archivio vuoto)", max_preview)
+    return InvestigationResult(
+        path=str(path),
+        type="zip",
+        summary=summary,
+        preview=preview,
+        keywords=keywords,
+        size_bytes=path.stat().st_size,
+        children=children or None,
+    )
+
+
+def analyse_file(path: Path, *, max_preview: int) -> InvestigationResult:
+    suffix = path.suffix.lower()
+    if suffix in STRUCTURED_EXTENSIONS:
+        text = path.read_text(encoding="utf-8")
+        return analyse_structured(path, text, max_preview=max_preview)
+    if suffix in TEXT_EXTENSIONS:
+        text = path.read_text(encoding="utf-8")
+        return analyse_markdown(path, text, max_preview=max_preview)
+    if suffix == ".docx":
+        return analyse_docx(path, max_preview=max_preview)
+    if suffix == ".doc":
+        return analyse_doc(path, max_preview=max_preview)
+    if suffix in PDF_EXTENSIONS:
+        return analyse_pdf(path, max_preview=max_preview)
+    if suffix in ARCHIVE_EXTENSIONS:
+        return analyse_zip(path, max_preview=max_preview)
+    raise ValueError(f"Formato non supportato: {path}")
+
+
+def iter_targets(paths: Sequence[Path], *, recursive: bool) -> Iterable[Path]:
+    for path in paths:
+        if path.is_file():
+            if path.suffix.lower() in SUPPORTED_EXTENSIONS:
+                yield path
+            continue
+        if path.is_dir():
+            iterator = path.rglob("*") if recursive else path.iterdir()
+            for candidate in iterator:
+                if candidate.is_file() and candidate.suffix.lower() in SUPPORTED_EXTENSIONS:
+                    yield candidate
+            continue
+        yield path  # segnala percorsi non trovati
+
+
+def collect_investigation(
+    paths: Sequence[Path], *, recursive: bool, max_preview: int
+) -> List[InvestigationResult]:
+    results: List[InvestigationResult] = []
+    for target in iter_targets(paths, recursive=recursive):
+        if not target.exists():
+            results.append(
+                InvestigationResult(
+                    path=str(target),
+                    type="missing",
+                    summary="Percorso non trovato",
+                    preview="",
+                    keywords=[],
+                    size_bytes=0,
+                )
+            )
+            continue
+        try:
+            result = analyse_file(target, max_preview=max_preview)
+        except Exception as error:
+            results.append(
+                InvestigationResult(
+                    path=str(target),
+                    type="error",
+                    summary=f"Errore durante l'analisi: {error}",
+                    preview="",
+                    keywords=[],
+                    size_bytes=target.stat().st_size if target.exists() else 0,
+                )
+            )
+        else:
+            results.append(result)
+    return results
+
+
+def render_report(
+    results: Sequence[InvestigationResult], *, json_output: bool, stream: io.TextIOBase
+) -> None:
+    if json_output:
+        payload = [
+            {
+                "path": result.path,
+                "type": result.type,
+                "summary": result.summary,
+                "preview": result.preview,
+                "keywords": list(result.keywords),
+                "size_bytes": result.size_bytes,
+                "notes": result.notes,
+                "children": [
+                    {
+                        "path": child.path,
+                        "type": child.type,
+                        "summary": child.summary,
+                        "preview": child.preview,
+                        "keywords": list(child.keywords),
+                        "size_bytes": child.size_bytes,
+                        "notes": child.notes,
+                    }
+                    for child in (result.children or [])
+                ]
+                if result.children
+                else None,
+            }
+            for result in results
+        ]
+        json.dump(payload, stream, ensure_ascii=False, indent=2)
+        stream.write("\n")
+        return
+
+    for result in results:
+        header = f"=== {result.path} ({result.type}) ==="
+        stream.write(f"{header}\n")
+        stream.write(f"{result.summary}\n")
+        if result.keywords:
+            stream.write(f"Parole chiave: {', '.join(result.keywords)}\n")
+        if result.notes:
+            stream.write(f"Note: {result.notes}\n")
+        if result.preview:
+            stream.write("Preview:\n")
+            stream.write(textwrap.indent(result.preview, "  "))
+            stream.write("\n")
+        if result.children:
+            stream.write("Contenuti estratti:\n")
+            for child in result.children:
+                stream.write(
+                    textwrap.indent(
+                        f"- {child.path} [{child.type}]: {child.summary}\n", "  "
+                    )
+                )
+        stream.write("\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Analizza file di supporto per decidere quali integrare nel gioco.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("paths", nargs="+", help="File o directory da analizzare")
+    parser.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Analizza ricorsivamente le cartelle specificate",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Produce un output JSON facilmente parsabile",
+    )
+    parser.add_argument(
+        "--max-preview",
+        type=int,
+        default=400,
+        help="Numero massimo di caratteri mostrati nella preview",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    paths = [Path(p) for p in args.paths]
+    results = collect_investigation(
+        paths, recursive=args.recursive, max_preview=max(100, args.max_preview)
+    )
+    render_report(results, json_output=args.json, stream=sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - esecuzione diretta
+    sys.exit(main())

--- a/tools/py/requirements.txt
+++ b/tools/py/requirements.txt
@@ -2,3 +2,4 @@ PyYAML>=6.0        # parsing dei dataset YAML condivisi
 requests>=2.32.0   # download HTTP per sincronizzazioni e fetch manuali
 openai>=1.0.0      # accesso API per scripts/chatgpt_sync.py
 pytest>=8.0.0      # suite di test deterministici in tools/py
+pypdf>=4.0.0       # estrazione di testo dai PDF per l'indagine dei contenuti


### PR DESCRIPTION
## Summary
- extend the auto fetch dashboard to load external manifests and parse HTML/Markdown/JSON previews
- add a configurable manifest including wiki and shared canvas URLs plus an investigative CLI for JSON/Markdown/PDF/DOC/ZIP sources
- cover the new tooling with tests and declare the PDF dependency required for text extraction

## Testing
- PYTHONPATH=tools/py pytest

------
https://chatgpt.com/codex/tasks/task_e_68fbbd48ca5c83329fa4f65cd334608a