### PR TITLE
Populate ext v1.5 NPG pack and add validation docs

### DIFF
--- a/packs/evo_tactics_pack/README.md
+++ b/packs/evo_tactics_pack/README.md
@@ -37,6 +37,17 @@ python packs/evo_tactics_pack/tools/py/run_all_validators.py \
   --html-out packs/evo_tactics_pack/out/validation/last_report.html
 ```
 
+## Dataset NPG reattivi
+
+- L'array JSON principale è in `tools/py/vtt/npg_pack.json` e descrive bioma, ruolo, specie, loadout e ricompense di ogni NPG.
+- Lo schema di riferimento è `tools/py/schema/npg_schema.json` (replicato in `docs/npg_schema.json` per la consultazione rapida).
+
+Per verificare che il pacchetto rimanga coerente con lo schema, esegui:
+
+```bash
+python packs/evo_tactics_pack/tools/py/ext_v1_5/validate_package.py
+```
+
 ## Struttura del pack
 
 ```

--- a/packs/evo_tactics_pack/tools/py/vtt/npg_pack.json
+++ b/packs/evo_tactics_pack/tools/py/vtt/npg_pack.json
@@ -1,1 +1,522 @@
-{"_stub": "ok"}
+[
+  {
+    "id": "desert_vanguard_thermo_raptor",
+    "biome": "desert",
+    "role": "vanguard",
+    "attitude": "hostile",
+    "species": {
+      "id": "thermo-raptor",
+      "morph_budget": 14,
+      "parts": {
+        "locomotion": ["burrower"],
+        "metabolism": ["sand_digest"],
+        "offense": ["sand_claws"],
+        "defense": ["heat_scales"],
+        "senses": ["echolocation"]
+      }
+    },
+    "job": {
+      "id": "Vanguard",
+      "rank": 3,
+      "actives": ["muraglia_termica", "carica_scintilla"],
+      "passives": ["resistenza_termica", "guardia_pressurizzata"]
+    },
+    "traits": ["predatore", "apex"],
+    "gear": {
+      "weapon": "lancia_fusione",
+      "tags": ["pesante", "termico"],
+      "surges": ["heat_burst"]
+    },
+    "tactics": {
+      "opener": "sfondamento_termico",
+      "focus": "aggro_high",
+      "fallback": "ritirata_circolare"
+    },
+    "social_hooks": {
+      "intel": "Telemetria indica codice segnalazione 7A se ferito."
+    },
+    "rewards": {
+      "xp": 120,
+      "loot": ["carapace_fase_variabile", "alloy_shards"],
+      "faction_rep": {
+        "red_sands": 2
+      }
+    }
+  },
+  {
+    "id": "desert_artificer_silica_bloom",
+    "biome": "desert",
+    "role": "artificer",
+    "attitude": "calculating",
+    "species": {
+      "id": "silica-bloom",
+      "morph_budget": 11,
+      "parts": {
+        "locomotion": ["burrower"],
+        "metabolism": ["sand_digest"],
+        "offense": ["sand_claws"],
+        "defense": ["heat_scales"],
+        "senses": ["echolocation"]
+      }
+    },
+    "job": {
+      "id": "Artificer",
+      "rank": 2,
+      "actives": ["torretta_prismi", "campo_lente"],
+      "passives": ["stabilizzatori_sabbia"]
+    },
+    "traits": ["supporto", "costruttore"],
+    "gear": {
+      "weapon": "proiettore_prismi",
+      "tags": ["leggera", "costrutto"],
+      "surges": ["barriera_di_vetro"]
+    },
+    "tactics": {
+      "opener": "dispiegamento_torre",
+      "focus": "supporto_distanza",
+      "fallback": "rinforzo_linea"
+    },
+    "social_hooks": {
+      "bounty": "Collezionisti della Cupola pagano bonus per nuclei intatti."
+    },
+    "rewards": {
+      "xp": 95,
+      "loot": ["nucleo_prismatico"],
+      "credits": 160
+    }
+  },
+  {
+    "id": "desert_harvester_cactus_weaver",
+    "biome": "desert",
+    "role": "harvester",
+    "attitude": "opportunistic",
+    "species": {
+      "id": "cactus-weaver",
+      "morph_budget": 10,
+      "parts": {
+        "locomotion": ["burrower"],
+        "metabolism": ["sand_digest"],
+        "offense": ["sand_claws"],
+        "defense": ["heat_scales"],
+        "senses": ["echolocation"]
+      }
+    },
+    "job": {
+      "id": "Harvester",
+      "rank": 2,
+      "actives": ["rete_spinata", "sifone_sap"],
+      "passives": ["raccolto_notturno"]
+    },
+    "traits": ["ponte_ecologico", "taglio_materiali"],
+    "gear": {
+      "weapon": "frusta_vite",
+      "tags": ["media", "constrict"],
+      "surges": ["estrazione_lattice"]
+    },
+    "tactics": {
+      "opener": "imboscata_sabbiosa",
+      "focus": "disarmo_rifornimenti",
+      "fallback": "fuga_sotterranea"
+    },
+    "social_hooks": {
+      "quest": "Può guidare a un nido di acqua fossile se catturato vivo."
+    },
+    "rewards": {
+      "xp": 80,
+      "resources": {
+        "fibra_carnivora": 3,
+        "linfa_cristal": 1
+      }
+    }
+  },
+  {
+    "id": "desert_invoker_noctule",
+    "biome": "desert",
+    "role": "invoker",
+    "attitude": "protective",
+    "species": {
+      "id": "noctule-termico",
+      "morph_budget": 12,
+      "parts": {
+        "locomotion": ["glide_wings"],
+        "metabolism": ["sand_digest"],
+        "offense": ["sand_claws"],
+        "defense": ["heat_scales"],
+        "senses": ["echolocate"]
+      }
+    },
+    "job": {
+      "id": "Invoker",
+      "rank": 2,
+      "actives": ["risonanza_termica", "sciame_echolink"],
+      "passives": ["sincronizza_branchi"]
+    },
+    "traits": ["ponte_migratore", "sentinella_notturna"],
+    "gear": {
+      "weapon": "emettitore_sonar",
+      "tags": ["rituale", "leggera"],
+      "surges": ["scia_termocinetica"]
+    },
+    "tactics": {
+      "opener": "barrage_sonar",
+      "focus": "supporto_aereo",
+      "fallback": "disimpegno_verticale"
+    },
+    "social_hooks": {
+      "favor": "Alleato della cooperativa Dune-Glow se negoziato."
+    },
+    "rewards": {
+      "xp": 105,
+      "loot": ["respiro_a_scoppio"],
+      "intel": ["traiettorie_sciami"]
+    }
+  },
+  {
+    "id": "cavern_warden_resonant_guardian",
+    "biome": "cavern",
+    "role": "warden",
+    "attitude": "territorial",
+    "species": {
+      "id": "resonant-guardian",
+      "morph_budget": 13,
+      "parts": {
+        "locomotion": ["burrower"],
+        "metabolism": ["sand_digest"],
+        "offense": ["sand_claws"],
+        "defense": ["heat_scales"],
+        "senses": ["echolocation"]
+      }
+    },
+    "job": {
+      "id": "Warden",
+      "rank": 3,
+      "actives": ["aura_dissonanza", "baluardo_risonante"],
+      "passives": ["sentinella_caverna", "eco_vigil"]
+    },
+    "traits": ["custode_nido", "eco_armatura"],
+    "gear": {
+      "weapon": "martello_risonante",
+      "tags": ["pesante", "sonico"],
+      "surges": ["scudo_eco"]
+    },
+    "tactics": {
+      "opener": "sbarramento_risonante",
+      "focus": "protezione_nodi",
+      "fallback": "ritiro_fasi"
+    },
+    "social_hooks": {
+      "parley": "Aprirà il varco verso i pozzi di biosilice per chi recita il canto giusto."
+    },
+    "rewards": {
+      "xp": 130,
+      "loot": ["frammento_risonanza"],
+      "standing": {
+        "coorte_undercity": 1
+      }
+    }
+  },
+  {
+    "id": "cavern_invoker_echo_mystic",
+    "biome": "cavern",
+    "role": "invoker",
+    "attitude": "zealous",
+    "species": {
+      "id": "echo-mystic",
+      "morph_budget": 11,
+      "parts": {
+        "locomotion": ["burrower"],
+        "metabolism": ["sand_digest"],
+        "offense": ["sand_claws"],
+        "defense": ["heat_scales"],
+        "senses": ["echolocation"]
+      }
+    },
+    "job": {
+      "id": "Invoker",
+      "rank": 3,
+      "actives": ["rituale_vibrante", "spira_convergenza"],
+      "passives": ["mantello_risonante"]
+    },
+    "traits": ["cultista", "psionico"],
+    "gear": {
+      "weapon": "focalizzatore_cristallo",
+      "tags": ["rituale", "medio"],
+      "surges": ["implosione_eco"]
+    },
+    "tactics": {
+      "opener": "canto_risonanza",
+      "focus": "debuff_area",
+      "fallback": "illusione_fase"
+    },
+    "social_hooks": {
+      "lore": "Condivide coordinate di camere eco se salvato dai predatori acidi."
+    },
+    "rewards": {
+      "xp": 115,
+      "loot": ["cristalli_fase"],
+      "research": 2
+    }
+  },
+  {
+    "id": "cavern_skirmisher_mire_stalker",
+    "biome": "cavern",
+    "role": "skirmisher",
+    "attitude": "ambush",
+    "species": {
+      "id": "mire-stalker",
+      "morph_budget": 9,
+      "parts": {
+        "locomotion": ["burrower"],
+        "metabolism": ["sand_digest"],
+        "offense": ["sand_claws"],
+        "defense": ["heat_scales"],
+        "senses": ["echolocation"]
+      }
+    },
+    "job": {
+      "id": "Skirmisher",
+      "rank": 2,
+      "actives": ["dash_fango", "colpo_vitale"],
+      "passives": ["mimetismo_fungino"]
+    },
+    "traits": ["camouflage", "tracker"],
+    "gear": {
+      "weapon": "lama_spora",
+      "tags": ["leggera", "tossico"],
+      "surges": ["nuvola_spore"]
+    },
+    "tactics": {
+      "opener": "imboscata_verticale",
+      "focus": "colpisci_e_sfuma",
+      "fallback": "arrampicata_cupola"
+    },
+    "social_hooks": {
+      "threat": "Guida i branchi di larve acidule se lasciato fuggire."
+    },
+    "rewards": {
+      "xp": 90,
+      "loot": ["spore_psichiche_silenziate"],
+      "materials": {
+        "muschio_lucente": 2
+      }
+    }
+  },
+  {
+    "id": "cavern_harvester_glow_leecher",
+    "biome": "cavern",
+    "role": "harvester",
+    "attitude": "patient",
+    "species": {
+      "id": "glow-leecher",
+      "morph_budget": 10,
+      "parts": {
+        "locomotion": ["burrower"],
+        "metabolism": ["sand_digest"],
+        "offense": ["sand_claws"],
+        "defense": ["heat_scales"],
+        "senses": ["echolocation"]
+      }
+    },
+    "job": {
+      "id": "Harvester",
+      "rank": 1,
+      "actives": ["drenaggio_luce", "trappola_silice"],
+      "passives": ["raccolta_notturna"]
+    },
+    "traits": ["estrattore", "luminescente"],
+    "gear": {
+      "weapon": "sifone_lum",
+      "tags": ["supporto", "rituale"],
+      "surges": ["rigenerazione_collettore"]
+    },
+    "tactics": {
+      "opener": "oscuramento_caverna",
+      "focus": "depaupera_risorse",
+      "fallback": "ritiro_fessura"
+    },
+    "social_hooks": {
+      "deal": "Accetta scambi di nutrimento per rivelare depositi di clatrati."
+    },
+    "rewards": {
+      "xp": 70,
+      "loot": ["essenza_biolum"],
+      "supplies": {
+        "reagente_fungino": 3
+      }
+    }
+  },
+  {
+    "id": "badlands_vanguard_dune_stalker",
+    "biome": "badlands",
+    "role": "vanguard",
+    "attitude": "hostile",
+    "species": {
+      "id": "dune-stalker",
+      "morph_budget": 13,
+      "parts": {
+        "locomotion": ["burrower"],
+        "metabolism": ["sand_digest"],
+        "offense": ["sand_claws"],
+        "defense": ["heat_scales"],
+        "senses": ["echolocation"]
+      }
+    },
+    "job": {
+      "id": "Vanguard",
+      "rank": 3,
+      "actives": ["assalto_valanga", "sfida_predatoria"],
+      "passives": ["armatura_magnetica"]
+    },
+    "traits": ["predatore", "sabbiatore"],
+    "gear": {
+      "weapon": "falce_tempesta",
+      "tags": ["pesante", "magnetico"],
+      "surges": ["onda_sabbia"]
+    },
+    "tactics": {
+      "opener": "carica_cresta",
+      "focus": "aggro_linea",
+      "fallback": "scomparsa_dune"
+    },
+    "social_hooks": {
+      "intel": "Lascia tracce codificate leggibili dai ranger del sindacato."
+    },
+    "rewards": {
+      "xp": 140,
+      "loot": ["pigmenti_termici"],
+      "bounties": {
+        "guild_cacciatori": 3
+      }
+    }
+  },
+  {
+    "id": "badlands_artificer_ferrocolonia",
+    "biome": "badlands",
+    "role": "artificer",
+    "attitude": "calculating",
+    "species": {
+      "id": "ferrocolonia-magnetotattica",
+      "morph_budget": 12,
+      "parts": {
+        "locomotion": ["burrower"],
+        "metabolism": ["sand_digest"],
+        "offense": ["sand_claws"],
+        "defense": ["heat_scales"],
+        "senses": ["echolocation"]
+      }
+    },
+    "job": {
+      "id": "Artificer",
+      "rank": 3,
+      "actives": ["campo_magnetico", "mine_ferrose"],
+      "passives": ["sinapsi_colla"]
+    },
+    "traits": ["sciame", "ingegnere"],
+    "gear": {
+      "weapon": "nucleo_induttivo",
+      "tags": ["ingegneria", "medio"],
+      "surges": ["impulso_gauss"]
+    },
+    "tactics": {
+      "opener": "reticolo_magnetico",
+      "focus": "controllo_area",
+      "fallback": "scissione_sciame"
+    },
+    "social_hooks": {
+      "rumor": "Contiene coordinate per relè sotto-tempesta se analizzato."
+    },
+    "rewards": {
+      "xp": 110,
+      "loot": ["enzimi_chelanti"],
+      "components": {
+        "ferroliquido": 4
+      }
+    }
+  },
+  {
+    "id": "badlands_skirmisher_echo_wing",
+    "biome": "badlands",
+    "role": "skirmisher",
+    "attitude": "alert",
+    "species": {
+      "id": "echo-wing",
+      "morph_budget": 9,
+      "parts": {
+        "locomotion": ["glide_wings"],
+        "metabolism": ["sand_digest"],
+        "offense": ["sand_claws"],
+        "defense": ["heat_scales"],
+        "senses": ["echolocation"]
+      }
+    },
+    "job": {
+      "id": "Skirmisher",
+      "rank": 2,
+      "actives": ["raffica_lame", "tuffo_sonico"],
+      "passives": ["radar_stormo"]
+    },
+    "traits": ["ricognitore", "ponte"],
+    "gear": {
+      "weapon": "chakram_sonici",
+      "tags": ["leggera", "aerea"],
+      "surges": ["onda_risonanza"]
+    },
+    "tactics": {
+      "opener": "divebomb_sonico",
+      "focus": "harass_linea",
+      "fallback": "quota_superiore"
+    },
+    "social_hooks": {
+      "ally": "Scorta carovane se guadagna fiducia."
+    },
+    "rewards": {
+      "xp": 85,
+      "loot": ["scheletro_idro_regolante"],
+      "intel": ["sentieri_aerei"]
+    }
+  },
+  {
+    "id": "badlands_harvester_sand_burrower",
+    "biome": "badlands",
+    "role": "harvester",
+    "attitude": "methodical",
+    "species": {
+      "id": "sand-burrower",
+      "morph_budget": 10,
+      "parts": {
+        "locomotion": ["burrower"],
+        "metabolism": ["sand_digest"],
+        "offense": ["sand_claws"],
+        "defense": ["heat_scales"],
+        "senses": ["echolocation"]
+      }
+    },
+    "job": {
+      "id": "Harvester",
+      "rank": 2,
+      "actives": ["carico_sabbia", "drenaggio_metalli"],
+      "passives": ["minatore_notturno"]
+    },
+    "traits": ["estrattore", "logistica"],
+    "gear": {
+      "weapon": "trapano_sabbia",
+      "tags": ["pesante", "industriale"],
+      "surges": ["murena_sabbia"]
+    },
+    "tactics": {
+      "opener": "trappola_sotto",
+      "focus": "isolamento_bersaglio",
+      "fallback": "immersione_profonda"
+    },
+    "social_hooks": {
+      "contract": "Accetta marchi di guida verso depositi se riceve componenti oliosi."
+    },
+    "rewards": {
+      "xp": 92,
+      "resources": {
+        "minerale_ferroso": 5,
+        "schegge_ceramiche": 2
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- replace the stubbed `npg_pack.json` with the full roster of biome-specific NPG records
- document the pack location and quick validation command in the Evo Tactics README

## Testing
- python packs/evo_tactics_pack/tools/py/ext_v1_5/validate_package.py

------
https://chatgpt.com/codex/tasks/task_e_68fdba1301c4833284c4a64eb8770570