### PR TITLE
Clarify pilot session plan scenarios and storage paths

### DIFF
--- a/docs/playtest/pilot-session-2025-11-12.md
+++ b/docs/playtest/pilot-session-2025-11-12.md
@@ -1,6 +1,6 @@
 # Sessione pilota 12 novembre 2025
 
-> **Nota di allineamento (aggiornamento 2025-02-18):** questo piano sostituisce le indicazioni scenario precedenti ed è sincronizzato con la scheda `docs/playtest/SESSION-2025-11-12.md`.
+> **Nota di allineamento (aggiornamento 2025-02-18):** questo piano sostituisce le indicazioni scenario precedenti, confermando gli scenari `BAL-05`, `PROG-04` ed `EVT-03` documentati in `docs/playtest/SESSION-2025-11-12.md`.
 
 ## Obiettivi
 - Validare gli scenari di bilanciamento `BAL-05`, la progressione `PROG-04` e l'evento speciale `EVT-03` come definito in `docs/playtest/SESSION-2025-11-12.md`.
@@ -30,7 +30,7 @@
 - Build `alpha-balancing` installata su 5 postazioni con controller e tastiera.
 - Savegame "Pilot-Nov2025" con progressione fino al capitolo 4.
 - Accesso a `docs/playtest/scenari-test.md` e ai prerequisiti segnalati.
-- Cartella condivisa `logs/pilot-2025-11-12/` per video, log e screenshot (creare prima della sessione) allineata ai percorsi in `docs/playtest/SESSION-2025-11-12.md`.
+- Cartella condivisa `logs/playtests/2025-11-12/` per video, log e screenshot (creare prima della sessione) in modo coerente con i percorsi indicati nel report della sessione.
 - Copie stampate o digitali del `feedback-template.md` per ogni partecipante.
 - Foglio di calcolo telemetrico collegato a `telemetry/pilot-session-2025-11-12.xlsx`.
 - Link stanza virtuale di supporto (Teams "Playtest Ops") per emergenze tecniche.
@@ -38,6 +38,6 @@
 
 ## Deliverable post-sessione
 1. Compilare e aggiornare `docs/playtest/SESSION-2025-11-12.md` (scenario `BAL-05`, `PROG-04`, `EVT-03`) seguendo la procedura descritta in `procedura-post-sessione.md`.
-2. Archiviare log, screenshot e registrazioni nella cartella `logs/pilot-2025-11-12/` con naming coerente, includendo `damage.json`, `progression-metrics.csv` ed `effects-trace.log`.
+2. Archiviare log, screenshot e registrazioni nella cartella `logs/playtests/2025-11-12/` con naming coerente, includendo `damage.json`, `progression-metrics.csv` ed `effects-trace.log`.
 3. Aprire issue su tracker con etichetta `encounter-balance` per ogni bug confermato e collegarle al documento della sessione.
 4. Pianificare eventuali sessioni di follow-up sulla base delle criticità emerse e documentare le decisioni nella sezione "Azioni successive" del report.


### PR DESCRIPTION
## Summary
- highlight that the pilot-session briefing now uses scenarios BAL-05, PROG-04 and EVT-03 to match the session report
- align the shared asset directory references in the pilot-session plan with the session report paths

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68fefae3e41c833298f1fa98d7ba3c64