### PR TITLE
Refine generator UI with shared tokens

### DIFF
--- a/docs/evo-tactics-pack/generator.html
+++ b/docs/evo-tactics-pack/generator.html
@@ -143,7 +143,7 @@
                 </div>
             </div>
               <section
-                class="generator-profiles"
+                class="generator-profiles surface-panel surface-panel--overlay"
                 id="generator-profiles"
                 aria-labelledby="generator-profiles-title"
               >
@@ -193,7 +193,7 @@
               </div>
             </form>
             <section
-              class="generator-export-panel"
+              class="generator-export-panel surface-panel surface-panel--overlay"
               id="generator-export"
               aria-labelledby="generator-export-title"
             >
@@ -322,15 +322,16 @@
                 </p>
               </article>
             </section>
-            <div class="generator-summary__pins">
+            <div class="generator-summary__pins surface-panel surface-panel--tight">
               <h4 class="generator-summary__subtitle">Specie pinnate</h4>
               <p class="generator-summary__empty" id="generator-pinned-empty">
-                Nessuna specie pinnata. Usa il pulsante 📌 sulle card per aggiungerle.
+                Nessuna specie pinnata. Usa il pulsante
+                <span class="icon icon--inline" aria-hidden="true">📌</span>pin sulle card per aggiungerle.
               </p>
               <ul class="generator-pins" id="generator-pinned-list" aria-live="polite"></ul>
             </div>
             <section
-              class="generator-history"
+              class="generator-history surface-panel surface-panel--overlay"
               id="generator-history"
               aria-labelledby="generator-history-title"
               data-flow-node="history"
@@ -353,7 +354,7 @@
               <ol class="generator-history__list" id="generator-history-list" aria-live="polite"></ol>
             </section>
             <section
-              class="generator-activity"
+              class="generator-activity surface-panel surface-panel--overlay"
               id="generator-activity"
               aria-labelledby="generator-activity-title"
             >
@@ -429,7 +430,7 @@
               <ol class="generator-timeline" id="generator-log" aria-live="polite"></ol>
             </section>
             <section
-              class="generator-compare"
+              class="generator-compare surface-panel surface-panel--overlay"
               id="generator-compare-panel"
               aria-labelledby="generator-compare-title"
             >

--- a/docs/site.css
+++ b/docs/site.css
@@ -1,19 +1,83 @@
 :root {
   color-scheme: dark;
-  --bg: #05070b;
-  --surface: rgba(22, 27, 34, 0.75);
-  --surface-strong: rgba(13, 17, 23, 0.9);
-  --border: rgba(110, 118, 129, 0.3);
-  --border-strong: rgba(110, 118, 129, 0.6);
-  --accent: #58a6ff;
-  --accent-strong: #388bfd;
-  --accent-muted: rgba(88, 166, 255, 0.1);
-  --text: #f0f6fc;
-  --text-muted: #8b949e;
-  --shadow: 0 24px 60px rgba(2, 6, 23, 0.65);
-  --radius: 20px;
+  /* Typography */
+  --font-family-sans: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-family-mono: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.88rem;
+  --font-size-md: 1rem;
+  --font-size-lg: 1.3rem;
+  --line-height-tight: 1.25;
+  --line-height-regular: 1.5;
+  --line-height-relaxed: 1.7;
+
+  /* Color tokens */
+  --color-canvas: #05070b;
+  --color-surface-low: rgba(12, 18, 28, 0.72);
+  --color-surface-base: rgba(15, 20, 28, 0.88);
+  --color-surface-raised: rgba(22, 27, 34, 0.78);
+  --color-surface-overlay: rgba(13, 17, 23, 0.92);
+  --color-border-subtle: rgba(110, 118, 129, 0.2);
+  --color-border-strong: rgba(110, 118, 129, 0.55);
+  --color-border-glow: rgba(88, 166, 255, 0.35);
+  --color-text-primary: #f0f6fc;
+  --color-text-secondary: #c5d0dc;
+  --color-text-muted: #8b949e;
+  --color-accent-400: #58a6ff;
+  --color-accent-500: #388bfd;
+  --color-accent-soft: rgba(88, 166, 255, 0.18);
+  --color-accent-muted: rgba(88, 166, 255, 0.1);
+  --color-success-400: #34d399;
+  --color-success-700: rgba(6, 22, 15, 0.92);
+  --color-warn-400: #facc15;
+  --color-warn-700: rgba(35, 24, 8, 0.92);
+  --color-error-400: #f87171;
+  --color-error-700: rgba(38, 12, 17, 0.92);
+  --color-info-400: rgba(88, 166, 255, 0.8);
+  --color-info-700: rgba(10, 24, 45, 0.92);
+  --tone-success-border: rgba(52, 211, 153, 0.65);
+  --tone-success-surface: rgba(34, 197, 94, 0.18);
+  --tone-success-backdrop: rgba(6, 22, 15, 0.92);
+  --tone-success-foreground: rgba(190, 252, 210, 0.95);
+  --tone-warn-border: rgba(250, 204, 21, 0.7);
+  --tone-warn-surface: rgba(250, 204, 21, 0.2);
+  --tone-warn-backdrop: rgba(35, 24, 8, 0.92);
+  --tone-warn-foreground: rgba(250, 240, 190, 0.95);
+  --tone-error-border: rgba(248, 113, 113, 0.75);
+  --tone-error-surface: rgba(248, 113, 113, 0.22);
+  --tone-error-backdrop: rgba(38, 12, 17, 0.92);
+  --tone-error-foreground: rgba(255, 210, 210, 0.95);
+  --tone-info-border: rgba(88, 166, 255, 0.6);
+  --tone-info-surface: rgba(88, 166, 255, 0.2);
+  --tone-info-backdrop: rgba(10, 24, 45, 0.92);
+  --tone-info-foreground: rgba(188, 215, 255, 0.95);
+
+  /* Elevations */
+  --shadow-xs: 0 8px 18px rgba(2, 6, 23, 0.35);
+  --shadow-sm: 0 12px 24px rgba(2, 6, 23, 0.45);
+  --shadow-md: 0 18px 40px rgba(2, 6, 23, 0.55);
+  --shadow-lg: 0 24px 60px rgba(2, 6, 23, 0.65);
+  --radius-md: 16px;
+  --radius-lg: 20px;
+  --radius-pill: 999px;
   --transition: 200ms ease;
-  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+
+  /* Backwards compatibility tokens */
+  --bg: var(--color-canvas);
+  --surface: var(--color-surface-raised);
+  --surface-strong: var(--color-surface-overlay);
+  --border: var(--color-border-subtle);
+  --border-strong: var(--color-border-strong);
+  --accent: var(--color-accent-400);
+  --accent-strong: var(--color-accent-500);
+  --accent-muted: var(--color-accent-muted);
+  --text: var(--color-text-primary);
+  --text-muted: var(--color-text-muted);
+  --shadow: var(--shadow-lg);
+  --radius: var(--radius-lg);
+
+  font-family: var(--font-family-sans);
 }
 
 * {
@@ -25,14 +89,16 @@ body {
   margin: 0;
   padding: 0;
   background: radial-gradient(circle at 20% 20%, rgba(88, 166, 255, 0.15), transparent 55%),
-    radial-gradient(circle at 80% 0%, rgba(191, 90, 242, 0.1), transparent 50%), var(--bg);
-  color: var(--text);
+    radial-gradient(circle at 80% 0%, rgba(191, 90, 242, 0.1), transparent 50%), var(--color-canvas);
+  color: var(--color-text-primary);
   min-height: 100%;
 }
 
 body {
   display: flex;
   flex-direction: column;
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-regular);
 }
 
 a {
@@ -554,10 +620,10 @@ a:focus-visible {
   display: grid;
   gap: 16px;
   padding: 20px;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  background: var(--surface-strong);
-  box-shadow: var(--shadow);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-overlay);
+  box-shadow: var(--shadow-sm);
 }
 
 .anchor-nav__header {
@@ -569,10 +635,10 @@ a:focus-visible {
 
 .anchor-nav__title {
   margin: 0;
-  font-size: 0.82rem;
+  font-size: var(--font-size-xs);
   text-transform: uppercase;
   letter-spacing: 0.18em;
-  color: var(--text-muted);
+  color: var(--color-text-muted);
 }
 
 .anchor-nav__toggle {
@@ -601,22 +667,22 @@ a:focus-visible {
   gap: 10px;
   padding: 8px 12px;
   border-radius: 12px;
-  color: var(--text-muted);
-  font-size: 0.95rem;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
   transition: background var(--transition), color var(--transition), box-shadow var(--transition);
 }
 
 .anchor-nav__link:hover,
 .anchor-nav__link:focus-visible {
-  background: rgba(88, 166, 255, 0.2);
-  color: var(--text);
+  background: var(--color-accent-soft);
+  color: var(--color-text-primary);
   text-decoration: none;
 }
 
 .anchor-nav__link.is-active {
-  background: var(--accent-muted);
-  color: var(--text);
-  box-shadow: inset 0 0 0 1px rgba(88, 166, 255, 0.35);
+  background: var(--color-accent-muted);
+  color: var(--color-text-primary);
+  box-shadow: inset 0 0 0 1px var(--color-border-glow);
 }
 
 .codex-breadcrumb {
@@ -1053,39 +1119,75 @@ body.codex-open {
 }
 
 .card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
   padding: 28px;
-  backdrop-filter: blur(16px);
-  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow-md);
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
 .card--highlight {
-  background: rgba(15, 20, 28, 0.92);
-  border-color: rgba(88, 166, 255, 0.4);
+  background: var(--color-surface-overlay);
+  border-color: var(--color-border-glow);
+  box-shadow: var(--shadow-lg);
 }
 
 .card h3 {
   margin: 0;
-  font-size: 1.3rem;
+  font-size: var(--font-size-lg);
 }
 
 .card p {
   margin: 0;
-  color: var(--text-muted);
-  line-height: 1.6;
+  color: var(--color-text-muted);
+  line-height: var(--line-height-relaxed);
 }
 
 .card ul {
   margin: 0;
   padding-left: 18px;
-  color: var(--text-muted);
+  color: var(--color-text-muted);
   display: grid;
   gap: 6px;
+}
+
+.surface-panel {
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-base);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow-xs);
+  padding: 18px;
+}
+
+.surface-panel--overlay {
+  background: var(--color-surface-overlay);
+  border-color: var(--color-border-strong);
+  box-shadow: var(--shadow-sm);
+}
+
+.surface-panel--accent {
+  border-color: var(--color-border-glow);
+  box-shadow: var(--shadow-md);
+}
+
+.surface-panel--tight {
+  padding: 14px 16px;
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.icon--inline {
+  margin-right: 0.35em;
 }
 
 .card--list {
@@ -1220,10 +1322,6 @@ body.codex-open {
 .generator-activity {
   display: grid;
   gap: 18px;
-  padding: 18px;
-  border-radius: 16px;
-  border: 1px solid rgba(88, 166, 255, 0.18);
-  background: rgba(10, 18, 34, 0.7);
 }
 
 .generator-activity__header {
@@ -1249,9 +1347,9 @@ body.codex-open {
   gap: 8px;
   padding: 4px 6px;
   margin: 0;
-  border: 1px solid rgba(88, 166, 255, 0.15);
-  border-radius: 999px;
-  background: rgba(88, 166, 255, 0.05);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-low);
 }
 
 .generator-activity__tones legend {
@@ -1271,12 +1369,12 @@ body.codex-open {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 0.85rem;
-  color: rgba(197, 214, 255, 0.8);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
 }
 
 .generator-activity__pinned input {
-  accent-color: rgba(88, 166, 255, 0.85);
+  accent-color: var(--color-accent-400);
 }
 
 .generator-activity__export {
@@ -1425,46 +1523,46 @@ body.codex-open {
 
 .generator-timeline__item[data-tone="success"] .generator-timeline__marker,
 .generator-timeline__tone--success {
-  border-color: rgba(74, 222, 128, 0.65);
-  background: rgba(6, 22, 15, 0.9);
-  color: rgba(190, 252, 210, 0.95);
+  border-color: var(--tone-success-border);
+  background: var(--tone-success-backdrop);
+  color: var(--tone-success-foreground);
 }
 
 .generator-timeline__tone--success {
-  background: rgba(34, 197, 94, 0.18);
+  background: var(--tone-success-surface);
 }
 
 .generator-timeline__item[data-tone="warn"] .generator-timeline__marker,
 .generator-timeline__tone--warn {
-  border-color: rgba(250, 204, 21, 0.7);
-  background: rgba(35, 24, 8, 0.9);
-  color: rgba(250, 240, 190, 0.95);
+  border-color: var(--tone-warn-border);
+  background: var(--tone-warn-backdrop);
+  color: var(--tone-warn-foreground);
 }
 
 .generator-timeline__tone--warn {
-  background: rgba(250, 204, 21, 0.2);
+  background: var(--tone-warn-surface);
 }
 
 .generator-timeline__item[data-tone="error"] .generator-timeline__marker,
 .generator-timeline__tone--error {
-  border-color: rgba(248, 113, 113, 0.75);
-  background: rgba(38, 12, 17, 0.9);
-  color: rgba(255, 210, 210, 0.95);
+  border-color: var(--tone-error-border);
+  background: var(--tone-error-backdrop);
+  color: var(--tone-error-foreground);
 }
 
 .generator-timeline__tone--error {
-  background: rgba(248, 113, 113, 0.22);
+  background: var(--tone-error-surface);
 }
 
 .generator-timeline__item[data-tone="info"] .generator-timeline__marker,
 .generator-timeline__tone--info {
-  border-color: rgba(88, 166, 255, 0.6);
-  background: rgba(10, 24, 45, 0.92);
-  color: rgba(188, 215, 255, 0.95);
+  border-color: var(--tone-info-border);
+  background: var(--tone-info-backdrop);
+  color: var(--tone-info-foreground);
 }
 
 .generator-timeline__tone--info {
-  background: rgba(88, 166, 255, 0.2);
+  background: var(--tone-info-surface);
 }
 
 .generator-timeline__item[data-tone="success"] .generator-timeline__content {
@@ -1551,10 +1649,10 @@ body.codex-open {
   display: grid;
   gap: 16px;
   padding: 24px;
-  border-radius: 20px;
-  border: 1px solid rgba(88, 166, 255, 0.35);
-  background: linear-gradient(150deg, rgba(12, 19, 40, 0.92), rgba(7, 12, 24, 0.88));
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border-glow);
+  background: linear-gradient(150deg, var(--color-surface-overlay), rgba(7, 12, 24, 0.9));
+  box-shadow: var(--shadow-md);
 }
 
 .generator-summary__title {
@@ -1570,9 +1668,9 @@ body.codex-open {
 
 .generator-summary__metric {
   padding: 14px;
-  border-radius: 16px;
-  background: rgba(88, 166, 255, 0.08);
-  border: 1px solid rgba(88, 166, 255, 0.2);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border-subtle);
   display: grid;
   gap: 6px;
   align-content: center;
@@ -1581,29 +1679,29 @@ body.codex-open {
 
 .generator-summary__label {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: var(--font-size-xs);
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: rgba(156, 215, 255, 0.8);
+  color: var(--color-text-muted);
 }
 
 .generator-summary__value {
   margin: 0;
   font-size: 1.6rem;
   font-weight: 700;
-  color: #e2f0ff;
+  color: var(--color-text-primary);
 }
 
 .generator-summary__status {
   margin: 0;
-  font-size: 0.92rem;
-  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
 }
 
 .generator-summary__note {
   margin: -6px 0 0;
-  font-size: 0.78rem;
-  color: rgba(156, 215, 255, 0.8);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
 }
 
 .generator-narrative {
@@ -1723,7 +1821,7 @@ body.codex-open {
 
 .generator-summary.is-rare-event {
   animation: generatorRareGlow 900ms ease;
-  box-shadow: 0 26px 60px rgba(88, 166, 255, 0.32), inset 0 0 0 1px rgba(88, 166, 255, 0.25);
+  box-shadow: var(--shadow-lg), inset 0 0 0 1px var(--color-border-glow);
 }
 
 @keyframes narrativePanelPulse {
@@ -1769,16 +1867,16 @@ body.codex-open {
 
 .generator-summary__subtitle {
   margin: 0;
-  font-size: 0.88rem;
+  font-size: var(--font-size-sm);
   text-transform: uppercase;
   letter-spacing: 0.14em;
-  color: rgba(226, 240, 255, 0.7);
+  color: var(--color-text-secondary);
 }
 
 .generator-summary__empty {
   margin: 0;
-  font-size: 0.78rem;
-  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
 }
 
 .generator-summary[data-has-pins="false"] .generator-summary__pins {
@@ -1787,10 +1885,6 @@ body.codex-open {
 
 .generator-profiles {
   margin-top: 16px;
-  padding: 18px;
-  border-radius: 18px;
-  border: 1px solid rgba(88, 166, 255, 0.25);
-  background: rgba(9, 16, 30, 0.78);
   display: grid;
   gap: 14px;
 }
@@ -1805,13 +1899,13 @@ body.codex-open {
 
 .generator-profiles__hint {
   margin: 0;
-  font-size: 0.78rem;
-  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
 }
 
 .generator-profiles__empty {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: var(--font-size-xs);
   color: rgba(255, 255, 255, 0.4);
 }
 
@@ -1824,9 +1918,9 @@ body.codex-open {
 }
 
 .generator-profiles__slot {
-  border-radius: 16px;
-  border: 1px solid rgba(88, 166, 255, 0.22);
-  background: rgba(12, 20, 36, 0.85);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-low);
   display: grid;
   gap: 8px;
   padding: 14px 16px;
@@ -1842,9 +1936,9 @@ body.codex-open {
 
 .generator-profiles__slot-name {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: var(--font-size-sm);
   font-weight: 600;
-  color: #e2f0ff;
+  color: var(--color-text-primary);
 }
 
 .generator-profiles__slot-actions {
@@ -1854,44 +1948,40 @@ body.codex-open {
 }
 
 .generator-profiles__action {
-  font-size: 0.78rem;
+  font-size: var(--font-size-xs);
   padding: 6px 12px;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  background: rgba(88, 166, 255, 0.12);
-  color: rgba(226, 240, 255, 0.85);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-base);
+  color: var(--color-text-secondary);
   cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease;
+  transition: border-color var(--transition), background var(--transition);
 }
 
 .generator-profiles__action:hover,
 .generator-profiles__action:focus-visible {
-  border-color: rgba(130, 196, 255, 0.6);
-  background: rgba(88, 166, 255, 0.22);
+  border-color: var(--color-border-glow);
+  background: var(--color-accent-soft);
 }
 
 .generator-profiles__summary {
   margin: 0;
-  font-size: 0.8rem;
-  color: rgba(208, 225, 255, 0.86);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
 }
 
 .generator-profiles__timestamp {
   margin: 0;
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   color: rgba(255, 255, 255, 0.4);
 }
 
 .generator-profiles__reset {
-  font-size: 0.78rem;
+  font-size: var(--font-size-xs);
 }
 
 .generator-history {
   margin-top: 24px;
-  padding: 18px;
-  border-radius: 18px;
-  border: 1px solid rgba(88, 166, 255, 0.25);
-  background: rgba(9, 16, 30, 0.78);
   display: grid;
   gap: 14px;
 }
@@ -1913,9 +2003,9 @@ body.codex-open {
 }
 
 .generator-history__entry {
-  border-radius: 16px;
-  border: 1px solid rgba(88, 166, 255, 0.22);
-  background: rgba(12, 20, 36, 0.88);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-low);
   padding: 14px 16px;
   display: grid;
   gap: 12px;
@@ -1931,13 +2021,13 @@ body.codex-open {
 
 .generator-history__entry-title {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: var(--font-size-sm);
   font-weight: 600;
-  color: #e2f0ff;
+  color: var(--color-text-primary);
 }
 
 .generator-history__entry-time {
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: rgba(255, 255, 255, 0.45);
 }
 
@@ -1950,26 +2040,26 @@ body.codex-open {
 
 .generator-history__metric {
   padding: 10px 12px;
-  border-radius: 14px;
-  background: rgba(88, 166, 255, 0.12);
-  border: 1px solid rgba(88, 166, 255, 0.25);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-base);
+  border: 1px solid var(--color-border-subtle);
   display: grid;
   gap: 4px;
 }
 
 .generator-history__metric dt {
   margin: 0;
-  font-size: 0.72rem;
+  font-size: var(--font-size-xs);
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: rgba(156, 215, 255, 0.72);
+  color: var(--color-text-muted);
 }
 
 .generator-history__metric dd {
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
-  color: #e2f0ff;
+  color: var(--color-text-primary);
 }
 
 .generator-history__preview {
@@ -1984,10 +2074,10 @@ body.codex-open {
 
 .generator-history__preview-label {
   margin: 0;
-  font-size: 0.72rem;
+  font-size: var(--font-size-xs);
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: rgba(156, 215, 255, 0.6);
+  color: var(--color-text-muted);
 }
 
 .generator-history__chips {
@@ -2003,24 +2093,24 @@ body.codex-open {
 }
 
 .generator-history__action {
-  font-size: 0.78rem;
+  font-size: var(--font-size-xs);
   padding: 6px 12px;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  background: rgba(88, 166, 255, 0.14);
-  color: rgba(226, 240, 255, 0.86);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-base);
+  color: var(--color-text-secondary);
   cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease;
+  transition: border-color var(--transition), background var(--transition);
 }
 
 .generator-history__action:hover,
 .generator-history__action:focus-visible {
-  border-color: rgba(130, 196, 255, 0.6);
-  background: rgba(88, 166, 255, 0.22);
+  border-color: var(--color-border-glow);
+  background: var(--color-accent-soft);
 }
 
 .generator-history__clear {
-  font-size: 0.78rem;
+  font-size: var(--font-size-xs);
 }
 
 .generator-summary[data-has-history="false"] .generator-history {
@@ -2030,12 +2120,7 @@ body.codex-open {
 .generator-export-panel {
   display: grid;
   gap: 16px;
-  padding: 20px;
   margin-top: 20px;
-  border-radius: 20px;
-  border: 1px solid rgba(88, 166, 255, 0.25);
-  background: rgba(7, 12, 24, 0.78);
-  backdrop-filter: blur(18px);
 }
 
 .generator-export-panel__header {
@@ -2065,8 +2150,8 @@ body.codex-open {
 .generator-export__meta,
 .generator-export__empty {
   margin: 0;
-  font-size: 0.82rem;
-  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
 }
 
 .generator-export__list {
@@ -2078,15 +2163,15 @@ body.codex-open {
 }
 
 .generator-export__item {
-  border-radius: 16px;
-  border: 1px solid rgba(88, 166, 255, 0.25);
-  background: rgba(12, 20, 36, 0.85);
-  transition: border-color 0.2s ease, transform 0.2s ease;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-low);
+  transition: border-color var(--transition), transform var(--transition);
 }
 
 .generator-export__item:focus-within,
 .generator-export__item:hover {
-  border-color: rgba(130, 196, 255, 0.55);
+  border-color: var(--color-border-glow);
   transform: translateY(-1px);
 }
 
@@ -2123,43 +2208,46 @@ body.codex-open {
 }
 
 .generator-export__item-title {
+  margin: 0;
+  font-size: var(--font-size-sm);
   font-weight: 600;
-  color: #e2f0ff;
+  color: var(--color-text-primary);
 }
 
 .generator-export__item-format {
-  font-size: 0.72rem;
+  margin: 0;
+  font-size: var(--font-size-xs);
   text-transform: uppercase;
-  letter-spacing: 0.16em;
-  color: rgba(156, 215, 255, 0.72);
+  letter-spacing: 0.14em;
+  color: var(--color-text-muted);
 }
 
 .generator-export__item-badge {
-  font-size: 0.68rem;
+  font-size: var(--font-size-xs);
   text-transform: uppercase;
-  letter-spacing: 0.18em;
-  border-radius: 999px;
+  letter-spacing: 0.16em;
+  border-radius: var(--radius-pill);
   padding: 0.2rem 0.6rem;
-  background: rgba(88, 166, 255, 0.18);
-  color: rgba(226, 240, 255, 0.82);
+  background: var(--color-surface-base);
+  color: var(--color-text-secondary);
 }
 
 .generator-export__item-description {
   margin: 0;
-  font-size: 0.8rem;
-  color: rgba(208, 225, 255, 0.92);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
 }
 
 .generator-export__item-path {
   margin: 0;
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-family: var(--font-mono, "Fira Code", monospace);
-  color: rgba(156, 215, 255, 0.72);
+  color: var(--color-text-muted);
 }
 
 .generator-export__item-hint {
   margin: 0;
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: rgba(255, 196, 138, 0.88);
 }
 
@@ -2182,31 +2270,31 @@ body.codex-open {
   display: grid;
   gap: 12px;
   padding: 16px;
-  border-radius: 16px;
-  border: 1px solid rgba(88, 166, 255, 0.2);
-  background: rgba(10, 16, 28, 0.6);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-low);
 }
 
 .generator-export__preview details {
-  border-radius: 12px;
-  border: 1px solid rgba(88, 166, 255, 0.16);
-  background: rgba(9, 14, 24, 0.72);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-base);
   padding: 10px 12px;
 }
 
 .generator-export__preview summary {
   cursor: pointer;
-  font-size: 0.82rem;
-  color: rgba(226, 240, 255, 0.8);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
 }
 
 .generator-export__preview pre {
   margin: 8px 0 0;
   max-height: 220px;
   overflow: auto;
-  font-size: 0.75rem;
-  background: rgba(4, 7, 14, 0.85);
-  border-radius: 10px;
+  font-size: var(--font-size-xs);
+  background: rgba(4, 7, 14, 0.9);
+  border-radius: var(--radius-md);
   padding: 12px;
 }
 
@@ -2217,45 +2305,41 @@ body.codex-open {
 
 .generator-dossier__title {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: var(--font-size-sm);
   text-transform: uppercase;
   letter-spacing: 0.14em;
-  color: rgba(226, 240, 255, 0.72);
+  color: var(--color-text-secondary);
 }
 
 .generator-dossier__hint {
   margin: 0;
-  font-size: 0.75rem;
-  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
 }
 
 .generator-dossier__preview {
-  border-radius: 14px;
-  border: 1px solid rgba(88, 166, 255, 0.18);
-  background: rgba(17, 26, 44, 0.78);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-base);
   padding: 12px;
   max-height: 320px;
   overflow: auto;
-  color: #f4f6ff;
+  color: var(--color-text-primary);
 }
 
 .generator-dossier__preview h1,
 .generator-dossier__preview h2,
 .generator-dossier__preview h3 {
-  color: #f4f6ff;
+  color: var(--color-text-primary);
 }
 
 .generator-dossier__preview p {
-  color: rgba(226, 240, 255, 0.8);
+  color: var(--color-text-secondary);
 }
 
 .generator-compare {
   display: grid;
   gap: 14px;
-  padding: 18px;
-  border-radius: 16px;
-  border: 1px solid rgba(88, 166, 255, 0.22);
-  background: rgba(9, 14, 28, 0.78);
 }
 
 .generator-compare__header {
@@ -2265,22 +2349,22 @@ body.codex-open {
 
 .generator-compare__title {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: var(--font-size-sm);
   text-transform: uppercase;
   letter-spacing: 0.14em;
-  color: rgba(226, 240, 255, 0.7);
+  color: var(--color-text-secondary);
 }
 
 .generator-compare__hint {
   margin: 0;
-  font-size: 0.78rem;
-  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
 }
 
 .generator-compare__empty {
   margin: 0;
-  font-size: 0.8rem;
-  color: rgba(156, 215, 255, 0.82);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
 }
 
 .generator-compare__list {
@@ -2297,9 +2381,9 @@ body.codex-open {
   align-items: flex-start;
   justify-content: space-between;
   padding: 12px 14px;
-  border-radius: 14px;
-  border: 1px solid rgba(88, 166, 255, 0.2);
-  background: rgba(12, 20, 36, 0.8);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-low);
 }
 
 .generator-compare__info {
@@ -2307,17 +2391,18 @@ body.codex-open {
   gap: 6px;
 }
 
+
 .generator-compare__name {
   margin: 0;
-  font-size: 0.95rem;
-  color: #e2f0ff;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
   font-weight: 600;
 }
 
 .generator-compare__meta {
   margin: 0;
-  font-size: 0.78rem;
-  color: rgba(156, 215, 255, 0.78);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
 }
 
 .generator-compare__metrics {
@@ -2328,8 +2413,8 @@ body.codex-open {
 }
 
 .generator-compare__metric {
-  font-size: 0.75rem;
-  color: rgba(195, 220, 255, 0.85);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -2338,8 +2423,8 @@ body.codex-open {
 .generator-compare__metric-label {
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  font-size: 0.68rem;
-  color: rgba(148, 196, 255, 0.7);
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
 }
 
 .generator-compare__remove {
@@ -2363,9 +2448,9 @@ body.codex-open {
   position: relative;
   min-height: 240px;
   padding: 12px;
-  border-radius: 14px;
-  border: 1px dashed rgba(88, 166, 255, 0.2);
-  background: rgba(10, 18, 32, 0.72);
+  border-radius: var(--radius-md);
+  border: 1px dashed var(--color-border-subtle);
+  background: var(--color-surface-low);
 }
 
 .generator-compare__chart canvas {
@@ -2375,7 +2460,7 @@ body.codex-open {
 
 .generator-compare__fallback {
   margin: 12px 0 0;
-  font-size: 0.78rem;
+  font-size: var(--font-size-xs);
   color: rgba(244, 114, 182, 0.8);
 }
 
@@ -2399,9 +2484,9 @@ body.codex-open {
   display: grid;
   gap: 6px;
   padding: 10px 12px;
-  border-radius: 14px;
-  border: 1px solid rgba(88, 166, 255, 0.22);
-  background: rgba(6, 10, 22, 0.82);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-low);
 }
 
 .generator-pins__item[data-state="stale"] {
@@ -2418,13 +2503,13 @@ body.codex-open {
 
 .generator-pins__name {
   font-weight: 600;
-  color: #e2f0ff;
-  font-size: 0.95rem;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
 }
 
 .generator-pins__meta {
-  font-size: 0.78rem;
-  color: rgba(156, 215, 255, 0.82);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
 }
 
 .generator-pins__controls {
@@ -2434,11 +2519,11 @@ body.codex-open {
 
 .generator-pins__unpin {
   border: 1px solid rgba(248, 204, 21, 0.4);
-  background: rgba(248, 204, 21, 0.1);
+  background: rgba(248, 204, 21, 0.12);
   color: #facc15;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 4px 10px;
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   cursor: pointer;

--- a/docs/templates/dossier.html
+++ b/docs/templates/dossier.html
@@ -6,26 +6,48 @@
     <style>
       :root {
         color-scheme: light;
-        font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        --font-family-sans: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        --font-size-xs: 0.75rem;
+        --font-size-sm: 0.88rem;
+        --font-size-md: 1rem;
+        --font-size-lg: 1.3rem;
+        --line-height-tight: 1.25;
+        --line-height-regular: 1.5;
+        --line-height-relaxed: 1.7;
+        --color-canvas: #f5f7fb;
+        --color-surface-base: #ffffff;
+        --color-surface-muted: #f2f6ff;
+        --color-border-subtle: #dbe3f4;
+        --color-border-strong: #c5cee0;
+        --color-text-primary: #1b1d21;
+        --color-text-secondary: #40495b;
+        --color-text-muted: #5b6475;
+        --color-accent-400: #3b82f6;
+        --color-accent-soft: rgba(59, 130, 246, 0.12);
+        --radius-md: 12px;
+        --radius-lg: 16px;
+        --radius-pill: 999px;
+        --shadow-md: 0 10px 25px rgba(16, 23, 36, 0.08);
       }
       body {
         margin: 0;
         padding: 2.4rem;
-        font-size: 14px;
-        line-height: 1.5;
-        color: #1b1d21;
-        background: #f5f7fb;
+        font-family: var(--font-family-sans);
+        font-size: var(--font-size-sm);
+        line-height: var(--line-height-regular);
+        color: var(--color-text-primary);
+        background: var(--color-canvas);
       }
       h1,
       h2,
       h3,
       h4 {
         font-weight: 600;
-        color: #15171a;
+        color: var(--color-text-primary);
         margin-top: 0;
       }
       h1 {
-        font-size: 2.2rem;
+        font-size: 2.1rem;
         margin-bottom: 0.4rem;
       }
       h2 {
@@ -39,20 +61,22 @@
       p {
         margin-top: 0;
         margin-bottom: 0.8rem;
+        color: var(--color-text-secondary);
       }
       .dossier__meta {
-        font-size: 0.9rem;
-        color: #5b6475;
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
       }
       .dossier__layout {
         display: grid;
         gap: 1.6rem;
       }
       .dossier__section {
-        background: #ffffff;
-        border-radius: 16px;
+        background: var(--color-surface-base);
+        border-radius: var(--radius-lg);
+        border: 1px solid var(--color-border-subtle);
         padding: 1.6rem;
-        box-shadow: 0 10px 25px rgba(16, 23, 36, 0.08);
+        box-shadow: var(--shadow-md);
       }
       .dossier__grid {
         display: grid;
@@ -62,12 +86,13 @@
         display: inline-flex;
         align-items: center;
         gap: 0.4rem;
-        border-radius: 999px;
-        background: #e9eef8;
-        padding: 0.2rem 0.8rem;
-        font-size: 0.75rem;
+        border-radius: var(--radius-pill);
+        background: var(--color-accent-soft);
+        color: var(--color-accent-400);
+        padding: 0.25rem 0.85rem;
+        font-size: var(--font-size-xs);
         text-transform: uppercase;
-        letter-spacing: 0.06em;
+        letter-spacing: 0.08em;
       }
       .dossier__list {
         list-style: none;
@@ -77,10 +102,10 @@
         gap: 0.8rem;
       }
       .dossier__list-item {
-        border: 1px solid #e1e6f0;
-        border-radius: 12px;
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
         padding: 1rem;
-        background: #fdfdff;
+        background: var(--color-surface-muted);
       }
       .dossier__list-item h3 {
         margin-bottom: 0.4rem;
@@ -96,21 +121,27 @@
       .dossier__chip {
         display: inline-flex;
         align-items: center;
-        border-radius: 999px;
-        background: #dee6fb;
-        color: #1b2a52;
-        font-size: 0.75rem;
+        border-radius: var(--radius-pill);
+        background: var(--color-accent-soft);
+        color: var(--color-accent-400);
+        font-size: var(--font-size-xs);
         padding: 0.2rem 0.6rem;
       }
       .dossier__pair {
         display: flex;
         flex-wrap: wrap;
         gap: 0.6rem 1.2rem;
-        font-size: 0.85rem;
-        color: #40495b;
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
       }
       .dossier__pair span {
         white-space: nowrap;
+      }
+      .icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 1;
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- add shared color, typography, elevation, and tone tokens to the dashboard stylesheet and surface-panel utilities
- refresh generator panels, pins, activity, and history layouts to consume the new tokens and updated icon styling
- align the dossier export template with the shared tokens for consistent colors and spacing

## Testing
- python tests/validate_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68fe8e7dd83483329da9a46399beff3e