### PR TITLE
Aggiorna scenari playtest e pianificazione sessione pilota

### DIFF
--- a/docs/playtest/SESSION-template.md
+++ b/docs/playtest/SESSION-template.md
@@ -24,6 +24,7 @@
 ## Bug e ticket
 | ID issue | Titolo | Stato | Etichette | Link |
 | --- | --- | --- | --- | --- |
+| | | | `encounter-balance` / ... | |
 
 ## Materiali archiviati
 - Log: `logs/SESSION-YYYY-MM-DD/`

--- a/docs/playtest/feedback-template.md
+++ b/docs/playtest/feedback-template.md
@@ -1,6 +1,8 @@
 # Template raccolta feedback playtest
 
-Compilare un documento per partecipante al termine della sessione (o durante pause concordate). Le domande aperte possono essere integrate con note dell'osservatore.
+Compilare un documento per partecipante al termine della sessione (o durante pause concordate).
+Le domande aperte possono essere integrate con note dell'osservatore.
+Indicare sempre l'ID scenario (es. `BAL-01`) per facilitare il collegamento con i ticket di bug.
 
 ## Dati generali
 - **Sessione:** `SESSION-YYYY-MM-DD`
@@ -26,7 +28,7 @@ Compilare un documento per partecipante al termine della sessione (o durante pau
 2. Hai riscontrato bug visivi o narrativi durante l'evento?
 
 ## Problemi tecnici
-- Lista di bug riscontrati (con passi di riproduzione e severità).
+- Lista di bug riscontrati (con passi di riproduzione, severità e indicazione se richiede etichetta `encounter-balance`).
 - Note su prestazioni, input o stabilità.
 
 ## Suggerimenti aggiuntivi

--- a/docs/playtest/pilot-session-2025-11-12.md
+++ b/docs/playtest/pilot-session-2025-11-12.md
@@ -3,6 +3,7 @@
 ## Obiettivi
 - Validare gli scenari di bilanciamento `BAL-01` e `BAL-02`, la progressione `PROG-01` e l'evento speciale `EVT-01`.
 - Verificare il flusso di raccolta feedback e la procedura post-sessione.
+- Allineare team di design, QA e narrativa sulle priorità di rilascio di novembre 2025.
 
 ## Partecipanti
 | Ruolo | Nome | Responsabilità |
@@ -21,6 +22,7 @@
 - **11:20-12:10** — Esecuzione scenario `BAL-02` e `PROG-01`.
 - **12:10-12:30** — Discussione guidata sull'evento `EVT-01` e raccolta feedback immediato.
 - **12:30-13:00** — Compilazione template feedback individuale e consolidamento note.
+- **13:00-13:15** — Debrief operativo (QA + design) e definizione follow-up.
 
 ## Materiali e preparazione
 - Build `alpha-balancing` installata su 5 postazioni con controller e tastiera.
@@ -29,9 +31,11 @@
 - Cartella condivisa `logs/pilot-2025-11-12/` per video, log e screenshot (creare prima della sessione).
 - Copie stampate o digitali del `feedback-template.md` per ogni partecipante.
 - Foglio di calcolo telemetrico collegato a `telemetry/pilot-session-2025-11-12.xlsx`.
+- Link stanza virtuale di supporto (Teams "Playtest Ops") per emergenze tecniche.
+- Check-list hardware (periferiche, cuffie, microfoni) completata e firmata da QA Lead entro il 11/11.
 
 ## Deliverable post-sessione
 1. Compilare `docs/playtest/SESSION-2025-11-12.md` seguendo la procedura descritta in `procedura-post-sessione.md`.
 2. Archiviare log, screenshot e registrazioni nella cartella `logs/pilot-2025-11-12/` con naming coerente.
-3. Aprire issue su tracker con etichetta `encounter-balance` per ogni bug confermato.
-4. Pianificare eventuali sessioni di follow-up sulla base delle criticità emerse.
+3. Aprire issue su tracker con etichetta `encounter-balance` per ogni bug confermato e collegarle al documento della sessione.
+4. Pianificare eventuali sessioni di follow-up sulla base delle criticità emerse e documentare le decisioni nella sezione "Azioni successive" del report.

--- a/docs/playtest/scenari-test.md
+++ b/docs/playtest/scenari-test.md
@@ -1,30 +1,36 @@
 # Elenco scenari di test
 
-Questo documento riassume gli scenari di playtest programmati per verificare bilanciamento, progressione e reazioni agli eventi speciali. Ogni scenario è progettato per essere eseguito in autonomia o all'interno di una sessione pilota più ampia. Gli scenari che ricadono nel perimetro critico vengono tracciati con priorità e frequenza dedicate in `scenari-critici.md`.
+Questo documento riassume gli scenari di playtest programmati per verificare bilanciamento, progressione e reazioni agli eventi speciali.
+Ogni scenario è progettato per essere eseguito in autonomia o all'interno di una sessione pilota più ampia.
+Gli scenari che ricadono nel perimetro critico vengono tracciati con priorità e frequenza dedicate in `scenari-critici.md`.
+
+Per ogni scenario sono riportati gli obiettivi chiave, le metriche da raccogliere, i prerequisiti tecnici e la cadenza consigliata con cui
+ripetere il test nel corso delle iterazioni. Le cadenze sono suggerite dal team di design e QA per garantire che ognuna delle aree di verifica
+riceva attenzione costante.
 
 ## 1. Bilanciamento degli incontri
 
-| ID | Scenario | Obiettivi | Metriche principali | Prerequisiti |
-| --- | --- | --- | --- | --- |
-| BAL-01 | "Campo di battaglia iniziale" | Verificare la difficoltà percepita del primo incontro multi-unità. | Tasso di vittoria, danno medio subito, tempo per completare lo scontro. | Build `alpha-balancing` con configurazioni standard dei personaggi livello 1. |
-| BAL-02 | "Boss intermedio" | Validare la curva di difficoltà al passaggio dalla mid-campaign. | Numero di tentativi prima della vittoria, consumo risorse, feedback qualitativo sul pattern del boss. | Savegame capitolo 4, equipaggiamento livello 12, accesso a log di combattimento. |
-| BAL-03 | "Horde mode" | Stress test della gestione spawn massivi e prestazioni AI. | Frame rate minimo, tempo di risoluzione turno, segnalazioni di comportamenti erratici. | Modalità horde attiva da configurazione `configs/horde_balancing.json`. |
+| ID | Scenario | Obiettivi | Metriche principali | Prerequisiti | Cadenza |
+| --- | --- | --- | --- | --- | --- |
+| BAL-01 | "Campo di battaglia iniziale" | Verificare la difficoltà percepita del primo incontro multi-unità. | Tasso di vittoria, danno medio subito, tempo per completare lo scontro. | Build `alpha-balancing` con configurazioni standard dei personaggi livello 1. | Ad ogni build settimanale. |
+| BAL-02 | "Boss intermedio" | Validare la curva di difficoltà al passaggio dalla mid-campaign. | Numero di tentativi prima della vittoria, consumo risorse, feedback qualitativo sul pattern del boss. | Savegame capitolo 4, equipaggiamento livello 12, accesso a log di combattimento. | Ogni milestone narrativa. |
+| BAL-03 | "Horde mode" | Stress test della gestione spawn massivi e prestazioni AI. | Frame rate minimo, tempo di risoluzione turno, segnalazioni di comportamenti erratici. | Modalità horde attiva da configurazione `configs/horde_balancing.json`. | Fine sprint tecnico. |
 
 ## 2. Progressione
 
-| ID | Scenario | Obiettivi | Metriche principali | Prerequisiti |
-| --- | --- | --- | --- | --- |
-| PROG-01 | "Percorso tutorial" | Misurare la comprensione delle meccaniche base dopo il tutorial. | Step completati senza aiuto, domande frequenti, tempo totale. | Build di onboarding, checklist di onboarding stampata. |
-| PROG-02 | "Sblocco abilità ramo esploratore" | Valutare chiarezza dei requisiti e soddisfazione ricompense. | Numero di tentativi, scelta dei perk, feedback narrativo. | Profilo giocatore livello 8, feature flag `explorer_branch` attivo. |
-| PROG-03 | "Gestione risorse hub" | Testare economia e ritmo di upgrade del quartier generale. | Bilancio risorse dopo 3 cicli, percentuale di upgrade completati, momenti di stallo. | Save hub con progressione media, foglio di calcolo per tracciamento risorse. |
+| ID | Scenario | Obiettivi | Metriche principali | Prerequisiti | Cadenza |
+| --- | --- | --- | --- | --- | --- |
+| PROG-01 | "Percorso tutorial" | Misurare la comprensione delle meccaniche base dopo il tutorial. | Step completati senza aiuto, domande frequenti, tempo totale. | Build di onboarding, checklist di onboarding stampata. | Ogni volta che vengono introdotte nuove meccaniche. |
+| PROG-02 | "Sblocco abilità ramo esploratore" | Valutare chiarezza dei requisiti e soddisfazione ricompense. | Numero di tentativi, scelta dei perk, feedback narrativo. | Profilo giocatore livello 8, feature flag `explorer_branch` attivo. | Ogni sprint di progressione (mensile). |
+| PROG-03 | "Gestione risorse hub" | Testare economia e ritmo di upgrade del quartier generale. | Bilancio risorse dopo 3 cicli, percentuale di upgrade completati, momenti di stallo. | Save hub con progressione media, foglio di calcolo per tracciamento risorse. | Inizio e fine di ogni ciclo trimestrale. |
 
 ## 3. Eventi speciali
 
-| ID | Scenario | Obiettivi | Metriche principali | Prerequisiti |
-| --- | --- | --- | --- | --- |
-| EVT-01 | "Tempesta dimensionale" | Valutare chiarezza comunicazioni e reazioni del team. | Decisioni prese dai giocatori, tempo di risposta, bug grafici. | Script evento `event_dimensional_storm.json`, effetti particellari aggiornati. |
-| EVT-02 | "Alleanza inattesa" | Testare ramificazioni narrative in caso di scelta cooperativa. | Percentuale di scelta cooperativa, coerenza dialoghi, flag narrativi corretti. | Build narrativa `branching-v3`, foglio storyline aggiornato. |
-| EVT-03 | "Anomalia reliquia" | Controllare puzzle e ricompense legate agli artefatti. | Tasso di completamento, numero di tentativi puzzle, feedback sulla ricompensa. | Puzzle pack `relic_omega`, accesso a log puzzle. |
+| ID | Scenario | Obiettivi | Metriche principali | Prerequisiti | Cadenza |
+| --- | --- | --- | --- | --- | --- |
+| EVT-01 | "Tempesta dimensionale" | Valutare chiarezza comunicazioni e reazioni del team. | Decisioni prese dai giocatori, tempo di risposta, bug grafici. | Script evento `event_dimensional_storm.json`, effetti particellari aggiornati. | Ogni rilascio di VFX o UI d'allerta. |
+| EVT-02 | "Alleanza inattesa" | Testare ramificazioni narrative in caso di scelta cooperativa. | Percentuale di scelta cooperativa, coerenza dialoghi, flag narrativi corretti. | Build narrativa `branching-v3`, foglio storyline aggiornato. | Revisioni narrative bimestrali. |
+| EVT-03 | "Anomalia reliquia" | Controllare puzzle e ricompense legate agli artefatti. | Tasso di completamento, numero di tentativi puzzle, feedback sulla ricompensa. | Puzzle pack `relic_omega`, accesso a log puzzle. | Quando vengono introdotti nuovi artefatti. |
 
 ## Modalità di esecuzione
 
@@ -32,5 +38,6 @@ Questo documento riassume gli scenari di playtest programmati per verificare bil
 2. Registrare gameplay (video o log) e annotare metriche quantitative.
 3. Raccogliere feedback qualitativo immediato tramite il template predisposto (`feedback-template.md`).
 4. Archiviare i risultati nella cartella della sessione corrispondente (vedere `procedura-post-sessione.md`).
+5. Verificare che eventuali bug relativi agli incontri siano tracciati con issue etichettate `encounter-balance`.
 
 Aggiornare questo documento quando vengono aggiunti nuovi scenari o varianti significative.


### PR DESCRIPTION
## Summary
- aggiorna l'elenco degli scenari di test con cadenze consigliate e richiamo all'etichetta `encounter-balance`
- estende la pianificazione della sessione pilota del 12/11/2025 con logistica, debrief e materiali aggiuntivi
- raffina i template di feedback e di report di sessione per collegare bug e scenari

## Testing
- not run (documentazione)


------
https://chatgpt.com/codex/tasks/task_e_68febe04c91083328412c7760fb2dce1