### PR TITLE
Add export previews and persist generator activity log

### DIFF
--- a/docs/evo-tactics-pack/generator.html
+++ b/docs/evo-tactics-pack/generator.html
@@ -32,30 +32,44 @@
       </nav>
     </header>
 
-    <main class="layout">
-      <section class="section">
-        <article class="card card--highlight">
-          <form class="form" id="generator-form">
-            <h2 class="form__title">Parametri</h2>
-            <div class="grid grid--three">
-              <label class="form__field">
-                <span>Numero di biomi</span>
-                <input id="nBiomi" type="number" min="1" max="6" value="2" />
-              </label>
-              <label class="form__field">
-                <span>Flags richiesti</span>
-                <select id="flags" multiple size="5"></select>
-              </label>
-              <label class="form__field">
-                <span>Ruoli trofici</span>
-                <select id="roles" multiple size="5"></select>
-              </label>
-              <label class="form__field">
-                <span>Tag funzionali</span>
-                <select id="tags" multiple size="6"></select>
-              </label>
+    <main class="layout layout--generator">
+      <aside class="generator-sidebar">
+        <article class="card card--highlight generator-card">
+          <form class="form generator-form" id="generator-form">
+            <div class="generator-form__header">
+              <h2 class="form__title">Parametri di generazione</h2>
+              <p class="generator-form__description">
+                Personalizza i vincoli prima di estrarre un ecosistema completo con biomi, specie
+                e seed dedicati.
+              </p>
             </div>
-            <div class="form__actions">
+            <div class="generator-form__section">
+              <h3 class="generator-form__legend">Vincoli principali</h3>
+              <div class="generator-form__grid">
+                <label class="form__field">
+                  <span>Numero di biomi</span>
+                  <input id="nBiomi" type="number" min="1" max="6" value="2" />
+                </label>
+              </div>
+            </div>
+            <div class="generator-form__section">
+              <h3 class="generator-form__legend">Filtra ecosistema</h3>
+              <div class="generator-form__grid generator-form__grid--filters">
+                <label class="form__field">
+                  <span>Flags richiesti</span>
+                  <select id="flags" multiple size="5"></select>
+                </label>
+                <label class="form__field">
+                  <span>Ruoli trofici</span>
+                  <select id="roles" multiple size="5"></select>
+                </label>
+                <label class="form__field">
+                  <span>Tag funzionali</span>
+                  <select id="tags" multiple size="6"></select>
+                </label>
+              </div>
+            </div>
+            <div class="form__actions generator-form__actions">
               <button type="button" class="button" data-action="roll-ecos">🎲 Genera ecosistema</button>
               <button type="button" class="button button--secondary" data-action="reroll-biomi">↻ Re-roll biomi</button>
               <button type="button" class="button button--secondary" data-action="reroll-species">↻ Re-roll specie</button>
@@ -64,35 +78,129 @@
               <button type="button" class="button button--ghost" data-action="export-yaml">⬇︎ YAML</button>
             </div>
           </form>
-          <p class="form__hint" id="generator-status" aria-live="polite"></p>
+          <section
+            class="generator-summary"
+            id="generator-summary"
+            aria-labelledby="generator-summary-title"
+          >
+            <h3 class="generator-summary__title" id="generator-summary-title">Riepilogo rapido</h3>
+            <dl class="generator-summary__metrics">
+              <div class="generator-summary__metric">
+                <dt class="generator-summary__label">Biomi</dt>
+                <dd class="generator-summary__value" data-summary="biomes">0</dd>
+              </div>
+              <div class="generator-summary__metric">
+                <dt class="generator-summary__label">Specie</dt>
+                <dd class="generator-summary__value" data-summary="species">0</dd>
+              </div>
+              <div class="generator-summary__metric">
+                <dt class="generator-summary__label">Seed</dt>
+                <dd class="generator-summary__value" data-summary="seeds">0</dd>
+              </div>
+            </dl>
+            <p class="generator-summary__status" id="generator-status" aria-live="polite">
+              Carica il catalogo per iniziare.
+            </p>
+            <p class="generator-summary__note" id="generator-last-action">Ultimo aggiornamento: —</p>
+          </section>
         </article>
-      </section>
+      </aside>
 
-      <section class="section">
-        <div class="section__header">
-          <h2>Pacchetti di tratti ambientali</h2>
-          <p>
-            Anteprima delle tavolozze di tratti per biomi estremi, reti connesse e cluster
-            avanzati da usare come riferimento durante la generazione.
-          </p>
-        </div>
-        <div id="trait-grid" class="grid grid--cards" aria-live="polite"></div>
-      </section>
+      <section class="generator-results">
+        <article class="card generator-panel" aria-labelledby="monitor-panel-title">
+          <header class="generator-panel__header">
+            <div>
+              <p class="section__kicker">Controllo produzione</p>
+              <h2 id="monitor-panel-title">Monitor del generatore</h2>
+            </div>
+            <p>
+              Osserva in tempo reale lo stato delle azioni e prepara i file esportabili
+              direttamente nella struttura del repository.
+            </p>
+          </header>
+          <div class="generator-monitor">
+            <section class="generator-monitor__stream" aria-live="polite">
+              <div class="generator-monitor__header">
+                <h3 class="generator-monitor__title">Attività recenti</h3>
+                <p class="generator-monitor__hint">
+                  Ultimi eventi generati dalle azioni sui pulsanti e sul caricamento dei
+                  dati.
+                </p>
+              </div>
+              <ol class="generator-log" id="generator-log"></ol>
+              <p class="placeholder" id="generator-log-empty">
+                Le azioni che esegui compariranno qui in ordine dal più recente.
+              </p>
+            </section>
+            <section class="generator-monitor__exports">
+              <div class="generator-monitor__header">
+                <h3 class="generator-monitor__title">File esportabili</h3>
+                <p class="generator-monitor__hint">
+                  Suggerimenti per salvare JSON e YAML nella cartella corretta del pack con
+                  una descrizione sintetica del contenuto.
+                </p>
+              </div>
+              <p class="generator-export__meta" id="generator-export-meta">
+                Genera un ecosistema per preparare il manifest dei file.
+              </p>
+              <ul class="generator-export-list" id="generator-export-list"></ul>
+              <p class="placeholder" id="generator-export-empty">
+                Non ci sono ancora file suggeriti: genera o ricalcola l'ecosistema per
+                popolare il manifest.
+              </p>
+              <div class="generator-export-preview" id="generator-export-preview" hidden>
+                <details class="export-preview" id="generator-preview-json-details">
+                  <summary class="export-preview__summary">Anteprima JSON</summary>
+                  <pre class="export-preview__content"><code id="generator-preview-json"></code></pre>
+                </details>
+                <details class="export-preview" id="generator-preview-yaml-details">
+                  <summary class="export-preview__summary">Anteprima YAML</summary>
+                  <pre class="export-preview__content"><code id="generator-preview-yaml"></code></pre>
+                </details>
+              </div>
+              <p class="placeholder" id="generator-preview-empty">
+                Quando l'ecosistema è pronto troverai qui l'anteprima JSON e YAML pronta da
+                copiare o salvare.
+              </p>
+            </section>
+          </div>
+        </article>
 
-      <section class="section">
-        <div class="section__header">
-          <h2>Biomi selezionati</h2>
-          <p>Ogni scheda mostra i link utili al YAML originale, foodweb e report HTML.</p>
-        </div>
-        <div id="biome-grid" class="grid grid--cards" aria-live="polite"></div>
-      </section>
+        <article class="card generator-panel" aria-labelledby="trait-panel-title">
+          <header class="generator-panel__header">
+            <div>
+              <p class="section__kicker">Tratti ambientali</p>
+              <h2 id="trait-panel-title">Pacchetti di tratti ambientali</h2>
+            </div>
+            <p>
+              Anteprima delle tavolozze di tratti per biomi estremi, reti connesse e cluster avanzati
+              da usare come riferimento durante la generazione.
+            </p>
+          </header>
+          <div id="trait-grid" class="grid grid--cards generator-grid" aria-live="polite"></div>
+        </article>
 
-      <section class="section">
-        <div class="section__header">
-          <h2>Encounter seed generati</h2>
-          <p>Il budget di minaccia viene calcolato in base al tier delle specie estratte.</p>
-        </div>
-        <div id="seed-grid" class="grid grid--cards" aria-live="polite"></div>
+        <article class="card generator-panel" aria-labelledby="biome-panel-title">
+          <header class="generator-panel__header">
+            <div>
+              <p class="section__kicker">Biomi sintetici</p>
+              <h2 id="biome-panel-title">Biomi selezionati</h2>
+            </div>
+            <p>Ogni scheda mostra i link utili al YAML originale, foodweb e report HTML.</p>
+          </header>
+          <div id="biome-grid" class="grid grid--cards generator-grid" aria-live="polite"></div>
+        </article>
+
+        <article class="card generator-panel" aria-labelledby="seed-panel-title">
+          <header class="generator-panel__header">
+            <div>
+              <p class="section__kicker">Encounter</p>
+              <h2 id="seed-panel-title">Encounter seed generati</h2>
+            </div>
+            <p>Il budget di minaccia viene calcolato in base al tier delle specie estratte.</p>
+          </header>
+          <div id="seed-grid" class="grid grid--cards generator-grid" aria-live="polite"></div>
+        </article>
       </section>
     </main>
   </body>

--- a/docs/evo-tactics-pack/generator.js
+++ b/docs/evo-tactics-pack/generator.js
@@ -2,6 +2,7 @@ import {
   loadPackCatalog,
   manualLoadCatalog,
   getPackRootCandidates,
+  PACK_PATH,
 } from "./pack-data.js";
 
 const elements = {
@@ -14,9 +15,31 @@ const elements = {
   traitGrid: document.getElementById("trait-grid"),
   seedGrid: document.getElementById("seed-grid"),
   status: document.getElementById("generator-status"),
+  summaryContainer: document.getElementById("generator-summary"),
+  summaryCounts: {
+    biomes: document.querySelector("[data-summary=\"biomes\"]"),
+    species: document.querySelector("[data-summary=\"species\"]"),
+    seeds: document.querySelector("[data-summary=\"seeds\"]"),
+  },
+  lastAction: document.getElementById("generator-last-action"),
+  logList: document.getElementById("generator-log"),
+  logEmpty: document.getElementById("generator-log-empty"),
+  exportMeta: document.getElementById("generator-export-meta"),
+  exportList: document.getElementById("generator-export-list"),
+  exportEmpty: document.getElementById("generator-export-empty"),
+  exportPreview: document.getElementById("generator-export-preview"),
+  exportPreviewEmpty: document.getElementById("generator-preview-empty"),
+  exportPreviewJson: document.getElementById("generator-preview-json"),
+  exportPreviewYaml: document.getElementById("generator-preview-yaml"),
+  exportPreviewJsonDetails: document.getElementById("generator-preview-json-details"),
+  exportPreviewYamlDetails: document.getElementById("generator-preview-yaml-details"),
 };
 
 const PACK_ROOT_CANDIDATES = getPackRootCandidates();
+const EXPORT_BASE_FOLDER = `${PACK_PATH}out/generator/`;
+const STORAGE_KEYS = {
+  activityLog: "evo-generator-activity-log",
+};
 
 const state = {
   data: null,
@@ -26,11 +49,14 @@ const state = {
   traitDetailsIndex: new Map(),
   hazardRegistry: null,
   hazardsIndex: new Map(),
+  activityLog: [],
+  lastFilters: { flags: [], roles: [], tags: [] },
   pick: {
     ecosystem: {},
     biomes: [],
     species: {},
     seeds: [],
+    exportSlug: null,
   },
 };
 
@@ -38,6 +64,8 @@ let packContext = null;
 let resolvedCatalogUrl = null;
 let resolvedPackRoot = null;
 let packDocsBase = null;
+let cachedStorage = null;
+let storageChecked = false;
 
 const TRAIT_CATEGORY_LABELS = {
   biomi_estremi: "Biomi estremi",
@@ -54,10 +82,272 @@ function applyCatalogContext(data, context) {
   populateFilters(data);
 }
 
+function calculatePickMetrics() {
+  const biomes = state.pick?.biomes ?? [];
+  const speciesBuckets = state.pick?.species ?? {};
+  const seeds = state.pick?.seeds ?? [];
+  const biomeCount = Array.isArray(biomes) ? biomes.length : 0;
+  const speciesCount = Object.values(speciesBuckets).reduce(
+    (sum, list) => sum + (Array.isArray(list) ? list.length : 0),
+    0
+  );
+  const seedCount = Array.isArray(seeds) ? seeds.length : 0;
+  return { biomeCount, speciesCount, seedCount };
+}
+
 function setStatus(message, tone = "info") {
-  if (!elements.status) return;
-  elements.status.textContent = message;
-  elements.status.dataset.tone = tone;
+  const now = new Date();
+  if (elements.status) {
+    elements.status.textContent = message;
+    elements.status.dataset.tone = tone;
+  }
+  if (elements.lastAction) {
+    const formatted = now.toLocaleTimeString("it-IT", { hour: "2-digit", minute: "2-digit" });
+    elements.lastAction.textContent = `Ultimo aggiornamento: ${formatted}`;
+    elements.lastAction.dataset.tone = tone;
+    elements.lastAction.title = now.toLocaleString("it-IT");
+  }
+  recordActivity(message, tone, now);
+}
+
+function updateSummaryCounts() {
+  const { biomeCount, speciesCount, seedCount } = calculatePickMetrics();
+
+  elements.summaryCounts?.biomes?.textContent = biomeCount;
+  elements.summaryCounts?.species?.textContent = speciesCount;
+  elements.summaryCounts?.seeds?.textContent = seedCount;
+
+  if (elements.summaryContainer) {
+    const hasResults = biomeCount + speciesCount + seedCount > 0;
+    elements.summaryContainer.dataset.hasResults = hasResults ? "true" : "false";
+  }
+
+  renderExportManifest();
+}
+
+function getActivityStorage() {
+  if (storageChecked) {
+    return cachedStorage;
+  }
+  storageChecked = true;
+  try {
+    if (typeof window === "undefined" || !window.localStorage) {
+      cachedStorage = null;
+      return cachedStorage;
+    }
+    const testKey = "__generator_log_test__";
+    window.localStorage.setItem(testKey, "1");
+    window.localStorage.removeItem(testKey);
+    cachedStorage = window.localStorage;
+  } catch (error) {
+    console.warn("LocalStorage non disponibile per il monitor del generatore", error);
+    cachedStorage = null;
+  }
+  return cachedStorage;
+}
+
+function persistActivityLog() {
+  const storage = getActivityStorage();
+  if (!storage) return;
+  try {
+    const serialisable = state.activityLog.map((entry) => ({
+      message: entry.message,
+      tone: entry.tone,
+      timestamp: entry.timestamp instanceof Date ? entry.timestamp.toISOString() : entry.timestamp,
+    }));
+    storage.setItem(STORAGE_KEYS.activityLog, JSON.stringify(serialisable));
+  } catch (error) {
+    console.warn("Impossibile salvare il registro attività", error);
+  }
+}
+
+function restoreActivityLog() {
+  const storage = getActivityStorage();
+  if (!storage) return;
+  try {
+    const raw = storage.getItem(STORAGE_KEYS.activityLog);
+    if (!raw) return;
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return;
+    state.activityLog = parsed
+      .map((entry) => {
+        if (!entry?.message) return null;
+        const timestamp = entry.timestamp ? new Date(entry.timestamp) : new Date();
+        return {
+          message: entry.message,
+          tone: entry.tone ?? "info",
+          timestamp,
+        };
+      })
+      .filter(Boolean)
+      .slice(0, 20);
+  } catch (error) {
+    console.warn("Impossibile ripristinare il registro attività", error);
+  }
+}
+
+function recordActivity(message, tone = "info", timestamp = new Date()) {
+  if (!message) return;
+  const entry = {
+    message,
+    tone,
+    timestamp: timestamp instanceof Date ? timestamp : new Date(timestamp),
+  };
+  state.activityLog.unshift(entry);
+  state.activityLog = state.activityLog.slice(0, 20);
+  persistActivityLog();
+  renderActivityLog();
+}
+
+function renderActivityLog() {
+  const list = elements.logList;
+  const empty = elements.logEmpty;
+  if (!list) return;
+
+  list.innerHTML = "";
+  const entries = state.activityLog ?? [];
+  const hasEntries = entries.length > 0;
+  list.hidden = !hasEntries;
+  if (empty) {
+    empty.hidden = hasEntries;
+  }
+
+  if (!hasEntries) {
+    return;
+  }
+
+  entries.forEach((entry) => {
+    const item = document.createElement("li");
+    item.className = "generator-log__item";
+    item.dataset.tone = entry.tone ?? "info";
+
+    const time = document.createElement("p");
+    time.className = "generator-log__time";
+    time.textContent = entry.timestamp.toLocaleTimeString("it-IT", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+
+    const messageText = document.createElement("p");
+    messageText.className = "generator-log__message";
+    messageText.textContent = entry.message;
+
+    item.append(time, messageText);
+    list.appendChild(item);
+  });
+}
+
+function ensureExportSlug() {
+  if (state.pick.exportSlug) {
+    return state.pick.exportSlug;
+  }
+  const base = state.pick.ecosystem?.id || randomId("ecos");
+  const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+  const slug = slugify(`${base}-${stamp}`);
+  state.pick.exportSlug = slug || randomId("ecos");
+  return state.pick.exportSlug;
+}
+
+function renderExportPreview(payload) {
+  const container = elements.exportPreview;
+  const empty = elements.exportPreviewEmpty;
+  if (!container || !empty) return;
+
+  const hasPayload = Boolean(payload);
+  container.hidden = !hasPayload;
+  empty.hidden = hasPayload;
+
+  if (!hasPayload) {
+    if (elements.exportPreviewJson) elements.exportPreviewJson.textContent = "";
+    if (elements.exportPreviewYaml) elements.exportPreviewYaml.textContent = "";
+    if (elements.exportPreviewJsonDetails) elements.exportPreviewJsonDetails.open = false;
+    if (elements.exportPreviewYamlDetails) elements.exportPreviewYamlDetails.open = false;
+    return;
+  }
+
+  const jsonDetails = elements.exportPreviewJsonDetails;
+  const yamlDetails = elements.exportPreviewYamlDetails;
+  const jsonWasOpen = Boolean(jsonDetails?.open);
+  const yamlWasOpen = Boolean(yamlDetails?.open);
+
+  if (elements.exportPreviewJson) {
+    elements.exportPreviewJson.textContent = JSON.stringify(payload, null, 2);
+  }
+  if (elements.exportPreviewYaml) {
+    elements.exportPreviewYaml.textContent = toYAML(payload);
+  }
+
+  if (jsonDetails) jsonDetails.open = jsonWasOpen;
+  if (yamlDetails) yamlDetails.open = yamlWasOpen;
+}
+
+function renderExportManifest(filters = state.lastFilters) {
+  const list = elements.exportList;
+  const empty = elements.exportEmpty;
+  const meta = elements.exportMeta;
+  if (!list || !empty || !meta) return;
+
+  list.innerHTML = "";
+
+  const { biomeCount, speciesCount, seedCount } = calculatePickMetrics();
+  const hasContent = biomeCount + speciesCount + seedCount > 0;
+
+  list.hidden = !hasContent;
+  empty.hidden = hasContent;
+
+  if (!hasContent) {
+    meta.textContent = "Genera un ecosistema per preparare il manifest dei file.";
+    renderExportPreview(null);
+    return;
+  }
+
+  const slug = ensureExportSlug();
+  const folder = EXPORT_BASE_FOLDER;
+  const filterSummary = summariseFilters(filters ?? state.lastFilters ?? {});
+  const ecosystemLabel = state.pick.ecosystem?.label ?? "Ecosistema sintetico";
+
+  meta.innerHTML = `Cartella consigliata: <code>${folder}</code> · ${
+    filterSummary ? `Filtri: ${filterSummary}.` : "Nessun filtro attivo."
+  } · Anteprima disponibile qui sotto.`;
+
+  const suggestions = [
+    {
+      name: `${slug}.json`,
+      format: "JSON",
+      description: `Dump completo dell'ecosistema "${ecosystemLabel}" con ${biomeCount} biomi, ${speciesCount} specie e ${seedCount} seed.`,
+    },
+    {
+      name: `${slug}.yaml`,
+      format: "YAML",
+      description: `Manifesto YAML pronto per commit in ${folder}, utile per revisioni manuali o pipeline esterne.`,
+    },
+  ];
+
+  suggestions.forEach((suggestion) => {
+    const item = document.createElement("li");
+    item.className = "generator-export";
+
+    const title = document.createElement("h4");
+    title.className = "generator-export__title";
+    title.append(document.createTextNode(suggestion.name));
+    const format = document.createElement("span");
+    format.className = "generator-export__format";
+    format.textContent = suggestion.format;
+    title.appendChild(format);
+
+    const description = document.createElement("p");
+    description.className = "generator-export__description";
+    description.textContent = suggestion.description;
+
+    const path = document.createElement("p");
+    path.className = "generator-export__path";
+    path.textContent = `${folder}${suggestion.name}`;
+
+    item.append(title, description, path);
+    list.appendChild(item);
+  });
+
+  renderExportPreview(exportPayload(filters));
 }
 
 function getSelectedValues(select) {
@@ -824,11 +1114,13 @@ function resolvePackHref(relativePath) {
 }
 
 function currentFilters() {
-  return {
+  const filters = {
     flags: getSelectedValues(elements.flags),
     roles: getSelectedValues(elements.roles),
     tags: getSelectedValues(elements.tags),
   };
+  state.lastFilters = filters;
+  return filters;
 }
 
 function summariseFilters(filters) {
@@ -1129,10 +1421,11 @@ function rerollSeeds(filters) {
 }
 
 function renderBiomes(filters) {
+  updateSummaryCounts();
   const grid = elements.biomeGrid;
   if (!grid) return;
   grid.innerHTML = "";
-
+  
   if (!state.pick.biomes.length) {
     const placeholder = document.createElement("p");
     placeholder.className = "placeholder";
@@ -1223,9 +1516,11 @@ function renderBiomes(filters) {
     }
     grid.appendChild(card);
   });
+
 }
 
 function renderSeeds() {
+  updateSummaryCounts();
   const container = elements.seedGrid;
   if (!container) return;
   container.innerHTML = "";
@@ -1288,6 +1583,7 @@ function renderSeeds() {
     card.append(list);
     container.appendChild(card);
   });
+
 }
 
 function exportPayload(filters) {
@@ -1524,6 +1820,7 @@ function attachActions() {
           connessioni: synthesiseConnections(pool),
         };
         state.pick.biomes = pool;
+        state.pick.exportSlug = null;
         rerollSpecies(filters);
         rerollSeeds(filters);
         renderBiomes(filters);
@@ -1541,6 +1838,14 @@ function attachActions() {
         const n = Math.max(1, Math.min(parseInt(elements.nBiomi.value, 10) || state.pick.biomes.length, 6));
         const pool = generateSyntheticBiomes(state.data.biomi, n);
         state.pick.biomes = pool;
+        state.pick.ecosystem = {
+          id: state.pick.ecosystem?.id || randomId("ecos"),
+          label: `Rete sintetica (${pool.length} biomi)`,
+          synthetic: true,
+          sources: state.data.ecosistema?.biomi?.map((b) => b.id) ?? [],
+          connessioni: synthesiseConnections(pool),
+        };
+        state.pick.exportSlug = null;
         rerollSpecies(filters);
         rerollSeeds(filters);
         renderBiomes(filters);
@@ -1570,14 +1875,16 @@ function attachActions() {
       }
       case "export-json": {
         const payload = exportPayload(filters);
-        downloadFile("ecosystem_pick.json", JSON.stringify(payload, null, 2), "application/json");
+        const slug = ensureExportSlug();
+        downloadFile(`${slug}.json`, JSON.stringify(payload, null, 2), "application/json");
         setStatus("Esportazione JSON completata.");
         break;
       }
       case "export-yaml": {
         const payload = exportPayload(filters);
         const yaml = toYAML(payload);
-        downloadFile("ecosystem_pick.yaml", yaml, "text/yaml");
+        const slug = ensureExportSlug();
+        downloadFile(`${slug}.yaml`, yaml, "text/yaml");
         setStatus("Esportazione YAML completata.");
         break;
       }
@@ -1617,6 +1924,9 @@ async function loadData() {
   }
 }
 
+updateSummaryCounts();
+restoreActivityLog();
+renderActivityLog();
 renderTraitExpansions();
 attachActions();
 loadData();

--- a/docs/site.css
+++ b/docs/site.css
@@ -502,6 +502,391 @@ a:focus-visible {
   padding: 24px 5vw 80px;
 }
 
+.layout--generator {
+  display: grid;
+  gap: 32px;
+  align-items: start;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.generator-sidebar {
+  position: relative;
+  display: grid;
+  gap: 24px;
+}
+
+.generator-card {
+  position: sticky;
+  top: 32px;
+  display: grid;
+  gap: 28px;
+}
+
+.generator-results {
+  display: grid;
+  gap: 32px;
+}
+
+.generator-panel {
+  gap: 24px;
+}
+
+.generator-panel__header {
+  display: grid;
+  gap: 8px;
+}
+
+.generator-panel__header p {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.generator-monitor {
+  display: grid;
+  gap: 24px;
+}
+
+.generator-monitor__header {
+  display: grid;
+  gap: 6px;
+}
+
+.generator-monitor__title {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.generator-monitor__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.generator-log {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 12px;
+}
+
+.generator-log__item {
+  display: grid;
+  gap: 6px;
+  padding: 14px 18px;
+  border-radius: 14px;
+  border: 1px solid rgba(88, 166, 255, 0.24);
+  background: rgba(88, 166, 255, 0.1);
+  transition: border-color var(--transition), background var(--transition), transform var(--transition);
+}
+
+.generator-log__item[data-tone="info"] {
+  border-color: rgba(88, 166, 255, 0.34);
+  background: rgba(88, 166, 255, 0.15);
+}
+
+.generator-log__item[data-tone="warn"] {
+  border-color: rgba(251, 191, 36, 0.6);
+  background: rgba(251, 191, 36, 0.15);
+}
+
+.generator-log__item[data-tone="error"] {
+  border-color: rgba(248, 113, 113, 0.7);
+  background: rgba(248, 113, 113, 0.18);
+}
+
+.generator-log__time {
+  margin: 0;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+.generator-log__message {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.generator-export__meta {
+  margin: 0 0 12px;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.generator-export-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 16px;
+}
+
+.generator-export {
+  display: grid;
+  gap: 8px;
+  padding: 16px 18px;
+  border-radius: 14px;
+  border: 1px solid rgba(88, 166, 255, 0.28);
+  background: rgba(88, 166, 255, 0.12);
+  transition: border-color var(--transition), background var(--transition), transform var(--transition);
+}
+
+.generator-export__title {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 1rem;
+}
+
+.generator-export__format {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  background: rgba(88, 166, 255, 0.22);
+  color: var(--text-muted);
+}
+
+.generator-export__description {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--text-muted);
+}
+
+.generator-export__path {
+  margin: 0;
+  padding: 6px 12px;
+  border-radius: 10px;
+  background: rgba(88, 166, 255, 0.12);
+  color: var(--accent);
+  font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+  word-break: break-all;
+}
+
+.generator-export-preview {
+  margin-top: 18px;
+  display: grid;
+  gap: 12px;
+}
+
+.export-preview {
+  border: 1px solid rgba(88, 166, 255, 0.24);
+  border-radius: 14px;
+  background: rgba(88, 166, 255, 0.1);
+  overflow: hidden;
+  transition: border-color var(--transition), background var(--transition), transform var(--transition);
+}
+
+.export-preview[open] {
+  border-color: rgba(88, 166, 255, 0.34);
+  background: rgba(88, 166, 255, 0.16);
+}
+
+.export-preview__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0;
+  padding: 14px 18px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+}
+
+.export-preview__summary::-webkit-details-marker {
+  display: none;
+}
+
+.export-preview__summary::after {
+  content: "Apri";
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.export-preview[open] .export-preview__summary::after {
+  content: "Chiudi";
+}
+
+.export-preview__content {
+  margin: 0;
+  padding: 16px 20px 20px;
+  background: rgba(2, 6, 15, 0.8);
+  border-top: 1px solid rgba(88, 166, 255, 0.24);
+  max-height: 320px;
+  overflow: auto;
+  font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.export-preview__content code {
+  display: block;
+  white-space: pre;
+}
+
+.generator-grid {
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+}
+
+.generator-grid > * {
+  min-height: 100%;
+}
+
+.generator-summary {
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 18px;
+  border: 1px solid rgba(88, 166, 255, 0.24);
+  background: rgba(8, 12, 19, 0.8);
+  backdrop-filter: blur(14px);
+  transition: border-color var(--transition), background var(--transition), transform var(--transition);
+}
+
+.generator-summary[data-has-results="true"] {
+  border-color: rgba(88, 166, 255, 0.36);
+  background: rgba(10, 16, 24, 0.92);
+}
+
+.generator-summary__title {
+  margin: 0;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--text-muted);
+}
+
+.generator-summary__metrics {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+}
+
+.generator-summary__metrics dt,
+.generator-summary__metrics dd {
+  margin: 0;
+}
+
+.generator-summary__metric {
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+  border-radius: 14px;
+  background: rgba(88, 166, 255, 0.08);
+  border: 1px solid rgba(88, 166, 255, 0.18);
+  transition: transform var(--transition), border-color var(--transition), background var(--transition);
+}
+
+.generator-summary[data-has-results="true"] .generator-summary__metric {
+  background: rgba(88, 166, 255, 0.18);
+  border-color: rgba(88, 166, 255, 0.42);
+  transform: translateY(-2px);
+}
+
+.generator-summary__label {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.generator-summary__value {
+  margin: 0;
+  font-size: 1.9rem;
+  font-weight: 600;
+}
+
+.generator-summary__status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.generator-summary__status[data-tone="error"] {
+  color: #f87171;
+}
+
+.generator-summary__status[data-tone="warn"] {
+  color: #fbbf24;
+}
+
+.generator-summary__note {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.generator-summary__note[data-tone="error"] {
+  color: #f87171;
+}
+
+.generator-summary__note[data-tone="warn"] {
+  color: #fbbf24;
+}
+
+@media (min-width: 1080px) {
+  .layout--generator {
+    grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  }
+
+  .generator-results {
+    gap: 36px;
+  }
+}
+
+@media (min-width: 720px) {
+  .generator-form__grid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+
+  .generator-form__grid--filters {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .generator-summary__metrics {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+}
+
+@media (min-width: 960px) {
+  .generator-panel__header {
+    grid-template-columns: 1fr minmax(220px, 320px);
+    align-items: end;
+  }
+
+  .generator-panel__header > p {
+    justify-self: end;
+    text-align: right;
+  }
+
+  .generator-monitor {
+    grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  }
+}
+
+@media (min-width: 1440px) {
+  .generator-grid {
+    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+  }
+}
+
 .section {
   margin-bottom: 72px;
 }
@@ -785,6 +1170,59 @@ a:focus-visible {
   gap: 12px;
 }
 
+.generator-form {
+  gap: 24px;
+}
+
+.generator-form__header {
+  display: grid;
+  gap: 10px;
+}
+
+.generator-form__description {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.generator-form__section {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(88, 166, 255, 0.2);
+  background: rgba(88, 166, 255, 0.06);
+}
+
+.generator-form__section:hover {
+  border-color: rgba(88, 166, 255, 0.4);
+  background: rgba(88, 166, 255, 0.1);
+}
+
+.generator-form__legend {
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.generator-form__grid {
+  display: grid;
+  gap: 16px;
+}
+
+.generator-form__grid--filters {
+  gap: 18px;
+}
+
+.generator-form__actions {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
 .form label {
   font-size: 0.9rem;
   color: var(--text-muted);
@@ -929,6 +1367,15 @@ a:focus-visible {
   .hero__content {
     max-width: none;
   }
+
+  .layout--generator {
+    gap: 24px;
+  }
+
+  .generator-card {
+    position: relative;
+    top: 0;
+  }
 }
 
 @media (max-width: 720px) {
@@ -963,6 +1410,14 @@ a:focus-visible {
 
   .card--frame iframe {
     min-height: 420px;
+  }
+
+  .generator-form__section {
+    padding: 16px;
+  }
+
+  .generator-summary {
+    padding: 18px;
   }
 }
 


### PR DESCRIPTION
## Summary
- add collapsible JSON and YAML previews to the generator export manifest
- persist the generator monitor activity log in localStorage between sessions
- style the new preview panel to match the existing generator layout

## Testing
- Not run (static front-end updates)

------
https://chatgpt.com/codex/tasks/task_e_68fdba0ab0fc8332b7d3592498d8dc3c