### PR TITLE
Document roadmap-linked triage cadence

### DIFF
--- a/docs/piani/roadmap.md
+++ b/docs/piani/roadmap.md
@@ -8,6 +8,19 @@
 5. **Retro Support/QA (martedì 17:00 CET)** — Porta le domande aperte in `docs/faq.md`, assegna owner/stato, collega le registrazioni onboarding e pianifica follow-up sulle configurazioni CLI condivise.【F:docs/README.md†L30-L34】【F:docs/faq.md†L1-L120】
 6. **Pubblicazione estratti** — Deposita screenshot HUD e asset nella cartella Drive (`docs/presentations/`), citando build CLI e commit di riferimento, quindi cross-link nei Canvas aggiornati.【F:docs/README.md†L28-L32】【F:docs/presentations/2025-02-vc-briefing.md†L1-L20】
 7. **Riepilogo PR giornaliero (entro 18:00 CET)** — Esegui `python tools/py/daily_pr_report.py --repo <owner/repo> --date <YYYY-MM-DD>` oppure verifica il workflow `daily-pr-summary`; salva l'output in `docs/chatgpt_changes/` e aggiorna changelog, roadmap, checklist e Canvas includendo le modifiche al refactor CLI.【F:docs/README.md†L32-L38】【F:docs/tool_run_report.md†L1-L40】
+8. **Review roadmap & comunicazione** — Ogni martedì 16:30-17:15 CET consolidare gli esiti della review settimanale: aggiornare questa pagina con stato milestone (`RM-*`), elencare bug chiusi o riassegnati e pubblicare riepilogo nel canale `#vc-docs`/Drive per l'allineamento stakeholder.【F:docs/process/qa_reporting_schema.md†L138-L164】
+
+## Mappatura milestone → componenti/feature
+
+| ID | Milestone | Componenti / feature principali (`component_tag`) | Note ticketing |
+| --- | --- | --- | --- |
+| RM-1 | Smart HUD & SquadSync | `hud`, `squadsync`, `telemetry-alerts`, `hud-notifications` | I ticket devono collegare screenshot HUD e log `hud_alert_log`; usare `roadmap_milestone = "RM-1 Smart HUD & SquadSync"`. |
+| RM-2 | Export telemetria incrementale | `drive-export`, `telemetry-sync`, `schema-validation` | Allegare esiti script `driveSync.gs` e report conformità; i bug bloccanti vanno segnalati anche in `#support-ops`. |
+| RM-3 | Rilascio e comunicazione | `release-ops`, `marketing-assets`, `visual-regression` | Collegare diff grafici e materiali marketing; aggiornare checklist comunicazione e pianificare annunci Slack/Drive. |
+| RM-4 | Esperienze di Mating e Nido | `nido-experience`, `romance-systems`, `biome-interactions` | Per bug multi-bioma aprire sotto-task dedicati mantenendo `roadmap_milestone` principale. |
+| RM-5 | Missioni verticali e supporto live | `mission-design`, `evac-timers`, `squadsync-support` | Associare log missione e note playtest; i timer evacuazione usano anche `component_tag = mission-design`. |
+| RM-0 | Bilanciamento pacchetti PI e telemetria EMA _(completata)_ | `pi-balance`, `ema-metrics`, `hud-alerts` | Ticket storici rimangono consultabili per regressioni; usare `status = closed` se riaperti come riferimento storico. |
+| RM-0b | Automazione export telemetria VC → Drive _(completata)_ | `drive-export`, `automation` | Mantenere collegamento per audit in caso di regressioni o nuove richieste di compliance. |
 
 ## Milestone completate (Ondata 1 — 2025-11-03)
 > **Aggiornamento 2025-11-03** — Prima ondata completata: la pipeline Drive Sync per i log VC è attiva, il bilanciamento PI/EMA è allineato con i dataset e gli alert HUD oltre soglia 0.60 guidano il nuovo tuning di "Skydock Siege".
@@ -55,6 +68,7 @@
 - **Retro settimanale VC (martedì 17:00 CET)** — PM, Analytics, QA: revisione alert HUD, aggiornamento metriche risk/cohesion e decisioni di follow-up smart feature.【F:docs/playtest/INSIGHTS-2025-11.md†L22-L26】
 - **Demo quindicinale (venerdì settimana dispari, 15:00 CET)** — Mostrare riduzione alert duration e stato export incrementale a Design Council + Tech Lead; registrare decisioni in `docs/tool_run_report.md`.【F:docs/playtest/INSIGHTS-2025-11.md†L22-L26】【F:docs/tool_run_report.md†L1-L40】
 - **Checkpoint roadmap mensile** — Aggiornare questa pagina e `docs/Canvas/feature-updates.md` dopo ogni ciclo di demo per confermare priorità e criteri di uscita.【F:docs/Canvas/feature-updates.md†L1-L40】
+- **Review settimanale roadmap & quality (martedì 16:30 CET)** — Consolidare esiti della review: aggiornare tabella mappatura milestone, chiudere o riassegnare bug nel tracker con `roadmap_milestone` coerente e comunicare highlight in `#vc-docs`.【F:docs/process/qa_reporting_schema.md†L138-L164】
 
 ## Prossimi passi
 - Documentare esempi di encounter generati (CLI Python) e associarli a test di difficoltà per ciascun bioma.【F:data/biomes.yaml†L1-L13】 _In corso: radar/specie comparate disponibili nella dashboard generator._
@@ -64,6 +78,7 @@
 - Aggiornare i canvas principali con screenshot e note del playtest VC. **Completato** tramite pannello HUD e metriche annotate nel Canvas principale.【F:docs/Canvas/feature-updates.md†L9-L20】
 - Integrare esportazione client-side dei log VC (`session-metrics.yaml`) direttamente nella pipeline Drive una volta stabilizzato il tuning risk.
 - Formalizzare la pipeline di archiviazione presentazioni in `docs/presentations/` collegando milestone e release.【F:docs/presentations/2025-02-vc-briefing.md†L1-L20】
+- Pubblicare entro le 18:00 CET il riepilogo della review settimanale con link ai ticket chiusi/riassegnati e sezione "Delta roadmap" per il team cross-funzionale (Slack `#vc-docs`, cartella Drive `reports/roadmap/`).【F:docs/process/qa_reporting_schema.md†L138-L164】
 
 ## Riepilogo PR giornaliero
 <!-- daily-pr-summary:start -->

--- a/docs/process/qa_reporting_schema.md
+++ b/docs/process/qa_reporting_schema.md
@@ -32,6 +32,8 @@
 | `owner` | Persona o team responsabile del follow-up. | Garantisce accountability; allineato con richieste QA/Support.【F:docs/support/bug-template.md†L12-L16】 |
 | `priority` | Enum (`critical`, `high`, `medium`, `low`). | Uniforma severity tra pipeline automatiche e manuali. |
 | `status` | Enum (`open`, `triaged`, `in_progress`, `blocked`, `resolved`, `closed`). | Stato unificato rispetto ai tracker manuali esistenti.【F:docs/playtest/SESSION-template.md†L21-L28】 |
+| `component_tag` | Identifica il modulo o la feature coinvolta (`hud`, `squadsync`, `drive-export`, `nido-experience`, ecc.). | Consente di incrociare rapidamente le segnalazioni con le aree di codice/feature attive e supporta report mirati.【F:docs/piani/roadmap.md†L26-L85】 |
+| `roadmap_milestone` | Riferimento alla milestone della roadmap in formato `RM-<numero>` (es. `RM-1 Smart HUD & SquadSync`). | Abilita il collegamento diretto con gli obiettivi roadmap, facilitando la prioritizzazione e la comunicazione agli stakeholder.【F:docs/piani/roadmap.md†L26-L88】 |
 | `evidence_links` | Lista URL/path verso log, screenshot, video. | Evita informazioni disperse in note libere; supporta audit.【F:docs/drive-sync.md†L41-L75】【F:tools/py/visual_regression.py†L1-L120】 |
 | `detailed_description` | Campo testo lungo opzionale per note contestuali e metrica telemetria correlata. | Mantiene compatibilità con note esistenti (`notes[]`, session report).【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L32-L83】 |
 
@@ -46,6 +48,8 @@ Proposto formato JSON/YAML normalizzato da adottare in fogli Drive e tracker:
   owner: "QA Lead"
   priority: high
   status: triaged
+  component_tag: hud
+  roadmap_milestone: "RM-1 Smart HUD & SquadSync"
   evidence_links:
     - drive://telemetry/reports/2025-11-05/hud_alert_delta.png
     - repo://logs/playtests/2025-11-05-vc/session-metrics.yaml#L1-L40
@@ -57,6 +61,8 @@ Proposto formato JSON/YAML normalizzato da adottare in fogli Drive e tracker:
   owner: "Tools Dev"
   priority: medium
   status: open
+  component_tag: visual-regression
+  roadmap_milestone: "RM-3 Rilascio e comunicazione"
   evidence_links:
     - repo://logs/visual_runs/2025-11-06/generator/diff.png
     - repo://config/visual_baseline.json
@@ -66,12 +72,25 @@ Proposto formato JSON/YAML normalizzato da adottare in fogli Drive e tracker:
 
 ### Workflow di validazione
 1. **Raccolta** — Ogni pipeline produce un record conforme allo schema (es. script Python che converte `session-metrics.yaml`).
-2. **Triage** — QA/DevOps filtrano per `source` e assegnano `owner` e `priority` entro 24h (stand-up QA martedì 10:00 CET, retro giovedì 16:00 CET).【F:docs/24-TELEMETRIA_VC.md†L13-L29】
-3. **Aggiornamento stato** — Ogni variazione (`status`) deve essere notificata nel canale Slack corrispondente (`#vc-telemetry`, `#support-ops`) allegando link record/fogli.【F:config/cli/telemetry.yaml†L1-L18】【F:docs/faq.md†L9-L40】
-4. **Archiviazione** — Script `driveSync.gs` sincronizza il foglio `[VC Logs] QA Tracker` con i record normalizzati; export settimanale archiviato in `telemetria/reports`.【F:docs/drive-sync.md†L41-L88】
+2. **Triage** — QA/DevOps filtrano per `source`, `component_tag` e milestone (`roadmap_milestone`) assegnando `owner` e `priority` entro 24h (stand-up QA martedì 10:00 CET, retro giovedì 16:00 CET).【F:docs/24-TELEMETRIA_VC.md†L13-L29】【F:docs/piani/roadmap.md†L26-L88】
+3. **Aggiornamento stato** — Ogni variazione (`status`) deve essere notificata nel canale Slack corrispondente (`#vc-telemetry`, `#support-ops`) allegando link record/fogli e citando la milestone collegata per favorire l'allineamento roadmap.【F:config/cli/telemetry.yaml†L1-L18】【F:docs/piani/roadmap.md†L26-L88】【F:docs/faq.md†L9-L40】
+4. **Archiviazione** — Script `driveSync.gs` sincronizza il foglio `[VC Logs] QA Tracker` con i record normalizzati; export settimanale archiviato in `telemetria/reports`. Mantenere colonne `component_tag` e `roadmap_milestone` per report e filtri condivisi.【F:docs/drive-sync.md†L41-L88】【F:docs/piani/roadmap.md†L26-L88】
 5. **Revisione stakeholder** — Validazione schema in retro quindicinale Telemetria (Design/Tech/QA/DevOps); decisioni registrate in `docs/tool_run_report.md`.【F:docs/Telemetria-VC.md†L34-L58】【F:docs/tool_run_report.md†L1-L32】
 
 ### Prossimi passi
 - Preparare script di trasformazione (`tools/py`) per generare i record schema da `session-metrics.yaml` e output visual regression.
 - Aggiornare template Drive/Notion con i nuovi campi obbligatori e definire mapping canali Slack → `source`.
 - Condividere il documento con referenti QA (V. Romano), Telemetria (D. Errani) e DevOps (owner Drive Sync) per approvazione; tracciare feedback in `docs/tool_run_report.md` prossimo stand-up.
+
+## 5. Rituali di triage e review
+
+| Rituale | Frequenza & orario | Partecipanti | Agenda sintetica | Deliverable |
+| --- | --- | --- | --- | --- |
+| **Standup triage roadmap/bug** | Giornaliero lavorativo · 09:30-09:45 CET | QA Lead, PM, rappresentante Tech/Support di turno | 1) Rassegna nuove segnalazioni e ticket con `status = open`.<br>2) Assegnazione o riassegnazione `owner`, verifica `component_tag` e `roadmap_milestone`.<br>3) Escalation urgente verso `#vc-ops` o stakeholder roadmap. | Board aggiornato con campi obbligatori, note rapide nel canale `#vc-telemetry`. |
+| **Review roadmap & quality** | Settimanale · Martedì 16:30-17:15 CET (post retro telemetria) | PM, Lead Design, Analytics, QA, Support | 1) Stato milestone (`RM-*`) con focus su deliverable e blocker.<br>2) Verifica bug aperti per milestone, decisione `resolved`/`blocked` o riassegnazione.<br>3) Aggiornamento roadmap pubblico e note di comunicazione (Slack/Drive). | Roadmap aggiornata, elenco bug chiusi/riassegnati, messaggio riepilogo nel canale `#vc-docs`. |
+| **Retro quindicinale estesa** | Venerdì settimana dispari · 15:00-16:00 CET | Design Council, Tech Lead, QA | Approfondimento metriche, revisione decisioni review settimanale, raccolta azioni di medio termine. | Decision log aggiornato in `docs/tool_run_report.md`, eventuali revisioni allo schema QA. |
+
+### Applicazione operativa
+- Il PM prepara entro le 09:15 CET il report delle nuove segnalazioni dal tracker con raggruppamento per `component_tag`/`roadmap_milestone`.
+- Durante lo standup si aggiornano i ticket direttamente (campo `roadmap_milestone`) o si aprono sotto-task collegati se la segnalazione impatta più componenti.
+- Dopo la review settimanale, il PM aggiorna `docs/piani/roadmap.md` e invia nota riassuntiva su `#vc-docs`, mentre QA chiude o riassegna i bug nel tracker.


### PR DESCRIPTION
## Summary
- map existing roadmap milestones to component tags and add guidance for ticket linkage
- extend QA reporting schema with roadmap milestone/component fields and new triage rituals
- formalize weekly review updates and communications in the roadmap process

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fee24f8ae88332853aa95d0ccf6815