### PR TITLE
Fix PI balance alert channel for risk HUD

### DIFF
--- a/docs/hooks/ema-metrics.md
+++ b/docs/hooks/ema-metrics.md
@@ -32,7 +32,7 @@
            timeLowHp: payload.indices.risk.time_low_hp_turns,
          },
        });
-       commandBus.emit("pi.balance.alert", payload);
+      commandBus.emit("pi.balance.alerts", payload);
       }
     });
     ```
@@ -49,7 +49,7 @@
 | --- | --- | --- | --- | --- |
 | `telemetry.ema.update` | Motore → Telemetria | Middleware VC | `{ missionId, turn, ema, indices }` | Frequenza: a fine turno (debounce 200 ms). |
 | `hud.alert.risk-high` | Middleware VC | HUD overlay | `{ id, severity, message, metadata }` | Soglia ingresso 0.60, uscita 0.58 (isteresi). |
-| `pi.balance.alert` | Middleware VC | Notifica PI | `{ missionId, roster, indices }` | Smista su Slack/Teams per revisione bilanciamento. |
+| `pi.balance.alerts` | Middleware VC | Notifica PI | `{ missionId, roster, indices }` | Smista su Slack/Teams per revisione bilanciamento. |
 
 ## Next steps condivisi con team client
 - Validare in staging la latenza dell'alert rispetto agli eventi `aeon_overload` (target: <250 ms post-evento).

--- a/tools/ts/tests/hud_alerts.test.ts
+++ b/tools/ts/tests/hud_alerts.test.ts
@@ -22,7 +22,7 @@ test('risk HUD alert triggers once above threshold and notifies PI team', () => 
     },
   };
 
-  commandBus.on('pi.balance.alert', (payload) => {
+  commandBus.on('pi.balance.alerts', (payload) => {
     notified.push(payload);
   });
 


### PR DESCRIPTION
## Summary
- update the risk HUD alert test harness to listen on the plural `pi.balance.alerts` channel emitted by the command bus
- refresh the EMA metrics hook documentation so examples and hook tables reference the pluralized PI balance channel

## Testing
- ⚠️ `node --test tools/ts/tests/hud_alerts.test.ts` *(fails: ERR_MODULE_NOT_FOUND for tools/ts/hud_alerts.js – repository lacks built JS artefacts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fee78838dc8332bda9ef9a0568965b