### PR TITLE
Fix simulator data root override in dashboard

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -162,7 +162,13 @@
             <div class="stack">
               <div class="stack__row">
                 <span class="stack__label">Data root attiva:</span>
-                <a id="data-root-preview" href="test-interface/" target="_blank" rel="noreferrer">test-interface/</a>
+                <a
+                  id="data-root-preview"
+                  href="test-interface/"
+                  target="_blank"
+                  rel="noreferrer"
+                  >Rilevamento automatico</a
+                >
               </div>
               <div class="stack__row">
                 <span class="stack__label">URL simulatore:</span>

--- a/docs/site.js
+++ b/docs/site.js
@@ -82,10 +82,10 @@ function computeDataRoot(config = currentConfig) {
   }
   if (config.repo && config.branch) {
     return ensureTrailingSlash(
-      `https://raw.githubusercontent.com/${config.repo}/${config.branch}/docs/test-interface/`
+      `https://raw.githubusercontent.com/${config.repo}/${config.branch}/`
     );
   }
-  return "test-interface/";
+  return "";
 }
 
 function computeSimulatorUrl(config = currentConfig) {
@@ -116,8 +116,15 @@ function updateSimulatorPreview() {
   const simulatorUrl = computeSimulatorUrl();
 
   if (elements.dataRootPreview) {
-    elements.dataRootPreview.textContent = dataRoot;
-    elements.dataRootPreview.href = dataRoot.startsWith("http") ? dataRoot : simulatorUrl;
+    if (dataRoot) {
+      elements.dataRootPreview.textContent = dataRoot;
+      elements.dataRootPreview.href = dataRoot.startsWith("http")
+        ? dataRoot
+        : simulatorUrl;
+    } else {
+      elements.dataRootPreview.textContent = "Rilevamento automatico";
+      elements.dataRootPreview.href = simulatorUrl;
+    }
   }
 
   if (elements.simulatorLink) {


### PR DESCRIPTION
## Summary
- ensure the dashboard hub passes the raw repository root to the embedded simulator instead of the test-interface folder
- show a clearer "Rilevamento automatico" label for the default data root preview in the hub UI

## Testing
- pytest tests/validate_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68fd1042b1f88332b7453ad440d95eaf