### PR TITLE
Add playtest documentation for scenarios and pilot session

### DIFF
--- a/docs/playtest/SESSION-template.md
+++ b/docs/playtest/SESSION-template.md
@@ -1,0 +1,40 @@
+# Report sessione di playtest — SESSION-YYYY-MM-DD
+
+## Informazioni generali
+- **Data:**
+- **Luogo/piattaforma:**
+- **Sessione pilota o follow-up:**
+- **Facilitatrice/tore:**
+- **Partecipanti principali:**
+
+## Scenari eseguiti
+| Scenario ID | Descrizione | Stato completamento | Note |
+| --- | --- | --- | --- |
+
+## Metriche raccolte
+- **Bilanciamento:** (es. tasso vittoria, danno medio, tempo incontro)
+- **Progressione:** (es. step completati, risorse finali)
+- **Eventi speciali:** (es. decisioni prese, bug visivi)
+
+## Sintesi feedback
+- **Punti di forza osservati:**
+- **Problematiche riscontrate:**
+- **Suggerimenti ricorrenti:**
+
+## Bug e ticket
+| ID issue | Titolo | Stato | Etichette | Link |
+| --- | --- | --- | --- | --- |
+
+## Materiali archiviati
+- Log: `logs/SESSION-YYYY-MM-DD/`
+- Screenshot/Video: `logs/SESSION-YYYY-MM-DD/media/`
+- Feedback individuali: `docs/playtest/SESSION-YYYY-MM-DD/feedback/`
+- Altri allegati:
+
+## Azioni successive
+1. ...
+2. ...
+3. ...
+
+---
+Compilato da: `Nome` — `Ruolo`

--- a/docs/playtest/feedback-template.md
+++ b/docs/playtest/feedback-template.md
@@ -1,0 +1,37 @@
+# Template raccolta feedback playtest
+
+Compilare un documento per partecipante al termine della sessione (o durante pause concordate). Le domande aperte possono essere integrate con note dell'osservatore.
+
+## Dati generali
+- **Sessione:** `SESSION-YYYY-MM-DD`
+- **Partecipante:**
+- **Ruolo/Profilo:**
+- **Scenario/i giocati:**
+
+## Esperienza generale
+1. Come valuteresti la difficoltà complessiva degli scenari provati? (1-5) — Motivare.
+2. Hai incontrato momenti di frustrazione o confusione? Descrivi quando e perché.
+3. Quali elementi ti sono piaciuti maggiormente?
+
+## Bilanciamento
+1. Gli scontri erano coerenti con le tue aspettative rispetto al livello del personaggio?
+2. Ci sono abilità o nemici che ti sono sembrati sbilanciati? Specifica.
+
+## Progressione
+1. I requisiti per progredire erano chiari? Hai dovuto ripetere attività inaspettate?
+2. Le ricompense ricevute sono state soddisfacenti? Suggerimenti di miglioramento?
+
+## Eventi speciali
+1. L'evento speciale era comprensibile nel suo funzionamento e nelle conseguenze?
+2. Hai riscontrato bug visivi o narrativi durante l'evento?
+
+## Problemi tecnici
+- Lista di bug riscontrati (con passi di riproduzione e severità).
+- Note su prestazioni, input o stabilità.
+
+## Suggerimenti aggiuntivi
+Spazio libero per commenti, idee o richieste future.
+
+---
+
+**Istruzioni per la consegna:** salvare il file compilato nella cartella della sessione (`docs/playtest/SESSION-YYYY-MM-DD/feedback/`) o allegarlo al documento principale della sessione.

--- a/docs/playtest/pilot-session-2025-11-12.md
+++ b/docs/playtest/pilot-session-2025-11-12.md
@@ -1,0 +1,37 @@
+# Sessione pilota 12 novembre 2025
+
+## Obiettivi
+- Validare gli scenari di bilanciamento `BAL-01` e `BAL-02`, la progressione `PROG-01` e l'evento speciale `EVT-01`.
+- Verificare il flusso di raccolta feedback e la procedura post-sessione.
+
+## Partecipanti
+| Ruolo | Nome | Responsabilità |
+| --- | --- | --- |
+| Facilitatrice | Marta Bianchi | Conduzione della sessione, gestione tempi, moderazione Q&A. |
+| QA Lead | Luca Ferretti | Tracking bug, verifica prerequisiti tecnici, coordinamento logging. |
+| Game Designer | Elisa Conti | Valutazione bilanciamento, raccolta feedback qualitativo. |
+| Narrative Designer | Paolo Riva | Monitoraggio coerenza narrativa durante EVT-01. |
+| Osservatori esterni | 3 tester esperti | Partecipazione al playtest e compilazione template feedback. |
+
+## Calendario
+- **09:30-10:00** — Setup postazioni, verifica build `alpha-balancing` e savegame dedicati.
+- **10:00-10:20** — Briefing introduttivo e reminder sulle regole di feedback.
+- **10:20-11:10** — Esecuzione scenario `BAL-01` (registrazione video + telemetria).
+- **11:10-11:20** — Break tecnico.
+- **11:20-12:10** — Esecuzione scenario `BAL-02` e `PROG-01`.
+- **12:10-12:30** — Discussione guidata sull'evento `EVT-01` e raccolta feedback immediato.
+- **12:30-13:00** — Compilazione template feedback individuale e consolidamento note.
+
+## Materiali e preparazione
+- Build `alpha-balancing` installata su 5 postazioni con controller e tastiera.
+- Savegame "Pilot-Nov2025" con progressione fino al capitolo 4.
+- Accesso a `docs/playtest/scenari-test.md` e ai prerequisiti segnalati.
+- Cartella condivisa `logs/pilot-2025-11-12/` per video, log e screenshot (creare prima della sessione).
+- Copie stampate o digitali del `feedback-template.md` per ogni partecipante.
+- Foglio di calcolo telemetrico collegato a `telemetry/pilot-session-2025-11-12.xlsx`.
+
+## Deliverable post-sessione
+1. Compilare `docs/playtest/SESSION-2025-11-12.md` seguendo la procedura descritta in `procedura-post-sessione.md`.
+2. Archiviare log, screenshot e registrazioni nella cartella `logs/pilot-2025-11-12/` con naming coerente.
+3. Aprire issue su tracker con etichetta `encounter-balance` per ogni bug confermato.
+4. Pianificare eventuali sessioni di follow-up sulla base delle criticità emerse.

--- a/docs/playtest/procedura-post-sessione.md
+++ b/docs/playtest/procedura-post-sessione.md
@@ -1,0 +1,27 @@
+# Procedura post-sessione di playtest
+
+Questa procedura descrive i passaggi da completare immediatamente dopo ogni sessione di playtest.
+
+## 1. Creazione documentazione della sessione
+1. Copiare il template `SESSION-template.md` e rinominarlo in `SESSION-YYYY-MM-DD.md` nella cartella `docs/playtest/`.
+2. Compilare tutte le sezioni con i dati raccolti (partecipanti, scenari eseguiti, metriche, sintesi feedback).
+3. Allegare alla sezione finale i link o i percorsi ai log, screenshot e registrazioni.
+
+## 2. Archiviazione materiali
+1. Creare la cartella `logs/SESSION-YYYY-MM-DD/` (o equivalente specificata nel piano di sessione).
+2. Salvare in cartella:
+   - Log di gioco esportati e file telemetrici.
+   - Screenshot e registrazioni video rinominati con convenzione `SCENARIO-ID_descrizione_estensione`.
+   - Feedback compilati (`feedback-template.md`) in sottocartella `feedback/`.
+3. Verificare che i file siano sincronizzati con il drive condiviso (se applicabile).
+
+## 3. Gestione bug
+1. Rivedere la lista problemi emersi con il QA Lead.
+2. Per ogni bug confermato relativo agli incontri o al bilanciamento, aprire una issue sul tracker e applicare l'etichetta `encounter-balance`.
+3. Collegare l'issue alla sessione di playtest (riferimento al documento `SESSION-YYYY-MM-DD.md`).
+
+## 4. Retrospettiva breve
+1. Annotare nel documento della sessione eventuali follow-up necessari (design, engineering, narrative).
+2. Programmare una riunione di revisione se il numero di bug critici supera la soglia concordata.
+
+Seguire questa procedura garantisce tracciabilità e coerenza nella raccolta dati dei playtest.

--- a/docs/playtest/scenari-test.md
+++ b/docs/playtest/scenari-test.md
@@ -1,0 +1,36 @@
+# Elenco scenari di test
+
+Questo documento riassume gli scenari di playtest programmati per verificare bilanciamento, progressione e reazioni agli eventi speciali. Ogni scenario è progettato per essere eseguito in autonomia o all'interno di una sessione pilota più ampia.
+
+## 1. Bilanciamento degli incontri
+
+| ID | Scenario | Obiettivi | Metriche principali | Prerequisiti |
+| --- | --- | --- | --- | --- |
+| BAL-01 | "Campo di battaglia iniziale" | Verificare la difficoltà percepita del primo incontro multi-unità. | Tasso di vittoria, danno medio subito, tempo per completare lo scontro. | Build `alpha-balancing` con configurazioni standard dei personaggi livello 1. |
+| BAL-02 | "Boss intermedio" | Validare la curva di difficoltà al passaggio dalla mid-campaign. | Numero di tentativi prima della vittoria, consumo risorse, feedback qualitativo sul pattern del boss. | Savegame capitolo 4, equipaggiamento livello 12, accesso a log di combattimento. |
+| BAL-03 | "Horde mode" | Stress test della gestione spawn massivi e prestazioni AI. | Frame rate minimo, tempo di risoluzione turno, segnalazioni di comportamenti erratici. | Modalità horde attiva da configurazione `configs/horde_balancing.json`. |
+
+## 2. Progressione
+
+| ID | Scenario | Obiettivi | Metriche principali | Prerequisiti |
+| --- | --- | --- | --- | --- |
+| PROG-01 | "Percorso tutorial" | Misurare la comprensione delle meccaniche base dopo il tutorial. | Step completati senza aiuto, domande frequenti, tempo totale. | Build di onboarding, checklist di onboarding stampata. |
+| PROG-02 | "Sblocco abilità ramo esploratore" | Valutare chiarezza dei requisiti e soddisfazione ricompense. | Numero di tentativi, scelta dei perk, feedback narrativo. | Profilo giocatore livello 8, feature flag `explorer_branch` attivo. |
+| PROG-03 | "Gestione risorse hub" | Testare economia e ritmo di upgrade del quartier generale. | Bilancio risorse dopo 3 cicli, percentuale di upgrade completati, momenti di stallo. | Save hub con progressione media, foglio di calcolo per tracciamento risorse. |
+
+## 3. Eventi speciali
+
+| ID | Scenario | Obiettivi | Metriche principali | Prerequisiti |
+| --- | --- | --- | --- | --- |
+| EVT-01 | "Tempesta dimensionale" | Valutare chiarezza comunicazioni e reazioni del team. | Decisioni prese dai giocatori, tempo di risposta, bug grafici. | Script evento `event_dimensional_storm.json`, effetti particellari aggiornati. |
+| EVT-02 | "Alleanza inattesa" | Testare ramificazioni narrative in caso di scelta cooperativa. | Percentuale di scelta cooperativa, coerenza dialoghi, flag narrativi corretti. | Build narrativa `branching-v3`, foglio storyline aggiornato. |
+| EVT-03 | "Anomalia reliquia" | Controllare puzzle e ricompense legate agli artefatti. | Tasso di completamento, numero di tentativi puzzle, feedback sulla ricompensa. | Puzzle pack `relic_omega`, accesso a log puzzle. |
+
+## Modalità di esecuzione
+
+1. Preparare l'ambiente di test secondo i prerequisiti indicati.
+2. Registrare gameplay (video o log) e annotare metriche quantitative.
+3. Raccogliere feedback qualitativo immediato tramite il template predisposto (`feedback-template.md`).
+4. Archiviare i risultati nella cartella della sessione corrispondente (vedere `procedura-post-sessione.md`).
+
+Aggiornare questo documento quando vengono aggiunti nuovi scenari o varianti significative.


### PR DESCRIPTION
## Summary
- add a structured list of balancing, progression, and special event playtest scenarios
- schedule the November 12, 2025 pilot session with participants, materials, and deliverables
- provide templates for session reports, participant feedback, and post-session procedures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe6f88650c8332add53c3950fb0c51