### PR TITLE
Sync EMA telemetry parameters and Skydock Siege hotfix

### DIFF
--- a/data/missions/skydock_siege.yaml
+++ b/data/missions/skydock_siege.yaml
@@ -1,5 +1,5 @@
 skydock_siege:
-  revision: "2025-11-05-vc"
+  revision: "2025-02-15-vc-hotfix"
   source_logs:
     - session: alpha
       tier: "Tier 2"
@@ -22,24 +22,12 @@ skydock_siege:
         weighted_index: 0.51
       tilt:
         score: 0.44
-    - session: delta
-      tier: "Tier 3 (retest)"
-      risk:
-        time_low_hp_turns: 7
-        weighted_index: 0.59
-      tilt:
-        score: 0.46
-      hud_alerts:
-        triggered_turn: 11
-        cleared_turn: 13
-        weighted_index_peak: 0.62
-        notification_channel: "pi.balance.alerts"
   targets:
     tier_2:
       time_low_hp_turns_max: 5
       tilt_score_max: 0.50
     tier_3:
-      time_low_hp_turns_max: 7
+      time_low_hp_turns_max: 6
       tilt_score_max: 0.48
     tier_3_coop:
       time_low_hp_turns_max: 5
@@ -49,43 +37,55 @@ skydock_siege:
       - id: evacuation_timer_turns
         from: 7
         to: 6
-        rationale: "Timer ridotto di un turno: l'alert HUD anticipa l'estrazione quando il rischio supera 0.60, mantenendo il tilt Delta/Bravo sotto 0.50."
+        rationale: "Timer ridotto di un turno: l'alert HUD anticipa l'estrazione quando il rischio supera 0.60, mantenendo il tilt Alpha/Bravo sotto 0.50."
       - id: aeon_overload_warning_cooldown_turns
-        from: 5
-        to: 3
-        rationale: "Preavviso più frequente per preparare rotazioni di guardia: il retest Delta mostra picchi solo temporanei (0.62 → 0.57 in due turni)."
+        from: 3
+        to: 2
+        rationale: "Preavviso ancora più frequente: Bravo registra 11 turni a HP critico; anticipare il ping permette di attivare riposizionamenti prima del burst."
       - id: aeon_overload_damage_pct
-        from: 0.28
-        to: 0.24
-        rationale: "I picchi di danno dell'overload hanno allineato Alpha e Bravo a finestre EMA >0.60; riduciamo il burst per restare nel range di rischio previsto."
+        from: 0.24
+        to: 0.21
+        rationale: "Riduzione ulteriore del burst: con i log VC del 15/02 Bravo supera la soglia risk 0.60 in concomitanza con 11 turni low HP."
+      - id: shield_relay_absorb_pct
+        from: 0.35
+        to: 0.42
+        rationale: "Aumentiamo l'assorbimento degli scudi condivisi per abbassare il tempo in HP critico durante le ondate Aeon."
     tier_3:
       - id: shield_relay_cooldown_turns
-        from: 4
-        to: 3
-        rationale: "Riduzione ulteriore: il trend `time_low_hp_turns` scende a 7 nel retest, ma restano picchi durante la finestra Overload."
+        from: 3
+        to: 2
+        rationale: "Cooldown più stretto: Bravo resta 11 turni in low HP; portiamo il reset scudi a 2 turni per coprire wave consecutive."
       - id: medkit_drop_turns
-        from: [6, 12]
-        to: [5, 10]
-        rationale: "Medkit anticipato di un turno e finestra di follow-up più stretta per comprimere i periodi a HP critico nei turni 10-12 (Bravo/Delta)."
-      - id: pi_balance_handoff_window
-        from: 4
+        from: [5, 10]
+        to: [4, 9]
+        rationale: "Anticipiamo entrambi i rifornimenti di un turno per sanare il corridoio evac (turni 9-12)."
+      - id: emergency_nanogel_charges
+        from: 2
         to: 3
-        rationale: "Allineare la finestra di intervento PI all'alert HUD → conferma ack canale `pi.balance.alerts` entro tre turni."
+        rationale: "Carica aggiuntiva per le classi senza heal: ridurre `time_low_hp_turns` medio sotto 7 in Tier 3."
+      - id: pi_balance_handoff_window
+        from: 3
+        to: 2
+        rationale: "HUD alert >0.60 deve ricevere ack entro due turni per garantire intervento sulle nuove finestre EMA."
     tier_3_coop:
       - id: support_drone_priority
         from: "threat_highest"
         to: "hp_lowest"
         rationale: "In co-op Charlie resta sotto controllo ma beneficia di redirect immediato per proteggere il supporto Helix durante Aeon overload."
       - id: support_drone_cooldown_turns
-        from: 4
-        to: 3
-        rationale: "Il playtest co-op mostra spikes brevi a rischio 0.58: riduciamo la finestra per mantenere tilt <0.50 anche con alert attivo."
+        from: 3
+        to: 2
+        rationale: "Spike brevi (risk 0.58) rientrano più rapidamente con un cooldown di 2 turni sui droni di supporto."
+      - id: emergency_nanogel_charges
+        from: 2
+        to: 4
+        rationale: "Co-op consente distribuzione rapida: due cariche extra coprono i check-point turni 8 e 12."
   monitoring:
     - metric: risk.time_low_hp_turns
-      expected_trend: "Retest Delta/Echo stabilizza il trend a 7 turni su Tier 3; mantenere <=5 in co-op."
+      expected_trend: "Applicare il tuning VC 15/02: Tier 3 deve scendere a <=6 (target 5 nelle run successive), co-op mantenere <=5."
     - metric: risk.weighted_index
       hud_alert_threshold: 0.60
       action: "Trigger avviso HUD (fascia gialla) e ping automatico al canale PI balance."
-      validation: "Alert attivato al turno 11 (0.62) e chiuso entro due tick quando l'EMA riscende a 0.57."
+      validation: "Alert attivato al turno 11 (0.62) nella run Bravo; ack entro due turni sfruttando finestra `pi_balance_handoff_window` ridotta."
     - metric: tilt.score
-      expected_trend: "Tilt medio 0.46 nel retest Delta; mantenere <0.50 sincronizzando timer evacuazione e cooldown supporto."
+      expected_trend: "Log VC 15/02: tilt 0.52 (Alpha) e 0.48 (Bravo); mantenere <0.50 sincronizzando evacuazione e supporto."

--- a/data/telemetry.yaml
+++ b/data/telemetry.yaml
@@ -2,7 +2,7 @@ telemetry:
   ema_alpha: 0.3
   windows:
     turn: true
-    phase_weights: {early: 0.20, mid: 0.40, late: 0.40}
+    phase_weights: {early: 0.25, mid: 0.35, late: 0.40}
   hud_breakdown:
     roles:
       vanguard: {target: 0.22, tolerance: 0.04, alert: 0.30}
@@ -18,7 +18,7 @@ telemetry:
       R4: {target: 0.12, tolerance: 0.04, alert: 0.18}
       R5: {target: 0.04, tolerance: 0.02, alert: 0.08}
   debounce_ms: 200
-  idle_threshold_s: 8
+  idle_threshold_s: 10
   normalization: "ema_capped_minmax"
   normalization_params:
     floor: 0.15

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,7 +19,8 @@
 ### Changed
 - Il generatore seleziona di default il bundle demo per le esportazioni e
   aggiorna il manifest con press kit e insight.
-- Allineate le finestre EMA (`phase_weights` 0.20/0.40/0.40, `idle_threshold_s` 8) e definite le nuove sezioni `hud_breakdown`, `telemetry_targets` e `pe_economy.curve` per sincronizzare i log Delta/Echo con la curva PE aggiornata.
+- Allineate le finestre EMA (`phase_weights` 0.25/0.35/0.40, `idle_threshold_s` 10) e definite le nuove sezioni `hud_breakdown`, `telemetry_targets` e `pe_economy.curve` per sincronizzare i log VC con la curva PE aggiornata.
+- Hotfix missione "Skydock Siege" (build VC 2025-02-15): scudi potenziati, medkit anticipati e ack PI in 2 turni per riportare `risk.time_low_hp_turns` entro il target Tier 3 (<=6).
 - Consolidato il calendario comunicazioni con Marketing/Product definendo owner, cadenza (daily standup + sync settimanale) e canali condivisi per il piano feedback post-annuncio.
 - Registrato l'impegno congiunto Marketing/Product e QA per il checkpoint finale e per il rilascio del pacchetto asset aggiornato.
 

--- a/docs/hooks/ema-metrics.md
+++ b/docs/hooks/ema-metrics.md
@@ -13,6 +13,7 @@
      turn: state.turn,
      ema: state.ema, // alpha 0.3, pesi fase 0.25/0.35/0.40
      indices: state.indices,
+     idleThreshold: 10,
    });
    ```
    - L'oggetto `state.ema` espone `window` (turno) e frame `phase_weights` aggiornati.
@@ -37,6 +38,7 @@
     });
     ```
     - L'alert HUD usa colore giallo (warning) e si auto-disarma quando la media scende sotto 0.58 per due tick consecutivi.
+    - La finestra `idleThreshold` aggiornata (10 s) assicura coerenza tra dataset e log VC 2025-02-15.
     - `commandBus.emit` notifica il canale PI balance per follow-up immediato.
     - Il recorder telemetrico archivia l'evento in `hud_alert_log` (vedi `logs/playtests/2025-11-05-vc/session-metrics.yaml`).
 

--- a/docs/piani/roadmap.md
+++ b/docs/piani/roadmap.md
@@ -13,10 +13,10 @@
 
 1. **Bilanciamento pacchetti PI e telemetria EMA**
    - `telemetry.pe_economy` espone ora curva e costi completi, sincronizzati con `pi_shop` per tutte le opzioni acquistabili.【F:data/telemetry.yaml†L1-L72】【F:data/packs.yaml†L1-L88】
-   - Il middleware `tools/ts/hud_alerts.ts` consuma gli eventi `ema.update`, aggiorna l'HUD e notifica il canale `pi.balance.alerts`, con log missione aggiornati nel dossier di tuning.【F:tools/ts/hud_alerts.ts†L1-L206】【F:data/missions/skydock_siege.yaml†L1-L64】
-   - `docs/hooks/ema-metrics.md` descrive gli hook condivisi con il team client e i parametri di smoothing approvati per la build VC.【F:docs/hooks/ema-metrics.md†L1-L52】
+   - Il middleware `tools/ts/hud_alerts.ts` consuma gli eventi `ema.update`, aggiorna l'HUD e notifica il canale `pi.balance.alerts`, con log missione aggiornati nel dossier di tuning.【F:tools/ts/hud_alerts.ts†L1-L206】【F:data/missions/skydock_siege.yaml†L1-L84】
+   - `docs/hooks/ema-metrics.md` descrive gli hook condivisi con il team client, con le finestre EMA aggiornate (0.25/0.35/0.40) e l'idle threshold da 10 s approvato per la build VC.【F:docs/hooks/ema-metrics.md†L1-L52】
 2. **Alert HUD Risk & rituning “Skydock Siege”**
-   - Il mission file registra i nuovi timer (evacuazione 6 turni, cooldown ridotti) e documenta l'attivazione dell'alert HUD >0.60 durante i retest Delta.【F:data/missions/skydock_siege.yaml†L1-L82】
+   - Il mission file registra il tuning hotfix VC 15/02 (scudi potenziati, medkit anticipati, ack PI in 2 turni) per abbassare `time_low_hp_turns` di Bravo da 11 a <=6.【F:data/missions/skydock_siege.yaml†L1-L86】【F:logs/playtests/2025-02-15-vc/session-metrics.yaml†L23-L58】
    - I log missione VC includono le finestre EMA e la cronologia degli alert per l'esportazione Drive.【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L37-L79】
 3. **Automazione export telemetria VC → Drive**
    - `docs/drive-sync.md` contiene ora la procedura autorizzativa e i trigger cron per Apps Script; i run 2025-10-24 e 2025-11-01 confermano la sincronizzazione fogli/log.【F:docs/drive-sync.md†L17-L57】【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L37-L79】
@@ -25,7 +25,7 @@
 > **Priorità riviste (Ondata 2)** — Alla luce dei dati di novembre 2025, le smart feature (HUD + SquadSync) precedono l'estensione export; la roadmap integra checkpoint di validazione continui.【F:docs/playtest/INSIGHTS-2025-11.md†L3-L26】
 
 1. **Smart HUD & SquadSync** _(priorità alta)_
-   - Consolidare gli acknowledgment automatici degli alert risk >0.60 e validare che rientrino entro 2 turni medi su due sessioni consecutive (`delta`, `echo`).【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L35-L91】【F:docs/playtest/INSIGHTS-2025-11.md†L4-L19】
+   - Consolidare gli acknowledgment automatici degli alert risk >0.60 e validare che rientrino entro 2 turni medi su due sessioni consecutive (`alpha`, `bravo`).【F:logs/playtests/2025-02-15-vc/session-metrics.yaml†L23-L58】【F:docs/playtest/INSIGHTS-2025-11.md†L4-L19】
    - Integrare messaggi contestuali HUD e aggiornare il Canvas dedicato con screenshot e dati di coesione ≥0.78 post-playtest QA.【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L9-L37】【F:docs/Canvas/feature-updates.md†L9-L40】
    - **Criteri di uscita:** risk index medio ≤0.58 su roster co-op, durata alert ≤1.5 turni e tilt score <0.50 per due build consecutive.【F:docs/playtest/INSIGHTS-2025-11.md†L8-L19】
 2. **Export telemetria incrementale** _(priorità media)_
@@ -48,7 +48,7 @@
    - Preparare il playtest di "Skydock Siege" con obiettivi multilivello e timer di evacuazione.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
    - Collegare Reattori Aeon, filtro SquadSync e protocolli di soccorso alla pipeline telemetrica co-op.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
    - Applicare il nuovo layout HUD: grafici risk/cohesion sovrapposti e log esportabili in `.yaml` direttamente da Canvas per i vertical slice.【F:docs/Canvas/feature-updates.md†L9-L20】 _Layout completato con radar/timeline aggiornati; alert automatici >0.60 attivi dal tuning del 2025-11-03._
-   - Bilanciare i timer di evacuazione in funzione dei picchi `risk.time_low_hp_turns` registrati nelle squadre Bravo e Charlie, mantenendo l'obiettivo di tilt < 0.50; revisione 2025-11-05 documentata in `data/missions/skydock_siege.yaml`.【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L19-L36】【F:data/missions/skydock_siege.yaml†L1-L82】 _Monitorare eventuali regressioni nei prossimi playtest QA._
+    - Bilanciare i timer di evacuazione in funzione dei picchi `risk.time_low_hp_turns` registrati nelle squadre Bravo e Charlie, mantenendo l'obiettivo di tilt < 0.50; hotfix VC 15/02 documentato in `data/missions/skydock_siege.yaml`.【F:logs/playtests/2025-02-15-vc/session-metrics.yaml†L23-L94】【F:data/missions/skydock_siege.yaml†L1-L91】 _Monitorare eventuali regressioni nei prossimi playtest QA._
 
 ## Allineamento stakeholder e checkpoint
 - **Retro settimanale VC (martedì 17:00 CET)** — PM, Analytics, QA: revisione alert HUD, aggiornamento metriche risk/cohesion e decisioni di follow-up smart feature.【F:docs/playtest/INSIGHTS-2025-11.md†L22-L26】


### PR DESCRIPTION
## Summary
- align EMA phase weights and idle threshold with the VC 2025-02-15 telemetry snapshot
- document the updated EMA hooks and mission hotfix adjustments to cut `risk.time_low_hp_turns`
- update the Skydock Siege mission tuning, roadmap, and changelog to track the new Tier 3 targets

## Testing
- python tools/py/validate_datasets.py

------
https://chatgpt.com/codex/tasks/task_e_68feab9a1e448332ad11ff495e171b61