### PR TITLE
Add radar comparison UI to ecosystem generator

### DIFF
--- a/docs/evo-tactics-pack/generator.html
+++ b/docs/evo-tactics-pack/generator.html
@@ -12,6 +12,7 @@
     <meta name="data-branch" content="main" />
     <title>Ecosystem Pack · Generatore</title>
     <link rel="stylesheet" href="../site.css" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
     <script type="module" src="generator.js" defer></script>
   </head>
   <body>
@@ -175,6 +176,32 @@
               </p>
               <ul class="generator-pins" id="generator-pinned-list" aria-live="polite"></ul>
             </div>
+            <section
+              class="generator-compare"
+              id="generator-compare-panel"
+              aria-labelledby="generator-compare-title"
+            >
+              <div class="generator-compare__header">
+                <h4 class="generator-compare__title" id="generator-compare-title">
+                  Confronto specie
+                </h4>
+                <p class="generator-compare__hint">
+                  Seleziona fino a tre specie con il pulsante <span aria-hidden="true">📊</span>
+                  <span class="visually-hidden">Confronta</span> sulle card per visualizzare il grafico radar.
+                </p>
+              </div>
+              <p class="generator-compare__empty" id="generator-compare-empty">
+                Nessuna specie in confronto. Usa il pulsante 📊 sulle card per aggiungerle.
+              </p>
+              <ul class="generator-compare__list" id="generator-compare-list" aria-live="polite"></ul>
+              <div class="generator-compare__chart" id="generator-compare-chart" hidden>
+                <canvas id="generator-compare-canvas" aria-describedby="generator-compare-title"></canvas>
+                <p class="generator-compare__fallback" id="generator-compare-fallback" hidden>
+                  Impossibile caricare il grafico radar. Controlla la connessione o la console per
+                  ulteriori dettagli.
+                </p>
+              </div>
+            </section>
           </section>
         </article>
         </section>

--- a/docs/site.css
+++ b/docs/site.css
@@ -1293,6 +1293,144 @@ body.codex-open {
   opacity: 0.7;
 }
 
+.generator-compare {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 16px;
+  border: 1px solid rgba(88, 166, 255, 0.22);
+  background: rgba(9, 14, 28, 0.78);
+}
+
+.generator-compare__header {
+  display: grid;
+  gap: 6px;
+}
+
+.generator-compare__title {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(226, 240, 255, 0.7);
+}
+
+.generator-compare__hint {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.generator-compare__empty {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(156, 215, 255, 0.82);
+}
+
+.generator-compare__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 12px;
+}
+
+.generator-compare__item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(88, 166, 255, 0.2);
+  background: rgba(12, 20, 36, 0.8);
+}
+
+.generator-compare__info {
+  display: grid;
+  gap: 6px;
+}
+
+.generator-compare__name {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #e2f0ff;
+  font-weight: 600;
+}
+
+.generator-compare__meta {
+  margin: 0;
+  font-size: 0.78rem;
+  color: rgba(156, 215, 255, 0.78);
+}
+
+.generator-compare__metrics {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+}
+
+.generator-compare__metric {
+  font-size: 0.75rem;
+  color: rgba(195, 220, 255, 0.85);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.generator-compare__metric-label {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.68rem;
+  color: rgba(148, 196, 255, 0.7);
+}
+
+.generator-compare__remove {
+  background: none;
+  border: none;
+  color: rgba(244, 114, 182, 0.85);
+  font-size: 0.85rem;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 10px;
+  transition: background var(--transition), color var(--transition);
+}
+
+.generator-compare__remove:hover,
+.generator-compare__remove:focus-visible {
+  background: rgba(244, 114, 182, 0.15);
+  color: rgba(249, 168, 212, 0.95);
+}
+
+.generator-compare__chart {
+  position: relative;
+  min-height: 240px;
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px dashed rgba(88, 166, 255, 0.2);
+  background: rgba(10, 18, 32, 0.72);
+}
+
+.generator-compare__chart canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.generator-compare__fallback {
+  margin: 12px 0 0;
+  font-size: 0.78rem;
+  color: rgba(244, 114, 182, 0.8);
+}
+
+.generator-summary[data-has-comparison="false"] #generator-compare-panel {
+  opacity: 0.75;
+}
+
+.generator-summary[data-has-comparison="false"] .generator-compare__chart {
+  display: none;
+}
+
 .generator-pins {
   margin: 0;
   padding: 0;
@@ -1550,6 +1688,11 @@ body.codex-open {
   box-shadow: 0 0 0 1px rgba(250, 204, 21, 0.32), inset 0 1px 0 rgba(250, 204, 21, 0.2);
 }
 
+.species-card[data-compare="true"] {
+  border-color: rgba(110, 231, 183, 0.55);
+  box-shadow: 0 0 0 1px rgba(110, 231, 183, 0.28), inset 0 1px 0 rgba(16, 185, 129, 0.25);
+}
+
 .species-card__media {
   height: 64px;
   width: 64px;
@@ -1663,6 +1806,12 @@ body.codex-open {
   background: rgba(250, 204, 21, 0.2);
   border-color: rgba(250, 204, 21, 0.6);
   color: #facc15;
+}
+
+.quick-button--compare.is-active {
+  background: rgba(16, 185, 129, 0.2);
+  border-color: rgba(16, 185, 129, 0.45);
+  color: #6ee7b7;
 }
 
 .quick-button:focus-visible {


### PR DESCRIPTION
## Summary
- integrate a Chart.js radar chart and comparison panel into the generator page
- add compare buttons on species cards with tier, hazard, and role metrics feeding the chart
- style the comparison overlay and states in the shared site stylesheet

## Testing
- node --check docs/evo-tactics-pack/generator.js

------
https://chatgpt.com/codex/tasks/task_e_68fe62cf141c83329a126649a8e5e0e9