### PR TITLE
Aggiorna note VC novembre 2025 con metriche QA

### DIFF
--- a/docs/Canvas/feature-updates.md
+++ b/docs/Canvas/feature-updates.md
@@ -10,10 +10,10 @@
 - **Reattori Aeon** — Risorsa leggendaria che abilita poteri temporali specifici per le Forme Armoniche.【F:data/chatgpt/2025-10-23/snapshot-20251023T101500Z.json†L1-L6】
 - **Telemetry Risk Tuning 2025-10-24** — Nuovo metodo `ema_capped_minmax` con segnale `overcap_guard_events` e smoothing 0.2 per ridurre i falsi positivi nelle squadre Bravo/Delta.【F:data/telemetry.yaml†L2-L25】【F:logs/playtests/2025-10-24-vc/session-metrics.yaml†L1-L62】
 
-### Aggiornamento QA 2025-11-01
-- **Metriche Canvas aggiornate** — Il dashboard VC mostra risk medio 0.55 (Delta 0.55, Echo 0.58, Bravo 0.52) e coesione media 0.81 con varianza <0.10 sulle squadre QA finali.【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L1-L44】
-- **Visual HUD** — Inserire screenshot ricalcolato con gradienti risk rivisti e timeline SquadSync entro il pacchetto `v0.6.0-rc1`; allegare callout su picco Echo wave 3 risolto live.【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L19-L44】
-- **Azioni successive** — Pubblicare grafici aggiornati in Canvas/Drive e collegare annuncio Slack programmato il 2025-11-07 ore 16:00 CET al changelog RC.【F:docs/changelog.md†L21-L33】【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L37-L45】 Coordinare il nuovo riepilogo quotidiano delle PR per mantenere Mission Control e Canvas sincronizzati.
+### Aggiornamento QA 2025-11-05
+- **Metriche Canvas aggiornate** — Il dashboard VC mostra risk medio 0.57 (Delta 0.59, Echo 0.54) e coesione 0.72/0.80 con tilt <0.46 dopo il retest client r2823.【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L1-L83】
+- **Visual HUD** — Aggiornare lo screenshot con alert risk turno 11 (Delta) e note ack PI automatico; includere grafico coesione con support actions 12/18 per Delta/Echo nel pacchetto `v0.6.0-rc1`.【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L1-L83】
+- **Azioni successive** — Pubblicare grafici aggiornati in Canvas/Drive e collegare annuncio Slack programmato il 2025-11-07 ore 16:00 CET al changelog RC; includere estratto metriche nel briefing Drive entro le 18:00 CET.【F:docs/changelog.md†L66-L79】【F:docs/piani/roadmap.md†L72-L85】【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L1-L88】 Coordinare il nuovo riepilogo quotidiano delle PR per mantenere Mission Control e Canvas sincronizzati.
 
 ## Riepilogo quotidiano PR
 <!-- daily-pr-summary:start -->

--- a/docs/Telemetria-VC.md
+++ b/docs/Telemetria-VC.md
@@ -32,8 +32,8 @@
 
 ## Revisioni Programmate
 - Review telemetria settimanali (martedì 10:00 CET, giovedì 16:00 CET) e retro quindicinale coordinata da Design/Tech Lead con materiali raccolti entro le 18:00 CET nella cartella `telemetria/reports`. Tutte le sessioni sono registrate sul calendario `Evo-Tactics / VC Reviews` e l'owner pubblica riepilogo in `docs/tool_run_report.md` o ADR dedicati.【F:docs/24-TELEMETRIA_VC.md†L14-L29】
-- KPI monitorati: tasso conversione NPG, durata scontri per bioma, attivazioni Protocollo di soccorso, StressWave medio per squadra, coesione aggregata (Delta/Echo).【F:appendici/C-CANVAS_NPG_BIOMI.txt†L83-L132】【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L1-L79】
+- KPI monitorati: tasso conversione NPG, durata scontri per bioma, attivazioni Protocollo di soccorso, StressWave medio per squadra, coesione aggregata (Delta/Echo).【F:appendici/C-CANVAS_NPG_BIOMI.txt†L83-L132】【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L1-L102】
 
 ## Stato Attuale
 - Metodo `ema_capped_minmax` introdotto il 2025-10-24 riduce falsi positivi su squadre Bravo/Delta; monitorare smoothing 0.2 durante playtest successivi.【F:docs/Canvas/feature-updates.md†L11-L24】【F:data/telemetry.yaml†L17-L25】
-- Dashboard VC aggiornata 2025-11-01 mostra risk medio 0.55 e coesione 0.81, con timeline HUD da allegare al tag `v0.6.0-rc1`. Coordinare annunci Slack programmati 2025-11-07 16:00 CET con changelog RC.【F:docs/Canvas/feature-updates.md†L24-L38】【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L1-L45】【F:docs/changelog.md†L21-L33】
+- Dashboard VC aggiornata 2025-11-05 mostra risk medio 0.57 (Delta 0.59, Echo 0.54) e coesione 0.72/0.80, con timeline HUD e alert risk turno 11 da allegare al tag `v0.6.0-rc1`. Coordinare annunci Slack programmati 2025-11-07 16:00 CET con changelog RC e briefing Drive 18:00 CET.【F:docs/Canvas/feature-updates.md†L17-L27】【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L1-L88】【F:docs/changelog.md†L66-L79】【F:docs/piani/roadmap.md†L72-L85】

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,15 +37,15 @@
 
 ## [2025-11] VC Patch Note (RC)
 ### Stato feature
-- **HUD Risk/Cohesion Overlay** — Pronto per release; metriche QA 2025-11-01 confermano risk medio 0.55 e coesione 0.81 dopo il tuning EMA 0.2.【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L1-L45】
-- **Protocollo SquadSync Playbook** — Deployato con successo nelle squadre Echo/Bravo; resta monitoraggio su picchi risk >0.60 durante wave prolungate.【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L19-L44】
-- **Missione Skydock Siege (vertical slice)** — Contenuti narrativi e timer evacuazione completi; mantenere focus su supporto Aeon Overclock con guardie condivise.【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L31-L36】
+- **HUD Risk/Cohesion Overlay** — Pronto per release; metriche QA 2025-11-05 confermano risk medio 0.57 (Delta 0.59, Echo 0.54) e coesione 0.76/0.80 con alert HUD mitigati entro 2 turni.【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L1-L88】
+- **Protocollo SquadSync Playbook** — Deploy confermato su Echo/Delta con cooldown supporti ottimizzato; mantenere monitoraggio su picchi risk 0.62 per eventi Aeon Overclock e ack PI automatici.【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L9-L83】
+- **Missione Skydock Siege (vertical slice)** — Contenuti narrativi e timer evacuazione completi; tuning Tier 3 stabile con tilt <0.46 e timer evacuazione a 6 turni.【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L1-L102】
 
 ### Issue note
-- **Picco risk Echo wave 3** — Evento isolato (0.62) risolto con swap supporti; verificare alert in tempo reale nel rollout finale.【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L24-L33】
-- **Allineamento annunci** — Coordinare il calendario cross-team e gli aggiornamenti Canvas prima del tag `v0.6.0-rc1`.
+- **Alert risk Delta turno 11** — Picco 0.62 mitigato entro due turni con ack PI e cooldown relay; verificare replicabilità nel prossimo smoke test.【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L19-L83】
+- **Allineamento annunci** — Confermare agenda riunione cross-team 2025-11-06 (10:30 CET) e invio comunicazioni Slack/Drive post tag `v0.6.0-rc1` alle 16:00/18:00 CET del 2025-11-07.【F:docs/piani/roadmap.md†L72-L85】
 
 ### Prossimi passi
-- Pubblicare il tag `v0.6.0-rc1` dopo conferma QA e distribuire note VC al team ampliato.
-- Aggiornare materiali marketing/Canvas con screenshot HUD e grafici risk/cohesion aggiornati al 2025-11-01.【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L37-L45】
+- Pubblicare il tag `v0.6.0-rc1` dopo conferma QA 2025-11-05 e distribuire note VC al team ampliato.
+- Aggiornare materiali marketing/Canvas con screenshot HUD e grafici risk/cohesion aggiornati al playtest 2025-11-05 (Delta/Echo).【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L1-L88】【F:docs/Canvas/feature-updates.md†L17-L27】
 - Creare il tag Git ufficiale a chiusura QA, notificare Marketing Ops e Product con recap su asset HUD aggiornati e collegare la libreria screenshot revisionata.

--- a/docs/checklist/project-setup-todo.md
+++ b/docs/checklist/project-setup-todo.md
@@ -66,9 +66,9 @@ ogni esecuzione importante, annotando data, esito e note operative.
 ## 10. Rilascio e comunicazione
 - [ ] Redigere un changelog in `docs/changelog.md` prima di ogni release o consegna intermedia. _Next milestone: patch note VC novembre 2025 — owner Marketing Ops._ 
 - [x] Preparare materiali di comunicazione (slide, demo video, note) in `docs/presentations/` — creato briefing VC con asset collegati a milestone e release.【F:docs/presentations/2025-02-vc-briefing.md†L1-L20】
-- [ ] Coordinarsi con il team marketing/prodotto per pianificare annunci e raccolta feedback. _Riunione cross-team fissata per 2025-11-06 (product lead: C. Neri)._ 
+- [ ] Coordinarsi con il team marketing/prodotto per pianificare annunci e raccolta feedback. _Riunione cross-team fissata per 2025-11-06 (product lead: C. Neri) con recap Slack `#vc-launch` ore 16:00 CET e briefing Drive ore 18:00 CET post tag `v0.6.0-rc1`._
 - [ ] Creare un tag Git (`git tag vX.Y.Z && git push origin vX.Y.Z`) dopo la validazione finale. _Promemoria: tag `v0.6.0-rc1` dopo completamento QA._
-- [ ] Aggiornare periodicamente i materiali con screenshot HUD e metriche risk/cohesion post-playtest.【F:docs/Canvas/feature-updates.md†L9-L20】【F:logs/playtests/2025-02-15-vc/session-metrics.yaml†L33-L122】 _Ultimo refresh 2025-10-24; prossimo aggiornamento richiesto dopo QA di novembre._
+- [ ] Aggiornare periodicamente i materiali con screenshot HUD e metriche risk/cohesion post-playtest.【F:docs/Canvas/feature-updates.md†L1-L40】【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L1-L102】 _Ultimo refresh 2025-11-05 con dati Delta/Echo r2823; verificare allegati prima del tag `v0.6.0-rc1`._
 
 ## 11. Knowledge sharing e onboarding
 - [x] Aggiornare `docs/README.md` e le guide in `docs/piani/` con le nuove procedure adottate. _Completato con il riepilogo post-ottobre 2025 e l'integrazione dei Canvas specializzati._【F:docs/README.md†L1-L38】【F:docs/piani/roadmap.md†L1-L60】

--- a/docs/piani/roadmap.md
+++ b/docs/piani/roadmap.md
@@ -69,6 +69,6 @@
 <!-- daily-pr-summary:end -->
 
 ## Comunicazioni release VC novembre 2025
-- **Riunione cross-team (2025-11-06, 10:30 CET)** — Confermata sala VC Bridge + call Meet per telemetria/client/narrativa. Agenda: revisione metriche QA 2025-11-01, readiness tag `v0.6.0-rc1`, canali di annuncio e checklist supporto live.【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L1-L45】
-- **Canali di annuncio** — Preparare messaggio principale in `#vc-launch` (Slack) alle 16:00 CET del 2025-11-07 con link a changelog e Canvas aggiornato; replicare su Drive/Briefing entro le 18:00 con estratto metriche e TODO follow-up.【F:docs/changelog.md†L21-L33】【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L37-L45】
-- **Timeline tag** — Dopo sign-off della riunione, creare il tag `v0.6.0-rc1`, allegare screenshot HUD aggiornati in Canvas e consegnare ai partner esterni entro il 2025-11-08.【F:docs/Canvas/feature-updates.md†L1-L60】【F:logs/playtests/2025-11-01-vc/session-metrics.yaml†L37-L45】
+- **Riunione cross-team (2025-11-06, 10:30 CET)** — Confermata sala VC Bridge + call Meet per telemetria/client/narrativa. Agenda: revisione metriche QA 2025-11-05, readiness tag `v0.6.0-rc1`, canali di annuncio e checklist supporto live.【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L1-L102】
+- **Canali di annuncio** — Preparare messaggio principale in `#vc-launch` (Slack) alle 16:00 CET del 2025-11-07 con link a changelog e Canvas aggiornato; replicare su Drive/Briefing entro le 18:00 con estratto metriche (risk Delta 0.59, Echo 0.54; coesione 0.72/0.80) e TODO follow-up.【F:docs/changelog.md†L66-L79】【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L1-L88】
+- **Timeline tag** — Dopo sign-off della riunione, creare il tag `v0.6.0-rc1`, allegare screenshot HUD aggiornati in Canvas e consegnare ai partner esterni entro il 2025-11-08.【F:docs/Canvas/feature-updates.md†L1-L60】【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L1-L102】


### PR DESCRIPTION
## Summary
- aggiorna la patch note VC di novembre 2025 con gli ultimi dati QA e il piano comunicazioni del tag v0.6.0-rc1
- riallinea roadmap, checklist e canvas con metriche risk/cohesion del playtest 2025-11-05 e i canali di annuncio
- sincronizza la documentazione telemetrica con gli alert HUD e le tempistiche di comunicazione aggiornate

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68fecca1a71c8332bfc8038b8cf3b33a