### PR TITLE
Document bug triage scales and intake checklist

### DIFF
--- a/docs/checklist/bug-intake.md
+++ b/docs/checklist/bug-intake.md
@@ -1,0 +1,30 @@
+# Bug Intake Checklist
+
+Utilizzare questa checklist prima di spostare una segnalazione dalla vista `Backlog - Triage` a `QA - Triaged` o prima di inviare un ticket al canale `#vc-ops`.
+
+## 1. Dati obbligatori
+- [ ] `Fonte` impostata sul canale corretto (`telemetry-log`, `drive-sync`, `visual-regression`, `playtest`, `support`, `altro`).
+- [ ] `Timestamp evento` valorizzato con data/ora ISO o turno+data normalizzato.
+- [ ] `Owner` assegnato.
+- [ ] `Priorità` selezionata (`critical`, `high`, `medium`, `low`) in base alla scala impatto.
+- [ ] `Riproducibilità` indicata (`confermata`, `parziale`, `non_riprodotta`).
+- [ ] `Frequenza` selezionata (`sempre`, `intermittente`, `raro`, `non_riprodotto`) coerente con le evidenze.
+- [ ] `Stato` in `open` o `triaged` con nota contestuale se si tratta di duplicato o escalation.
+
+## 2. Evidenze
+- [ ] Link a log principali allegati (`Link a evidenze` contiene almeno un URL valido o file caricato).
+- [ ] Screenshot/video collegati quando l'impatto è visivo (riportare `N/A` motivato se non applicabile).
+- [ ] Passi di riproduzione e risultato atteso/osservato documentati nella descrizione.
+
+## 3. Controlli di qualità
+- [ ] Confronto severità ↔ impatto: `critical`/`high` rispondono a definizioni della scala backlog.
+- [ ] Frequenza confermata tramite test locali o riferimenti log (citare run/playtest nelle note).
+- [ ] Stato di riproducibilità aggiornato nel template support (`confermata`, `parziale`, `non_riprodotta`).
+- [ ] Automazioni Slack/email verificate (record appare nelle viste destinate ai team corretti).
+
+## 4. Pre-revisione
+- [ ] Ticket collegato a issue GitHub/Jira se `Priorità` ≥ `high`.
+- [ ] Commento in `Note aggiuntive` con eventuali dipendenze o follow-up richiesti.
+- [ ] Checklist completata e salvata (spuntare nel campo `Checklist QA` o allegare screenshot al ticket).
+
+_Responsabile: QA Lead — aggiornare la checklist se cambiano campi obbligatori nel backlog._

--- a/docs/process/incident_reporting_table.md
+++ b/docs/process/incident_reporting_table.md
@@ -21,6 +21,8 @@
 | `Owner` | Collaborator | Assegnare responsabile follow-up (persona QA/Engineering/Product). |
 | `Stato` | Single select (`open`, `triaged`, `in_progress`, `blocked`, `resolved`, `closed`) | Aggiornare ad ogni cambio di stato; automazione per notifiche Slack. |
 | `Priorità` | Single select (`critical`, `high`, `medium`, `low`) | Definita da QA al triage; visibile in tutte le viste. |
+| `Riproducibilità` | Single select (`confermata`, `parziale`, `non_riprodotta`) | Indica lo stato di verifica QA; necessario per triage. |
+| `Frequenza` | Single select (`sempre`, `intermittente`, `raro`, `non_riprodotto`) | Obbligatoria; compilare in base alle osservazioni QA/log. |
 | `Link a evidenze` | URL multiple (campo "Attachment" + formula URL) | Caricare o linkare log, screenshot, video; minimo un riferimento valido. |
 | `Note aggiuntive` | Long text | Spazio per decisioni meeting, follow-up, dipendenze. |
 
@@ -51,14 +53,32 @@
   - Trigger "When record enters view" (`ENG - Attive`) → crea issue GitHub via integrazione se `Priorità` >= `high`.
   - Promemoria settimanale (lunedì 09:00) con summary record `open`/`blocked` ai lead (email).
 
-## 4. Linee guida di compilazione
-1. **Creazione segnalazione**: QA inserisce nuovo record appena validata la riproducibilità. Usare template descrizione: contesto → passi → risultato atteso → risultato osservato.
+## 4. Scala impatto e frequenza per il backlog
+
+Per garantire triage coerente e confrontabile tra sorgenti diverse, ogni record nel backlog deve includere sia l'impatto sia la frequenza stimati usando le seguenti scale oggettive.
+
+### Impatto
+- **Critical** — Blocco totale di una funzionalità core, crash, perdita dati o violazione SLA primaria. Richiede hotfix immediato e comunicazione incidenti.
+- **High** — Funzionalità principale degradata o comportamenti errati che impediscono il completamento di scenari QA/telemetria ma con workaround limitato disponibile.
+- **Medium** — Problemi che alterano l'esperienza utente senza interrompere il flusso principale (es. valori HUD errati, metriche fuori soglia ma con alternativa temporanea).
+- **Low** — Glitch estetici, incoerenze di copy o issue con impatto minimo sullo user journey e senza rischi per telemetria/dati.
+
+### Frequenza
+- **Sempre** — Riproducibile al 100% seguendo i passi descritti oppure si manifesta a ogni run/partita.
+- **Intermittente** — Si verifica almeno nel 30% dei tentativi o dei playtest monitorati, con pattern osservabile (es. ogni N° run, determinate squadre).
+- **Raro** — Inferiore al 30% dei tentativi, segnalato da pochi tester o log isolati; richiede ulteriori dati per conferma.
+- **Non riprodotto** — Non ancora riproducibile internamente; usare solo se i passi noti non generano il problema ma esistono evidenze esterne (log, video).
+
+Annotare il valore di impatto nella colonna `Priorità` (`critical` → Critical, `high` → High, ecc.) e la frequenza tramite nuova colonna `Frequenza` (single select). Registrare inoltre lo stato di verifica QA nella colonna `Riproducibilità` (`confermata`, `parziale`, `non_riprodotta`). I tre campi sono obbligatori per passare dalla vista `Backlog - Triage` a `QA - Triaged`.
+
+## 5. Linee guida di compilazione
+1. **Creazione segnalazione**: QA inserisce nuovo record appena validata la riproducibilità. Usare template descrizione: contesto → passi → risultato atteso → risultato osservato. Prima del triage spuntare la [Bug Intake Checklist](../checklist/bug-intake.md).
 2. **Triage giornaliero**: entro le 12:00 CET, QA aggiorna `Priorità` e assegna `Owner`. Se duplicato, impostare `Stato` = `closed` e nota con riferimento ID correlato.
 3. **Aggiornamento stato**: Owner deve aggiornare `Stato` entro 24h da ogni cambiamento significativo e allegare evidenze (commit, PR, video fix).
 4. **Chiusura**: richiede conferma QA (test di regressione) e nota con build/versione risolutiva. Automazione invia report chiusura a Product.
 5. **Note aggiuntive**: utilizzare per link a meeting note, follow-up esterni, decisioni di backlog.
 
-## 5. Condivisione e comunicazione
+## 6. Condivisione e comunicazione
 - **Link base**: condividere URL della base Airtable con permessi differenziati (QA/Eng editor, Product commenter, stakeholder read-only).
 - **Documentazione**: allegare questa guida in `docs/process/` e nel workspace Airtable (tab "Documentation").
 - **Onboarding**: pianificare sessione di walkthrough (30 min) con i tre team; registrare la demo e salvare link in `Note aggiuntive` della segnalazione `SR-0001` (entry di test).

--- a/docs/support/bug-template.md
+++ b/docs/support/bug-template.md
@@ -8,7 +8,12 @@
 - **Log allegati**: `logs/cli/<data>.log`, estratto `docs/chatgpt_changes/sync-<data>.md`
 - **Esito smoke test**: link a `logs/cli/qa/<data>/`
 - **Impatto**: `blocking` | `degraded` | `info`
+- **Severità**: `critical` | `high` | `medium` | `low` (vedi scala backlog in `docs/process/incident_reporting_table.md`)
+- **Frequenza**: `sempre` | `intermittente` | `raro` | `non_riprodotto` (coerente con backlog `Frequenza`)
+- **Stato riproducibilità**: `confermata` | `parziale` | `non_riprodotta`
 - **Azioni intraprese**: rollback/manual fix/ri-esecuzione
 - **Owner escalation**: Support Lead / QA Lead / Tools Dev
+- **Link log**: URL/Drive al log principale (obbligatorio)
+- **Link screenshot/video**: evidenza visiva (PNG/MP4) oppure `N/A` se non applicabile
 
 _Compila il template in Drive e collega il ticket `#vc-ops` relativo._


### PR DESCRIPTION
## Summary
- document objective impact and frequency scales in the incident reporting backlog guidance and require reproducibility tracking
- update the support bug template with severity, frequency, reproducibility, and evidence link fields aligned to the backlog schema
- add a QA bug intake checklist to validate completeness before triage or escalation

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68fee11b62c483329af82337bf644c87