### PR TITLE
Fix PI balance alert channel for risk HUD

### DIFF
--- a/tools/ts/hud_alerts.ts
+++ b/tools/ts/hud_alerts.ts
@@ -156,7 +156,7 @@ export function registerRiskHudAlertSystem({
       hudLayer.raiseAlert?.(alert);
 
       if (typeof commandBus.emit === 'function') {
-        commandBus.emit('pi.balance.alert', {
+        commandBus.emit('pi.balance.alerts', {
           missionId: payload.missionId,
           roster: payload.roster,
           indices: payload.indices,


### PR DESCRIPTION
## Summary
- align the risk HUD command bus emission with the configured `pi.balance.alerts` channel so listeners receive PI balance alerts

## Testing
- not run (reason: no automated tests exercised for this targeted change)


------
https://chatgpt.com/codex/tasks/task_e_68fee3cf44a48332897004ee2a57de35