### PR TITLE
Align Enneagram compat map with engine aliases

### DIFF
--- a/docs/evo-tactics-pack/ennea-themes.md
+++ b/docs/evo-tactics-pack/ennea-themes.md
@@ -6,6 +6,27 @@ comportamentali. Le soglie di attivazione sono derivate dai dataset YAML
 condivisi nel repository e alimentano sia i generatori Ennea sia i report
 telemetrici TV.
 
+## Stats & Eventi engine (v0.3)
+- **Statistiche supportate**: `ac`, `aura_radius`, `bond_aura`, `burst_damage`,
+  `charisma_checks`, `counter_chance`, `damage_taken`, `duel_bonus`,
+  `evasion`, `hp_max`, `initiative`, `initiative_adv`, `melee_damage`, `pe`,
+  `pp`, `ranged_damage`, `self_reliance`, `sg`, `skill_success`,
+  `stamina_regen`, `stealth`, `support_power`, `teamwork_bonus`.
+- **Trigger monitorati**: `on_adjacent_ally`, `on_ally_downed`,
+  `on_ambush_initiated`, `on_coordinate_action`,
+  `on_damage_taken_then_counter`, `on_finisher_hit`,
+  `on_first_blood_received`, `on_goal_blocked`, `on_initiative_win`,
+  `on_isolation`, `on_new_area_discovered`, `on_setback`,
+  `on_skill_check_under_pressure`, `on_stealth_start`.
+- **Alias namespaced**: le voci di compatibilità usano ora la forma
+  `<dominio>.<sottodominio>.<metrica>` (es. `combat.defense.ac`,
+  `events.team.coordinate_action`) per collegare direttamente gli identificativi
+  del motore agli hook tematici senza traduzioni ad hoc.
+- **Limiti confermati**: i gruppi esclusivi (`core_emotion`, `hornevian`,
+  `harmonic`, `object_rel`) rispettano 1–2 attivazioni per incontro e i passivi
+  mantengono `instincts_stack_with: none` con cap `add_pct` 0.2 e
+  `add_flat_initiative` 4.
+
 ## Biome Coherence (Tipo 1)
 - **Dataset & Hooks**: `themes.yaml` → `reformer_1`, `personality_module.v1.json` → `mechanics_registry.hooks["theme.reformer_1"].links`, `dataset.themes[reformer_1]`.
 - **Scopo**: mantenere coerenza tra biomi, affissi e mutazioni per ridurre

--- a/packs/evo_tactics_pack/tools/py/modules/personality/enneagram/compat_map.json
+++ b/packs/evo_tactics_pack/tools/py/modules/personality/enneagram/compat_map.json
@@ -1,222 +1,229 @@
 {
-  "version": "0.2.0",
-  "updated_at": "2025-10-26T17:27:57.296199",
+  "version": "0.3.0",
+  "updated_at": "2025-10-26T22:41:51Z",
   "stats": {
     "ac": {
       "aliases": [
-        "armor_class",
-        "defense"
+        "combat.defense.ac",
+        "combat.defense.rating"
       ]
     },
     "aura_radius": {
       "aliases": [
-        "aura_range",
-        "team_aura_radius"
+        "support.aura.radius",
+        "support.aura.spread"
       ]
     },
     "bond_aura": {
       "aliases": [
-        "ally_bond",
-        "coordination_aura"
+        "support.bond.link_strength",
+        "support.bond.radius"
       ]
     },
     "burst_damage": {
       "aliases": [
-        "burst",
-        "alpha_damage"
+        "combat.damage.burst",
+        "combat.alpha_strike.damage"
       ]
     },
     "charisma_checks": {
       "aliases": [
-        "presence",
-        "influence_checks"
+        "social.charisma.check",
+        "skill.social.charisma"
       ]
     },
     "counter_chance": {
       "aliases": [
-        "riposte_rate",
-        "counter_rate"
+        "combat.counter.chance",
+        "combat.reaction.counter_rate"
       ]
     },
     "damage_taken": {
       "aliases": [
-        "incoming_damage",
-        "damage_received"
+        "combat.damage.taken",
+        "combat.incoming_damage"
       ]
     },
     "duel_bonus": {
       "aliases": [
-        "duelist_edge"
+        "combat.duel.bonus",
+        "combat.duelist.edge"
       ]
     },
     "evasion": {
       "aliases": [
-        "dodge",
-        "evasion_rate"
+        "combat.defense.evasion",
+        "combat.defense.dodge_rate"
       ]
     },
     "hp_max": {
       "aliases": [
-        "max_hp",
-        "health_max"
+        "resources.hp.max",
+        "vitals.health.max"
       ]
     },
     "initiative": {
       "aliases": [
-        "init",
-        "initiative_score"
+        "combat.initiative.base",
+        "combat.initiative.score"
       ]
     },
     "initiative_adv": {
       "aliases": [
-        "init_adv",
-        "initiative_advantage"
+        "combat.initiative.advantage",
+        "combat.initiative.bonus"
       ]
     },
     "melee_damage": {
       "aliases": [
-        "melee_dmg",
-        "atk_melee_damage"
+        "combat.melee.damage",
+        "combat.attack.melee"
       ]
     },
     "pe": {
       "aliases": [
-        "energy_points",
-        "stamina_points"
+        "resources.pe",
+        "economy.energy_points"
       ]
     },
     "pp": {
       "aliases": [
-        "power_points",
-        "pp_total"
+        "resources.pp",
+        "economy.power_points"
       ]
     },
     "ranged_damage": {
       "aliases": [
-        "ranged_dmg",
-        "atk_ranged_damage"
+        "combat.ranged.damage",
+        "combat.attack.ranged"
       ]
     },
     "self_reliance": {
       "aliases": [
-        "solo_bonus",
-        "independent_bonus"
+        "tactics.self_reliance",
+        "tactics.solo_bonus"
       ]
     },
     "sg": {
       "aliases": [
-        "shield_gauge",
-        "tilt_resistance"
+        "defense.shield.gauge",
+        "defense.tilt_resistance"
       ]
     },
     "skill_success": {
       "aliases": [
-        "skill_check_bonus",
-        "skill_success_rate"
+        "skills.check.success",
+        "skills.success_rate"
       ]
     },
     "stamina_regen": {
       "aliases": [
-        "stam_regen",
-        "endurance_regen"
+        "resources.stamina.regen",
+        "resources.endurance.regen"
       ]
     },
     "stealth": {
       "aliases": [
-        "stealth_score",
-        "concealment"
+        "skills.stealth",
+        "skills.concealment"
       ]
     },
     "support_power": {
       "aliases": [
-        "support",
-        "heal_power"
+        "support.power",
+        "support.healing.power"
       ]
     },
     "teamwork_bonus": {
       "aliases": [
-        "coordination_bonus"
+        "support.teamwork.bonus",
+        "support.coordination.bonus"
       ]
     }
   },
   "events": {
     "on_adjacent_ally": {
       "aliases": [
-        "on_ally_close",
-        "on_bond_range"
+        "events.tactical.ally_adjacent",
+        "events.team.bond_range"
       ]
     },
     "on_ally_downed": {
       "aliases": [
-        "on_ally_down",
-        "on_ally_ko"
+        "events.tactical.ally_downed",
+        "events.team.ally_ko"
       ]
     },
     "on_ambush_initiated": {
       "aliases": [
-        "on_ambush",
-        "on_surprise_round"
+        "events.tactical.ambush_started",
+        "events.tactical.surprise_round"
       ]
     },
     "on_coordinate_action": {
       "aliases": [
-        "on_team_action",
-        "on_help_action"
+        "events.team.coordinate_action",
+        "events.support.assist_performed"
       ]
     },
     "on_damage_taken_then_counter": {
       "aliases": [
-        "on_hit_then_counter"
+        "events.reaction.counter_after_hit",
+        "events.reaction.hit_then_counter"
       ]
     },
     "on_finisher_hit": {
       "aliases": [
-        "on_finisher_resolved"
+        "events.combat.finisher_hit",
+        "events.combat.finisher_resolved"
       ]
     },
     "on_first_blood_received": {
       "aliases": [
-        "on_first_blood",
-        "on_first_hit_taken"
+        "events.combat.first_blood_taken",
+        "events.combat.first_hit_taken"
       ]
     },
     "on_goal_blocked": {
       "aliases": [
-        "on_objective_denied",
-        "on_interrupt"
+        "events.objective.goal_blocked",
+        "events.objective.interrupt"
       ]
     },
     "on_initiative_win": {
       "aliases": [
-        "on_win_initiative"
+        "events.combat.initiative_win",
+        "events.combat.initiative_check_win"
       ]
     },
     "on_isolation": {
       "aliases": [
-        "on_no_ally_near",
-        "on_solo_state"
+        "events.state.isolation",
+        "events.team.solo_state"
       ]
     },
     "on_new_area_discovered": {
       "aliases": [
-        "on_area_reveal"
+        "events.exploration.new_area",
+        "events.exploration.area_reveal"
       ]
     },
     "on_setback": {
       "aliases": [
-        "on_fail_check",
-        "on_damage_spike"
+        "events.challenge.setback",
+        "events.challenge.fail_check"
       ]
     },
     "on_skill_check_under_pressure": {
       "aliases": [
-        "on_skill_clutch",
-        "on_skill_high_dc"
+        "events.challenge.skill_under_pressure",
+        "events.challenge.skill_high_dc"
       ]
     },
     "on_stealth_start": {
       "aliases": [
-        "on_enter_stealth"
+        "events.stealth.enter",
+        "events.stealth.started"
       ]
     }
   },

--- a/packs/evo_tactics_pack/tools/py/modules/personality/enneagram/personality_module.v1.json
+++ b/packs/evo_tactics_pack/tools/py/modules/personality/enneagram/personality_module.v1.json
@@ -2122,224 +2122,231 @@
     ]
   },
   "compatibility": {
-    "version": "0.2.0",
-    "updated_at": "2025-10-26T17:27:57.296199",
+    "version": "0.3.0",
+    "updated_at": "2025-10-26T22:41:51Z",
     "stats": {
       "ac": {
         "aliases": [
-          "armor_class",
-          "defense"
+          "combat.defense.ac",
+          "combat.defense.rating"
         ]
       },
       "aura_radius": {
         "aliases": [
-          "aura_range",
-          "team_aura_radius"
+          "support.aura.radius",
+          "support.aura.spread"
         ]
       },
       "bond_aura": {
         "aliases": [
-          "ally_bond",
-          "coordination_aura"
+          "support.bond.link_strength",
+          "support.bond.radius"
         ]
       },
       "burst_damage": {
         "aliases": [
-          "burst",
-          "alpha_damage"
+          "combat.damage.burst",
+          "combat.alpha_strike.damage"
         ]
       },
       "charisma_checks": {
         "aliases": [
-          "presence",
-          "influence_checks"
+          "social.charisma.check",
+          "skill.social.charisma"
         ]
       },
       "counter_chance": {
         "aliases": [
-          "riposte_rate",
-          "counter_rate"
+          "combat.counter.chance",
+          "combat.reaction.counter_rate"
         ]
       },
       "damage_taken": {
         "aliases": [
-          "incoming_damage",
-          "damage_received"
+          "combat.damage.taken",
+          "combat.incoming_damage"
         ]
       },
       "duel_bonus": {
         "aliases": [
-          "duelist_edge"
+          "combat.duel.bonus",
+          "combat.duelist.edge"
         ]
       },
       "evasion": {
         "aliases": [
-          "dodge",
-          "evasion_rate"
+          "combat.defense.evasion",
+          "combat.defense.dodge_rate"
         ]
       },
       "hp_max": {
         "aliases": [
-          "max_hp",
-          "health_max"
+          "resources.hp.max",
+          "vitals.health.max"
         ]
       },
       "initiative": {
         "aliases": [
-          "init",
-          "initiative_score"
+          "combat.initiative.base",
+          "combat.initiative.score"
         ]
       },
       "initiative_adv": {
         "aliases": [
-          "init_adv",
-          "initiative_advantage"
+          "combat.initiative.advantage",
+          "combat.initiative.bonus"
         ]
       },
       "melee_damage": {
         "aliases": [
-          "melee_dmg",
-          "atk_melee_damage"
+          "combat.melee.damage",
+          "combat.attack.melee"
         ]
       },
       "pe": {
         "aliases": [
-          "energy_points",
-          "stamina_points"
+          "resources.pe",
+          "economy.energy_points"
         ]
       },
       "pp": {
         "aliases": [
-          "power_points",
-          "pp_total"
+          "resources.pp",
+          "economy.power_points"
         ]
       },
       "ranged_damage": {
         "aliases": [
-          "ranged_dmg",
-          "atk_ranged_damage"
+          "combat.ranged.damage",
+          "combat.attack.ranged"
         ]
       },
       "self_reliance": {
         "aliases": [
-          "solo_bonus",
-          "independent_bonus"
+          "tactics.self_reliance",
+          "tactics.solo_bonus"
         ]
       },
       "sg": {
         "aliases": [
-          "shield_gauge",
-          "tilt_resistance"
+          "defense.shield.gauge",
+          "defense.tilt_resistance"
         ]
       },
       "skill_success": {
         "aliases": [
-          "skill_check_bonus",
-          "skill_success_rate"
+          "skills.check.success",
+          "skills.success_rate"
         ]
       },
       "stamina_regen": {
         "aliases": [
-          "stam_regen",
-          "endurance_regen"
+          "resources.stamina.regen",
+          "resources.endurance.regen"
         ]
       },
       "stealth": {
         "aliases": [
-          "stealth_score",
-          "concealment"
+          "skills.stealth",
+          "skills.concealment"
         ]
       },
       "support_power": {
         "aliases": [
-          "support",
-          "heal_power"
+          "support.power",
+          "support.healing.power"
         ]
       },
       "teamwork_bonus": {
         "aliases": [
-          "coordination_bonus"
+          "support.teamwork.bonus",
+          "support.coordination.bonus"
         ]
       }
     },
     "events": {
       "on_adjacent_ally": {
         "aliases": [
-          "on_ally_close",
-          "on_bond_range"
+          "events.tactical.ally_adjacent",
+          "events.team.bond_range"
         ]
       },
       "on_ally_downed": {
         "aliases": [
-          "on_ally_down",
-          "on_ally_ko"
+          "events.tactical.ally_downed",
+          "events.team.ally_ko"
         ]
       },
       "on_ambush_initiated": {
         "aliases": [
-          "on_ambush",
-          "on_surprise_round"
+          "events.tactical.ambush_started",
+          "events.tactical.surprise_round"
         ]
       },
       "on_coordinate_action": {
         "aliases": [
-          "on_team_action",
-          "on_help_action"
+          "events.team.coordinate_action",
+          "events.support.assist_performed"
         ]
       },
       "on_damage_taken_then_counter": {
         "aliases": [
-          "on_hit_then_counter"
+          "events.reaction.counter_after_hit",
+          "events.reaction.hit_then_counter"
         ]
       },
       "on_finisher_hit": {
         "aliases": [
-          "on_finisher_resolved"
+          "events.combat.finisher_hit",
+          "events.combat.finisher_resolved"
         ]
       },
       "on_first_blood_received": {
         "aliases": [
-          "on_first_blood",
-          "on_first_hit_taken"
+          "events.combat.first_blood_taken",
+          "events.combat.first_hit_taken"
         ]
       },
       "on_goal_blocked": {
         "aliases": [
-          "on_objective_denied",
-          "on_interrupt"
+          "events.objective.goal_blocked",
+          "events.objective.interrupt"
         ]
       },
       "on_initiative_win": {
         "aliases": [
-          "on_win_initiative"
+          "events.combat.initiative_win",
+          "events.combat.initiative_check_win"
         ]
       },
       "on_isolation": {
         "aliases": [
-          "on_no_ally_near",
-          "on_solo_state"
+          "events.state.isolation",
+          "events.team.solo_state"
         ]
       },
       "on_new_area_discovered": {
         "aliases": [
-          "on_area_reveal"
+          "events.exploration.new_area",
+          "events.exploration.area_reveal"
         ]
       },
       "on_setback": {
         "aliases": [
-          "on_fail_check",
-          "on_damage_spike"
+          "events.challenge.setback",
+          "events.challenge.fail_check"
         ]
       },
       "on_skill_check_under_pressure": {
         "aliases": [
-          "on_skill_clutch",
-          "on_skill_high_dc"
+          "events.challenge.skill_under_pressure",
+          "events.challenge.skill_high_dc"
         ]
       },
       "on_stealth_start": {
         "aliases": [
-          "on_enter_stealth"
+          "events.stealth.enter",
+          "events.stealth.started"
         ]
       }
     },


### PR DESCRIPTION
## Summary
- replace provisional Enneagram stat/event aliases with namespaced engine identifiers and bump the compatibility manifest to v0.3.0
- mirror the refreshed alias mapping inside personality_module.v1.json to keep the packaged module consistent
- document the canonical stats, triggers, and stacking limits in the Ennea themes guide using the new naming scheme

## Testing
- python packs/evo_tactics_pack/tools/legacy/validate_v7.py
- python packs/evo_tactics_pack/tools/py/ext_v1_5/validate_v7.py

------
https://chatgpt.com/codex/tasks/task_e_68fea1b5a788833287df276b7ccc54d7