### PR TITLE
Fix daily summary workflow to cover previous day's merges

### DIFF
--- a/.github/workflows/daily-pr-summary.yml
+++ b/.github/workflows/daily-pr-summary.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           python tools/py/daily_pr_report.py \
             --repo "${{ github.repository }}" \
-            --date "$(date -u +%Y-%m-%d)"
+            --date "$(date -u -d 'yesterday' +%Y-%m-%d)"
 
       - name: Commit changes
         run: |


### PR DESCRIPTION
## Summary
- update the daily PR summary workflow to report on the previous day's merges so all PRs are included

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68fee3c9ddcc8332b9710c3fdd9ce561