### PR TITLE
Document drive sync quotas and trigger guidance

### DIFF
--- a/docs/checklist/milestones.md
+++ b/docs/checklist/milestones.md
@@ -15,4 +15,5 @@
 ## Completare prossimamente
 - [x] Collegare esport automatizzato dei log VC a Google Sheet (`scripts/driveSync.gs`).
   - Fogli di riferimento: [VC Telemetry Sync](https://docs.google.com/spreadsheets/d/1VCExampleTelemetrySync/edit) · [PI Packs Sync](https://docs.google.com/spreadsheets/d/1PIExamplePacksSync/edit)
+  - 2025-10-27 · ⚠️ Esecuzione pilota non verificata in ambiente locale: necessario l'accesso a Google Apps Script per confermare tempi di esecuzione e coerenza dei fogli generati.
 - [x] Aggiornare i Canvas principali con note sulle nuove feature CLI.【F:docs/Canvas/feature-updates.md†L3-L40】

--- a/docs/drive-sync.md
+++ b/docs/drive-sync.md
@@ -7,6 +7,7 @@ Questa guida spiega come configurare lo script `scripts/driveSync.gs` su Google 
 - **Cartella Drive dedicata** contenente i file `.yaml` o `.yml` da sincronizzare.
 - **Autorizzazioni** per spostare file nella cartella e creare nuovi Spreadsheet.
 - **Quota Apps Script disponibile**: massimo 20 trigger per progetto e chiamate `UrlFetchApp` sufficienti per scaricare la libreria YAML.
+- **Credenziali OAuth**: al primo avvio verranno richiesti i consensi per accedere a Drive, Spreadsheet, Script Properties, Cache e UrlFetch; confermare lo scope completo (`https://www.googleapis.com/auth/drive`, `.../drive.file`, `.../spreadsheets`, `.../script.external_request`).
 
 ## Configurazione iniziale
 1. Apri [script.google.com](https://script.google.com) e crea un nuovo progetto collegato alla cartella Drive che contiene gli YAML ("Nuovo > Script" dall'interno della cartella).
@@ -17,7 +18,8 @@ Questa guida spiega come configurare lo script `scripts/driveSync.gs` su Google 
    - `DRIVE_SYNC_YAML_LIB_URL`: URL della libreria js-yaml (lasciare il default salvo mirror interni).
    - `DRIVE_SYNC_AUTOSYNC_ENABLED`: `true`/`false` per attivare il trigger automatico.
    - `DRIVE_SYNC_AUTOSYNC_EVERY_HOURS`: intervallo di riesecuzione (1-24).
-4. Salva e autorizza lo script eseguendo manualmente `convertYamlToSheets()` dalla barra "Run".
+4. Salva il progetto, apri `Project Settings > Scopes` e verifica che gli scope siano coerenti con gli accessi richiesti; se necessario, forzare il re-deploy eliminando eventuali scope obsoleti.
+5. Autorizza lo script eseguendo manualmente `convertYamlToSheets()` dalla barra "Run" e seguendo il flusso OAuth.
 
 ## Test manuale (`convertYamlToSheets`)
 1. Preparare nella cartella Drive uno o più file YAML di test (es. `sample.yaml`).
@@ -32,7 +34,24 @@ Questa guida spiega come configurare lo script `scripts/driveSync.gs` su Google 
 2. Eseguire `ensureAutoSyncTrigger()`:
    - Lo script controlla che le autorizzazioni siano concesse; in caso contrario fornisce l'URL per completare l'OAuth.
    - Se non esiste già un trigger sul metodo `convertYamlToSheets`, ne crea uno con frequenza pari all'intervallo configurato.
+   - Il trigger suggerito per i dataset principali è **ogni 6 ore** (valore predefinito di `DRIVE_SYNC_AUTOSYNC_EVERY_HOURS`), con fallback giornaliero se l'intervallo viene impostato ≥24 ore.
 3. È possibile rimuovere i trigger con `removeAutoSyncTriggers()` o dal pannello "Triggers".
+
+### Trigger consigliati
+| Handler                | Tipo       | Frequenza | Note |
+|------------------------|------------|-----------|------|
+| `convertYamlToSheets`  | time-based | ogni 6 h  | Mantiene sincronizzati i dataset YAML principali senza saturare le quote giornaliere. |
+| `convertYamlToSheets`  | manuale    | on demand | Usare come fallback in caso di errori nel trigger automatico. |
+
+Documentare nel pannello `Triggers` di Apps Script l'utente proprietario: il progetto deve appartenere a un account con permessi di modifica sulla cartella condivisa, altrimenti i fogli non vengono spostati nel Drive di destinazione.
+
+## Quote e limiti
+- **Esecuzione script**: max 6 minuti per esecuzione e 90 minuti totali/giorno per account consumer.
+- **Chiamate `UrlFetchApp`**: 20.000 richieste/giorno; lo script utilizza una singola richiesta per recuperare `js-yaml` (riusata tramite cache).
+- **Operazioni su Drive/Spreadsheet**: 10 minuti/giorno per `DriveApp` e 100 MB/giorno di scrittura su Spreadsheet; il dataset attuale è ben al di sotto del limite ma monitorare `Executions` in caso di picchi.
+- **Trigger**: max 20 per progetto (già ricordato sopra) e 90 esecuzioni/ora per trigger time-based; il ritmo ogni 6 ore è sicuro.
+
+Quando le quote vengono esaurite, Apps Script registra errori `Exceeded maximum execution time` o `Service invoked too many times` nei log: impostare notifiche email dal pannello `Triggers` per intercettare gli eventi.
 
 ## Limiti e note operative
 - L'esecuzione dipende da `UrlFetchApp`: verificare che l'URL della libreria sia raggiungibile; usare un mirror se il CDN è bloccato.


### PR DESCRIPTION
## Summary
- expand the Drive sync runbook with OAuth scope requirements, trigger cadence recommendations, and core Apps Script quotas
- note in the milestone checklist that the pilot synchronization still needs confirmation in a live Apps Script environment

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68fe688440988332b1fc4c5f4705cf5c