### PR TITLE
Log roll_pack parity audit outputs and update checklist

### DIFF
--- a/docs/checklist/project-setup-todo.md
+++ b/docs/checklist/project-setup-todo.md
@@ -28,7 +28,7 @@ ogni esecuzione importante, annotando data, esito e note operative.
 - [x] Avviare `python roll_pack.py <MBTI> <archetipo> ../../data/packs.yaml --seed demo` e verificare che l'output (chiavi `pack`, `combo`, `total_cost`, ecc.) coincida con la CLI TypeScript. _Esito coincidente con la CLI TS._
 - [x] Generare encounter di prova: `python generate_encounter.py <bioma> ../../data/biomes.yaml` per
       ogni bioma disponibile, salvando gli output in `docs/examples/` o nella sezione encounter. _Output aggiornati per savana/caverna/palude (seed `demo`) in `docs/examples/` il 2025-10-26._
-- [ ] Documentare eventuali discrepanze CLI TS/Python e aprire issue se necessarie.
+- [x] Documentare eventuali discrepanze CLI TS/Python e aprire issue se necessarie. _Verifica 2025-10-27: seed `demo` (ENTP/invoker) e `alpha42` (ISFJ/support) → diff nullo tra `node tools/ts/dist/roll_pack.js` e `python tools/py/roll_pack.py`; log salvati in `logs/tooling/2025-10-27-roll_pack/`._
 
 ## 5. Interfaccia web di test
 - [x] Avviare un server locale dalla radice: `python -m http.server 8000`. _Verificato su porta 8000 con richiesta `curl`._

--- a/docs/tool_run_report.md
+++ b/docs/tool_run_report.md
@@ -14,6 +14,13 @@
 - Eseguito controllo locale sui log YAML con lo script Python ad-hoc per rilevare la presenza del metadato `cycle` prima di attivare il filtro `minCycle` del nuovo flusso Hub Ops (`scripts/driveSync.gs`). Tutti i file attuali restituiscono `detected_cycle: null`, confermando che l'estensione includerà automaticamente i dataset dei cicli successivi non appena il campo verrà popolato.【5e2837†L1-L33】
 - Annotata la disponibilità della funzione Apps Script `convertYamlToSheetsDryRun()` per allegare ai report il riepilogo delle operazioni senza toccare i fogli reali.【F:scripts/driveSync.gs†L82-L210】
 
+## 2025-10-27 — `roll_pack` CLI parity audit
+- Eseguiti i comandi della checklist per confrontare TypeScript/Python: `node tools/ts/dist/roll_pack.js` e `python tools/py/roll_pack.py` contro `data/packs.yaml`.
+  - Coppia `ENTP`/`invoker` con seed `demo`.
+  - Coppia `ISFJ`/`support` con seed `alpha42`.
+- Gli output JSON sono stati salvati in `logs/tooling/2025-10-27-roll_pack/` e confrontati con `diff -u`; non sono emerse differenze (diff vuoto in entrambi i confronti).【F:logs/tooling/2025-10-27-roll_pack/node_ENTP_invoker_seed_demo.json†L1-L19】【F:logs/tooling/2025-10-27-roll_pack/python_ENTP_invoker_seed_demo.json†L1-L19】【F:logs/tooling/2025-10-27-roll_pack/node_ISFJ_support_seed_alpha42.json†L1-L19】【F:logs/tooling/2025-10-27-roll_pack/python_ISFJ_support_seed_alpha42.json†L1-L19】
+- Nessun issue aperto: la parità tra implementazioni è confermata ai seed testati; la checklist viene aggiornata con riferimento ai log odierni.
+
 ## 2025-10-26 — `roll_pack` CLI parity spot-check
 - Eseguiti `node tools/ts/dist/roll_pack.js` e `python tools/py/roll_pack.py` con seed condiviso `demo` sulle coppie `ENTP`/`invoker` e `ISFJ`/`support`, utilizzando `data/packs.yaml`.
 - I risultati JSON delle due implementazioni sono stati salvati localmente (`/tmp/node_*`, `/tmp/py_*`) e confrontati tramite `diff -u`.

--- a/logs/tooling/2025-10-27-roll_pack/node_ENTP_invoker_seed_demo.json
+++ b/logs/tooling/2025-10-27-roll_pack/node_ENTP_invoker_seed_demo.json
@@ -1,0 +1,29 @@
+{
+  "inputs": {
+    "form": "ENTP",
+    "job": "invoker"
+  },
+  "pack": "A",
+  "combo": [
+    "job_ability",
+    "trait_T1"
+  ],
+  "total_cost": 7,
+  "cost_breakdown": [
+    {
+      "item": "job_ability",
+      "cost": 4
+    },
+    {
+      "item": "trait_T1",
+      "cost": 3
+    }
+  ],
+  "rolls": {
+    "d20": 19
+  },
+  "selection": {
+    "table": "BIAS_JOB",
+    "notes": "Vang: B/D; Skir: C/E; Ward: E/G; Art: A/F; Inv: A/J; Harv: D/J"
+  }
+}

--- a/logs/tooling/2025-10-27-roll_pack/node_ISFJ_support_seed_alpha42.json
+++ b/logs/tooling/2025-10-27-roll_pack/node_ISFJ_support_seed_alpha42.json
@@ -1,0 +1,34 @@
+{
+  "inputs": {
+    "form": "ISFJ",
+    "job": "support"
+  },
+  "pack": "F",
+  "combo": [
+    "sigillo_forma",
+    "job_ability",
+    "starter_bioma"
+  ],
+  "total_cost": 7,
+  "cost_breakdown": [
+    {
+      "item": "sigillo_forma",
+      "cost": 2
+    },
+    {
+      "item": "job_ability",
+      "cost": 4
+    },
+    {
+      "item": "starter_bioma",
+      "cost": 1
+    }
+  ],
+  "rolls": {
+    "d20": 11
+  },
+  "selection": {
+    "table": "F",
+    "notes": null
+  }
+}

--- a/logs/tooling/2025-10-27-roll_pack/python_ENTP_invoker_seed_demo.json
+++ b/logs/tooling/2025-10-27-roll_pack/python_ENTP_invoker_seed_demo.json
@@ -1,0 +1,29 @@
+{
+  "inputs": {
+    "form": "ENTP",
+    "job": "invoker"
+  },
+  "pack": "A",
+  "combo": [
+    "job_ability",
+    "trait_T1"
+  ],
+  "total_cost": 7,
+  "cost_breakdown": [
+    {
+      "item": "job_ability",
+      "cost": 4
+    },
+    {
+      "item": "trait_T1",
+      "cost": 3
+    }
+  ],
+  "rolls": {
+    "d20": 19
+  },
+  "selection": {
+    "table": "BIAS_JOB",
+    "notes": "Vang: B/D; Skir: C/E; Ward: E/G; Art: A/F; Inv: A/J; Harv: D/J"
+  }
+}

--- a/logs/tooling/2025-10-27-roll_pack/python_ISFJ_support_seed_alpha42.json
+++ b/logs/tooling/2025-10-27-roll_pack/python_ISFJ_support_seed_alpha42.json
@@ -1,0 +1,34 @@
+{
+  "inputs": {
+    "form": "ISFJ",
+    "job": "support"
+  },
+  "pack": "F",
+  "combo": [
+    "sigillo_forma",
+    "job_ability",
+    "starter_bioma"
+  ],
+  "total_cost": 7,
+  "cost_breakdown": [
+    {
+      "item": "sigillo_forma",
+      "cost": 2
+    },
+    {
+      "item": "job_ability",
+      "cost": 4
+    },
+    {
+      "item": "starter_bioma",
+      "cost": 1
+    }
+  ],
+  "rolls": {
+    "d20": 11
+  },
+  "selection": {
+    "table": "F",
+    "notes": null
+  }
+}


### PR DESCRIPTION
## Summary
- capture roll_pack outputs for shared TypeScript and Python seeds and store them under logs/tooling
- record the 2025-10-27 parity audit in docs/tool_run_report.md with references to the saved JSON files
- mark the checklist item about documenting CLI discrepancies as completed with links to the new logs

## Testing
- node tools/ts/dist/roll_pack.js ENTP invoker data/packs.yaml --seed demo
- node tools/ts/dist/roll_pack.js ISFJ support data/packs.yaml --seed alpha42
- python tools/py/roll_pack.py ENTP invoker data/packs.yaml --seed demo
- python tools/py/roll_pack.py ISFJ support data/packs.yaml --seed alpha42

------
https://chatgpt.com/codex/tasks/task_e_68fee7a45cac8332b362a790396c3fde