### PR TITLE
Add biome manifest and metadata validation

### DIFF
--- a/data/biomes.yaml
+++ b/data/biomes.yaml
@@ -1,7 +1,229 @@
 biomes:
-  savana: {diff_base: 2, mod_biome: 1, affixes: ["termico","luminescente","spore_diluite","sabbia"]}
-  caverna: {diff_base: 3, mod_biome: 2, affixes: ["eco","cristallino","fangoso","acque_nere"]}
-  palude: {diff_base: 3, mod_biome: 1, affixes: ["fangoso","tossico","luminescente","viti"]}
+  savana:
+    label: "Savana Ionizzata"
+    summary: "Dune fotoniche con branchi adattivi e rovine sepolte."
+    diff_base: 2
+    mod_biome: 1
+    affixes:
+      - termico
+      - luminescente
+      - spore_diluite
+      - sabbia
+    hazard:
+      description: "Tempeste ioniche e sabbia vetrificata che erodono equipaggiamento."
+      severity: medium
+      stress_modifiers:
+        exposure: 0.03
+        sandstorm: 0.06
+    npc_archetypes:
+      primary:
+        - predoni_nomadi
+        - guardiani_delle_dune
+      support:
+        - cartografi_erranti
+    stresswave:
+      baseline: 0.28
+      escalation_rate: 0.04
+      event_thresholds:
+        support: 0.5
+        overrun: 0.7
+    narrative:
+      tone: "Western sci-fi e sopravvivenza carovaniera."
+      hooks:
+        - "Recuperare convogli cristallizzati e nodi di risonanza sepolti."
+        - "Mediare tregue tra clan itineranti e guardiani della tempesta."
+  caverna:
+    label: "Caverna Risonante"
+    summary: "Gallerie cristalline dove eco e pressioni invertite modellano la fauna."
+    diff_base: 3
+    mod_biome: 2
+    affixes:
+      - eco
+      - cristallino
+      - fangoso
+      - acque_nere
+    hazard:
+      description: "Risonanze amplificate, crolli spontanei e pozze acide."
+      severity: high
+      stress_modifiers:
+        echo_feedback: 0.05
+        collapse: 0.08
+    npc_archetypes:
+      primary:
+        - guardiani_risonanza
+        - bracconieri_echomantici
+      support:
+        - cartografi_subsonici
+    stresswave:
+      baseline: 0.32
+      escalation_rate: 0.05
+      event_thresholds:
+        support: 0.55
+        overrun: 0.75
+    narrative:
+      tone: "Esplorazione claustrofobica guidata da acustica e luce riflessa."
+      hooks:
+        - "Disinnescare camere di eco instabile prima del collasso."
+        - "Estrarre cristalli risonanti senza allertare i custodi del nido."
+    aliases:
+      - caverna_risonante
+  palude:
+    label: "Palude Tossica"
+    summary: "Acque stagnanti bio-luminescenti con fauna mutagena."
+    diff_base: 3
+    mod_biome: 1
+    affixes:
+      - fangoso
+      - tossico
+      - luminescente
+      - viti
+    hazard:
+      description: "Miasmi corrosivi e radici che intrappolano i movimenti."
+      severity: medium
+      stress_modifiers:
+        miasma: 0.04
+        entanglement: 0.06
+    npc_archetypes:
+      primary:
+        - custodi_miasmatici
+        - druidi_sporeguard
+      support:
+        - raccoglitori_di_fluoro
+    stresswave:
+      baseline: 0.3
+      escalation_rate: 0.04
+      event_thresholds:
+        support: 0.52
+        overrun: 0.72
+    narrative:
+      tone: "Survival horror organico e diplomazia con culti simbiotici."
+      hooks:
+        - "Recuperare reagenti bio-luminescenti per le squadre mediche."
+        - "Placare le colonie simbiotiche prima che scatenino la nube tossica."
+  canyons_risonanti:
+    label: "Canyons Risonanti"
+    summary: "Labirinto ventoso di gole armoniche alimentate da risonanza."
+    diff_base: 4
+    mod_biome: 2
+    affixes:
+      - echo_surge
+      - shifting_winds
+    hazard:
+      description: "Cadute rovinose e tunnel sonori che amplificano StressWave (+0.05 scoperti)."
+      severity: high
+      stress_modifiers:
+        open_ground: 0.05
+        collapse: 0.07
+    npc_archetypes:
+      primary:
+        - sibilant_wardens
+        - echo_drifters
+      support:
+        - risonatori_nomadi
+    stresswave:
+      baseline: 0.3
+      escalation_rate: 0.05
+      event_thresholds:
+        rescue: 0.6
+        overrun: 0.8
+    narrative:
+      tone: "Duelli sonori e trattative con tribù eco-sintonizzate."
+      hooks:
+        - "Stabilizzare ponti risonanti prima delle tempeste di vento."
+        - "Seguire tracce sonore per rintracciare nidi dispersivi."
+  foresta_miceliale:
+    label: "Foresta Miceliale"
+    summary: "Canopia micotica bioluminescente dove la rete fungina coordina la fauna."
+    diff_base: 3
+    mod_biome: 2
+    affixes:
+      - spore_bloom
+      - myco_link
+    hazard:
+      description: "Visibilità ridotta, radici bloccanti e spore neuroreattive."
+      severity: medium
+      stress_modifiers:
+        spores: 0.04
+        entanglement: 0.06
+    npc_archetypes:
+      primary:
+        - verdant_shepherds
+        - fungal_titans
+      support:
+        - myco_empath
+    stresswave:
+      baseline: 0.27
+      escalation_rate: 0.04
+      event_thresholds:
+        hive_alert: 0.58
+        overrun: 0.76
+    narrative:
+      tone: "Fantasia bioluminescente con rischio di simbiosi forzata."
+      hooks:
+        - "Mappare nodi miceliali per isolare la rete neurale."
+        - "Convincere i guardiani a condividere antidoti spora."
+  atollo_obsidiana:
+    label: "Atollo Obsidiana"
+    summary: "Arcipelago magnetico con maree EMP e piattaforme mobili."
+    diff_base: 4
+    mod_biome: 3
+    affixes:
+      - resonance_tide
+      - shard_storm
+    hazard:
+      description: "Maree magnetiche, correnti EMP e schegge taglienti."
+      severity: high
+      stress_modifiers:
+        tidal_surge: 0.06
+        emp_flash: 0.07
+    npc_archetypes:
+      primary:
+        - aegis_corsairs
+        - gale_splicers
+      support:
+        - ingegneri_falena
+    stresswave:
+      baseline: 0.33
+      escalation_rate: 0.05
+      event_thresholds:
+        support: 0.57
+        overrun: 0.78
+    narrative:
+      tone: "Pirateria magnetica e assedi anfibi high-tech."
+      hooks:
+        - "Proteggere i reattori a risonanza dagli attacchi delle maree."
+        - "Recuperare shard ossidiani prima dell'arrivo della tempesta."
+  mezzanotte_orbitale:
+    label: "Mezzanotte Orbitale"
+    summary: "Stazione orbitale in decadimento con gravità variabile."
+    diff_base: 4
+    mod_biome: 3
+    affixes:
+      - zero_g_flux
+      - alarm_cascade
+    hazard:
+      description: "Zero-G intermittente, allarmi a cascata e compartimenti depressurizzati."
+      severity: high
+      stress_modifiers:
+        zero_g: 0.05
+        lockdown: 0.08
+    npc_archetypes:
+      primary:
+        - skydock_sentinels
+        - aeon_engineers
+      support:
+        - droni_manutentori
+    stresswave:
+      baseline: 0.35
+      escalation_rate: 0.06
+      event_thresholds:
+        rescue: 0.6
+        lockdown: 0.82
+    narrative:
+      tone: "Thriller techno con evacuazioni di emergenza e sabotaggi."
+      hooks:
+        - "Ripristinare i reattori Aeon prima del blackout totale."
+        - "Neutralizzare l'allarme a cascata per evitare l'arrivo dei rinforzi."
 vc_adapt:
   aggro_high: {add_control: 1, add_guardia: 1}
   cohesion_high: {add_knockback: 1}
@@ -10,8 +232,28 @@ vc_adapt:
   risk_high: {add_burst: 1, reduce_armor: 1}
 mutations:
   SG_max: 3
-  t0_table_d12: [Adrenalina, Fasici, Spine, Cromatofori, Tendini, EcoFlash, SangueGelido, Chelazione, MicroDroni, RisonanzaMentale, ZanneSottili, Immunoscossa]
-  t1_table_d8: [LamelleAcide, Cartilagine, SensiTermici, FibreCorte, GhiandolaFeroce, OmbraRadente, PlaccaCristallina, EcoBranco]
+  t0_table_d12:
+    - Adrenalina
+    - Fasici
+    - Spine
+    - Cromatofori
+    - Tendini
+    - EcoFlash
+    - SangueGelido
+    - Chelazione
+    - MicroDroni
+    - RisonanzaMentale
+    - ZanneSottili
+    - Immunoscossa
+  t1_table_d8:
+    - LamelleAcide
+    - Cartilagine
+    - SensiTermici
+    - FibreCorte
+    - GhiandolaFeroce
+    - OmbraRadente
+    - PlaccaCristallina
+    - EcoBranco
 frequencies:
   trap_trigger: {t0: 0.6, t1: 0.2, none: 0.2}
   crit_event: {t0: 0.4, t1: 0.1, none: 0.5}

--- a/data/test-fixtures/minimal/data/biomes.yaml
+++ b/data/test-fixtures/minimal/data/biomes.yaml
@@ -6,3 +6,28 @@ biomes:
     features:
       - "Foliage luminescente"
       - "Campi magnetici stabili"
+    diff_base: 1
+    mod_biome: 0
+    affixes: []
+    hazard:
+      description: "TODO: definire hazard specifico per la fixture."
+      severity: low
+      stress_modifiers:
+        exposure: 0.0
+    npc_archetypes:
+      primary: []
+      support: []
+    stresswave:
+      baseline: 0.2
+      escalation_rate: 0.03
+      event_thresholds:
+        support: 0.4
+        overrun: 0.6
+    narrative:
+      tone: "TBD"
+      hooks:
+        - "TODO: gancio narrativo di esempio per la fixture."
+vc_adapt:
+  demo: {}
+mutations: {}
+frequencies: {}

--- a/docs/biomes/manifest.md
+++ b/docs/biomes/manifest.md
@@ -1,0 +1,30 @@
+# Manifest Biomi
+
+Questo documento elenca i biomi menzionati nei canvas progettuali, nei dataset delle specie e negli esempi di encounter, fornendo un identificatore canonico da utilizzare in `data/biomes.yaml` e nelle integrazioni future.
+
+## Convenzioni
+- **ID canonico**: chiave snake_case utilizzata nei dataset YAML.
+- **Alias**: varianti già presenti nei dataset legacy (per esempio classi o chiavi storiche).
+- **Fonti**: file che menzionano esplicitamente il bioma.
+- I campi introdotti nella nuova struttura YAML possono temporaneamente contenere i placeholder `TODO` / `TBD` finché non vengono definiti contenuti finali.
+
+## Indice canonico
+
+| ID | Nome di riferimento | Alias | Fonti principali | Note |
+| --- | --- | --- | --- | --- |
+| `savana` | Savana ionizzata | – | `data/biomes.yaml`, `docs/examples/encounter_savana.txt` | Bioma già integrato nel generatore encounter.【F:data/biomes.yaml†L3-L26】【F:docs/examples/encounter_savana.txt†L1-L47】 |
+| `caverna` | Caverna risonante | `caverna_risonante` | `data/biomes.yaml`, `data/species.yaml`, `docs/examples/encounter_caverna.txt` | Canonico per i piani ambientali della forma Dune Stalker.【F:data/biomes.yaml†L27-L52】【F:data/species.yaml†L58-L87】【F:docs/examples/encounter_caverna.txt†L1-L47】 |
+| `palude` | Palude tossica | – | `data/biomes.yaml`, `docs/examples/encounter_palude.txt` | Già presente negli esempi encounter generati.【F:data/biomes.yaml†L53-L76】【F:docs/examples/encounter_palude.txt†L1-L47】 |
+| `canyons_risonanti` | Canyons Risonanti | – | `appendici/C-CANVAS_NPG_BIOMI.txt` | Canvas NPG con StressWave +0.05 per turno scoperto.【F:appendici/C-CANVAS_NPG_BIOMI.txt†L19-L38】 |
+| `foresta_miceliale` | Foresta Miceliale | – | `appendici/C-CANVAS_NPG_BIOMI.txt` | Canvas NPG con affissi Spore Bloom / Myco Link.【F:appendici/C-CANVAS_NPG_BIOMI.txt†L39-L47】 |
+| `atollo_obsidiana` | Atollo Obsidiana | – | `appendici/C-CANVAS_NPG_BIOMI.txt` | Canvas NPG con maree magnetiche e shard storm.【F:appendici/C-CANVAS_NPG_BIOMI.txt†L48-L56】 |
+| `mezzanotte_orbitale` | Mezzanotte Orbitale (Stazione) | – | `appendici/C-CANVAS_NPG_BIOMI.txt` | Canvas stazione orbitale Zero-G Flux / Alarm Cascade.【F:appendici/C-CANVAS_NPG_BIOMI.txt†L57-L65】 |
+| `aurora_grove` | Bosco Aurora (fixture) | – | `data/test-fixtures/minimal/data/biomes.yaml` | Bioma di test per le fixture minimal del validatore.【F:data/test-fixtures/minimal/data/biomes.yaml†L1-L8】 |
+
+## Sorgenti verificate
+- Canvas C — NPG Reattivi, Biomi & Director.【F:appendici/C-CANVAS_NPG_BIOMI.txt†L1-L65】
+- Dataset specie (`data/species.yaml`).【F:data/species.yaml†L1-L87】
+- Dataset biomi (`data/biomes.yaml`) e fixture minimal correlate.【F:data/biomes.yaml†L1-L76】【F:data/test-fixtures/minimal/data/biomes.yaml†L1-L8】
+- Esempi di encounter generati in `docs/examples/`.【F:docs/examples/encounter_savana.txt†L1-L47】【F:docs/examples/encounter_caverna.txt†L1-L47】【F:docs/examples/encounter_palude.txt†L1-L47】
+
+Questo manifesto va aggiornato ogni volta che nuovi biomi vengono introdotti in canvas, dataset o script di generazione.

--- a/tools/py/validate_datasets.py
+++ b/tools/py/validate_datasets.py
@@ -79,6 +79,77 @@ def validate_biomes() -> List[str]:
             if "affixes" in payload and not isinstance(payload["affixes"], list):
                 errors.append(f"{path}: biome '{biome}' -> 'affixes' deve essere lista")
 
+            hazard = payload.get("hazard")
+            if not isinstance(hazard, dict):
+                errors.append(f"{path}: biome '{biome}' -> 'hazard' deve essere una mappa")
+            else:
+                if not hazard.get("description"):
+                    errors.append(f"{path}: biome '{biome}' -> 'hazard.description' obbligatoria")
+                if "severity" not in hazard:
+                    errors.append(f"{path}: biome '{biome}' -> 'hazard.severity' mancante")
+                stress_mod = hazard.get("stress_modifiers")
+                if stress_mod is not None and not isinstance(stress_mod, dict):
+                    errors.append(
+                        f"{path}: biome '{biome}' -> 'hazard.stress_modifiers' deve essere una mappa"
+                    )
+
+            npc_archetypes = payload.get("npc_archetypes")
+            if not isinstance(npc_archetypes, dict):
+                errors.append(
+                    f"{path}: biome '{biome}' -> 'npc_archetypes' deve essere una mappa"
+                )
+            else:
+                for key in ("primary", "support"):
+                    if key not in npc_archetypes:
+                        errors.append(
+                            f"{path}: biome '{biome}' -> 'npc_archetypes.{key}' mancante"
+                        )
+                    elif not isinstance(npc_archetypes.get(key), list):
+                        errors.append(
+                            f"{path}: biome '{biome}' -> 'npc_archetypes.{key}' deve essere lista"
+                        )
+
+            stresswave = payload.get("stresswave")
+            if not isinstance(stresswave, dict):
+                errors.append(f"{path}: biome '{biome}' -> 'stresswave' deve essere una mappa")
+            else:
+                for key in ("baseline", "escalation_rate"):
+                    if key not in stresswave:
+                        errors.append(
+                            f"{path}: biome '{biome}' -> 'stresswave.{key}' mancante"
+                        )
+                    else:
+                        value = stresswave.get(key)
+                        if not isinstance(value, (int, float)):
+                            errors.append(
+                                f"{path}: biome '{biome}' -> 'stresswave.{key}' deve essere numerico"
+                            )
+                thresholds = stresswave.get("event_thresholds")
+                if not isinstance(thresholds, dict) or not thresholds:
+                    errors.append(
+                        f"{path}: biome '{biome}' -> 'stresswave.event_thresholds' deve essere mappa non vuota"
+                    )
+                else:
+                    for name, value in thresholds.items():
+                        if not isinstance(value, (int, float)):
+                            errors.append(
+                                f"{path}: biome '{biome}' -> 'stresswave.event_thresholds.{name}' deve essere numerico"
+                            )
+
+            narrative = payload.get("narrative")
+            if not isinstance(narrative, dict):
+                errors.append(f"{path}: biome '{biome}' -> 'narrative' deve essere una mappa")
+            else:
+                if not narrative.get("tone"):
+                    errors.append(
+                        f"{path}: biome '{biome}' -> 'narrative.tone' obbligatoria"
+                    )
+                hooks = narrative.get("hooks")
+                if not isinstance(hooks, list) or not hooks:
+                    errors.append(
+                        f"{path}: biome '{biome}' -> 'narrative.hooks' deve essere lista non vuota"
+                    )
+
     mutations = data.get("mutations", {})
     if not isinstance(mutations, dict):
         errors.append(f"{path}: 'mutations' deve essere una mappa")


### PR DESCRIPTION
## Summary
- document the canonical biome identifiers across canvas, species, and encounter sources
- expand `data/biomes.yaml` with hazard, NPC archetype, StressWave, and narrative metadata while adding the missing canvas biomes
- extend the dataset validator and fixtures to enforce the new required fields

## Testing
- python tools/py/validate_datasets.py

------
https://chatgpt.com/codex/tasks/task_e_68ff4d0110b48332b54957dab45c8f18