### PR TITLE
Fix investigate_sources wrapper import

### DIFF
--- a/scripts/investigate_sources.py
+++ b/scripts/investigate_sources.py
@@ -4,12 +4,42 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Callable
 
 TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools" / "py"
-if str(TOOLS_DIR) not in sys.path:
-    sys.path.insert(0, str(TOOLS_DIR))
 
-from investigate_sources import main as investigate_main  # type: ignore
+
+def _load_tool_main() -> Callable[[], int]:
+    """Carica la funzione ``main`` dal tool vero e proprio.
+
+    Il modulo del tool risiede in ``tools/py`` con lo stesso nome di questo
+    wrapper. Importarlo direttamente causerebbe quindi un conflitto: Python
+    troverebbe prima questo file (``scripts/investigate_sources.py``) e
+    ripeterebbe l'import, generando un modulo parzialmente inizializzato.
+
+    Utilizziamo ``importlib`` per caricare il file target assegnandogli un nome
+    univoco nello ``sys.modules`` in modo da evitare l'import circolare.
+    """
+
+    from importlib.util import module_from_spec, spec_from_file_location
+
+    spec = spec_from_file_location("tools.py.investigate_sources", TOOLS_DIR / "investigate_sources.py")
+    if spec is None or spec.loader is None:  # pragma: no cover - fallisce solo se il file sparisce
+        raise ImportError("Impossibile caricare il modulo tools.py.investigate_sources")
+
+    module = module_from_spec(spec)
+    sys.modules.setdefault("tools.py.investigate_sources", module)
+    spec.loader.exec_module(module)
+
+    try:
+        main_callable = getattr(module, "main")
+    except AttributeError as error:  # pragma: no cover - protegge da modifiche inattese
+        raise ImportError("Il modulo tools.py.investigate_sources non espone 'main'") from error
+
+    return main_callable
+
+
+investigate_main = _load_tool_main()
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- load the real investigate_sources tool via importlib with a unique module name to avoid circular imports
- expose the CLI entry point through the dynamically loaded module

## Testing
- pytest tests/test_investigate_sources.py

------
https://chatgpt.com/codex/tasks/task_e_68ff31e865888332b722af5b682d7bd7