### PR TITLE
Update Evo-Tactics pack overview with pipeline insights

### DIFF
--- a/docs/evo-tactics-pack/reports/overview.html
+++ b/docs/evo-tactics-pack/reports/overview.html
@@ -45,6 +45,17 @@
 
       <section class="section">
         <div class="section__header">
+          <h2>Pipeline &amp; validazioni</h2>
+          <p>Esiti più recenti degli stage CI/QA per l'export del pack.</p>
+        </div>
+        <div class="card card--list">
+          <div id="pipeline-list" class="feed" aria-live="polite"></div>
+        </div>
+        <p id="pipeline-error" class="form__hint" data-tone="warn" hidden></p>
+      </section>
+
+      <section class="section">
+        <div class="section__header">
           <h2>Connessioni tra biomi</h2>
           <p>Bridge, corridor e spillover registrati nel meta-ecosistema.</p>
         </div>
@@ -60,6 +71,17 @@
         </div>
         <div class="card">
           <ul id="overview-datasets"></ul>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section__header">
+          <h2>Specie chiave &amp; ponti</h2>
+          <p>Flag strategici e specie multi-bioma utili alla pianificazione degli stage successivi.</p>
+        </div>
+        <div class="card card--list">
+          <div id="flag-metrics" class="chip-list chip-list--compact" aria-live="polite"></div>
+          <table id="bridge-table" class="table" aria-live="polite"></table>
         </div>
       </section>
 

--- a/docs/evo-tactics-pack/reports/overview.js
+++ b/docs/evo-tactics-pack/reports/overview.js
@@ -5,6 +5,27 @@ const metricsEl = document.getElementById("overview-metrics");
 const connectionsTable = document.getElementById("connections-table");
 const datasetsList = document.getElementById("overview-datasets");
 const biomesGrid = document.getElementById("overview-biomes");
+const pipelineList = document.getElementById("pipeline-list");
+const pipelineError = document.getElementById("pipeline-error");
+const flagMetricsEl = document.getElementById("flag-metrics");
+const bridgeTable = document.getElementById("bridge-table");
+
+const FLAG_LABELS = [
+  ["apex", "Apex"],
+  ["keystone", "Keystone"],
+  ["bridge", "Bridge"],
+  ["threat", "Threat"],
+  ["event", "Eventi"],
+  ["sentient", "Sentienti"],
+];
+
+const STAGE_LABELS = {
+  "validate_ecosistema_v2_0.py": "Validazione meta-ecosistema",
+  "validate_cross_foodweb_v1_0.py": "Validazione connessioni cross-bioma",
+  "validate_bioma_v1_1.py": "Validazione bioma",
+  "validate_species_v1_7.py": "Validazione specie",
+  "validate_foodweb_v1_0.py": "Validazione foodweb",
+};
 
 function setSummary(message) {
   if (summaryEl) {
@@ -102,11 +123,95 @@ function renderDatasets(context, data) {
     external: true,
     note: "Dettaglio macchine e warning",
   });
+  appendDataset("Meta network YAML", context.resolvePackHref("data/ecosystems/network/meta_network_alpha.yaml"), {
+    external: true,
+    note: "Schema 2.0",
+  });
+  appendDataset("Meta ecosistema YAML", context.resolvePackHref("data/ecosistemi/meta_ecosistema_alpha.yaml"), {
+    external: true,
+    note: "Ricevuta & regole",
+  });
+  appendDataset("Cross events YAML", context.resolvePackHref("data/ecosistemi/cross_events.yaml"), {
+    external: true,
+    note: "Propagazione eventi",
+  });
   (data.ecosistema?.biomi || []).forEach((biomeRef) => {
     appendDataset(`Bioma YAML · ${biomeRef.id}`, context.resolveDocHref(biomeRef.path), {
       external: true,
     });
   });
+}
+
+function formatActiveFlags(flags) {
+  return Object.entries(flags || {})
+    .filter(([, value]) => Boolean(value))
+    .map(([key]) => key);
+}
+
+function renderFlagMetrics(species) {
+  if (!flagMetricsEl) return;
+  flagMetricsEl.innerHTML = "";
+  const counts = new Map();
+  (species || []).forEach((sp) => {
+    FLAG_LABELS.forEach(([flag]) => {
+      if (sp.flags?.[flag]) {
+        counts.set(flag, (counts.get(flag) || 0) + 1);
+      }
+    });
+  });
+  FLAG_LABELS.forEach(([flag, label]) => {
+    const chip = createMetric(label, counts.get(flag) || 0);
+    chip.classList.add("chip--compact");
+    flagMetricsEl.appendChild(chip);
+  });
+}
+
+function renderBridgeSpecies(context, species) {
+  if (!bridgeTable) return;
+  bridgeTable.innerHTML = "";
+
+  const bridges = (species || [])
+    .filter((sp) => sp.flags?.bridge)
+    .sort((a, b) => a.display_name.localeCompare(b.display_name, "it", { sensitivity: "base" }));
+
+  const head = document.createElement("thead");
+  head.innerHTML = `
+    <tr>
+      <th>Specie</th>
+      <th>Biomi</th>
+      <th>Ruolo trofico</th>
+      <th>Flag attivi</th>
+      <th>Dataset</th>
+    </tr>`;
+  bridgeTable.appendChild(head);
+
+  const body = document.createElement("tbody");
+  if (!bridges.length) {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 5;
+    cell.textContent = "Nessuna specie ponte definita.";
+    row.appendChild(cell);
+    body.appendChild(row);
+  } else {
+    bridges.forEach((sp) => {
+      const row = document.createElement("tr");
+      const flags = formatActiveFlags(sp.flags).join(", ") || "—";
+      const biomes = (sp.biomes || []).join(", ") || "—";
+      const href = context.resolveDocHref(sp.path);
+      row.innerHTML = `
+        <td>
+          <strong>${sp.display_name}</strong>
+          <p class="form__hint">(${sp.id})</p>
+        </td>
+        <td>${biomes}</td>
+        <td>${sp.role_trofico || "—"}</td>
+        <td>${flags}</td>
+        <td><a href="${href}" target="_blank" rel="noreferrer">Apri YAML</a></td>`;
+      body.appendChild(row);
+    });
+  }
+  bridgeTable.appendChild(body);
 }
 
 function renderBiomeCard(context, biome) {
@@ -153,6 +258,131 @@ function renderBiomes(context, biomes) {
   });
 }
 
+function createStatusChip(status, label) {
+  const chip = document.createElement("span");
+  chip.className = "chip chip--compact";
+  chip.dataset.status = status;
+  chip.textContent = label;
+  return chip;
+}
+
+function parseValidationStage(report) {
+  const command = report.cmd || "";
+  const tokens = command.split(/\s+/).filter(Boolean);
+  const scriptToken = tokens.find((token) => token.endsWith(".py"));
+  const scriptName = scriptToken ? scriptToken.split("/").pop() : null;
+  const scriptIndex = scriptToken ? tokens.indexOf(scriptToken) : -1;
+
+  let target = null;
+  if (scriptIndex >= 0) {
+    const candidate = tokens[scriptIndex + 1];
+    if (candidate && !candidate.startsWith("-")) {
+      target = candidate;
+    }
+  }
+
+  if (!target && tokens.includes("--species-root")) {
+    const idx = tokens.indexOf("--species-root");
+    target = tokens[idx + 1];
+  }
+
+  const normalizedTarget = target ? target.split("/").pop() : null;
+  const label = scriptName ? STAGE_LABELS[scriptName] || scriptName.replace(/_/g, " ").replace(/\.py$/, "") : "Stage pipeline";
+
+  return {
+    label,
+    script: scriptName,
+    target: normalizedTarget,
+  };
+}
+
+async function loadValidationReport(context) {
+  const url = context.resolvePackHref("out/validation/last_report.json");
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+function formatStageHeading(stage) {
+  if (!stage.target) {
+    return stage.label;
+  }
+  const cleaned = stage.target.replace(/\.(ya?ml)$/i, "");
+  return `${stage.label} · ${cleaned}`;
+}
+
+async function renderPipelineStatus(context) {
+  if (!pipelineList) return;
+  pipelineList.innerHTML = "";
+  if (pipelineError) {
+    pipelineError.hidden = true;
+  }
+
+  try {
+    const report = await loadValidationReport(context);
+    const entries = Array.isArray(report.reports) ? report.reports : [];
+
+    if (!entries.length) {
+      const empty = document.createElement("p");
+      empty.className = "form__hint";
+      empty.textContent = "Nessun esito registrato per la pipeline.";
+      pipelineList.appendChild(empty);
+      return;
+    }
+
+    entries.forEach((entry) => {
+      const item = document.createElement("article");
+      item.className = "feed__item";
+
+      const stage = parseValidationStage(entry);
+      const heading = document.createElement("h4");
+      heading.textContent = formatStageHeading(stage);
+
+      const statusLine = document.createElement("div");
+      statusLine.className = "chip-list chip-list--compact";
+      const hasWarning = /warn/i.test(entry.stdout || "") || /warn/i.test(entry.stderr || "");
+      const status = entry.code === 0 ? (hasWarning ? "warn" : "ok") : "error";
+      const label =
+        status === "ok"
+          ? "OK"
+          : status === "warn"
+          ? "Warning"
+          : entry.code !== undefined
+          ? `Errore (${entry.code})`
+          : "Errore";
+      statusLine.appendChild(createStatusChip(status, label));
+
+      const details = [entry.stdout, entry.stderr]
+        .map((value) => value?.trim())
+        .filter(Boolean)
+        .join(" \u2022 ");
+
+      item.append(heading, statusLine);
+
+      if (details) {
+        const note = document.createElement("p");
+        note.textContent = details;
+        item.appendChild(note);
+      } else if (stage.script) {
+        const scriptNote = document.createElement("p");
+        scriptNote.className = "form__hint";
+        scriptNote.textContent = stage.script;
+        item.appendChild(scriptNote);
+      }
+
+      pipelineList.appendChild(item);
+    });
+  } catch (error) {
+    console.warn("Impossibile caricare il report di validazione", error);
+    if (pipelineError) {
+      pipelineError.textContent = "Impossibile recuperare gli esiti della pipeline di validazione.";
+      pipelineError.hidden = false;
+    }
+  }
+}
+
 function formatGeneratedAt(value) {
   if (!value) return null;
   const parsed = new Date(value);
@@ -185,9 +415,16 @@ async function init() {
     renderConnections(data.ecosistema?.connessioni ?? []);
     renderDatasets(context, data);
     renderBiomes(context, data.biomi ?? []);
+    renderFlagMetrics(data.species ?? []);
+    renderBridgeSpecies(context, data.species ?? []);
+    await renderPipelineStatus(context);
   } catch (error) {
     console.error("Impossibile caricare il catalogo del pack", error);
     setSummary("Errore durante il caricamento del pack. Controlla la console del browser.");
+    if (pipelineError) {
+      pipelineError.textContent = "Pipeline non disponibile per errore nel caricamento del pack.";
+      pipelineError.hidden = false;
+    }
   }
 }
 

--- a/docs/site.css
+++ b/docs/site.css
@@ -1087,6 +1087,28 @@ body.codex-open {
   color: var(--text);
 }
 
+.chip[data-status="ok"] {
+  border-color: var(--tone-success-border);
+  background: var(--tone-success-surface);
+  color: var(--tone-success-foreground);
+}
+
+.chip[data-status="warn"] {
+  border-color: var(--tone-warn-border);
+  background: var(--tone-warn-surface);
+  color: var(--tone-warn-foreground);
+}
+
+.chip[data-status="error"] {
+  border-color: var(--tone-error-border);
+  background: var(--tone-error-surface);
+  color: var(--tone-error-foreground);
+}
+
+#flag-metrics {
+  margin-bottom: 16px;
+}
+
 .manifest-block {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a pipeline and validation section to the Evo-Tactics pack overview so GitHub Pages readers can see the latest CI stage outcomes
- expose new dataset links for the meta network, Italian meta-ecosystem receipt and cross-event propagation files
- highlight bridge species and aggregated flag metrics together with status-chip styling for validation results

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68fefce331a08332b6694f06359eb180