### PR TITLE
Document post-October 2025 processes and CLI ADR

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,17 @@ Questi file sono scheletri collegati ai **Canvas** già creati in ChatGPT. Copia
 - `SistemaNPG-PF-Mutazioni.md` — NPG reattivi, PF, mutazioni T0/T1/T2, fusioni (Canvas C).
 - `Mating-Reclutamento-Nido.md` — Attrazione, Affinità/Fiducia, standard di nido, eredità (Canvas D).
 
+## Procedure post-ottobre 2025
+Dal ciclo VC-2025-10 in avanti utilizziamo un flusso documentale condiviso con Support/QA e Telemetria.
+
+1. **Sync settimanale (martedì, 15:00 CET)** — raccogli log telemetrici e note playtest in `docs/chatgpt_changes/` (`sync-<AAAAMMGG>.md`).
+2. **Aggiornamento checklist** — segna in `docs/checklist/` lo stato milestone e collega la sessione Git (`logs/playtests/<data>-vc`).
+3. **Allineamento roadmap** — aggiorna `docs/piani/roadmap.md` dopo ogni sync e ping il canale `#vc-docs` con il diff principale.
+4. **Pubblicazione estratti** — inserisci highlight nel Canvas principale e allega screenshot HUD nel drive (`docs/presentations/`).
+5. **Retro settimanale Support/QA** — importa le domande aperte in `docs/faq.md` e tagga l’owner nel file.
+
+Seguendo questi step possiamo mantenere aggiornati i Canvas e i dataset di gioco senza perdere le decisioni successive al refactor CLI.
+
 ## Sottocartelle operative
 
 - `Canvas/` — Note rapide estratte dai canvas principali, più callout su nuove feature e regole aggiornate.

--- a/docs/adr/ADR-2025-11-refactor-cli.md
+++ b/docs/adr/ADR-2025-11-refactor-cli.md
@@ -1,0 +1,26 @@
+# ADR-2025-11: Consolidamento refactor CLI
+
+- **Data**: 2025-11-05
+- **Stato**: Proposto
+- **Owner**: Lead Dev Platform
+- **Stakeholder**: Team Tools, Support, QA, Narrative Ops
+
+## Contesto
+Il refactor della CLI di gestione pacchetti (script `tools/cli.py`) introdotto nel ciclo VC-2025-10 ha unificato le funzioni di deploy, raccolta telemetria e generazione encounter. L'adozione estesa richiede policy aggiornate per ambienti locali, pipeline CI e supporto live.
+
+## Decisione
+1. **Strutturare la CLI in moduli** (`commands/`, `services/`) con entrypoint unico `game-cli` per evitare duplicazioni.
+2. **Introdurre profili di esecuzione** (`playtest`, `telemetry`, `support`) leggendo le configurazioni da `config/cli/<profilo>.yaml`.
+3. **Stabilire log operativi** in `logs/cli/<AAAA-MM-DD>.log` e inviarli quotidianamente al bucket condiviso (`drive-sync`).
+4. **Vincolare merge su branch principali** alla riuscita dei nuovi smoke test CLI (`scripts/cli_smoke.sh`).
+
+## Conseguenze
+- Richiede aggiornamento documentazione (`docs/README.md`, `docs/piani/roadmap.md`) e materiale onboarding dedicato.
+- Le squadre Support/QA devono migrare agli script profilati prima dell'onboarding del 2025-11-18.
+- Possibile aumento temporaneo dei tempi di build CI finché i container caching non sono aggiornati.
+- Abilitato monitoraggio più granulare sulle chiamate CLI, facilitando debug di encounter generati.
+
+## Azioni di follow-up
+- [ ] Pubblicare guida CLI aggiornata in `docs/tools/` (nuovo file).
+- [ ] Aggiornare i workflow CI per includere `scripts/cli_smoke.sh`.
+- [ ] Confermare con Support/QA la rotazione dei token API per profilo `support`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,23 @@
+# Domande frequenti — Support & QA
+
+Aggiornato al ciclo VC-2025-10. Nuove domande vengono raccolte dopo ogni retro settimanale (martedì).
+
+## Support
+
+| Domanda | Risposta rapida | Owner | Stato |
+| ------- | ---------------- | ----- | ----- |
+| Come abilitiamo i log CLI giornalieri nel profilo `support`? | Usare `game-cli support init --logs daily` e verificare upload su bucket Drive Sync entro le 18:00 CET. | Support Lead | In corso (test 2025-11-07).
+| Qual è la procedura di escalation se `game-cli deploy` fallisce in produzione? | Aprire ticket `#vc-ops`, allegare log `logs/cli/<data>.log`, eseguire rollback con profilo `support`. | Support Lead | Attivo.
+| Quando ruotare i token API condivisi? | Ogni lunedì mattina seguendo il playbook `config/cli/support.yaml` > sezione `credentials`. | Security Liaison | Da pianificare post-onboarding.
+
+## QA
+
+| Domanda | Risposta rapida | Owner | Stato |
+| ------- | ---------------- | ----- | ----- |
+| Come eseguiamo gli smoke test CLI? | Run `scripts/cli_smoke.sh --profile playtest` e allega output nella cartella `logs/cli/qa/`. | QA Lead | Pianificato per 2025-11-08.
+| Dove registriamo gli esiti dei playtest VC? | Nel tracker `docs/checklist/playtest-status.md` + allegato `logs/playtests/<data>-vc/summary.yaml`. | QA Analyst | Continuo.
+| Chi conferma la copertura telemetria dopo ogni build? | QA Lead coordina con Telemetria usando il report `docs/chatgpt_changes/sync-<data>.md`. | Telemetria POC | In corso.
+
+## Da raccogliere
+- Post-onboarding 2025-11-18: aggiungere sezione `Troubleshooting CLI` con snippet ricorrenti.
+- Verificare disponibilità di template escalation nel drive Support entro 2025-11-12.

--- a/docs/piani/roadmap.md
+++ b/docs/piani/roadmap.md
@@ -1,5 +1,10 @@
 # Roadmap Operativa
 
+## Procedura post-ottobre 2025
+- Sincronizza le milestone VC-2025-10+ con il report settimanale (`docs/chatgpt_changes/`).
+- Chiudi o aggiorna le issue operative nel canale `#vc-docs` prima di spostare le attività in *Prossimi passi*.
+- Ogni retro Support/QA deve produrre una nota in `docs/faq.md` con owner e stato di follow-up.
+
 ## Milestone attive
 1. **Bilanciare pacchetti PI tra Forme**  
  - Validare il bias `random_general_d20` rispetto alle nuove combinazioni `bias_d12` per evitare inflazione di PE.【F:data/packs.yaml†L5-L88】

--- a/docs/presentations/2025-11-18-onboarding.md
+++ b/docs/presentations/2025-11-18-onboarding.md
@@ -1,0 +1,26 @@
+# Onboarding Support/QA — 18 novembre 2025
+
+## Obiettivi sessione
+- Allineare il team sulle modifiche al refactor CLI e sui profili `playtest` e `support`.
+- Presentare il flusso post-ottobre 2025 per aggiornamento documentazione e raccolta FAQ.
+- Eseguire esercitazioni pratiche sulla generazione encounter e sulla pipeline Drive Sync.
+
+## Agenda
+| Orario | Blocco | Owner | Note |
+| ------ | ------ | ----- | ---- |
+| 09:30-09:45 | Benvenuto & contesto release VC | Narrative Ops | Aggiornamento roadmap e telemetria.
+| 09:45-10:30 | Workshop CLI refactor | Lead Dev Platform | Demo `game-cli` + profili, log operativi.
+| 10:30-11:00 | QA Hands-on | QA Lead | Import smoke test CLI in pipeline locale.
+| 11:00-11:30 | Support sync | Support Lead | Escalation standard, bucket log condiviso.
+| 11:30-12:00 | Retro + raccolta FAQ | Tutti | Aggiornamento `docs/faq.md` e azioni follow-up.
+
+## Materiali da preparare
+- Slide aggiornate (deck 15 pagine) nel Drive, cartella `Presentations/Onboarding-2025-11-18`.
+- Demo script `scripts/cli_smoke.sh` con commenti.
+- Accessi temporanei per ambienti di test (`support` profile) validi fino al 2025-11-25.
+- Template FAQ (`docs/faq.md`) con sezione Support e QA.
+
+## Azioni post-sessione
+- Raccolta feedback tramite form Google (deadline 2025-11-19).
+- Consolidare le domande in `docs/faq.md` e assegnare owner.
+- Registrare la sessione e allegare il link in `docs/presentations/assets/`.


### PR DESCRIPTION
## Summary
- detail the post-October 2025 documentation workflow and sync cadence
- add procedural notes to the roadmap and publish the CLI refactor ADR
- stage onboarding materials for the 2025-11-18 session and start the Support/QA FAQ

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe71ec0e548332a060772573469dee