### PR TITLE
feat: align telemetry pe costs and skydock tuning

### DIFF
--- a/data/missions/skydock_siege.yaml
+++ b/data/missions/skydock_siege.yaml
@@ -1,0 +1,55 @@
+skydock_siege:
+  revision: "2025-02-15-vc"
+  source_logs:
+    - session: alpha
+      tier: "Tier 2"
+      risk:
+        time_low_hp_turns: 6
+        weighted_index: 0.58
+    - session: bravo
+      tier: "Tier 3"
+      risk:
+        time_low_hp_turns: 11
+        weighted_index: 0.63
+    - session: charlie
+      tier: "Tier 3 (Co-op)"
+      risk:
+        time_low_hp_turns: 5
+        weighted_index: 0.51
+  targets:
+    tier_2:
+      time_low_hp_turns_max: 5
+    tier_3:
+      time_low_hp_turns_max: 7
+    tier_3_coop:
+      time_low_hp_turns_max: 5
+  adjustments:
+    shared:
+      - id: evacuation_timer_turns
+        from: 6
+        to: 7
+        rationale: "Turno extra per completare il ciclo di cure prima della spinta finale; riduce il tempo prolungato in HP critico registrato nelle sessioni Alpha/Bravo."
+      - id: aeon_overload_damage_pct
+        from: 0.28
+        to: 0.24
+        rationale: "I picchi di danno dell'overload hanno allineato Alpha e Bravo a finestre EMA >0.60; riduciamo il burst per restare nel range di rischio previsto."
+    tier_3:
+      - id: shield_relay_cooldown_turns
+        from: 5
+        to: 4
+        rationale: "Bravo ha accumulato 11 turni a HP critico; accelerare il relay consente rotazioni di guardia prima della successiva ondata d'assedio."
+      - id: medkit_drop_turns
+        from: [9]
+        to: [6, 12]
+        rationale: "Distribuzione doppia dei medkit per interrompere sequenze prolungate senza cure dopo l'overload dei droni."
+    tier_3_coop:
+      - id: support_drone_priority
+        from: "threat_highest"
+        to: "hp_lowest"
+        rationale: "In co-op Charlie resta sotto controllo ma beneficia di redirect immediato per proteggere il supporto Helix durante Aeon overload."
+  monitoring:
+    - metric: risk.time_low_hp_turns
+      expected_trend: "Rivalutare dopo il prossimo VC: target <=7 su Tier 3."
+    - metric: risk.weighted_index
+      hud_alert_threshold: 0.60
+      action: "Trigger avviso HUD (fascia gialla) e ping automatico al canale PI balance."

--- a/data/telemetry.yaml
+++ b/data/telemetry.yaml
@@ -2,9 +2,9 @@ telemetry:
   ema_alpha: 0.3
   windows:
     turn: true
-    phase_weights: {early: 0.20, mid: 0.40, late: 0.40}
+    phase_weights: {early: 0.25, mid: 0.35, late: 0.40}
   debounce_ms: 200
-  idle_threshold_s: 8
+  idle_threshold_s: 10
   normalization: "ema_capped_minmax"
   normalization_params:
     floor: 0.15
@@ -33,6 +33,6 @@ pe_economy:
   style_bonus: {formula: "floor((sum_vc - 2.8)*3)", cap: 3}
   optional_objectives_cap: 2
   mission_cap: 10
-  costs: {trait_T1: 3, trait_T2: 6, trait_T3: 10, job_ability: 4, ultimate_slot: 6}
+  costs: {trait_T1: 3, trait_T2: 6, trait_T3: 10, job_ability: 4, ultimate_slot: 6, cap_pt: 2, guardia_situazionale: 2, starter_bioma: 1, sigillo_forma: 2}
   unlocks_per_mission_cap: 2
   dormancy_after_missions_without_trigger: 2

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,11 @@
 - Registro manutenzione 2025-10-24 con reinstallazione dipendenze `tools/ts` e `tools/py` documentato in `logs/tooling/2025-10-24-tooling.md`.
 - Nota di manutenzione in `docs/chatgpt_sync_status.md` per l'ambiente corrente (Node 22.19.0 / Python 3.11.12).
 - Verbale test manuali 2025-10-26 per `docs/test-interface/` con esiti positivi su ricarica YAML e suite pulsanti automatici.
+- Documentazione hook EMA/HUD per trasmissione metriche e alert risk in `docs/hooks/ema-metrics.md`.
+- Dataset di tuning missione `data/missions/skydock_siege.yaml` con target `risk.time_low_hp_turns` e interventi condivisi con il team VC.
+
+### Changed
+- Aggiornate le finestre EMA (`phase_weights`, `idle_threshold_s`) e i costi PE (`cap_pt`, `guardia_situazionale`, `starter_bioma`, `sigillo_forma`) in `data/telemetry.yaml` per allineare i log VC e il negozio PI.
 
 ### Fixed
 - Allineamento degli output `roll_pack` tra CLI TypeScript e Python utilizzando seed condiviso (`demo`).

--- a/docs/hooks/ema-metrics.md
+++ b/docs/hooks/ema-metrics.md
@@ -1,0 +1,56 @@
+# Hook — Trasmissione Metriche EMA & Alert Risk HUD
+
+## Contesto
+- Dataset sorgente: `data/telemetry.yaml` (`ema_alpha`, `windows.phase_weights`, normalizzazione `ema_capped_minmax`).
+- Mission tuning: `data/missions/skydock_siege.yaml` definisce target `risk.time_low_hp_turns` e l'alert HUD >0.60 come azione di monitoraggio condivisa.
+- Playtest di riferimento: log VC `logs/playtests/2025-02-15-vc/session-metrics.yaml` (sessioni Alpha/Bravo/Charlie).
+
+## Flusso di trasmissione
+1. **Motore client → Telemetria**
+   ```ts
+   telemetryBus.emit("ema.update", {
+     missionId: context.missionId,
+     turn: state.turn,
+     ema: state.ema, // alpha 0.3, pesi fase 0.25/0.35/0.40
+     indices: state.indices,
+   });
+   ```
+   - L'oggetto `state.ema` espone `window` (turno) e frame `phase_weights` aggiornati.
+   - `indices` include `risk.weighted_index` e `risk.time_low_hp_turns` per confronto diretto con i target del tuning.
+
+2. **Middleware VC (client)**
+   ```ts
+   telemetryBus.on("ema.update", (payload) => {
+     hudLayer.updateTrend("risk", payload.indices.risk);
+     if (payload.indices.risk.weighted_index >= 0.60) {
+       hudLayer.raiseAlert({
+         id: "risk-high",
+         severity: "warning",
+         message: "Risk EMA oltre soglia 0.60",
+         metadata: {
+           weightedIndex: payload.indices.risk.weighted_index,
+           timeLowHp: payload.indices.risk.time_low_hp_turns,
+         },
+       });
+       commandBus.emit("pi.balance.alert", payload);
+     }
+   });
+   ```
+   - L'alert HUD usa colore giallo (warning) e si auto-disarma quando la media scende sotto 0.58 per due tick consecutivi.
+   - `commandBus.emit` notifica il canale PI balance per follow-up immediato.
+
+3. **Persistenza & export**
+   - In coda missione, il client salva un frammento YAML con l'ultima finestra EMA e i momenti di attivazione dell'alert.
+   - Il file confluisce nella pipeline Drive/Canvas insieme alle metriche dei log VC.
+
+## Hook documentati
+| Hook ID | Origine | Destinazione | Payload | Note |
+| --- | --- | --- | --- | --- |
+| `telemetry.ema.update` | Motore → Telemetria | Middleware VC | `{ missionId, turn, ema, indices }` | Frequenza: a fine turno (debounce 200 ms). |
+| `hud.alert.risk-high` | Middleware VC | HUD overlay | `{ id, severity, message, metadata }` | Soglia ingresso 0.60, uscita 0.58 (isteresi). |
+| `pi.balance.alert` | Middleware VC | Notifica PI | `{ missionId, roster, indices }` | Smista su Slack/Teams per revisione bilanciamento. |
+
+## Next steps condivisi con team client
+- Validare in staging la latenza dell'alert rispetto agli eventi `aeon_overload` (target: <250 ms post-evento).
+- Aggiornare documentazione HUD con screenshot dei nuovi banner e relativo log export.
+- Integrare la sincronizzazione automatica dei frammenti YAML nel workflow `deploy-test-interface` per review rapida.

--- a/docs/piani/roadmap.md
+++ b/docs/piani/roadmap.md
@@ -3,11 +3,11 @@
 ## Milestone attive
 1. **Bilanciare pacchetti PI tra Forme**  
  - Validare il bias `random_general_d20` rispetto alle nuove combinazioni `bias_d12` per evitare inflazione di PE.【F:data/packs.yaml†L5-L88】
-  - Sincronizzare i costi `pi_shop` con la curva PE definita in `telemetry.pe_economy`.【F:data/packs.yaml†L1-L4】【F:data/telemetry.yaml†L23-L29】
+  - Sincronizzare i costi `pi_shop` con la curva PE definita in `telemetry.pe_economy` (aggiunti i valori mancanti per `cap_pt`, `guardia_situazionale`, `starter_bioma`, `sigillo_forma`).【F:data/packs.yaml†L1-L4】【F:data/telemetry.yaml†L23-L31】
   - Aggiornare il monitoraggio: `risk.weighted_index` si è stabilizzato a 0.57 nella sessione Delta dopo l'introduzione del segnale `overcap_guard`, ma resta da mitigare il picco 0.61 della sessione Echo.【F:logs/playtests/2025-10-24-vc/session-metrics.yaml†L14-L62】
   - Inserire alert HUD dedicati nella dashboard Canvas per segnalare automaticamente il superamento della soglia 0.60 durante i roll PI.【F:docs/Canvas/feature-updates.md†L9-L20】
 2. **Telemetria VC in game build**
-   - Integrare le finestre EMA (`ema_alpha`, `windows`) nel client per raccogliere dati reali.【F:data/telemetry.yaml†L1-L8】
+   - Integrare le finestre EMA (`ema_alpha`, `windows`) nel client per raccogliere dati reali, documentando gli hook HUD/telemetria condivisi con il team client.【F:data/telemetry.yaml†L1-L8】【F:docs/hooks/ema-metrics.md†L1-L52】
    - Mappare gli indici VC ai trigger Enneagram per generare feedback contestuali.【F:data/telemetry.yaml†L9-L22】
    - Risultati playtest 2025-10-24: Delta rientra nel range sicuro grazie al nuovo smoothing EMA (0.2), mentre Echo sfiora ancora la soglia 0.61 durante Aeon Overclock → pianificare timer di guardia condivisa.【F:logs/playtests/2025-10-24-vc/session-metrics.yaml†L1-L62】
    - Prossimo step client: esporre pannello HUD con breakdown EMA per squadra e log raw esportabile (`.yaml`) a fine missione, includendo il campo `overcap_guard_events`.
@@ -18,7 +18,7 @@
  - Preparare il playtest di "Skydock Siege" con obiettivi multilivello e timer di evacuazione.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
   - Collegare Reattori Aeon, filtro SquadSync e protocolli di soccorso alla pipeline telemetrica co-op.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
   - Applicare il nuovo layout HUD: grafici risk/cohesion sovrapposti e log esportabili in `.yaml` direttamente da Canvas per i vertical slice.【F:docs/Canvas/feature-updates.md†L9-L20】
-  - Bilanciare i timer di evacuazione in funzione dei picchi `risk.time_low_hp_turns` registrati nelle squadre Bravo e Charlie, mantenendo l'obiettivo di tilt < 0.50.【F:logs/playtests/2025-02-15-vc/session-metrics.yaml†L61-L121】
+  - Bilanciare i timer di evacuazione in funzione dei picchi `risk.time_low_hp_turns` registrati nelle squadre Bravo e Charlie, mantenendo l'obiettivo di tilt < 0.50; revisione 2025-02-15 documentata in `data/missions/skydock_siege.yaml`.【F:logs/playtests/2025-02-15-vc/session-metrics.yaml†L61-L121】【F:data/missions/skydock_siege.yaml†L1-L52】
 
 ## Prossimi passi
 - Documentare esempi di encounter generati (CLI Python) e associarli a test di difficoltà per ciascun bioma.【F:data/biomes.yaml†L1-L13】


### PR DESCRIPTION
## Summary
- align EMA phase weights/idle threshold with VC logs and extend PE cost table to cover PI shop entries
- capture Skydock Siege tuning adjustments in a dedicated mission dataset targeting reduced low-HP exposure
- document EMA → HUD hooks for risk alerts and refresh roadmap/changelog with the latest telemetry alignment

## Testing
- python3 tools/py/game_cli.py validate-datasets

------
https://chatgpt.com/codex/tasks/task_e_68fe6b3c1cd483329bcd4a80aa4feedb