### PR TITLE
Reset unavailable composer roles in composer panel

### DIFF
--- a/docs/evo-tactics-pack/generator.js
+++ b/docs/evo-tactics-pack/generator.js
@@ -7053,6 +7053,13 @@ function renderComposerPanel() {
         return b.count - a.count;
       });
 
+    const availableRoles = new Set(roleEntries.map((entry) => entry.role));
+    preferred.forEach((role) => {
+      if (!availableRoles.has(role)) {
+        preferred.delete(role);
+      }
+    });
+
     if (!roleEntries.length) {
       const empty = document.createElement("p");
       empty.className = "generator-composer__empty";


### PR DESCRIPTION
## Summary
- clear composer preferred roles when they are not present in the current roll

## Testing
- python tests/validate_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68fee3f5346083329bad1ec9cde649ce