### PR TITLE
Add global navigation to ecosystem pack pages

### DIFF
--- a/docs/evo-tactics-pack/catalog.html
+++ b/docs/evo-tactics-pack/catalog.html
@@ -15,6 +15,16 @@
     <script type="module" src="catalog.js" defer></script>
   </head>
   <body>
+    <nav class="global-nav" aria-label="Navigazione globale">
+      <a class="global-nav__home" href="../index.html">← Centro Operativo</a>
+      <div class="global-nav__links">
+        <a class="global-nav__link" href="index.html">Ecosystem Pack</a>
+        <a class="global-nav__link" href="generator.html">Generatore</a>
+        <a class="global-nav__link" href="catalog.html" aria-current="page">Catalogo</a>
+        <a class="global-nav__link" href="reports/index.html">Report</a>
+      </div>
+    </nav>
+
     <header class="section">
       <div class="section__header">
         <p class="section__kicker">Ecosystem Pack</p>

--- a/docs/evo-tactics-pack/generator.html
+++ b/docs/evo-tactics-pack/generator.html
@@ -24,6 +24,16 @@
     <script type="module" src="generator.js" defer></script>
   </head>
   <body>
+    <nav class="global-nav" aria-label="Navigazione globale">
+      <a class="global-nav__home" href="../index.html">← Centro Operativo</a>
+      <div class="global-nav__links">
+        <a class="global-nav__link" href="index.html">Ecosystem Pack</a>
+        <a class="global-nav__link" href="generator.html" aria-current="page">Generatore</a>
+        <a class="global-nav__link" href="catalog.html">Catalogo</a>
+        <a class="global-nav__link" href="reports/index.html">Report</a>
+      </div>
+    </nav>
+
     <header class="section">
       <div class="section__header">
         <p class="section__kicker">Ecosystem Pack</p>

--- a/docs/evo-tactics-pack/index.html
+++ b/docs/evo-tactics-pack/index.html
@@ -7,6 +7,16 @@
     <link rel="stylesheet" href="../site.css" />
   </head>
   <body>
+    <nav class="global-nav" aria-label="Navigazione globale">
+      <a class="global-nav__home" href="../index.html">← Centro Operativo</a>
+      <div class="global-nav__links">
+        <a class="global-nav__link" href="index.html" aria-current="page">Ecosystem Pack</a>
+        <a class="global-nav__link" href="generator.html">Generatore</a>
+        <a class="global-nav__link" href="catalog.html">Catalogo</a>
+        <a class="global-nav__link" href="reports/index.html">Report</a>
+      </div>
+    </nav>
+
     <header class="section">
       <div class="section__header">
         <p class="section__kicker">Evo-Tactics · Ecosystem Pack</p>

--- a/docs/evo-tactics-pack/reports/biomes/badlands.html
+++ b/docs/evo-tactics-pack/reports/biomes/badlands.html
@@ -15,6 +15,16 @@
     <script type="module" src="../biome.js" defer></script>
   </head>
   <body data-biome-id="badlands">
+    <nav class="global-nav" aria-label="Navigazione globale">
+      <a class="global-nav__home" href="../../../index.html">← Centro Operativo</a>
+      <div class="global-nav__links">
+        <a class="global-nav__link" href="../../index.html">Ecosystem Pack</a>
+        <a class="global-nav__link" href="../../generator.html">Generatore</a>
+        <a class="global-nav__link" href="../../catalog.html">Catalogo</a>
+        <a class="global-nav__link" href="../index.html" aria-current="page">Report</a>
+      </div>
+    </nav>
+
     <header class="section">
       <div class="section__header">
         <p class="section__kicker">Ecosystem Pack</p>

--- a/docs/evo-tactics-pack/reports/biomes/cryosteppe.html
+++ b/docs/evo-tactics-pack/reports/biomes/cryosteppe.html
@@ -15,6 +15,16 @@
     <script type="module" src="../biome.js" defer></script>
   </head>
   <body data-biome-id="cryosteppe">
+    <nav class="global-nav" aria-label="Navigazione globale">
+      <a class="global-nav__home" href="../../../index.html">← Centro Operativo</a>
+      <div class="global-nav__links">
+        <a class="global-nav__link" href="../../index.html">Ecosystem Pack</a>
+        <a class="global-nav__link" href="../../generator.html">Generatore</a>
+        <a class="global-nav__link" href="../../catalog.html">Catalogo</a>
+        <a class="global-nav__link" href="../index.html" aria-current="page">Report</a>
+      </div>
+    </nav>
+
     <header class="section">
       <div class="section__header">
         <p class="section__kicker">Ecosystem Pack</p>

--- a/docs/evo-tactics-pack/reports/biomes/deserto_caldo.html
+++ b/docs/evo-tactics-pack/reports/biomes/deserto_caldo.html
@@ -15,6 +15,16 @@
     <script type="module" src="../biome.js" defer></script>
   </head>
   <body data-biome-id="deserto_caldo">
+    <nav class="global-nav" aria-label="Navigazione globale">
+      <a class="global-nav__home" href="../../../index.html">← Centro Operativo</a>
+      <div class="global-nav__links">
+        <a class="global-nav__link" href="../../index.html">Ecosystem Pack</a>
+        <a class="global-nav__link" href="../../generator.html">Generatore</a>
+        <a class="global-nav__link" href="../../catalog.html">Catalogo</a>
+        <a class="global-nav__link" href="../index.html" aria-current="page">Report</a>
+      </div>
+    </nav>
+
     <header class="section">
       <div class="section__header">
         <p class="section__kicker">Ecosystem Pack</p>

--- a/docs/evo-tactics-pack/reports/biomes/foresta_temperata.html
+++ b/docs/evo-tactics-pack/reports/biomes/foresta_temperata.html
@@ -15,6 +15,16 @@
     <script type="module" src="../biome.js" defer></script>
   </head>
   <body data-biome-id="foresta_temperata">
+    <nav class="global-nav" aria-label="Navigazione globale">
+      <a class="global-nav__home" href="../../../index.html">← Centro Operativo</a>
+      <div class="global-nav__links">
+        <a class="global-nav__link" href="../../index.html">Ecosystem Pack</a>
+        <a class="global-nav__link" href="../../generator.html">Generatore</a>
+        <a class="global-nav__link" href="../../catalog.html">Catalogo</a>
+        <a class="global-nav__link" href="../index.html" aria-current="page">Report</a>
+      </div>
+    </nav>
+
     <header class="section">
       <div class="section__header">
         <p class="section__kicker">Ecosystem Pack</p>

--- a/docs/evo-tactics-pack/reports/index.html
+++ b/docs/evo-tactics-pack/reports/index.html
@@ -15,6 +15,16 @@
     <script type="module" src="index.js" defer></script>
   </head>
   <body>
+    <nav class="global-nav" aria-label="Navigazione globale">
+      <a class="global-nav__home" href="../../index.html">← Centro Operativo</a>
+      <div class="global-nav__links">
+        <a class="global-nav__link" href="../index.html">Ecosystem Pack</a>
+        <a class="global-nav__link" href="../generator.html">Generatore</a>
+        <a class="global-nav__link" href="../catalog.html">Catalogo</a>
+        <a class="global-nav__link" href="index.html" aria-current="page">Report</a>
+      </div>
+    </nav>
+
     <header class="section">
       <div class="section__header">
         <p class="section__kicker">Ecosystem Pack</p>

--- a/docs/evo-tactics-pack/reports/overview.html
+++ b/docs/evo-tactics-pack/reports/overview.html
@@ -15,6 +15,16 @@
     <script type="module" src="overview.js" defer></script>
   </head>
   <body>
+    <nav class="global-nav" aria-label="Navigazione globale">
+      <a class="global-nav__home" href="../../index.html">← Centro Operativo</a>
+      <div class="global-nav__links">
+        <a class="global-nav__link" href="../index.html">Ecosystem Pack</a>
+        <a class="global-nav__link" href="../generator.html">Generatore</a>
+        <a class="global-nav__link" href="../catalog.html">Catalogo</a>
+        <a class="global-nav__link" href="index.html" aria-current="page">Report</a>
+      </div>
+    </nav>
+
     <header class="section">
       <div class="section__header">
         <p class="section__kicker">Ecosystem Pack</p>

--- a/docs/evo-tactics-pack/reports/species-index.html
+++ b/docs/evo-tactics-pack/reports/species-index.html
@@ -15,6 +15,16 @@
     <script type="module" src="species-index.js" defer></script>
   </head>
   <body>
+    <nav class="global-nav" aria-label="Navigazione globale">
+      <a class="global-nav__home" href="../../index.html">← Centro Operativo</a>
+      <div class="global-nav__links">
+        <a class="global-nav__link" href="../index.html">Ecosystem Pack</a>
+        <a class="global-nav__link" href="../generator.html">Generatore</a>
+        <a class="global-nav__link" href="../catalog.html">Catalogo</a>
+        <a class="global-nav__link" href="index.html" aria-current="page">Report</a>
+      </div>
+    </nav>
+
     <header class="section">
       <div class="section__header">
         <p class="section__kicker">Ecosystem Pack</p>

--- a/docs/site.css
+++ b/docs/site.css
@@ -582,6 +582,71 @@ a:focus-visible {
   color: var(--text);
 }
 
+.global-nav {
+  padding: 24px 5vw 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.global-nav__home,
+.global-nav__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border-glow);
+  background: rgba(12, 20, 30, 0.78);
+  color: var(--color-text-primary);
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: var(--shadow-xs);
+  transition: transform var(--transition), background var(--transition), border-color var(--transition);
+}
+
+.global-nav__home:hover,
+.global-nav__home:focus-visible,
+.global-nav__link:hover,
+.global-nav__link:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(22, 32, 48, 0.9);
+  border-color: var(--color-accent-400);
+}
+
+.global-nav__home[aria-current="page"],
+.global-nav__link[aria-current="page"] {
+  background: var(--color-accent-soft);
+  border-color: var(--color-accent-400);
+}
+
+.global-nav__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-left: auto;
+}
+
+@media (max-width: 720px) {
+  .global-nav {
+    padding-top: 20px;
+  }
+
+  .global-nav__home,
+  .global-nav__link {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .global-nav__links {
+    width: 100%;
+    justify-content: center;
+    margin-left: 0;
+  }
+}
+
 .layout {
   flex: 1;
   padding: 24px 5vw 80px;


### PR DESCRIPTION
## Summary
- add a reusable global navigation bar across the Ecosystem Pack so every page links back to the Support Hub and sibling tools
- style the new navigation controls for desktop and mobile layouts in `site.css`

## Testing
- python tests/validate_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68fe8a3dd3a48332ad254bfbdd5bcd8c