### PR TITLE
Fix generator controls and add quickstart guide

### DIFF
--- a/docs/evo-tactics-pack/generator.html
+++ b/docs/evo-tactics-pack/generator.html
@@ -58,6 +58,15 @@
             <li class="anchor-nav__item">
               <a
                 class="anchor-nav__link"
+                href="#generator-guide"
+                data-anchor-target="guide"
+              >
+                Mini guida
+              </a>
+            </li>
+            <li class="anchor-nav__item">
+              <a
+                class="anchor-nav__link"
                 href="#generator-parameters"
                 data-anchor-target="parameters"
               >
@@ -123,6 +132,58 @@
             </p>
           </div>
           <ol class="generator-flow-map" id="generator-flow-map-list" aria-live="polite"></ol>
+        </section>
+
+        <section
+          class="section"
+          id="generator-guide"
+          aria-labelledby="generator-guide-title"
+          data-anchor-target="guide"
+        >
+          <div class="section__header">
+            <h2 id="generator-guide-title">Mini guida rapida</h2>
+            <p>
+              Quattro passaggi per ottenere rapidamente ecosistemi giocabili e sfruttare le funzioni
+              avanzate del generatore.
+            </p>
+          </div>
+          <article class="card card--highlight generator-guide">
+            <ol class="generator-guide__steps">
+              <li>
+                <h3>Imposta i parametri di base</h3>
+                <p>
+                  Scegli il numero di biomi e applica filtri su flag, ruoli e tag funzionali. I
+                  profili ti permettono di salvare combinazioni ricorrenti per i re-roll successivi.
+                </p>
+              </li>
+              <li>
+                <h3>Genera l'ecosistema</h3>
+                <p>
+                  Usa <strong>Genera ecosistema</strong> per creare una rete sintetica coerente. I
+                  pulsanti di re-roll ti consentono di rigenerare biomi, specie o seed mantenendo i
+                  vincoli scelti.
+                </p>
+              </li>
+              <li>
+                <h3>Affina con pinnature e cronologia</h3>
+                <p>
+                  Pinna le specie chiave, confronta fino a tre candidati e registra snapshot dalla
+                  cronologia per documentare le estrazioni migliori.
+                </p>
+              </li>
+              <li>
+                <h3>Esporta e condividi</h3>
+                <p>
+                  Sfrutta i preset del pannello Export per scaricare manifest JSON/YAML, bundle ZIP e
+                  dossier PDF/HTML già pronti per il tavolo di gioco.
+                </p>
+              </li>
+            </ol>
+            <p class="generator-guide__tip">
+              Suggerimento: attiva il <strong>Codex mode</strong> dal sommario laterale per avere
+              minimappe contestuali e collegamenti rapidi a ogni sezione.
+            </p>
+          </article>
         </section>
 
         <section

--- a/docs/evo-tactics-pack/generator.js
+++ b/docs/evo-tactics-pack/generator.js
@@ -558,9 +558,17 @@ function setStatus(message, tone = "info", options = {}) {
 function updateSummaryCounts() {
   const { biomeCount, speciesCount, seedCount, uniqueSpeciesCount } = calculatePickMetrics();
 
-  elements.summaryCounts?.biomes?.textContent = biomeCount;
-  elements.summaryCounts?.species?.textContent = speciesCount;
-  elements.summaryCounts?.seeds?.textContent = seedCount;
+  if (elements.summaryCounts) {
+    if (elements.summaryCounts.biomes) {
+      elements.summaryCounts.biomes.textContent = String(biomeCount);
+    }
+    if (elements.summaryCounts.species) {
+      elements.summaryCounts.species.textContent = String(speciesCount);
+    }
+    if (elements.summaryCounts.seeds) {
+      elements.summaryCounts.seeds.textContent = String(seedCount);
+    }
+  }
 
   if (elements.summaryContainer) {
     const hasResults = biomeCount + speciesCount + seedCount > 0;


### PR DESCRIPTION
## Summary
- avoid invalid optional chaining assignments when updating generator summary counters
- add a quickstart "Mini guida" section and navigation link to orient new users

## Testing
- node --check docs/evo-tactics-pack/generator.js

------
https://chatgpt.com/codex/tasks/task_e_68fef80d087083328fdb93b0772a1de3