### PR TITLE
Fix dossier species sort fallback

### DIFF
--- a/docs/evo-tactics-pack/generator.js
+++ b/docs/evo-tactics-pack/generator.js
@@ -1412,7 +1412,9 @@ async function generateDossierDocument(context) {
     speciesContainer.innerHTML = "";
     const speciesList = flattenSpeciesBuckets(context.speciesBuckets)
       .slice(0, 12)
-      .sort((a, b) => a.display_name.localeCompare(b.display_name));
+      .sort((a, b) =>
+        (a.display_name ?? a.id ?? "").localeCompare(b.display_name ?? b.id ?? "")
+      );
     speciesList.forEach((species) => {
       const item = doc.createElement("li");
       item.className = "dossier__list-item";


### PR DESCRIPTION
## Summary
- guard the dossier species sort against missing display names by falling back to IDs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fee3cc95b483329391336850303c9c