### PR TITLE
Handle compat metadata dictionaries for Ennea theme hooks

### DIFF
--- a/packs/evo_tactics_pack/tools/py/modules/personality/enneagram/hook_bindings.ts
+++ b/packs/evo_tactics_pack/tools/py/modules/personality/enneagram/hook_bindings.ts
@@ -137,19 +137,21 @@ function normaliseEffects(effects: any[]): HookEffect[] {
   }));
 }
 
+function normaliseCompatValues(value: any): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.map((entry) => `${entry}`);
+  if (typeof value === 'object') return Object.keys(value).map((entry) => `${entry}`);
+  return [`${value}`];
+}
+
 function mergeCompatBlock(compatBlock: any, stats: Set<string>, events: Set<string>) {
   if (!compatBlock) return;
 
-  const compatStats = compatBlock.stats;
-  if (Array.isArray(compatStats)) {
-    compatStats.map((stat: string) => resolveCompatStat(stat)).forEach((stat) => stats.add(stat));
-  } else if (compatStats && typeof compatStats === 'object') {
-    Object.keys(compatStats)
-      .map((stat) => resolveCompatStat(stat))
-      .forEach((stat) => stats.add(stat));
-  }
+  normaliseCompatValues(compatBlock.stats)
+    .map(resolveCompatStat)
+    .forEach((stat) => stats.add(stat));
 
-  arrayify<string>(compatBlock.events)
+  normaliseCompatValues(compatBlock.events)
     .map(resolveCompatEvent)
     .forEach((evt) => events.add(evt));
 }


### PR DESCRIPTION
## Summary
- normalise compatibility metadata lists so dictionary-based stats/events from trigger maps are merged into the exported sets
- ensure Ennea theme hook bindings include stat and event metadata declared alongside triggered effects

## Testing
- python packs/evo_tactics_pack/tools/py/ext_v1_5/validate_v7.py

------
https://chatgpt.com/codex/tasks/task_e_68fee3b4600c833280434608a0d7469a