### PR TITLE
Add November 2025 playtest insights and update roadmap priorities

### DIFF
--- a/docs/piani/roadmap.md
+++ b/docs/piani/roadmap.md
@@ -22,22 +22,29 @@
    - `docs/drive-sync.md` contiene ora la procedura autorizzativa e i trigger cron per Apps Script; i run 2025-10-24 e 2025-11-01 confermano la sincronizzazione fogli/log.【F:docs/drive-sync.md†L17-L57】【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L37-L79】
 
 ## Milestone attive
-> **Fase corrente (Ondata 2)** — Pianificare QA manuale, copertura comunicazione release e follow-up documentali post-playtest.
+> **Priorità riviste (Ondata 2)** — Alla luce dei dati di novembre 2025, le smart feature (HUD + SquadSync) precedono l'estensione export; la roadmap integra checkpoint di validazione continui.【F:docs/playtest/INSIGHTS-2025-11.md†L3-L26】
 
-1. **Preparazione QA manuale**
-   - Definire scenari critici e checklist sessioni, archiviandoli in `docs/playtest/` per il sign-off QA.【F:docs/checklist/action-items.md†L1-L47】
-   - Pianificare playtest interni, raccogliere report `SESSION-*.md` e aprire ticket per i bug confermati.【F:docs/checklist/action-items.md†L1-L47】
-2. **Rilascio e comunicazione**
+1. **Smart HUD & SquadSync** _(priorità alta)_
+   - Consolidare gli acknowledgment automatici degli alert risk >0.60 e validare che rientrino entro 2 turni medi su due sessioni consecutive (`delta`, `echo`).【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L35-L91】【F:docs/playtest/INSIGHTS-2025-11.md†L4-L19】
+   - Integrare messaggi contestuali HUD e aggiornare il Canvas dedicato con screenshot e dati di coesione ≥0.78 post-playtest QA.【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L9-L37】【F:docs/Canvas/feature-updates.md†L9-L40】
+   - **Criteri di uscita:** risk index medio ≤0.58 su roster co-op, durata alert ≤1.5 turni e tilt score <0.50 per due build consecutive.【F:docs/playtest/INSIGHTS-2025-11.md†L8-L19】
+2. **Export telemetria incrementale** _(priorità media)_
+   - Limitare l'export automatico ai log `session-metrics.yaml` già normalizzati, rinviando gli snapshot bulk finché la milestone Smart HUD non è chiusa.【F:docs/playtest/INSIGHTS-2025-11.md†L22-L25】【F:docs/drive-sync.md†L17-L57】
+   - Preparare script di validazione schema e lista di distribuzione Drive, con smoke test su dataset 24/10 → 05/11 per evitare regressioni nei campi risk/cohesion.【F:logs/playtests/2025-10-24-vc/session-metrics.yaml†L8-L73】【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L8-L91】
+   - **Criteri di uscita:** export schedulato che copre ≥90% dei campi Fase 0 e report di conformità approvato dal team Analytics.
+3. **Rilascio e comunicazione** _(priorità media)_
    - Redigere il changelog aggiornato, coordinare annunci marketing e preparare materiali HUD finali per il tag `v0.6.0-rc1`.【F:docs/changelog.md†L1-L40】
    - Allineare roadmap e Canvas con le milestone di release, includendo gli screenshot post-QA e collegando le nuove sintesi ai Canvas tematici creati in `docs/`.【F:docs/DesignDoc-Overview.md†L1-L70】【F:docs/Canvas/feature-updates.md†L1-L40】
-3. **Esperienze di Mating e Nido**
+   - **Criteri di uscita:** materiali di comunicazione approvati, post Slack programmato e repository Canvas aggiornato con i dati VC novembre 2025.【F:docs/playtest/INSIGHTS-2025-11.md†L3-L19】
+4. **Esperienze di Mating e Nido** _(priorità bassa, monitorare)_
    - Estendere `compat_forme` alle restanti 14 forme e definire cross-formula per `base_scores`.【F:data/mating.yaml†L1-L120】
    - Prototipare ambienti interattivi per `dune_stalker` ed `echo_morph`, validando risorse e privacy.【F:data/mating.yaml†L121-L180】
-4. **Missioni verticali e supporto live**
-   - Preparare il playtest di "Skydock Siege" con obiettivi multilivello e timer di evacuazione.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
-   - Collegare Reattori Aeon, filtro SquadSync e protocolli di soccorso alla pipeline telemetrica co-op.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
-   - Applicare il nuovo layout HUD: grafici risk/cohesion sovrapposti e log esportabili in `.yaml` direttamente da Canvas per i vertical slice.【F:docs/Canvas/feature-updates.md†L9-L20】 _Layout completato con radar/timeline aggiornati; alert automatici >0.60 attivi dal tuning del 2025-11-03._
-   - Bilanciare i timer di evacuazione in funzione dei picchi `risk.time_low_hp_turns` registrati nelle squadre Bravo e Charlie, mantenendo l'obiettivo di tilt < 0.50; revisione 2025-11-05 documentata in `data/missions/skydock_siege.yaml`.【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L19-L36】【F:data/missions/skydock_siege.yaml†L1-L82】 _Monitorare eventuali regressioni nei prossimi playtest QA._
+   - **Checkpoint:** riesaminare la priorità dopo la chiusura di Smart HUD per evitare conflitti di risorse con i playtest VC.
+
+## Allineamento stakeholder e checkpoint
+- **Retro settimanale VC (martedì 17:00 CET)** — PM, Analytics, QA: revisione alert HUD, aggiornamento metriche risk/cohesion e decisioni di follow-up smart feature.【F:docs/playtest/INSIGHTS-2025-11.md†L22-L26】
+- **Demo quindicinale (venerdì settimana dispari, 15:00 CET)** — Mostrare riduzione alert duration e stato export incrementale a Design Council + Tech Lead; registrare decisioni in `docs/tool_run_report.md`.【F:docs/playtest/INSIGHTS-2025-11.md†L22-L26】【F:docs/tool_run_report.md†L1-L40】
+- **Checkpoint roadmap mensile** — Aggiornare questa pagina e `docs/Canvas/feature-updates.md` dopo ogni ciclo di demo per confermare priorità e criteri di uscita.【F:docs/Canvas/feature-updates.md†L1-L40】
 
 ## Prossimi passi
 - Documentare esempi di encounter generati (CLI Python) e associarli a test di difficoltà per ciascun bioma.【F:data/biomes.yaml†L1-L13】 _In corso: radar/specie comparate disponibili nella dashboard generator._

--- a/docs/piani/roadmap.md
+++ b/docs/piani/roadmap.md
@@ -41,6 +41,15 @@
    - Prototipare ambienti interattivi per `dune_stalker` ed `echo_morph`, validando risorse e privacy.【F:data/mating.yaml†L121-L180】
    - **Checkpoint:** riesaminare la priorità dopo la chiusura di Smart HUD per evitare conflitti di risorse con i playtest VC.
 
+## Milestone in coda
+> **Ripianificazione post-Smart HUD** — Gli elementi seguenti restano aperti ma vengono accodati fino al completamento delle priorità Smart HUD/SquadSync.【F:docs/playtest/INSIGHTS-2025-11.md†L3-L26】
+
+1. **Missioni verticali e supporto live** _(in coda)_
+   - Preparare il playtest di "Skydock Siege" con obiettivi multilivello e timer di evacuazione.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
+   - Collegare Reattori Aeon, filtro SquadSync e protocolli di soccorso alla pipeline telemetrica co-op.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
+   - Applicare il nuovo layout HUD: grafici risk/cohesion sovrapposti e log esportabili in `.yaml` direttamente da Canvas per i vertical slice.【F:docs/Canvas/feature-updates.md†L9-L20】 _Layout completato con radar/timeline aggiornati; alert automatici >0.60 attivi dal tuning del 2025-11-03._
+   - Bilanciare i timer di evacuazione in funzione dei picchi `risk.time_low_hp_turns` registrati nelle squadre Bravo e Charlie, mantenendo l'obiettivo di tilt < 0.50; revisione 2025-11-05 documentata in `data/missions/skydock_siege.yaml`.【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L19-L36】【F:data/missions/skydock_siege.yaml†L1-L82】 _Monitorare eventuali regressioni nei prossimi playtest QA._
+
 ## Allineamento stakeholder e checkpoint
 - **Retro settimanale VC (martedì 17:00 CET)** — PM, Analytics, QA: revisione alert HUD, aggiornamento metriche risk/cohesion e decisioni di follow-up smart feature.【F:docs/playtest/INSIGHTS-2025-11.md†L22-L26】
 - **Demo quindicinale (venerdì settimana dispari, 15:00 CET)** — Mostrare riduzione alert duration e stato export incrementale a Design Council + Tech Lead; registrare decisioni in `docs/tool_run_report.md`.【F:docs/playtest/INSIGHTS-2025-11.md†L22-L26】【F:docs/tool_run_report.md†L1-L40】

--- a/docs/playtest/INSIGHTS-2025-11.md
+++ b/docs/playtest/INSIGHTS-2025-11.md
@@ -1,0 +1,26 @@
+# Insight playtest VC — Novembre 2025
+
+## Sintesi esecutiva
+- **Trend rischio/cohesion**: gli ultimi retest di "Skydock Siege" (05/11) mostrano risk index medio 0.565 (-0.045 rispetto al picco Tier 4 del 24/10) e cohesion medio 0.76 (+0.04), confermando l'efficacia del tuning EMA e degli alert HUD smart.【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L8-L91】【F:logs/playtests/2025-10-24-vc/session-metrics.yaml†L8-L79】
+- **Stabilizzazione alert HUD**: il tempo di permanenza sopra soglia risk è sceso da 2 turni medi (24/10) a 1.5 turni (05/11) con acknowledgment automatico PI entro 3 turni, riducendo il carico manuale del team bilanciamento.【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L35-L64】【F:logs/playtests/2025-10-24-vc/session-metrics.yaml†L8-L79】
+- **Copertura QA**: la sessione QA finale (01/11) mantiene tilt <0.50 e zero eventi low cohesion, abilitando il passaggio a focus su smart feature (HUD + SquadSync) prima di estendere gli export automatizzati.【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L1-L43】
+
+## Metriche chiave (Fase 0)
+| Metrica Fase 0 | 24/10 Delta | 24/10 Echo | 05/11 Delta | 05/11 Echo | Variazione | Osservazioni |
+| --- | --- | --- | --- | --- | --- | --- |
+| `risk.weighted_index` | 0.57 | 0.61 | 0.59 | 0.54 | ↓ medio -0.025 | Calo marcato in co-op grazie a cooldown drone supporto; singolo picco controllato su Delta. |
+| `cohesion.weighted_index` | 0.68 | 0.76 | 0.72 | 0.80 | ↑ medio +0.04 | Formazioni più rapide (+3 turni) e +2 azioni di supporto su Echo. |
+| `tilt.tilt_score` | 0.48 | 0.52 | 0.46 | 0.44 | ↓ medio -0.05 | Timer evacuazione ridotto a 6 turni mantiene tilt sotto 0.5. |
+| `hud_alerts.duration_turns` | 2 (stimato) | 2 | 2 | 1 | ↓ medio -0.5 | Alert co-op rientra in 1 turno, solo Delta richiede follow-up PI. |
+
+## Insight qualitativi
+- **Tuning cooldown relay/scudi** (Delta, 05/11): riduce low HP window a 3 turni e mantiene tilt 0.46; confermata richiesta di mantenere settaggio nella build release.【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L32-L91】
+- **Drone di supporto** (Echo, 05/11): portare cooldown a 3 turni elimina necessità di ping manuale PI e stabilizza risk a 0.54 con ack HUD autonomo.【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L52-L78】
+- **Overcap guard events**: assenti nel retest 05/11 (contro 3-6 eventi del 24/10), confermando che l'hotfix EMA 0.2 ha funzionato e che la priorità smart feature può superare l'espansione export per questa ondata.【F:logs/playtests/2025-10-24-vc/session-metrics.yaml†L18-L73】【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L8-L91】
+- **QA coverage** (01/11): tutte le squadre mantengono cohesion ≥0.78 e solo un high risk event >0.60, abilitando il via libera per la milestone "Smart HUD & SquadSync".【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L9-L37】
+
+## Raccomandazioni operative
+1. **Priorità smart feature** — Consolidare ack HUD automatico e migliorare messaggi contestuali (focus VC) prima di investire nell'export bulk verso Drive, sfruttando il calo di overcap guard e i tilt stabilizzati.
+2. **Export telemetria** — Limitare l'estensione export ai log già normalizzati (`session-metrics.yaml`) finché non si completa la checklist smart feature; pianificare un incremento successivo (milestone separata).
+3. **Monitoraggio continuo** — Integrare nel prossimo playtest (settimana 47) un controllo puntuale su `risk.time_low_hp_turns` per assicurare che il drone supporto resti efficace con roster variati.
+4. **Follow-up QA** — Mantenere retro settimanale con stakeholder analytics/QA e demo quindicinale focalizzata su HUD per mostrare riduzione alert duration.


### PR DESCRIPTION
## Summary
- add a November 2025 insight report consolidating qualitative and quantitative playtest metrics
- reprioritize the roadmap to focus on smart HUD & SquadSync work ahead of export automation, adding exit criteria for each milestone
- schedule recurring stakeholder checkpoints for weekly retros and biweekly demos tied to the updated priorities

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fea695c8e0833281c1b33a2583da4c