### PR TITLE
Add dataset status overview to mission control

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,6 +9,7 @@
       content="Centro di supporto per il progetto Evo-Tactics: stato aggiornamenti, test di simulazioni e link rapidi alla documentazione."
     />
     <link rel="stylesheet" href="site.css" />
+    <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js" defer></script>
     <script type="module" src="site.js" defer></script>
   </head>
   <body>
@@ -159,6 +160,44 @@
             <div class="meta-card">
               <span class="meta-card__label">Feed changelog</span>
               <strong class="meta-card__value" id="changelog-status">In caricamento…</strong>
+            </div>
+            <div class="meta-card meta-card--dataset" aria-live="polite">
+              <span class="meta-card__label">Stato dataset</span>
+              <strong class="meta-card__value" id="dataset-status">In rilevamento…</strong>
+              <dl class="meta-card__details" id="dataset-metrics">
+                <div>
+                  <dt>Forme MBTI</dt>
+                  <dd data-dataset-metric="forms">—</dd>
+                </div>
+                <div>
+                  <dt>Tabelle D20</dt>
+                  <dd data-dataset-metric="random">—</dd>
+                </div>
+                <div>
+                  <dt>Indici VC</dt>
+                  <dd data-dataset-metric="indices">—</dd>
+                </div>
+                <div>
+                  <dt>Biomi</dt>
+                  <dd data-dataset-metric="biomes">—</dd>
+                </div>
+                <div>
+                  <dt>Slot specie</dt>
+                  <dd data-dataset-metric="speciesSlots">—</dd>
+                </div>
+                <div>
+                  <dt>Sinergie</dt>
+                  <dd data-dataset-metric="speciesSynergies">—</dd>
+                </div>
+              </dl>
+              <p class="meta-card__hint" id="dataset-updated">Ultimo fetch: in attesa…</p>
+              <button
+                type="button"
+                class="button button--ghost meta-card__action"
+                id="refresh-datasets"
+              >
+                Aggiorna panoramica
+              </button>
             </div>
           </aside>
         </div>

--- a/docs/site.css
+++ b/docs/site.css
@@ -388,6 +388,48 @@ a:focus-visible {
   font-weight: 600;
 }
 
+.meta-card__details {
+  margin: 12px 0 6px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 12px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.meta-card__details div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.meta-card__details dt,
+.meta-card__details dd {
+  margin: 0;
+}
+
+.meta-card__details dt {
+  font-weight: 500;
+}
+
+.meta-card__details dd {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.meta-card__hint {
+  margin: 4px 0 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.meta-card__action {
+  margin-top: 12px;
+  width: 100%;
+  font-size: 0.85rem;
+}
+
 .hero__nav {
   position: relative;
   z-index: 1;


### PR DESCRIPTION
## Summary
- add a dataset status card to the Mission Control hero with quick metrics and refresh controls
- fetch YAML datasets from the configured data root, compute key counts, and surface them in the UI
- extend the Mission Control styles to support the new dataset overview layout

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68fd6184e92883328619d86bd6fd9c7e