### PR TITLE
Add EVT-02 narrative session plan and tracking

### DIFF
--- a/docs/playtest/EVT-02-session-plan.md
+++ b/docs/playtest/EVT-02-session-plan.md
@@ -1,0 +1,49 @@
+# Piano sessione dedicata — EVT-02 "Alleanza inattesa"
+
+## Sintesi coordinamento
+- **Finestra confermata:** 2025-03-05, 15:00-17:00 CET.
+- **Modalità:** QA Lab Torino (2 postazioni co-op) + stanza Teams "Narrative EVT-02".
+- **Responsabile QA:** Andrea Conti (Narrative QA lead).
+- **Supporto narrativa:** Giulia Parodi (writer support) — cura dialoghi e gestione branching.
+- **Tester confermati:** Marco Esposito, Lina Wu (co-op), backup remoto: Elisa Conti.
+- **Obiettivi principali:**
+  1. Validare ramificazioni cooperative post-patto, con verifica linee "Accordo provvisorio" e "Rinegoziazione".
+  2. Controllare sincronizzazione flag narrativi `evt02_alliance_state` e `evt02_reputation_delta`.
+  3. Registrare log decisioni e flag tramite export automatico + note osservatore.
+
+## Agenda dettagliata
+| Orario | Attività | Owner | Note |
+| --- | --- | --- | --- |
+| 15:00-15:10 | Setup postazioni, verifica build `branching-v3` e save `story-branch-ev02`. | A. Conti | Confermare hotfix dialoghi applicato.
+| 15:10-15:20 | Brief narrativo + ripasso flow chart. | G. Parodi | Utilizzare schema `docs/playtest/EVT-02-session-plan.md#flow-chart`.
+| 15:20-16:00 | Run 1 percorso cooperativo completo. | Tester co-op | Registrare clip OBS + esport flag automatico.
+| 16:00-16:10 | Debrief rapido, revisione log flag. | A. Conti + G. Parodi | Annotare incongruenze in tabella issue.
+| 16:10-16:40 | Run 2 con deviazioni su scelta opzionale "Richiedi tributo". | Tester co-op | Monitorare reazione NPC e gating reputazione.
+| 16:40-16:55 | Debrief finale + definizione follow-up. | Tutti | Identificare fix owner e priorità.
+| 16:55-17:00 | Upload log e aggiornamento report. | A. Conti | Salvare in `logs/playtests/2025-03-05-evt02/`.
+
+## Flow chart di riferimento
+```
+Nodo iniziale → Dialogo negoziazione → Scelta:
+  - Cooperare → Flag `evt02_alliance_state = cooperative`
+      → Check reputazione >= 2 → Dialogo "Accordo provvisorio" → Evento supporto in missione successiva.
+  - Rifiutare → Flag `evt02_alliance_state = refused`
+      → Avvio combattimento → Trigger EVT-02 fallback.
+```
+
+## Deliverable sessione
+- Aggiornare `docs/playtest/SESSION-2025-11-12.md` (sezione scenari) con stato EVT-02.
+- Compilare tabella incongruenze in `docs/playtest/tickets/EVT-02-event-special.md`.
+- Condividere recap nel canale `#qa-playtest` entro 18:00 con link a log e note.
+
+## Dipendenze aperte
+| Tipo | Descrizione | Owner | ETA |
+| --- | --- | --- | --- |
+| Build | Applicare hotfix dialoghi `evt02_coop_fix` (branch narrativa). | Team Narrative Tools | 2025-03-01 |
+| Tooling | Script export flag (CLI `scripts/playtest/export_evt_flags.sh`). | QA Tools | 2025-03-03 |
+| Localizzazione | Revisione linee coop EN/IT. | Localization | 2025-03-04 |
+
+## Contatti rapidi
+- Narrative QA: `andrea.conti@example.com`
+- Writer support: `giulia.parodi@example.com`
+- QA Tools: `qatools@example.com`

--- a/docs/playtest/SESSION-2025-11-12.md
+++ b/docs/playtest/SESSION-2025-11-12.md
@@ -13,11 +13,12 @@
 | BAL-05 | Assedio modulare (moduli difesa + ondate progressive) | Programmato | Richiede setup seed `siege-042` e telemetria DPS. |
 | PROG-04 | Sblocco moduli nave madre | Programmato | Validare curva XP con export `progression-metrics.csv`. |
 | EVT-03 | Eclissi di frontiera | Programmato | Acquisire video + `effects-trace.log` per verifica trigger. |
+| EVT-02 | Alleanza inattesa | Programmato | Slot narrativo 15:00-17:00 con Narrative QA; seguire `EVT-02-session-plan`. |
 
 ## Metriche raccolte
 - **Bilanciamento:** tasso vittoria target 55-65%, danno medio per ondata, consumo pozioni (log `damage.json`).
 - **Progressione:** XP guadagnata vs richiesta moduli, tempo sblocco, riserve risorse finali.
-- **Eventi speciali:** scelte narrative attive, occorrenze bug visuali, latenza trigger evento.
+- **Eventi speciali:** scelte narrative attive, occorrenze bug visuali, latenza trigger evento, coerenza flag `evt02_alliance_state`.
 
 ## Sintesi feedback
 - **Punti di forza osservati:** Da compilare post-sessione.
@@ -27,6 +28,7 @@
 ## Checklist raccolta feedback
 - [ ] Catturare almeno 5 screenshot chiave (HUD, eventi, economy) e salvarli in `logs/playtests/2025-11-12/media/`.
 - [ ] Registrare clip video per gli eventi speciali e allegarle alla cartella media con naming `event-<scenario>-<timestamp>.mp4`.
+- [ ] Eseguire export flag narrativi (`scripts/playtest/export_evt_flags.sh`) e archiviare l'output JSON in `logs/playtests/2025-11-12/evt-02/flags/`.
 - [ ] Esportare log telemetria (`damage.json`, `progression-metrics.csv`, `effects-trace.log`) e verificare l'integrità dei file.
 - [ ] Raccogliere feedback individuali tramite `docs/playtest/feedback-template.md` e archiviare i moduli in `docs/playtest/SESSION-2025-11-12/feedback/`.
 - [ ] Condividere il riepilogo nel canale Slack `#qa-playtest` entro 24h dalla sessione con link a questo report.
@@ -45,6 +47,7 @@
 
 ## Materiali archiviati
 - Log: `logs/playtests/2025-11-12/`
+- Log narrativi EVT-02: `logs/playtests/2025-11-12/evt-02/`
 - Screenshot/Video: `logs/playtests/2025-11-12/media/`
 - Feedback individuali: `docs/playtest/SESSION-2025-11-12/feedback/`
 - Altri allegati: `logs/playtests/2025-11-12/additional/`

--- a/docs/playtest/scenari-critici.md
+++ b/docs/playtest/scenari-critici.md
@@ -24,8 +24,16 @@ Questa lista evidenzia gli scenari che devono essere eseguiti a ogni ciclo di va
 | Scenario ID | Nome scenario | Priorità | Rischio principale | Owner | Frequenza minima | Ultima esecuzione | Note |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | EVT-01 | Tempesta dimensionale | Alta | Comunicazioni confuse e glitch particellari durante evento. | Design QA (S. Neri) | Ogni patch contenuti evento | 2025-02-27 | Patch DimensionalStorm 2025-02-27 validata: flash eliminato, monitorare bloom build console (#144). |
-| EVT-02 | Alleanza inattesa | Media | Ramificazioni narrative incoerenti e flag errati. | Narrative QA (A. Conti) | Ogni sprint narrativa | 2025-02-20 | Scenario non eseguito nella sessione corrente, mantenere follow-up. |
+| EVT-02 | Alleanza inattesa | Media | Ramificazioni narrative incoerenti e flag errati. | Narrative QA (A. Conti) | Ogni sprint narrativa | Pianificata 2025-03-05 | Slot dedicato 2025-03-05 15:00-17:00 CET con A. Conti + writer support (G. Parodi); riferimenti checklist pre-sessione. |
 | EVT-03 | Eclissi di frontiera | Alta | Trigger cinematico non sincronizzato e timer evento non resetta. | Event Owner (D. Bellini) | Ogni sessione con build evento | Pianificata 2025-11-12 | Richiede acquisizione video + log particellari (`effects-trace.log`). |
+
+### Checklist pre-sessione EVT-02 (Alleanza inattesa)
+
+- [ ] Confermare build narrativa `branching-v3` aggiornata con le patch dialoghi dedicate a EVT-02.
+- [ ] Allineare savegame `story-branch-ev02` al nodo "Accordo provvisorio" con flag cooperativo impostato.
+- [ ] Verificare presenza in sala/Teams di A. Conti (Narrative QA lead) e G. Parodi (writer support) + 2 tester co-op.
+- [ ] Aggiornare il piano operativo in `docs/playtest/EVT-02-session-plan.md` includendo punti di controllo storyline e log flag.
+- [ ] Predisporre cartella `logs/playtests/2025-03-05-evt02/` con sottocartelle `media/` e `flags/` per esport live.
 
 ## Criteri di aggiornamento
 - **Inserimento**: quando uno scenario produce bug critici ripetuti o copre metriche VC essenziali.

--- a/docs/playtest/tickets/EVT-02-event-special.md
+++ b/docs/playtest/tickets/EVT-02-event-special.md
@@ -1,0 +1,15 @@
+# Annotazioni ticket — EVT-02 "Alleanza inattesa"
+
+## Contesto
+Le incongruenze riportate derivano dalle revisioni narrative precedenti al playtest dedicato (ultimo controllo 2025-02-20) e dovranno essere tracciate nel tracker principale con etichetta `event-special` oltre alle tag funzionali rilevanti.
+
+## Ticket da aprire
+| ID provvisorio | Titolo | Descrizione sintetica | Stato | Etichette consigliate | Owner suggerito |
+| --- | --- | --- | --- | --- | --- |
+| EVT02-NAR-01 | Branch cooperativo richiama dialogo di tradimento | Dopo la scelta cooperativa, il nodo "Rinegoziazione forzata" viene attivato invece di "Accordo provvisorio" causando incoerenza narrativa e scelta duplicata. | Da aprire | `event-special`, `narrative-flow` | Narrative QA (A. Conti) |
+| EVT02-NAR-02 | Flag reputazione non aggiorna esito supporto | Il flag `evt02_reputation_delta` resta a valore neutro anche dopo la consegna risorse, impedendo lo sblocco del supporto alleato nella missione successiva. | Da aprire | `event-special`, `progression-sync` | Writer Support (G. Parodi) |
+
+## Azioni immediate
+1. Creare ticket GitHub per ogni voce utilizzando il template "Encounter bug" e allegare log esportati con `scripts/playtest/export_evt_flags.sh`.
+2. Collegare i ticket al report di sessione (`docs/playtest/SESSION-2025-11-12.md`) e aggiornare la sezione bug appena disponibili gli ID ufficiali.
+3. Validare i fix nella sessione dedicata del 2025-03-05 e aggiornare `scenari-critici.md` in base all'esito.

--- a/logs/playtests/2025-11-12/evt-02/flags/evt02_flags_20251027T111028.json
+++ b/logs/playtests/2025-11-12/evt-02/flags/evt02_flags_20251027T111028.json
@@ -1,0 +1,5 @@
+{
+  "session": "EVT-02",
+  "status": "placeholder",
+  "notes": "Sostituire con export reale dei flag narrativi una volta disponibile l'integrazione tooling."
+}

--- a/scripts/playtest/export_evt_flags.sh
+++ b/scripts/playtest/export_evt_flags.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SESSION_DIR="${1:-logs/playtests/2025-03-05-evt02}"
+OUTPUT_FILE="${SESSION_DIR}/flags/evt02_flags_$(date +%Y%m%dT%H%M%S).json"
+
+if [[ ! -d "${SESSION_DIR}" ]]; then
+  echo "[export_evt_flags] Creating session directory at ${SESSION_DIR}" >&2
+  mkdir -p "${SESSION_DIR}"
+fi
+
+mkdir -p "${SESSION_DIR}/flags"
+
+cat <<JSON > "${OUTPUT_FILE}"
+{
+  "session": "EVT-02",
+  "status": "placeholder",
+  "notes": "Sostituire con export reale dei flag narrativi una volta disponibile l'integrazione tooling."
+}
+JSON
+
+echo "[export_evt_flags] Placeholder export creato: ${OUTPUT_FILE}" >&2


### PR DESCRIPTION
## Summary
- schedule EVT-02 dedicated window in the critical-scenarios tracker and add a pre-session checklist
- integrate EVT-02 prep steps into the 2025-11-12 session report and document the coordination plan
- capture narrative inconsistencies as ticket annotations and add a placeholder flag-export script/log for the session

## Testing
- scripts/playtest/export_evt_flags.sh logs/playtests/2025-11-12/evt-02

------
https://chatgpt.com/codex/tasks/task_e_68ff5231d3f48332805918ae22b051e1