### PR TITLE
Add contextual insight panel and filter reuse metrics

### DIFF
--- a/docs/evo-tactics-pack/generator-benchmarks.md
+++ b/docs/evo-tactics-pack/generator-benchmarks.md
@@ -25,6 +25,17 @@
 - **Target**: punteggio ≥ 4/5 in sondaggio rapido con team design (scala Likert) e 0 errori critici di comprensione.
 - **Verifica**: walkthrough guidato + checklist linguaggio chiaro, accompagnato da test contrasto (WCAG AA).
 
+### Riutilizzo profili filtro
+- **Definizione**: numero di applicazioni dei profili salvati tramite pannello Parametri durante una sessione.
+- **Target**: ≥ 2 riusi medi a sessione, con metrica tracciata nei KPI (`profile-reuse`).
+- **Verifica**: controllo rapido del contatore in dashboard e correlazione con evento `profile-load` nel registro attività.
+
+## Insight contestuali e suggerimenti
+
+- Il pannello "Insight contestuali" estende il riepilogo con suggerimenti basati su catalogo, connessioni bioma-bioma e azioni recenti.
+- I pulsanti di salto rapido sfruttano il sistema di ancore per aprire direttamente Parametri, Biomi o Seed.
+- Ogni navigazione viene registrata nel log (`insight-navigate`) per misurare l'adozione dei suggerimenti.
+
 ## Visione, stakeholder e checkpoint
 
 - **Stakeholder coinvolti**: Lead Design (vision), Narrative Lead (hook), Tech Lead (pipeline export), QA (metriche), PM (roadmap).

--- a/docs/evo-tactics-pack/generator.html
+++ b/docs/evo-tactics-pack/generator.html
@@ -91,6 +91,15 @@
                 Encounter seed
               </a>
             </li>
+            <li class="anchor-nav__item">
+              <a
+                class="anchor-nav__link"
+                href="#generator-insights"
+                data-anchor-target="insights"
+              >
+                Insight contestuali
+              </a>
+            </li>
           </ol>
         </div>
       </nav>
@@ -321,6 +330,13 @@
                   Gli hook narrativi compariranno dopo la prima generazione.
                 </p>
               </article>
+              <article class="narrative-panel" id="generator-insight-panel">
+                <h5 class="narrative-panel__title">Suggerimenti rapidi</h5>
+                <p class="narrative-panel__body" id="generator-insight-empty">
+                  Genera un ecosistema per sbloccare consigli contestuali.
+                </p>
+                <ul class="generator-insight__list" id="generator-insight-list" hidden></ul>
+              </article>
             </section>
             <div class="generator-summary__pins surface-panel surface-panel--tight">
               <h4 class="generator-summary__subtitle">Specie pinnate</h4>
@@ -499,6 +515,21 @@
             ></div>
           </div>
         </section>
+
+        <section class="section" id="generator-insights" data-panel="insights">
+          <div class="section__header">
+            <h2>Insight contestuali</h2>
+            <p>
+              Raccomandazioni dinamiche basate sul catalogo e sull'utilizzo recente del generatore.
+            </p>
+          </div>
+          <article class="surface-panel" id="generator-insights-panel">
+            <p class="generator-summary__empty" id="generator-insights-empty">
+              Genera un ecosistema e applica filtri per vedere i suggerimenti dedicati.
+            </p>
+            <ul class="generator-insights__list" id="generator-insights-list" hidden></ul>
+          </article>
+        </section>
       </div>
 
       <aside
@@ -529,6 +560,10 @@
             <div class="generator-summary__metric">
               <dt class="generator-summary__label">Specie uniche</dt>
               <dd class="generator-summary__value" data-kpi="unique-species">0</dd>
+            </div>
+            <div class="generator-summary__metric">
+              <dt class="generator-summary__label">Riusi profili filtro</dt>
+              <dd class="generator-summary__value" data-kpi="profile-reuse">0</dd>
             </div>
           </dl>
         </section>


### PR DESCRIPTION
## Summary
- introduce quick insight lists and a dedicated anchor section with contextual recommendations tied to recent generator usage
- surface catalog-driven biome/species guidance plus filter profile reuse telemetry in the narrative panels and KPI sidebar
- document the new success metric and ensure navigation shortcuts log insight activity for auditing

## Testing
- python tests/validate_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68fe93d82d048332ac25cfdc9b379753