### PR TITLE
Add landing intro and improve generator access

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,45 +12,165 @@
     <script type="module" src="site.js" defer></script>
   </head>
   <body>
-    <header class="hero">
-      <div class="hero__inner">
-        <div class="hero__content">
-          <p class="hero__tagline">Supporto produzione</p>
-          <h1>Centro di Controllo Evo-Tactics</h1>
-          <p class="hero__description">
-            Un'unica plancia per seguire lo sviluppo del sistema, monitorare gli aggiornamenti
-            GitHub e provare rapidamente le nuove feature caricate sui branch di lavoro.
+    <header class="landing-hero" id="home">
+      <div class="landing-hero__inner">
+        <div class="landing-hero__content">
+          <p class="landing-hero__tagline">Gioco Intenti · Evo-Tactics</p>
+          <h1 id="landing-title">Benvenuti nel Centro Operativo di Intenti</h1>
+          <p class="landing-hero__description">
+            Evo-Tactics mette al centro squadre ibride impegnate a stabilizzare ecosistemi instabili. Questa pagina ti
+            guida dall'intenzione narrativa del progetto alle utility digitali che servono per preparare missioni,
+            generatori procedurali e strumenti di test.
           </p>
-          <div class="hero__actions">
-            <button type="button" class="button" id="hero-open-simulator">Apri il simulatore</button>
-            <a class="button button--secondary" href="40-ROADMAP.md">Roadmap</a>
-            <a class="button button--ghost" href="00-INDEX.md">Indice documentazione</a>
+          <div class="landing-hero__actions">
+            <a class="button" href="evo-tactics-pack/generator.html">Apri il generatore</a>
+            <a class="button button--secondary" href="#mission-control">Vai al Mission Control</a>
           </div>
         </div>
-        <aside class="hero__meta" aria-live="polite">
-          <div class="meta-card">
-            <span class="meta-card__label">Ultimo aggiornamento</span>
-            <strong class="meta-card__value" id="last-activity">In caricamento…</strong>
-          </div>
-          <div class="meta-card">
-            <span class="meta-card__label">Branch monitorata</span>
-            <strong class="meta-card__value" id="active-branch">—</strong>
-          </div>
-          <div class="meta-card">
-            <span class="meta-card__label">Feed changelog</span>
-            <strong class="meta-card__value" id="changelog-status">In caricamento…</strong>
-          </div>
+        <aside class="landing-hero__aside">
+          <h2 class="landing-hero__aside-title">Focus immediato</h2>
+          <ul class="landing-hero__highlights">
+            <li>Allinea l'intento del gioco con squadra, tono e pilastri tattici.</li>
+            <li>Scopri come si struttura una missione Evo-Tactics passo dopo passo.</li>
+            <li>Raggiungi con un click generatore, dashboard e strumenti di fetch dati.</li>
+          </ul>
         </aside>
       </div>
-      <nav class="hero__nav" aria-label="Navigazione principale">
-        <a href="#overview">Panoramica</a>
-        <a href="#updates">Aggiornamenti</a>
-        <a href="#simulator">Simulazioni</a>
-        <a href="#dashboards">Dashboard</a>
-        <a href="#resources">Risorse</a>
+      <nav class="landing-hero__menu" aria-label="Navigazione introduttiva">
+        <a href="#intent">Intento del gioco</a>
+        <a href="#flow">Come si svolge</a>
+        <a href="#structure">Mappa del sito</a>
+        <a href="#mission-control">Mission Control</a>
+        <a href="test-interface/index.html">Interfaccia Test</a>
+        <a href="evo-tactics-pack/generator.html">Generatore</a>
       </nav>
     </header>
-    <main class="layout">
+    <main class="landing-main" aria-labelledby="landing-title">
+      <section id="intent" class="landing-section">
+        <div class="landing-section__header">
+          <p class="landing-section__kicker">Intenti narrativi e tattici</p>
+          <h2>Perché esiste Evo-Tactics</h2>
+        </div>
+        <div class="landing-section__body">
+          <p>
+            Il gioco nasce per raccontare l'adattamento di cellule operative altamente specializzate. I giocatori sono
+            chiamati a leggere segnali biologici, rispondere alle crisi ambientali e costruire soluzioni collaborative
+            in tempo reale.
+          </p>
+          <ul class="landing-list">
+            <li>Tono techno-biologico con enfasi sull'evoluzione continua.</li>
+            <li>Squadre ibride tra ricerca, field ops e creatività tattica.</li>
+            <li>Loop di gioco basato su raccolta dati, decisioni rapide e mutazioni controllate.</li>
+          </ul>
+        </div>
+      </section>
+      <section id="flow" class="landing-section">
+        <div class="landing-section__header">
+          <p class="landing-section__kicker">Come si gioca</p>
+          <h2>Struttura di una missione</h2>
+        </div>
+        <div class="landing-section__body">
+          <ol class="landing-steps">
+            <li>
+              <strong>Briefing:</strong> scegli bioma, specie e telemetria critica usando il generatore o il catalogo del
+              pack.
+            </li>
+            <li>
+              <strong>Adattamento PI:</strong> assegna slot, forme MBTI e risorse tattiche consultando le dashboard di
+              Mission Control.
+            </li>
+            <li>
+              <strong>Playtest guidato:</strong> monitora loop, mutazioni e random table con gli strumenti di test,
+              registrando insight e nuove richieste di dati.
+            </li>
+            <li>
+              <strong>Debrief:</strong> sincronizza i risultati con la roadmap e aggiorna i dataset YAML per iterare.
+            </li>
+          </ol>
+          <p class="landing-section__note">
+            Ogni fase è supportata da una pagina dedicata: le trovi nella mappa del sito qui sotto e nella sezione Mission
+            Control.
+          </p>
+        </div>
+      </section>
+      <section id="structure" class="landing-section">
+        <div class="landing-section__header">
+          <p class="landing-section__kicker">Tutta la piattaforma</p>
+          <h2>Mappa rapida del sito</h2>
+        </div>
+        <div class="landing-grid">
+          <article class="card landing-card">
+            <h3>Mission Control</h3>
+            <p>
+              Dashboard principale per monitoraggio repository, configurazione del simulatore e accesso a changelog,
+              roadmap e documentazione.
+            </p>
+            <a class="button button--ghost" href="#mission-control">Vai al Mission Control</a>
+          </article>
+          <article class="card landing-card">
+            <h3>Generatore di ecosistemi</h3>
+            <p>
+              Tool procedurale per creare missioni, biomi e incontri. Collegato direttamente ai dataset YAML aggiornati.
+            </p>
+            <a class="button button--ghost" href="evo-tactics-pack/generator.html">Apri il generatore</a>
+          </article>
+          <article class="card landing-card">
+            <h3>Interfaccia Test &amp; Recap</h3>
+            <p>
+              Plancia di verifica rapida con overview MBTI, telemetria VC e strumenti di fetch manuale o automatico.
+            </p>
+            <a class="button button--ghost" href="test-interface/index.html">Apri l'interfaccia</a>
+          </article>
+          <article class="card landing-card">
+            <h3>Ecosystem Pack Hub</h3>
+            <p>
+              Raccolta completa di cataloghi, dataset e strumenti sperimentali per espandere l'universo Evo-Tactics.
+            </p>
+            <a class="button button--ghost" href="evo-tactics-pack/index.html">Esplora il pack</a>
+          </article>
+        </div>
+      </section>
+    </main>
+    <section id="mission-control" class="support-hub">
+      <header class="hero">
+        <div class="hero__inner">
+          <div class="hero__content">
+            <p class="hero__tagline">Supporto produzione</p>
+            <h1>Centro di Controllo Evo-Tactics</h1>
+            <p class="hero__description">
+              Un'unica plancia per seguire lo sviluppo del sistema, monitorare gli aggiornamenti
+              GitHub e provare rapidamente le nuove feature caricate sui branch di lavoro.
+            </p>
+            <div class="hero__actions">
+              <button type="button" class="button" id="hero-open-simulator">Apri il simulatore</button>
+              <a class="button button--secondary" href="40-ROADMAP.md">Roadmap</a>
+              <a class="button button--ghost" href="00-INDEX.md">Indice documentazione</a>
+            </div>
+          </div>
+          <aside class="hero__meta" aria-live="polite">
+            <div class="meta-card">
+              <span class="meta-card__label">Ultimo aggiornamento</span>
+              <strong class="meta-card__value" id="last-activity">In caricamento…</strong>
+            </div>
+            <div class="meta-card">
+              <span class="meta-card__label">Branch monitorata</span>
+              <strong class="meta-card__value" id="active-branch">—</strong>
+            </div>
+            <div class="meta-card">
+              <span class="meta-card__label">Feed changelog</span>
+              <strong class="meta-card__value" id="changelog-status">In caricamento…</strong>
+            </div>
+          </aside>
+        </div>
+        <nav class="hero__nav" aria-label="Navigazione principale">
+          <a href="#overview">Panoramica</a>
+          <a href="#updates">Aggiornamenti</a>
+          <a href="#simulator">Simulazioni</a>
+          <a href="#dashboards">Dashboard</a>
+          <a href="#resources">Risorse</a>
+        </nav>
+      </header>
+    <div class="layout">
       <section id="overview" class="section">
         <div class="section__header">
           <h2>Panoramica</h2>
@@ -211,6 +331,14 @@
             <a href="test-interface/index.html" class="button button--ghost">Apri dashboard</a>
           </article>
           <article class="card card--link">
+            <h3>Generatore di ecosistemi</h3>
+            <p>
+              Accesso diretto al tool procedurale per creare missioni, biomi e incontri pronti per il
+              playtest.
+            </p>
+            <a href="evo-tactics-pack/generator.html" class="button button--ghost">Apri generatore</a>
+          </article>
+          <article class="card card--link">
             <h3>Fetch automatico YAML</h3>
             <p>
               Pannello dedicato che scarica e valida tutti i file YAML dalla cartella
@@ -259,7 +387,8 @@
           </article>
         </div>
       </section>
-    </main>
+    </div>
+    </section>
     <footer class="footer">
       <p>
         Evo-Tactics · Centro di controllo sperimentale. Per feedback o suggerimenti apri una issue

--- a/docs/site.css
+++ b/docs/site.css
@@ -45,6 +45,221 @@ a:focus-visible {
   text-decoration: underline;
 }
 
+.landing-hero {
+  position: relative;
+  padding: 72px 5vw 56px;
+  overflow: hidden;
+  border-bottom: 1px solid rgba(88, 166, 255, 0.16);
+}
+
+.landing-hero::before {
+  content: "";
+  position: absolute;
+  inset: -160px;
+  background: radial-gradient(circle at 10% 20%, rgba(88, 166, 255, 0.35), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(191, 90, 242, 0.28), transparent 50%);
+  filter: blur(40px);
+  opacity: 0.8;
+  z-index: 0;
+}
+
+.landing-hero__inner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 36px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.landing-hero__content {
+  max-width: 640px;
+  display: grid;
+  gap: 18px;
+}
+
+.landing-hero__tagline {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.landing-hero__description {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.7;
+  font-size: 1.05rem;
+}
+
+.landing-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.landing-hero__aside {
+  position: relative;
+  z-index: 1;
+  max-width: 360px;
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 24px;
+  box-shadow: var(--shadow);
+}
+
+.landing-hero__aside-title {
+  margin: 0 0 12px;
+  font-size: 1.1rem;
+}
+
+.landing-hero__highlights {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 10px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.landing-hero__menu {
+  position: relative;
+  z-index: 1;
+  margin-top: 28px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.landing-hero__menu a {
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: rgba(240, 246, 252, 0.08);
+  color: var(--text-muted);
+  font-size: 0.92rem;
+  transition: background var(--transition), color var(--transition);
+}
+
+.landing-hero__menu a:hover,
+.landing-hero__menu a:focus-visible {
+  background: rgba(88, 166, 255, 0.2);
+  color: var(--text);
+  text-decoration: none;
+}
+
+.landing-main {
+  padding: 32px 5vw 72px;
+  display: grid;
+  gap: 40px;
+}
+
+.landing-section {
+  margin: 0 auto;
+  max-width: 1080px;
+  background: rgba(12, 18, 26, 0.78);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 36px;
+  box-shadow: var(--shadow);
+}
+
+.landing-section__header {
+  margin-bottom: 18px;
+}
+
+.landing-section__kicker {
+  margin: 0 0 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.landing-section__header h2 {
+  margin: 0;
+  font-size: 2.1rem;
+}
+
+.landing-section__body {
+  display: grid;
+  gap: 16px;
+}
+
+.landing-section__body p {
+  margin: 0 0 16px;
+  color: var(--text-muted);
+  line-height: 1.7;
+}
+
+.landing-list {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 8px;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.landing-steps {
+  counter-reset: step;
+  list-style: none;
+  margin: 0 0 16px;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.landing-steps li {
+  position: relative;
+  padding-left: 44px;
+  line-height: 1.6;
+  color: var(--text-muted);
+}
+
+.landing-steps li::before {
+  counter-increment: step;
+  content: counter(step);
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(88, 166, 255, 0.18);
+  border: 1px solid rgba(88, 166, 255, 0.35);
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.landing-section__note {
+  font-size: 0.92rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.landing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.landing-card {
+  gap: 16px;
+  background: rgba(9, 14, 21, 0.85);
+}
+
+.support-hub {
+  margin-top: 64px;
+  border-top: 1px solid rgba(88, 166, 255, 0.16);
+  background: linear-gradient(180deg, rgba(10, 14, 22, 0.75), rgba(5, 7, 11, 0.95));
+}
+
 .hero {
   padding: 48px 5vw 24px;
   position: relative;
@@ -551,6 +766,19 @@ a:focus-visible {
 }
 
 @media (max-width: 960px) {
+  .landing-hero {
+    padding: 56px 5vw 44px;
+  }
+
+  .landing-hero__inner {
+    flex-direction: column;
+  }
+
+  .landing-hero__aside {
+    max-width: none;
+    width: 100%;
+  }
+
   .hero__inner {
     flex-direction: column;
   }
@@ -565,6 +793,19 @@ a:focus-visible {
 }
 
 @media (max-width: 720px) {
+  .landing-main {
+    padding: 24px 5vw 56px;
+    gap: 28px;
+  }
+
+  .landing-section {
+    padding: 28px;
+  }
+
+  .landing-hero__menu {
+    gap: 8px;
+  }
+
   .hero {
     padding: 32px 5vw 16px;
   }


### PR DESCRIPTION
## Summary
- add an introductory landing hero that spiega gli intenti del gioco, il flusso di missione e offre scorciatoie ai tool principali
- integra il Mission Control esistente sotto una nuova sezione con card aggiuntive per raggiungere subito il generatore
- estende lo stylesheet con le classi della landing e gli adattamenti responsive dedicati

## Testing
- python - <<'PY' ...
  (script di controllo che verifica l'esistenza dei link interni in docs/index.html)
PY

------
https://chatgpt.com/codex/tasks/task_e_68fd1ef5d7b88332b009fd026675ee21