### PR TITLE
Normalize biome references to canonical ids

### DIFF
--- a/data/biome_aliases.yaml
+++ b/data/biome_aliases.yaml
@@ -1,0 +1,19 @@
+# Mapping legacy biome identifiers to new canonical biomes.
+# Each alias entry must resolve to a key present in data/biomes.yaml.
+aliases:
+  badlands:
+    canonical: canyons_risonanti
+    notes: "Badlands magnetiche integrate nel profilo dei Canyons Risonanti."
+  deserto_caldo:
+    canonical: savana
+    notes: "Deserto caldo aurorale migrato nella Savana Ionizzata."
+  foresta_temperata:
+    canonical: foresta_miceliale
+    notes: "Le foreste temperate legacy confluiscono nella Foresta Miceliale."
+  cryosteppe:
+    canonical: mezzanotte_orbitale
+    status: transitional
+    notes: "Specie cryosteppe in attesa di rework: collocate provvisoriamente nel teatro Mezzanotte Orbitale."
+  caverna_risonante:
+    canonical: caverna
+    notes: "Alias storico per la Caverna Risonante."

--- a/docs/catalog/species_trait_matrix.json
+++ b/docs/catalog/species_trait_matrix.json
@@ -5,7 +5,7 @@
         "evento_ecologico"
       ],
       "biomes": [
-        "cryosteppe"
+        "mezzanotte_orbitale"
       ],
       "core_traits": [
         "cuticole_cerose",
@@ -17,7 +17,7 @@
       ],
       "display_name": "Evento: Brina Tempestosa",
       "environment_focus": {
-        "biome_class": "cryosteppe"
+        "biome_class": "mezzanotte_orbitale"
       },
       "id": "evento-brinastorm",
       "morphotype": "volatore_planatore",
@@ -36,7 +36,7 @@
         "evento_ecologico"
       ],
       "biomes": [
-        "deserto_caldo"
+        "savana"
       ],
       "core_traits": [
         "cuticole_cerose",
@@ -48,7 +48,7 @@
       ],
       "display_name": "Evento: Ondata Termica Ionica",
       "environment_focus": {
-        "biome_class": "deserto_caldo"
+        "biome_class": "savana"
       },
       "id": "evento-ondata-termica",
       "morphotype": "volatore_planatore",
@@ -67,7 +67,7 @@
         "evento_ecologico"
       ],
       "biomes": [
-        "foresta_temperata"
+        "foresta_miceliale"
       ],
       "core_traits": [
         "pelli_fitte"
@@ -93,7 +93,7 @@
         "evento_ecologico"
       ],
       "biomes": [
-        "badlands"
+        "canyons_risonanti"
       ],
       "core_traits": [
         "cute_resistente_sali",
@@ -103,7 +103,7 @@
       ],
       "display_name": "Evento: Tempesta Ferrosa",
       "environment_focus": {
-        "biome_class": "badlands"
+        "biome_class": "canyons_risonanti"
       },
       "id": "evento-tempesta-ferrosa",
       "morphotype": "volatore_planatore",
@@ -157,7 +157,7 @@
         "Skirmisher"
       ],
       "biomes": [
-        "cryosteppe"
+        "mezzanotte_orbitale"
       ],
       "core_traits": [
         "cuticole_cerose",
@@ -169,7 +169,7 @@
       ],
       "display_name": "Gabbiano d’Aurora",
       "environment_focus": {
-        "biome_class": "cryosteppe"
+        "biome_class": "mezzanotte_orbitale"
       },
       "form_threshold": {
         "weight_budget": 12
@@ -191,7 +191,7 @@
         "minaccia_microbica"
       ],
       "biomes": [
-        "foresta_temperata"
+        "foresta_miceliale"
       ],
       "core_traits": [
         "pelli_fitte"
@@ -218,7 +218,7 @@
         "Warden"
       ],
       "biomes": [
-        "deserto_caldo"
+        "savana"
       ],
       "core_traits": [
         "cuticole_cerose",
@@ -230,7 +230,7 @@
       ],
       "display_name": "Cactus Weaver",
       "environment_focus": {
-        "biome_class": "deserto_caldo"
+        "biome_class": "savana"
       },
       "form_threshold": {
         "weight_budget": 12
@@ -252,7 +252,7 @@
         "predatore_terziario_apex"
       ],
       "biomes": [
-        "cryosteppe"
+        "mezzanotte_orbitale"
       ],
       "core_traits": [
         "cuticole_cerose",
@@ -264,7 +264,7 @@
       ],
       "display_name": "Cryo Lynx",
       "environment_focus": {
-        "biome_class": "cryosteppe"
+        "biome_class": "mezzanotte_orbitale"
       },
       "id": "cryo-lynx",
       "morphotype": "cursoriale_quadrupede",
@@ -283,7 +283,7 @@
         "predatore_terziario_apex"
       ],
       "biomes": [
-        "badlands"
+        "canyons_risonanti"
       ],
       "core_traits": [
         "cute_resistente_sali",
@@ -293,7 +293,7 @@
       ],
       "display_name": "Dune Stalker",
       "environment_focus": {
-        "biome_class": "badlands"
+        "biome_class": "canyons_risonanti"
       },
       "id": "dune-stalker",
       "morphotype": "cursoriale_quadrupede",
@@ -314,8 +314,15 @@
     },
     "dune_stalker": {
       "archetypes": [],
+      "biome_aliases": [
+        {
+          "alias": "caverna_risonante",
+          "canonical": "caverna",
+          "notes": "Alias storico per la Caverna Risonante."
+        }
+      ],
       "biomes": [
-        "caverna_risonante",
+        "caverna",
         "savana"
       ],
       "core_traits": [
@@ -359,10 +366,10 @@
         "Skirmisher"
       ],
       "biomes": [
-        "CRYOSTEPPE",
-        "DESERTO_CALDO",
-        "FORESTA_TEMPERATA",
-        "badlands"
+        "canyons_risonanti",
+        "foresta_miceliale",
+        "mezzanotte_orbitale",
+        "savana"
       ],
       "core_traits": [
         "cute_resistente_sali",
@@ -372,7 +379,7 @@
       ],
       "display_name": "Echo Wing",
       "environment_focus": {
-        "biome_class": "badlands"
+        "biome_class": "canyons_risonanti"
       },
       "form_threshold": {
         "weight_budget": 12
@@ -400,7 +407,7 @@
         "Warden"
       ],
       "biomes": [
-        "badlands"
+        "canyons_risonanti"
       ],
       "core_traits": [
         "cute_resistente_sali",
@@ -410,7 +417,7 @@
       ],
       "display_name": "Ferrocolonia Magnetotattica",
       "environment_focus": {
-        "biome_class": "badlands"
+        "biome_class": "canyons_risonanti"
       },
       "form_threshold": {
         "weight_budget": 13
@@ -437,7 +444,7 @@
         "predatore_terziario_apex"
       ],
       "biomes": [
-        "foresta_temperata"
+        "foresta_miceliale"
       ],
       "core_traits": [
         "pelli_fitte"
@@ -463,7 +470,7 @@
         "minaccia_microbica"
       ],
       "biomes": [
-        "badlands"
+        "canyons_risonanti"
       ],
       "core_traits": [
         "cute_resistente_sali",
@@ -473,7 +480,7 @@
       ],
       "display_name": "Nano Rust Bloom",
       "environment_focus": {
-        "biome_class": "badlands"
+        "biome_class": "canyons_risonanti"
       },
       "id": "nano-rust-bloom",
       "morphotype": "scavenger_corazzato",
@@ -498,7 +505,7 @@
         "Skirmisher"
       ],
       "biomes": [
-        "deserto_caldo"
+        "savana"
       ],
       "core_traits": [
         "cuticole_cerose",
@@ -510,7 +517,7 @@
       ],
       "display_name": "Noctule Termico",
       "environment_focus": {
-        "biome_class": "deserto_caldo"
+        "biome_class": "savana"
       },
       "form_threshold": {
         "weight_budget": 12
@@ -533,7 +540,7 @@
         "Warden"
       ],
       "biomes": [
-        "badlands"
+        "canyons_risonanti"
       ],
       "core_traits": [
         "cute_resistente_sali",
@@ -543,7 +550,7 @@
       ],
       "display_name": "Rust Scavenger",
       "environment_focus": {
-        "biome_class": "badlands"
+        "biome_class": "canyons_risonanti"
       },
       "form_threshold": {
         "weight_budget": 12
@@ -570,7 +577,7 @@
         "erbivoro_primario"
       ],
       "biomes": [
-        "badlands"
+        "canyons_risonanti"
       ],
       "core_traits": [
         "cute_resistente_sali",
@@ -580,7 +587,7 @@
       ],
       "display_name": "Sand Burrower",
       "environment_focus": {
-        "biome_class": "badlands"
+        "biome_class": "canyons_risonanti"
       },
       "id": "sand-burrower",
       "morphotype": "cursoriale_quadrupede",
@@ -604,7 +611,7 @@
         "ingegneri_ecosistema"
       ],
       "biomes": [
-        "foresta_temperata"
+        "foresta_miceliale"
       ],
       "core_traits": [
         "pelli_fitte"
@@ -633,7 +640,7 @@
         "minaccia_microbica"
       ],
       "biomes": [
-        "deserto_caldo"
+        "savana"
       ],
       "core_traits": [
         "cuticole_cerose",
@@ -645,7 +652,7 @@
       ],
       "display_name": "Silica Bloom",
       "environment_focus": {
-        "biome_class": "deserto_caldo"
+        "biome_class": "savana"
       },
       "id": "silica-bloom",
       "morphotype": "scavenger_corazzato",
@@ -665,7 +672,7 @@
         "Warden"
       ],
       "biomes": [
-        "cryosteppe"
+        "mezzanotte_orbitale"
       ],
       "core_traits": [
         "cuticole_cerose",
@@ -677,7 +684,7 @@
       ],
       "display_name": "Bisonte Nano della Steppa",
       "environment_focus": {
-        "biome_class": "cryosteppe"
+        "biome_class": "mezzanotte_orbitale"
       },
       "form_threshold": {
         "weight_budget": 12
@@ -699,7 +706,7 @@
         "minaccia_microbica"
       ],
       "biomes": [
-        "cryosteppe"
+        "mezzanotte_orbitale"
       ],
       "core_traits": [
         "cuticole_cerose",
@@ -711,7 +718,7 @@
       ],
       "display_name": "Thaw Rot",
       "environment_focus": {
-        "biome_class": "cryosteppe"
+        "biome_class": "mezzanotte_orbitale"
       },
       "id": "thaw-rot",
       "morphotype": "scavenger_corazzato",
@@ -730,7 +737,7 @@
         "predatore_terziario_apex"
       ],
       "biomes": [
-        "deserto_caldo"
+        "savana"
       ],
       "core_traits": [
         "cuticole_cerose",
@@ -742,7 +749,7 @@
       ],
       "display_name": "Thermo Raptor",
       "environment_focus": {
-        "biome_class": "deserto_caldo"
+        "biome_class": "savana"
       },
       "id": "thermo-raptor",
       "morphotype": "cursoriale_quadrupede",

--- a/packs/evo_tactics_pack/data/ecosistemi/cross_events.yaml
+++ b/packs/evo_tactics_pack/data/ecosistemi/cross_events.yaml
@@ -1,30 +1,31 @@
 schema_version: 1.0
 events:
-- species_id: evento-tempesta-ferrosa
-  from_nodes:
-  - BADLANDS
-  propagate_via:
-  - corridor
-  - seasonal_bridge
-  to_nodes:
-  - FORESTA_TEMPERATA
-  - DESERTO_CALDO
-  effect: polveri ferrose e carica magnetica, penalità visibilità/gear metallico
-- species_id: evento-ondata-termica
-  from_nodes:
-  - DESERTO_CALDO
-  propagate_via:
-  - corridor
-  to_nodes:
-  - BADLANDS
-  effect: ondata di calore e ionizzazione, stress termico esteso
-- species_id: evento-brinastorm
-  from_nodes:
-  - CRYOSTEPPE
-  propagate_via:
-  - seasonal_bridge
-  - corridor
-  to_nodes:
-  - FORESTA_TEMPERATA
-  - BADLANDS
-  effect: ghiaccio fine in sospensione, visibilità ridotta e attrito aumentato
+  - species_id: evento-tempesta-ferrosa
+    from_nodes:
+      - canyons_risonanti
+    propagate_via:
+      - corridor
+      - seasonal_bridge
+    to_nodes:
+      - foresta_miceliale
+      - savana
+    effect: polveri ferrose e carica magnetica, penalità visibilità/gear 
+      metallico
+  - species_id: evento-ondata-termica
+    from_nodes:
+      - savana
+    propagate_via:
+      - corridor
+    to_nodes:
+      - canyons_risonanti
+    effect: ondata di calore e ionizzazione, stress termico esteso
+  - species_id: evento-brinastorm
+    from_nodes:
+      - mezzanotte_orbitale
+    propagate_via:
+      - seasonal_bridge
+      - corridor
+    to_nodes:
+      - foresta_miceliale
+      - canyons_risonanti
+    effect: ghiaccio fine in sospensione, visibilità ridotta e attrito aumentato

--- a/packs/evo_tactics_pack/data/ecosistemi/meta_ecosistema_alpha.yaml
+++ b/packs/evo_tactics_pack/data/ecosistemi/meta_ecosistema_alpha.yaml
@@ -6,77 +6,77 @@ receipt:
   trace_hash: to-fill
 links:
   biomi:
-  - packs/evo_tactics_pack/data/ecosystems/badlands.biome.yaml
-  - packs/evo_tactics_pack/data/ecosystems/foresta_temperata.biome.yaml
-  - packs/evo_tactics_pack/data/ecosystems/deserto_caldo.biome.yaml
-  - packs/evo_tactics_pack/data/ecosystems/cryosteppe.biome.yaml
+    - packs/evo_tactics_pack/data/ecosystems/badlands.biome.yaml
+    - packs/evo_tactics_pack/data/ecosystems/foresta_temperata.biome.yaml
+    - packs/evo_tactics_pack/data/ecosystems/deserto_caldo.biome.yaml
+    - packs/evo_tactics_pack/data/ecosystems/cryosteppe.biome.yaml
 ecosistema:
   id: ET_NET_ALPHA
   label: Evo-Tactics Meta‑Ecosystem Alpha
   biomi:
-  - id: BADLANDS
-    biome_id: badlands
-    path: packs/evo_tactics_pack/data/ecosystems/badlands.biome.yaml
-    weight: 0.45
-  - id: FORESTA_TEMPERATA
-    biome_id: foresta_temperata
-    path: packs/evo_tactics_pack/data/ecosystems/foresta_temperata.biome.yaml
-    weight: 0.55
-  - id: DESERTO_CALDO
-    biome_id: deserto_caldo
-    path: packs/evo_tactics_pack/data/ecosystems/deserto_caldo.biome.yaml
-    weight: 0.4
-  - id: CRYOSTEPPE
-    biome_id: cryosteppe
-    path: packs/evo_tactics_pack/data/ecosystems/cryosteppe.biome.yaml
-    weight: 0.4
+    - id: BADLANDS
+      biome_id: canyons_risonanti
+      path: packs/evo_tactics_pack/data/ecosystems/badlands.biome.yaml
+      weight: 0.45
+    - id: FORESTA_TEMPERATA
+      biome_id: foresta_miceliale
+      path: packs/evo_tactics_pack/data/ecosystems/foresta_temperata.biome.yaml
+      weight: 0.55
+    - id: DESERTO_CALDO
+      biome_id: savana
+      path: packs/evo_tactics_pack/data/ecosystems/deserto_caldo.biome.yaml
+      weight: 0.4
+    - id: CRYOSTEPPE
+      biome_id: mezzanotte_orbitale
+      path: packs/evo_tactics_pack/data/ecosystems/cryosteppe.biome.yaml
+      weight: 0.4
   connessioni:
-  - from: BADLANDS
-    to: FORESTA_TEMPERATA
-    type: corridor
-    resistance: 0.6
-    seasonality: primavera/autunno
-    notes: gole ombreggiate e canyon → valichi boscosi
-  - from: FORESTA_TEMPERATA
-    to: BADLANDS
-    type: trophic_spillover
-    resistance: 0.4
-    seasonality: episodico
-    notes: boom detrito → pulse detritivoro in badlands
-  - from: BADLANDS
-    to: DESERTO_CALDO
-    type: corridor
-    resistance: 0.5
-    seasonality: estate
-    notes: canali wadi → dune mobili
-  - from: FORESTA_TEMPERATA
-    to: CRYOSTEPPE
-    type: seasonal_bridge
-    resistance: 0.6
-    seasonality: inverno
-    notes: valichi nevosi con copertura forestale rada
-  - from: CRYOSTEPPE
-    to: BADLANDS
-    type: trophic_spillover
-    resistance: 0.5
-    seasonality: episodico
-    notes: pulse detrito post disgelo
+    - from: BADLANDS
+      to: FORESTA_TEMPERATA
+      type: corridor
+      resistance: 0.6
+      seasonality: primavera/autunno
+      notes: gole ombreggiate e canyon → valichi boscosi
+    - from: FORESTA_TEMPERATA
+      to: BADLANDS
+      type: trophic_spillover
+      resistance: 0.4
+      seasonality: episodico
+      notes: boom detrito → pulse detritivoro in badlands
+    - from: BADLANDS
+      to: DESERTO_CALDO
+      type: corridor
+      resistance: 0.5
+      seasonality: estate
+      notes: canali wadi → dune mobili
+    - from: FORESTA_TEMPERATA
+      to: CRYOSTEPPE
+      type: seasonal_bridge
+      resistance: 0.6
+      seasonality: inverno
+      notes: valichi nevosi con copertura forestale rada
+    - from: CRYOSTEPPE
+      to: BADLANDS
+      type: trophic_spillover
+      resistance: 0.5
+      seasonality: episodico
+      notes: pulse detrito post disgelo
   bridge_species_map:
-  - species_id: echo-wing
-    roles:
-    - dispersore_ponte
-    - impollinatore
-    present_in_nodes:
-    - BADLANDS
-    - CRYOSTEPPE
-    - DESERTO_CALDO
-    - FORESTA_TEMPERATA
-  - species_id: ferrocolonia-magnetotattica
-    roles:
-    - sentinella
-    - ingegnere_ecosistema
-    present_in_nodes:
-    - BADLANDS
+    - species_id: echo-wing
+      roles:
+        - dispersore_ponte
+        - impollinatore
+      present_in_nodes:
+        - canyons_risonanti
+        - mezzanotte_orbitale
+        - savana
+        - foresta_miceliale
+    - species_id: ferrocolonia-magnetotattica
+      roles:
+        - sentinella
+        - ingegnere_ecosistema
+      present_in_nodes:
+        - canyons_risonanti
   rules:
     at_least:
       sentient: 1

--- a/packs/evo_tactics_pack/data/ecosystems/badlands.biome.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/badlands.biome.yaml
@@ -15,44 +15,44 @@ ecosistema:
     periodo_riferimento: 1991–2020
     fonti: []
   bioma:
-    classe_bioma: badlands
+    classe_bioma: canyons_risonanti
     ecoregione: Cold Desert / Eroded Plateaus
     koppen_zone:
-    - BSk
-    - BWk
+      - BSk
+      - BWk
     npp_gC_m2_anno: 220
     note: Alte concentrazioni di ossidi ferrosi; magnetismo locale anomalo
   morfologia:
     rilievo:
       quota_min_max_m:
-      - 120
-      - 980
+        - 120
+        - 980
       pendenza_media_gradi: 18
       rugosita_indice: 0.61
     forme_terreno:
-    - calanchi
-    - butte
-    - mesas
-    - gole
+      - calanchi
+      - butte
+      - mesas
+      - gole
     geologia_substrato:
-    - arenarie ferruginose
-    - scisti
-    - marne
+      - arenarie ferruginose
+      - scisti
+      - marne
     suolo_superficiale:
       tessitura: sabbia-limo
       pH: 7.8
       sostanza_organica_%: 0.9
     idrografia:
       corsi_acqua:
-      - wadi effimeri
+        - wadi effimeri
       zone_umide:
-      - pozzanghere salmastre temporanee
+        - pozzanghere salmastre temporanee
       falda: profonda
     frammentazione_connettivita:
       indice_frattura: 0.72
       corridoi_ecologici:
-      - canali wadi
-      - gole ombreggiate
+        - canali wadi
+        - gole ombreggiate
   composizione_aria:
     gas_maggiori_percento:
       N2: 78.08
@@ -70,8 +70,8 @@ ecosistema:
       polveri_sahariane: stagionali
     variazioni_stagionali_nota: Picchi polveri durante i dry-blowouts
     forzanti_locali:
-    - tempeste di sabbia
-    - ossidi ferrosi volatili
+      - tempeste di sabbia
+      - ossidi ferrosi volatili
   clima:
     classificazione_koppen: BSk
     temperatura_C:
@@ -84,11 +84,11 @@ ecosistema:
       totale_annuo: 180
       indice_stagionalita: estivo-debole
       mesi_secchi:
-      - giugno
-      - luglio
-      - agosto
+        - giugno
+        - luglio
+        - agosto
       mesi_umidi:
-      - novembre
+        - novembre
     vento:
       regime: foehn locali e jet di canyon
       velocita_media_m_s: 4.5
@@ -97,14 +97,14 @@ ecosistema:
       indice_aridita_P_su_ET0: 0.15
     estremi_e_rischi:
       eventi:
-      - tempeste_sabbia
-      - collassi di scarpate
-      - tempesta_sabbia_magnetica
-      - iron_shards
-      - magnetic_patches
+        - tempeste_sabbia
+        - collassi di scarpate
+        - tempesta_sabbia_magnetica
+        - iron_shards
+        - magnetic_patches
     teleconnessioni:
-    - ENSO
-    - EA
+      - ENSO
+      - EA
   abiotico:
     luce:
       radiazione_media_MJ_m2_giorno: 22.1
@@ -116,33 +116,33 @@ ecosistema:
     salinita: salina interna
   trofico:
     produttori:
-    - arbusti_xerofili
-    - crostoni_criptofite
-    - cianobatteri
+      - arbusti_xerofili
+      - crostoni_criptofite
+      - cianobatteri
     consumatori:
       primari:
-      - erbivori
-      - detritivori
+        - erbivori
+        - detritivori
       secondari:
-      - carnivori
-      - onnivori
+        - carnivori
+        - onnivori
       terziari:
-      - predatori_apicali
+        - predatori_apicali
     decompositori:
-    - funghi_criptoendoliti
-    - batteri
+      - funghi_criptoendoliti
+      - batteri
     reti_note:
-    - top-down episodiche da superpredatori nomadi
-    - bottom-up limitati da P,N
-    - catena del detrito dominante
+      - top-down episodiche da superpredatori nomadi
+      - bottom-up limitati da P,N
+      - catena del detrito dominante
   gruppi_funzionali:
     predatori: []
     prede_erbivori: []
     impollinatori: []
     dispersori_semi: []
     simbionti_mutualistici:
-    - licheni
-    - micorrize
+      - licheni
+      - micorrize
     parassiti_parasitoidi: []
     detritivori: []
     filtratori: []
@@ -150,66 +150,71 @@ ecosistema:
     specie_chiave_di_volta: []
   suolo:
     orizzonti:
-    - A
-    - Bk
-    - C
+      - A
+      - Bk
+      - C
     processi:
-    - fissazione_N
-    - nitrificazione
-    - denitrificazione
-    - mineralizzazione
+      - fissazione_N
+      - nitrificazione
+      - denitrificazione
+      - mineralizzazione
     microbioma:
-    - AMF
-    - batteri_nitrificanti
+      - AMF
+      - batteri_nitrificanti
     fauna_edafica:
-    - isopodi
-    - acarina_xero
-    - tenebrionidi
+      - isopodi
+      - acarina_xero
+      - tenebrionidi
   acque:
     comparti:
-    - biofilm
-    - benthos_wadi
+      - biofilm
+      - benthos_wadi
     processi:
-    - eutrofizzazione episodica
-    - evaporazione rapida
+      - eutrofizzazione episodica
+      - evaporazione rapida
     qualita:
       DO_mgL: 7.5
       BOD_mgL: 3.2
       conducibilita_uScm: 2200
   servizi_ecosistemici:
     supporto:
-    - cicli_nutrienti poveri ma stabili
+      - cicli_nutrienti poveri ma stabili
     regolazione:
-    - dissipazione polveri (crostoni)
+      - dissipazione polveri (crostoni)
     approvvigionamento:
-    - minerali ferrosi
-    - biomassa detritica
+      - minerali ferrosi
+      - biomassa detritica
     culturali:
-    - navigazione canyon
-    - siti di studio geologico
+      - navigazione canyon
+      - siti di studio geologico
   pressioni_stato_risposte:
     pressioni:
-    - erosione accelerata
-    - specie invasive
-    - over-scrapping
+      - erosione accelerata
+      - specie invasive
+      - over-scrapping
     indicatori_stato:
-    - albedo_index
-    - copertura_crosta
+      - albedo_index
+      - copertura_crosta
     risposte_gestione:
-    - stabilizzazione scarpate
-    - corridoi in ombra
+      - stabilizzazione scarpate
+      - corridoi in ombra
 links:
-  biome_id: badlands
+  biome_id: canyons_risonanti
   species_dir: packs/evo_tactics_pack/data/species/badlands
   foodweb: packs/evo_tactics_pack/data/foodwebs/badlands_foodweb.yaml
 registries:
-  functional_groups: packs/evo_tactics_pack/tools/config/registries/functional_groups.yaml
-  trophic_roles: packs/evo_tactics_pack/tools/config/registries/trophic_roles.yaml
-  biome_classes: packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml
-  climate_profiles: packs/evo_tactics_pack/tools/config/registries/climate_profiles.yaml
+  functional_groups: 
+    packs/evo_tactics_pack/tools/config/registries/functional_groups.yaml
+  trophic_roles: 
+    packs/evo_tactics_pack/tools/config/registries/trophic_roles.yaml
+  biome_classes: 
+    packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml
+  climate_profiles: 
+    packs/evo_tactics_pack/tools/config/registries/climate_profiles.yaml
   morphotypes: packs/evo_tactics_pack/tools/config/registries/morphotypes.yaml
   hazards: packs/evo_tactics_pack/tools/config/registries/hazards.yaml
-  env_to_traits: packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml
+  env_to_traits: 
+    packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml
 rules:
   at_least:
     sentient: 1
@@ -226,16 +231,16 @@ manifest:
     threat: 1
     event: 1
   functional_groups_present:
-  - detritivoro
-  - dispersore_semi
-  - impollinatore
-  - patogeno
-  - prede
-  - pulse_climatico
-  - regolazione_parassiti
-  - regolazione_prede
-  - simbionte
-  - specie_chiave
+    - detritivoro
+    - dispersore_semi
+    - impollinatore
+    - patogeno
+    - prede
+    - pulse_climatico
+    - regolazione_parassiti
+    - regolazione_prede
+    - simbionte
+    - specie_chiave
   foodweb_links:
     path: packs/evo_tactics_pack/data/foodwebs/badlands_foodweb.yaml
     sink_detrito: true

--- a/packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
@@ -7,7 +7,7 @@ receipt:
 ecosistema:
   id: BADLANDS
   label: Brulle Terre Ferrose
-  biome_id: badlands
+  biome_id: canyons_risonanti
   clima:
     temperatura_C:
       media_annua: 14.5
@@ -30,21 +30,21 @@ ecosistema:
       K: alto
   trofico:
     produttori:
-    - arbusti_xerofili
-    - crostoni_criptofite
-    - cianobatteri
+      - arbusti_xerofili
+      - crostoni_criptofite
+      - cianobatteri
     consumatori:
       primari:
-      - sand-burrower
-      - rust-scavenger
+        - sand-burrower
+        - rust-scavenger
       secondari:
-      - ferrocolonia-magnetotattica
-      - echo-wing
+        - ferrocolonia-magnetotattica
+        - echo-wing
       terziari:
-      - dune-stalker
+        - dune-stalker
     decompositori:
-    - nano-rust-bloom
-    - evento-tempesta-ferrosa
+      - nano-rust-bloom
+      - evento-tempesta-ferrosa
   note: Ecosistema desertico magnetizzato con pulse detritici stagionali.
 links:
   species_dir: packs/evo_tactics_pack/data/species/badlands

--- a/packs/evo_tactics_pack/data/ecosystems/cryosteppe.biome.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/cryosteppe.biome.yaml
@@ -8,53 +8,53 @@ ecosistema:
   metadati:
     nome: cryosteppe (scaffold)
     localizzazione:
-      lat: null
-      lon: null
-      quota_m: null
-      area_km2: null
+      lat:
+      lon:
+      quota_m:
+      area_km2:
     periodo_riferimento: 1991–2020
     fonti: []
   bioma:
-    classe_bioma: cryosteppe
+    classe_bioma: mezzanotte_orbitale
     ecoregione: ''
     koppen_zone:
-    - BSk
-    - Dfc
-    npp_gC_m2_anno: null
+      - BSk
+      - Dfc
+    npp_gC_m2_anno:
     note: ''
   morfologia:
     rilievo:
       quota_min_max_m:
-      - null
-      - null
-      pendenza_media_gradi: null
-      rugosita_indice: null
+        - 
+        - 
+      pendenza_media_gradi:
+      rugosita_indice:
     forme_terreno: []
     geologia_substrato: []
     suolo_superficiale:
       tessitura: ''
-      pH: null
-      sostanza_organica_%: null
+      pH:
+      sostanza_organica_%:
     idrografia:
       corsi_acqua: []
       zone_umide: []
       falda: profonda
     frammentazione_connettivita:
-      indice_frattura: null
+      indice_frattura:
       corridoi_ecologici: []
   composizione_aria:
     gas_maggiori_percento:
       N2: 78.08
       O2: 20.95
       Ar: 0.93
-      CO2: null
+      CO2:
     tracce_ppm:
-      CH4: null
-      N2O: null
-      O3_troposferico: null
+      CH4:
+      N2O:
+      O3_troposferico:
     aerosol_inquinanti:
-      PM10: null
-      PM2_5: null
+      PM10:
+      PM2_5:
       sali_marini: basso
       polveri_sahariane: sporadiche
     variazioni_stagionali_nota: ''
@@ -62,28 +62,28 @@ ecosistema:
   clima:
     classificazione_koppen: BSk
     temperatura_C:
-      media_annua: null
-      min_mese_piu_freddo: null
-      max_mese_piu_caldo: null
-      giorni_gelo_annui: null
-      giorni_ondata_calore_annui: null
+      media_annua:
+      min_mese_piu_freddo:
+      max_mese_piu_caldo:
+      giorni_gelo_annui:
+      giorni_ondata_calore_annui:
     precipitazioni_mm:
-      totale_annuo: null
-      indice_stagionalita: null
+      totale_annuo:
+      indice_stagionalita:
       mesi_secchi: []
       mesi_umidi: []
     vento:
       regime: ''
-      velocita_media_m_s: null
+      velocita_media_m_s:
     bilancio_idrico:
-      et0_mm: null
-      indice_aridita_P_su_ET0: null
+      et0_mm:
+      indice_aridita_P_su_ET0:
     estremi_e_rischi:
       eventi: []
     teleconnessioni: []
   abiotico:
     luce:
-      radiazione_media_MJ_m2_giorno: null
+      radiazione_media_MJ_m2_giorno:
       fotoperiodo: ''
     nutrienti:
       N: ''
@@ -111,24 +111,24 @@ ecosistema:
     specie_chiave_di_volta: []
   suolo:
     orizzonti:
-    - O
-    - A
-    - B
-    - C
+      - O
+      - A
+      - B
+      - C
     processi:
-    - fissazione_N
-    - nitrificazione
-    - denitrificazione
-    - mineralizzazione
+      - fissazione_N
+      - nitrificazione
+      - denitrificazione
+      - mineralizzazione
     microbioma: []
     fauna_edafica: []
   acque:
     comparti: []
     processi: []
     qualita:
-      DO_mgL: null
-      BOD_mgL: null
-      conducibilita_uScm: null
+      DO_mgL:
+      BOD_mgL:
+      conducibilita_uScm:
   servizi_ecosistemici:
     supporto: []
     regolazione: []
@@ -139,17 +139,22 @@ ecosistema:
     indicatori_stato: []
     risposte_gestione: []
 links:
-  biome_id: cryosteppe
+  biome_id: mezzanotte_orbitale
   species_dir: packs/evo_tactics_pack/data/species/cryosteppe
   foodweb: packs/evo_tactics_pack/data/foodwebs/cryosteppe_foodweb.yaml
 registries:
-  functional_groups: packs/evo_tactics_pack/tools/config/registries/functional_groups.yaml
-  trophic_roles: packs/evo_tactics_pack/tools/config/registries/trophic_roles.yaml
-  biome_classes: packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml
-  climate_profiles: packs/evo_tactics_pack/tools/config/registries/climate_profiles.yaml
+  functional_groups: 
+    packs/evo_tactics_pack/tools/config/registries/functional_groups.yaml
+  trophic_roles: 
+    packs/evo_tactics_pack/tools/config/registries/trophic_roles.yaml
+  biome_classes: 
+    packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml
+  climate_profiles: 
+    packs/evo_tactics_pack/tools/config/registries/climate_profiles.yaml
   morphotypes: packs/evo_tactics_pack/tools/config/registries/morphotypes.yaml
   hazards: packs/evo_tactics_pack/tools/config/registries/hazards.yaml
-  env_to_traits: packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml
+  env_to_traits: 
+    packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml
 rules:
   at_least:
     sentient: 1
@@ -166,14 +171,14 @@ manifest:
     threat: 1
     event: 1
   functional_groups_present:
-  - dispersore_semi
-  - impollinatore
-  - ingegneri_ecosistema
-  - patogeno
-  - predatore
-  - prede
-  - pulse_climatico
-  - specie_chiave
+    - dispersore_semi
+    - impollinatore
+    - ingegneri_ecosistema
+    - patogeno
+    - predatore
+    - prede
+    - pulse_climatico
+    - specie_chiave
   foodweb_links:
     path: packs/evo_tactics_pack/data/foodwebs/cryosteppe_foodweb.yaml
     sink_detrito: true

--- a/packs/evo_tactics_pack/data/ecosystems/cryosteppe.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/cryosteppe.ecosystem.yaml
@@ -7,7 +7,7 @@ receipt:
 ecosistema:
   id: CRYOSTEPPE
   label: Cryosteppe Magnetica
-  biome_id: cryosteppe
+  biome_id: mezzanotte_orbitale
   clima:
     temperatura_C:
       media_annua: -5.5
@@ -30,19 +30,20 @@ ecosistema:
       K: alto
   trofico:
     produttori:
-    - licheni_termocromici
-    - muschi_permafrost
-    - alghe_cryofile
+      - licheni_termocromici
+      - muschi_permafrost
+      - alghe_cryofile
     consumatori:
       primari:
-      - steppe-bison-mini
-      - aurora-gull
+        - steppe-bison-mini
+        - aurora-gull
       secondari:
-      - cryo-lynx
+        - cryo-lynx
     decompositori:
-    - thaw-rot
-    - biofilm_criogenico
-  note: Steppe criogenica con gradienti termici magnetici e ponti stagionali di ghiaccio.
+      - thaw-rot
+      - biofilm_criogenico
+  note: Steppe criogenica con gradienti termici magnetici e ponti stagionali di 
+    ghiaccio.
 links:
   species_dir: packs/evo_tactics_pack/data/species/cryosteppe
   foodweb: packs/evo_tactics_pack/data/foodwebs/cryosteppe_foodweb.yaml

--- a/packs/evo_tactics_pack/data/ecosystems/deserto_caldo.biome.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/deserto_caldo.biome.yaml
@@ -8,53 +8,53 @@ ecosistema:
   metadati:
     nome: deserto_caldo (scaffold)
     localizzazione:
-      lat: null
-      lon: null
-      quota_m: null
-      area_km2: null
+      lat:
+      lon:
+      quota_m:
+      area_km2:
     periodo_riferimento: 1991–2020
     fonti: []
   bioma:
-    classe_bioma: deserto_caldo
+    classe_bioma: savana
     ecoregione: ''
     koppen_zone:
-    - BWh
-    - BSh
-    npp_gC_m2_anno: null
+      - BWh
+      - BSh
+    npp_gC_m2_anno:
     note: ''
   morfologia:
     rilievo:
       quota_min_max_m:
-      - null
-      - null
-      pendenza_media_gradi: null
-      rugosita_indice: null
+        - 
+        - 
+      pendenza_media_gradi:
+      rugosita_indice:
     forme_terreno: []
     geologia_substrato: []
     suolo_superficiale:
       tessitura: ''
-      pH: null
-      sostanza_organica_%: null
+      pH:
+      sostanza_organica_%:
     idrografia:
       corsi_acqua: []
       zone_umide: []
       falda: profonda
     frammentazione_connettivita:
-      indice_frattura: null
+      indice_frattura:
       corridoi_ecologici: []
   composizione_aria:
     gas_maggiori_percento:
       N2: 78.08
       O2: 20.95
       Ar: 0.93
-      CO2: null
+      CO2:
     tracce_ppm:
-      CH4: null
-      N2O: null
-      O3_troposferico: null
+      CH4:
+      N2O:
+      O3_troposferico:
     aerosol_inquinanti:
-      PM10: null
-      PM2_5: null
+      PM10:
+      PM2_5:
       sali_marini: basso
       polveri_sahariane: sporadiche
     variazioni_stagionali_nota: ''
@@ -62,28 +62,28 @@ ecosistema:
   clima:
     classificazione_koppen: BWh
     temperatura_C:
-      media_annua: null
-      min_mese_piu_freddo: null
-      max_mese_piu_caldo: null
-      giorni_gelo_annui: null
-      giorni_ondata_calore_annui: null
+      media_annua:
+      min_mese_piu_freddo:
+      max_mese_piu_caldo:
+      giorni_gelo_annui:
+      giorni_ondata_calore_annui:
     precipitazioni_mm:
-      totale_annuo: null
-      indice_stagionalita: null
+      totale_annuo:
+      indice_stagionalita:
       mesi_secchi: []
       mesi_umidi: []
     vento:
       regime: ''
-      velocita_media_m_s: null
+      velocita_media_m_s:
     bilancio_idrico:
-      et0_mm: null
-      indice_aridita_P_su_ET0: null
+      et0_mm:
+      indice_aridita_P_su_ET0:
     estremi_e_rischi:
       eventi: []
     teleconnessioni: []
   abiotico:
     luce:
-      radiazione_media_MJ_m2_giorno: null
+      radiazione_media_MJ_m2_giorno:
       fotoperiodo: ''
     nutrienti:
       N: ''
@@ -111,24 +111,24 @@ ecosistema:
     specie_chiave_di_volta: []
   suolo:
     orizzonti:
-    - O
-    - A
-    - B
-    - C
+      - O
+      - A
+      - B
+      - C
     processi:
-    - fissazione_N
-    - nitrificazione
-    - denitrificazione
-    - mineralizzazione
+      - fissazione_N
+      - nitrificazione
+      - denitrificazione
+      - mineralizzazione
     microbioma: []
     fauna_edafica: []
   acque:
     comparti: []
     processi: []
     qualita:
-      DO_mgL: null
-      BOD_mgL: null
-      conducibilita_uScm: null
+      DO_mgL:
+      BOD_mgL:
+      conducibilita_uScm:
   servizi_ecosistemici:
     supporto: []
     regolazione: []
@@ -139,17 +139,22 @@ ecosistema:
     indicatori_stato: []
     risposte_gestione: []
 links:
-  biome_id: deserto_caldo
+  biome_id: savana
   species_dir: packs/evo_tactics_pack/data/species/deserto_caldo
   foodweb: packs/evo_tactics_pack/data/foodwebs/deserto_caldo_foodweb.yaml
 registries:
-  functional_groups: packs/evo_tactics_pack/tools/config/registries/functional_groups.yaml
-  trophic_roles: packs/evo_tactics_pack/tools/config/registries/trophic_roles.yaml
-  biome_classes: packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml
-  climate_profiles: packs/evo_tactics_pack/tools/config/registries/climate_profiles.yaml
+  functional_groups: 
+    packs/evo_tactics_pack/tools/config/registries/functional_groups.yaml
+  trophic_roles: 
+    packs/evo_tactics_pack/tools/config/registries/trophic_roles.yaml
+  biome_classes: 
+    packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml
+  climate_profiles: 
+    packs/evo_tactics_pack/tools/config/registries/climate_profiles.yaml
   morphotypes: packs/evo_tactics_pack/tools/config/registries/morphotypes.yaml
   hazards: packs/evo_tactics_pack/tools/config/registries/hazards.yaml
-  env_to_traits: packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml
+  env_to_traits: 
+    packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml
 rules:
   at_least:
     sentient: 1
@@ -166,14 +171,14 @@ manifest:
     threat: 1
     event: 1
   functional_groups_present:
-  - detritivoro
-  - dispersore_semi
-  - impollinatore
-  - ingegneri_ecosistema
-  - patogeno
-  - predatore
-  - pulse_climatico
-  - specie_chiave
+    - detritivoro
+    - dispersore_semi
+    - impollinatore
+    - ingegneri_ecosistema
+    - patogeno
+    - predatore
+    - pulse_climatico
+    - specie_chiave
   foodweb_links:
     path: packs/evo_tactics_pack/data/foodwebs/deserto_caldo_foodweb.yaml
     sink_detrito: true

--- a/packs/evo_tactics_pack/data/ecosystems/deserto_caldo.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/deserto_caldo.ecosystem.yaml
@@ -7,7 +7,7 @@ receipt:
 ecosistema:
   id: DESERTO_CALDO
   label: Deserto Caldo Vetrificato
-  biome_id: deserto_caldo
+  biome_id: savana
   clima:
     temperatura_C:
       media_annua: 32.0
@@ -30,21 +30,22 @@ ecosistema:
       K: medio
   trofico:
     produttori:
-    - cactus-weaver
-    - cianobatteri_dune
-    - arbusti_pioneer
+      - cactus-weaver
+      - cianobatteri_dune
+      - arbusti_pioneer
     consumatori:
       primari:
-      - silica-bloom
-      - arbusti_pioneer_detritivori
+        - silica-bloom
+        - arbusti_pioneer_detritivori
       secondari:
-      - noctule-termico
+        - noctule-termico
       terziari:
-      - thermo-raptor
+        - thermo-raptor
     decompositori:
-    - evento-ondata-termica
-    - biofilm_termico
-  note: Deserto iper-arido con lenti magnetiche sotterranee e trasporto di polveri ionizzate.
+      - evento-ondata-termica
+      - biofilm_termico
+  note: Deserto iper-arido con lenti magnetiche sotterranee e trasporto di 
+    polveri ionizzate.
 links:
   species_dir: packs/evo_tactics_pack/data/species/deserto_caldo
   foodweb: packs/evo_tactics_pack/data/foodwebs/deserto_caldo_foodweb.yaml

--- a/packs/evo_tactics_pack/data/ecosystems/foresta_temperata.biome.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/foresta_temperata.biome.yaml
@@ -18,36 +18,36 @@ ecosistema:
     classe_bioma: Foresta temperata umida
     ecoregione: Temperate Broadleaf & Mixed Forests
     koppen_zone:
-    - Cfb
+      - Cfb
     npp_gC_m2_anno: 900
     note: ''
   morfologia:
     rilievo:
       quota_min_max_m:
-      - 200
-      - 1200
+        - 200
+        - 1200
       pendenza_media_gradi: 12
       rugosita_indice: 0.42
     forme_terreno:
-    - valli alluvionali
-    - versanti collinari
+      - valli alluvionali
+      - versanti collinari
     geologia_substrato:
-    - calcari
-    - marne
+      - calcari
+      - marne
     suolo_superficiale:
       tessitura: limo-argilla
       pH: 6.2
       sostanza_organica_%: 5.1
     idrografia:
       corsi_acqua:
-      - torrenti variabili
+        - torrenti variabili
       zone_umide:
-      - stagni temporanei
+        - stagni temporanei
       falda: superficiale
     frammentazione_connettivita:
       indice_frattura: 0.3
       corridoi_ecologici:
-      - corridoio fluviale X
+        - corridoio fluviale X
   composizione_aria:
     gas_maggiori_percento:
       N2: 78.08
@@ -77,9 +77,9 @@ ecosistema:
       totale_annuo: 950
       indice_stagionalita: invernale
       mesi_secchi:
-      - luglio
+        - luglio
       mesi_umidi:
-      - novembre
+        - novembre
     vento:
       regime: brezza di valle/monte
       velocita_media_m_s: 2.5
@@ -88,10 +88,10 @@ ecosistema:
       indice_aridita_P_su_ET0: 1.27
     estremi_e_rischi:
       eventi:
-      - alluvioni lampo
-      - incendi sporadici
+        - alluvioni lampo
+        - incendi sporadici
     teleconnessioni:
-    - NAO
+      - NAO
   abiotico:
     luce:
       radiazione_media_MJ_m2_giorno: 14.5
@@ -103,20 +103,20 @@ ecosistema:
     salinita: dolce
   trofico:
     produttori:
-    - piante_superiori
-    - alghe
-    - cianobatteri
+      - piante_superiori
+      - alghe
+      - cianobatteri
     consumatori:
       primari:
-      - erbivori
-      - detritivori
+        - erbivori
+        - detritivori
       secondari:
-      - carnivori
+        - carnivori
       terziari:
-      - predatori_apicali
+        - predatori_apicali
     decompositori:
-    - funghi
-    - batteri
+      - funghi
+      - batteri
     reti_note: []
   gruppi_funzionali:
     predatori: []
@@ -124,9 +124,9 @@ ecosistema:
     impollinatori: []
     dispersori_semi: []
     simbionti_mutualistici:
-    - micorrize
-    - rizobi
-    - licheni
+      - micorrize
+      - rizobi
+      - licheni
     parassiti_parasitoidi: []
     detritivori: []
     filtratori: []
@@ -134,35 +134,35 @@ ecosistema:
     specie_chiave_di_volta: []
   suolo:
     orizzonti:
-    - O
-    - A
-    - B
-    - C
+      - O
+      - A
+      - B
+      - C
     processi:
-    - fissazione_N
-    - nitrificazione
-    - denitrificazione
-    - mineralizzazione
+      - fissazione_N
+      - nitrificazione
+      - denitrificazione
+      - mineralizzazione
     microbioma:
-    - AMF
-    - batteri_nitrificanti
-    - denitrificanti
+      - AMF
+      - batteri_nitrificanti
+      - denitrificanti
     fauna_edafica:
-    - lombrichi
-    - acari
-    - collemboli
-    - nematodi
+      - lombrichi
+      - acari
+      - collemboli
+      - nematodi
   acque:
     comparti:
-    - fitoplancton
-    - zooplancton
-    - nekton
-    - benthos
-    - periphyton
+      - fitoplancton
+      - zooplancton
+      - nekton
+      - benthos
+      - periphyton
     processi:
-    - stratificazione
-    - rimescolamento
-    - eutrofizzazione
+      - stratificazione
+      - rimescolamento
+      - eutrofizzazione
     qualita:
       DO_mgL: 9.5
       BOD_mgL: 2.1
@@ -174,16 +174,16 @@ ecosistema:
     culturali: []
   pressioni_stato_risposte:
     pressioni:
-    - frammentazione
-    - specie invasive
+      - frammentazione
+      - specie invasive
     indicatori_stato:
-    - NDVI
-    - IBE
+      - NDVI
+      - IBE
     risposte_gestione:
-    - corridoi
-    - ripristino radure
+      - corridoi
+      - ripristino radure
 links:
-  biome_id: foresta_temperata
+  biome_id: foresta_miceliale
   species_dir: packs/evo_tactics_pack/data/species/foresta_temperata
   foodweb: packs/evo_tactics_pack/data/foodwebs/foresta_temperata_foodweb.yaml
   npg_dir: packs/evo_tactics_pack/data/npg
@@ -196,13 +196,18 @@ rules:
     threat: 1
     event: 1
 registries:
-  functional_groups: packs/evo_tactics_pack/tools/config/registries/functional_groups.yaml
-  trophic_roles: packs/evo_tactics_pack/tools/config/registries/trophic_roles.yaml
-  biome_classes: packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml
-  climate_profiles: packs/evo_tactics_pack/tools/config/registries/climate_profiles.yaml
+  functional_groups: 
+    packs/evo_tactics_pack/tools/config/registries/functional_groups.yaml
+  trophic_roles: 
+    packs/evo_tactics_pack/tools/config/registries/trophic_roles.yaml
+  biome_classes: 
+    packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml
+  climate_profiles: 
+    packs/evo_tactics_pack/tools/config/registries/climate_profiles.yaml
   morphotypes: packs/evo_tactics_pack/tools/config/registries/morphotypes.yaml
   hazards: packs/evo_tactics_pack/tools/config/registries/hazards.yaml
-  env_to_traits: packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml
+  env_to_traits: 
+    packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml
 manifest:
   species_counts:
     apex: 1
@@ -211,9 +216,9 @@ manifest:
     threat: 1
     event: 1
   functional_groups_present:
-  - patogeno
-  - pulse_climatico
-  - specie_chiave
+    - patogeno
+    - pulse_climatico
+    - specie_chiave
   foodweb_links:
     path: packs/evo_tactics_pack/data/foodwebs/foresta_temperata_foodweb.yaml
     sink_detrito: true

--- a/packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
@@ -7,7 +7,7 @@ receipt:
 ecosistema:
   id: FORESTA_TEMPERATA
   label: Foresta Temperata Demo
-  biome_id: foresta_temperata
+  biome_id: foresta_miceliale
   clima:
     temperatura_C:
       media_annua: 11.2
@@ -30,21 +30,22 @@ ecosistema:
       K: medio
   trofico:
     produttori:
-    - piante_superiori
-    - alghe
-    - cianobatteri
+      - piante_superiori
+      - alghe
+      - cianobatteri
     consumatori:
       primari:
-      - cervidi_erborivori
-      - impollinatori_misti
+        - cervidi_erborivori
+        - impollinatori_misti
       secondari:
-      - lupus-temperatus
+        - lupus-temperatus
       terziari:
-      - sentinella-radice
+        - sentinella-radice
     decompositori:
-    - funghi_micotici
-    - biofilm_detritico
-  note: Ecosistema temperato montano con corridoi fluviali e cicli detritici marcati.
+      - funghi_micotici
+      - biofilm_detritico
+  note: Ecosistema temperato montano con corridoi fluviali e cicli detritici 
+    marcati.
 links:
   species_dir: packs/evo_tactics_pack/data/species/foresta_temperata
   foodweb: packs/evo_tactics_pack/data/foodwebs/foresta_temperata_foodweb.yaml

--- a/packs/evo_tactics_pack/data/ecosystems/network/cross_events.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/network/cross_events.yaml
@@ -1,30 +1,31 @@
 schema_version: 1.0
 events:
-- species_id: evento-tempesta-ferrosa
-  from_nodes:
-  - BADLANDS
-  propagate_via:
-  - corridor
-  - seasonal_bridge
-  to_nodes:
-  - FORESTA_TEMPERATA
-  - DESERTO_CALDO
-  effect: polveri ferrose e carica magnetica, penalità visibilità/gear metallico
-- species_id: evento-ondata-termica
-  from_nodes:
-  - DESERTO_CALDO
-  propagate_via:
-  - corridor
-  to_nodes:
-  - BADLANDS
-  effect: ondata di calore e ionizzazione, stress termico esteso
-- species_id: evento-brinastorm
-  from_nodes:
-  - CRYOSTEPPE
-  propagate_via:
-  - seasonal_bridge
-  - corridor
-  to_nodes:
-  - FORESTA_TEMPERATA
-  - BADLANDS
-  effect: ghiaccio fine in sospensione, visibilità ridotta e attrito aumentato
+  - species_id: evento-tempesta-ferrosa
+    from_nodes:
+      - canyons_risonanti
+    propagate_via:
+      - corridor
+      - seasonal_bridge
+    to_nodes:
+      - foresta_miceliale
+      - savana
+    effect: polveri ferrose e carica magnetica, penalità visibilità/gear 
+      metallico
+  - species_id: evento-ondata-termica
+    from_nodes:
+      - savana
+    propagate_via:
+      - corridor
+    to_nodes:
+      - canyons_risonanti
+    effect: ondata di calore e ionizzazione, stress termico esteso
+  - species_id: evento-brinastorm
+    from_nodes:
+      - mezzanotte_orbitale
+    propagate_via:
+      - seasonal_bridge
+      - corridor
+    to_nodes:
+      - foresta_miceliale
+      - canyons_risonanti
+    effect: ghiaccio fine in sospensione, visibilità ridotta e attrito aumentato

--- a/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
@@ -6,77 +6,78 @@ receipt:
   trace_hash: to-fill
 links:
   ecosystems:
-  - packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
-  - packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
-  - packs/evo_tactics_pack/data/ecosystems/deserto_caldo.ecosystem.yaml
-  - packs/evo_tactics_pack/data/ecosystems/cryosteppe.ecosystem.yaml
+    - packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
+    - packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
+    - packs/evo_tactics_pack/data/ecosystems/deserto_caldo.ecosystem.yaml
+    - packs/evo_tactics_pack/data/ecosystems/cryosteppe.ecosystem.yaml
 network:
   id: ET_NET_ALPHA
   label: Evo-Tactics Meta‑Ecosystem Alpha
   nodes:
-  - id: BADLANDS
-    biome_id: badlands
-    path: packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
-    weight: 0.45
-  - id: FORESTA_TEMPERATA
-    biome_id: foresta_temperata
-    path: packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
-    weight: 0.55
-  - id: DESERTO_CALDO
-    biome_id: deserto_caldo
-    path: packs/evo_tactics_pack/data/ecosystems/deserto_caldo.ecosystem.yaml
-    weight: 0.4
-  - id: CRYOSTEPPE
-    biome_id: cryosteppe
-    path: packs/evo_tactics_pack/data/ecosystems/cryosteppe.ecosystem.yaml
-    weight: 0.4
+    - id: BADLANDS
+      biome_id: canyons_risonanti
+      path: packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
+      weight: 0.45
+    - id: FORESTA_TEMPERATA
+      biome_id: foresta_miceliale
+      path: 
+        packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
+      weight: 0.55
+    - id: DESERTO_CALDO
+      biome_id: savana
+      path: packs/evo_tactics_pack/data/ecosystems/deserto_caldo.ecosystem.yaml
+      weight: 0.4
+    - id: CRYOSTEPPE
+      biome_id: mezzanotte_orbitale
+      path: packs/evo_tactics_pack/data/ecosystems/cryosteppe.ecosystem.yaml
+      weight: 0.4
   edges:
-  - from: BADLANDS
-    to: FORESTA_TEMPERATA
-    type: corridor
-    resistance: 0.6
-    seasonality: primavera/autunno
-    notes: gole ombreggiate e canyon → valichi boscosi
-  - from: FORESTA_TEMPERATA
-    to: BADLANDS
-    type: trophic_spillover
-    resistance: 0.4
-    seasonality: episodico
-    notes: boom detrito → pulse detritivoro in badlands
-  - from: BADLANDS
-    to: DESERTO_CALDO
-    type: corridor
-    resistance: 0.5
-    seasonality: estate
-    notes: canali wadi → dune mobili
-  - from: FORESTA_TEMPERATA
-    to: CRYOSTEPPE
-    type: seasonal_bridge
-    resistance: 0.6
-    seasonality: inverno
-    notes: valichi nevosi con copertura forestale rada
-  - from: CRYOSTEPPE
-    to: BADLANDS
-    type: trophic_spillover
-    resistance: 0.5
-    seasonality: episodico
-    notes: pulse detrito post disgelo
+    - from: BADLANDS
+      to: FORESTA_TEMPERATA
+      type: corridor
+      resistance: 0.6
+      seasonality: primavera/autunno
+      notes: gole ombreggiate e canyon → valichi boscosi
+    - from: FORESTA_TEMPERATA
+      to: BADLANDS
+      type: trophic_spillover
+      resistance: 0.4
+      seasonality: episodico
+      notes: boom detrito → pulse detritivoro in badlands
+    - from: BADLANDS
+      to: DESERTO_CALDO
+      type: corridor
+      resistance: 0.5
+      seasonality: estate
+      notes: canali wadi → dune mobili
+    - from: FORESTA_TEMPERATA
+      to: CRYOSTEPPE
+      type: seasonal_bridge
+      resistance: 0.6
+      seasonality: inverno
+      notes: valichi nevosi con copertura forestale rada
+    - from: CRYOSTEPPE
+      to: BADLANDS
+      type: trophic_spillover
+      resistance: 0.5
+      seasonality: episodico
+      notes: pulse detrito post disgelo
   bridge_species_map:
-  - species_id: echo-wing
-    roles:
-    - dispersore_ponte
-    - impollinatore
-    present_in_nodes:
-    - BADLANDS
-    - CRYOSTEPPE
-    - DESERTO_CALDO
-    - FORESTA_TEMPERATA
-  - species_id: ferrocolonia-magnetotattica
-    roles:
-    - sentinella
-    - ingegnere_ecosistema
-    present_in_nodes:
-    - BADLANDS
+    - species_id: echo-wing
+      roles:
+        - dispersore_ponte
+        - impollinatore
+      present_in_nodes:
+        - canyons_risonanti
+        - mezzanotte_orbitale
+        - savana
+        - foresta_miceliale
+    - species_id: ferrocolonia-magnetotattica
+      roles:
+        - sentinella
+        - ingegnere_ecosistema
+      present_in_nodes:
+        - canyons_risonanti
   rules:
     at_least:
       sentient: 1

--- a/packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml
@@ -7,11 +7,11 @@ receipt:
 id: dune-stalker
 display_name: Dune Stalker
 biomes:
-- badlands
+  - canyons_risonanti
 role_trofico: predatore_terziario_apex
 functional_tags:
-- specie_chiave
-- regolazione_prede
+  - specie_chiave
+  - regolazione_prede
 morphotype: cursoriale_quadrupede
 flags:
   apex: true
@@ -30,43 +30,43 @@ vc:
   tilt: 0.4
 spawn_rules:
   orario:
-  - notte
-  - crepuscolo
+    - notte
+    - crepuscolo
   meteo:
-  - tempesta_sabbia_magnetica
+    - tempesta_sabbia_magnetica
   densita: low
 balance:
   rarity: R3
   threat_tier: T3
   encounter_role: elite
 environment_affinity:
-  biome_class: badlands
+  biome_class: canyons_risonanti
   koppen:
-  - BSk
-  - BWk
+    - BSk
+    - BWk
   hazards_expected:
-  - tempeste_sabbia
-  - collassi di scarpate
-  - tempesta_sabbia_magnetica
-  - iron_shards
-  - magnetic_patches
+    - tempeste_sabbia
+    - collassi di scarpate
+    - tempesta_sabbia_magnetica
+    - iron_shards
+    - magnetic_patches
 derived_from_environment:
   suggested_traits:
-  - cute_resistente_sali
-  - enzimi_chelanti
-  - pelli_anti_ustione
-  - pigmenti_termici
+    - cute_resistente_sali
+    - enzimi_chelanti
+    - pelli_anti_ustione
+    - pigmenti_termici
   required_capabilities:
-  - build_cover
-  - dr_impact_cap
-  - non_metal_gear
-  - seal_vents
+    - build_cover
+    - dr_impact_cap
+    - non_metal_gear
+    - seal_vents
   jobs_bias:
-  - Vanguard
-  - Warden
+    - Vanguard
+    - Warden
 telemetry:
-  expected_pick_rate: null
-  spawn_weight: null
+  expected_pick_rate:
+  spawn_weight:
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml
@@ -7,14 +7,14 @@ receipt:
 id: echo-wing
 display_name: Echo Wing
 biomes:
-- badlands
-- FORESTA_TEMPERATA
-- DESERTO_CALDO
-- CRYOSTEPPE
+  - canyons_risonanti
+  - foresta_miceliale
+  - savana
+  - mezzanotte_orbitale
 role_trofico: dispersore_ponte
 functional_tags:
-- impollinatore
-- dispersore_semi
+  - impollinatore
+  - dispersore_semi
 morphotype: volatore_planatore
 flags:
   apex: false
@@ -28,9 +28,9 @@ pi_loadout:
   weight_budget: 12
   default_parts:
     locomotion:
-    - glide_wings
+      - glide_wings
     senses:
-    - echolocate
+      - echolocate
 vc:
   aggro: 0.2
   risk: 0.2
@@ -40,9 +40,9 @@ vc:
   tilt: 0.2
 spawn_rules:
   orario:
-  - diurno
+    - diurno
   meteo:
-  - sereno_freddo
+    - sereno_freddo
   densita: mid
 balance:
   rarity: R2
@@ -52,42 +52,42 @@ telemetry:
   expected_pick_rate: 0.18
   spawn_weight: 0.25
 jobs_synergy:
-- Skirmisher
-- Invoker
+  - Skirmisher
+  - Invoker
 environment_affinity:
-  biome_class: badlands
+  biome_class: canyons_risonanti
   koppen:
-  - BSk
-  - BWk
+    - BSk
+    - BWk
   hazards_expected:
-  - tempeste_sabbia
-  - collassi di scarpate
-  - tempesta_sabbia_magnetica
-  - iron_shards
-  - magnetic_patches
+    - tempeste_sabbia
+    - collassi di scarpate
+    - tempesta_sabbia_magnetica
+    - iron_shards
+    - magnetic_patches
   multibiome:
-  - BADLANDS
-  - CRYOSTEPPE
-  - DESERTO_CALDO
-  - FORESTA_TEMPERATA
+    - canyons_risonanti
+    - mezzanotte_orbitale
+    - savana
+    - foresta_miceliale
 derived_from_environment:
   suggested_traits:
-  - cute_resistente_sali
-  - enzimi_chelanti
-  - pelli_anti_ustione
-  - pigmenti_termici
+    - cute_resistente_sali
+    - enzimi_chelanti
+    - pelli_anti_ustione
+    - pigmenti_termici
   required_capabilities:
-  - build_cover
-  - dr_impact_cap
-  - non_metal_gear
-  - seal_vents
+    - build_cover
+    - dr_impact_cap
+    - non_metal_gear
+    - seal_vents
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+    - Skirmisher
+    - Vanguard
+    - Warden
 network_bridge_roles:
-- dispersore_ponte
-- impollinatore
+  - dispersore_ponte
+  - impollinatore
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml
@@ -7,10 +7,10 @@ receipt:
 id: evento-tempesta-ferrosa
 display_name: 'Evento: Tempesta Ferrosa'
 biomes:
-- badlands
+  - canyons_risonanti
 role_trofico: evento_ecologico
 functional_tags:
-- pulse_climatico
+  - pulse_climatico
 morphotype: volatore_planatore
 flags:
   apex: false
@@ -29,48 +29,48 @@ vc:
   tilt: 0.95
 ecology:
   trigger:
-  - gradienti magnetici + fronti vento
+    - gradienti magnetici + fronti vento
   contromisure:
-  - rifugi
-  - route in ombra
+    - rifugi
+    - route in ombra
 spawn_rules:
   orario:
-  - crepuscolo
+    - crepuscolo
   meteo:
-  - tempesta_sabbia_magnetica
+    - tempesta_sabbia_magnetica
   densita: low
 balance:
   rarity: R5
   threat_tier: T4
   encounter_role: boss
 environment_affinity:
-  biome_class: badlands
+  biome_class: canyons_risonanti
   koppen:
-  - BSk
-  - BWk
+    - BSk
+    - BWk
   hazards_expected:
-  - tempeste_sabbia
-  - collassi di scarpate
-  - tempesta_sabbia_magnetica
-  - iron_shards
-  - magnetic_patches
+    - tempeste_sabbia
+    - collassi di scarpate
+    - tempesta_sabbia_magnetica
+    - iron_shards
+    - magnetic_patches
 derived_from_environment:
   suggested_traits:
-  - cute_resistente_sali
-  - enzimi_chelanti
-  - pelli_anti_ustione
-  - pigmenti_termici
+    - cute_resistente_sali
+    - enzimi_chelanti
+    - pelli_anti_ustione
+    - pigmenti_termici
   required_capabilities:
-  - build_cover
-  - dr_impact_cap
-  - non_metal_gear
-  - seal_vents
+    - build_cover
+    - dr_impact_cap
+    - non_metal_gear
+    - seal_vents
   jobs_bias:
-  - Vanguard
-  - Warden
+    - Vanguard
+    - Warden
 telemetry:
-  expected_pick_rate: null
-  spawn_weight: null
+  expected_pick_rate:
+  spawn_weight:
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml
@@ -7,11 +7,11 @@ receipt:
 id: ferrocolonia-magnetotattica
 display_name: Ferrocolonia Magnetotattica
 biomes:
-- badlands
+  - canyons_risonanti
 role_trofico: predatore_regolatore_simbionte
 functional_tags:
-- simbionte
-- regolazione_parassiti
+  - simbionte
+  - regolazione_parassiti
 morphotype: ingegnere_radicante
 flags:
   apex: false
@@ -26,9 +26,9 @@ pi_loadout:
   weight_budget: 13
   default_parts:
     defense:
-    - elastomer_skin
+      - elastomer_skin
     senses:
-    - echolocate
+      - echolocate
     metabolism: burst_anaerobic
 vc:
   aggro: 0.4
@@ -38,13 +38,13 @@ vc:
   explore: 0.5
   tilt: 0.2
 services_links:
-- regolazione:parassiti
-- supporto:reticoli_biometallici
+  - regolazione:parassiti
+  - supporto:reticoli_biometallici
 spawn_rules:
   orario:
-  - diurno
+    - diurno
   meteo:
-  - tempesta_sabbia_magnetica
+    - tempesta_sabbia_magnetica
   densita: low
 balance:
   rarity: R3
@@ -54,11 +54,11 @@ telemetry:
   expected_pick_rate: 0.1
   spawn_weight: 0.12
 jobs_synergy:
-- Warden
-- Artificer
+  - Warden
+  - Artificer
 mate_synergy:
-- sinergizzatore_team
-- architetto
+  - sinergizzatore_team
+  - architetto
 social:
   affinity_base: 0.5
   trust_base: 2.5
@@ -69,36 +69,36 @@ mating:
     recruit_min_trust: 2
     mating_min_trust: 3
 environment_affinity:
-  biome_class: badlands
+  biome_class: canyons_risonanti
   koppen:
-  - BSk
-  - BWk
+    - BSk
+    - BWk
   hazards_expected:
-  - tempeste_sabbia
-  - collassi di scarpate
-  - tempesta_sabbia_magnetica
-  - iron_shards
-  - magnetic_patches
+    - tempeste_sabbia
+    - collassi di scarpate
+    - tempesta_sabbia_magnetica
+    - iron_shards
+    - magnetic_patches
   multibiome:
-  - BADLANDS
+    - canyons_risonanti
 derived_from_environment:
   suggested_traits:
-  - cute_resistente_sali
-  - enzimi_chelanti
-  - pelli_anti_ustione
-  - pigmenti_termici
+    - cute_resistente_sali
+    - enzimi_chelanti
+    - pelli_anti_ustione
+    - pigmenti_termici
   required_capabilities:
-  - build_cover
-  - dr_impact_cap
-  - non_metal_gear
-  - seal_vents
+    - build_cover
+    - dr_impact_cap
+    - non_metal_gear
+    - seal_vents
   services_links:
-  - regolazione:ritenzione_idrica
-  - supporto:stabilizzazione_suolo
+    - regolazione:ritenzione_idrica
+    - supporto:stabilizzazione_suolo
   jobs_bias:
-  - Vanguard
-  - Warden
+    - Vanguard
+    - Warden
 network_bridge_roles:
-- ingegnere_ecosistema
-- sentinella
+  - ingegnere_ecosistema
+  - sentinella
 genetic_traits: []

--- a/packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml
@@ -7,10 +7,10 @@ receipt:
 id: nano-rust-bloom
 display_name: Nano Rust Bloom
 biomes:
-- badlands
+  - canyons_risonanti
 role_trofico: minaccia_microbica
 functional_tags:
-- patogeno
+  - patogeno
 morphotype: scavenger_corazzato
 flags:
   apex: false
@@ -29,48 +29,48 @@ vc:
   tilt: 0.8
 ecology:
   trigger:
-  - umidità episodica + sali
+    - umidità episodica + sali
   contromisure:
-  - chelanti
-  - taglio flussi magnetici
+    - chelanti
+    - taglio flussi magnetici
 spawn_rules:
   orario:
-  - continuo
+    - continuo
   meteo:
-  - foschia_ferrosa
+    - foschia_ferrosa
   densita: mid
 balance:
   rarity: R3
   threat_tier: T3
   encounter_role: boss
 environment_affinity:
-  biome_class: badlands
+  biome_class: canyons_risonanti
   koppen:
-  - BSk
-  - BWk
+    - BSk
+    - BWk
   hazards_expected:
-  - tempeste_sabbia
-  - collassi di scarpate
-  - tempesta_sabbia_magnetica
-  - iron_shards
-  - magnetic_patches
+    - tempeste_sabbia
+    - collassi di scarpate
+    - tempesta_sabbia_magnetica
+    - iron_shards
+    - magnetic_patches
 derived_from_environment:
   suggested_traits:
-  - cute_resistente_sali
-  - enzimi_chelanti
-  - pelli_anti_ustione
-  - pigmenti_termici
+    - cute_resistente_sali
+    - enzimi_chelanti
+    - pelli_anti_ustione
+    - pigmenti_termici
   required_capabilities:
-  - build_cover
-  - dr_impact_cap
-  - non_metal_gear
-  - seal_vents
+    - build_cover
+    - dr_impact_cap
+    - non_metal_gear
+    - seal_vents
   jobs_bias:
-  - Vanguard
-  - Warden
+    - Vanguard
+    - Warden
 telemetry:
-  expected_pick_rate: null
-  spawn_weight: null
+  expected_pick_rate:
+  spawn_weight:
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml
@@ -7,11 +7,11 @@ receipt:
 id: rust-scavenger
 display_name: Rust Scavenger
 biomes:
-- badlands
+  - canyons_risonanti
 role_trofico: ingegneri_ecosistema
 functional_tags:
-- specie_chiave
-- detritivoro
+  - specie_chiave
+  - detritivoro
 morphotype: scavenger_corazzato
 flags:
   apex: false
@@ -25,9 +25,9 @@ pi_loadout:
   weight_budget: 12
   default_parts:
     defense:
-    - elastomer_skin
+      - elastomer_skin
     senses:
-    - echolocate
+      - echolocate
 vc:
   aggro: 0.3
   risk: 0.3
@@ -36,13 +36,13 @@ vc:
   explore: 0.4
   tilt: 0.2
 services_links:
-- supporto:stabilizzazione_suolo
-- regolazione:riciclo_metalli
+  - supporto:stabilizzazione_suolo
+  - regolazione:riciclo_metalli
 spawn_rules:
   orario:
-  - diurno
+    - diurno
   meteo:
-  - foschia_ferrosa
+    - foschia_ferrosa
   densita: mid
 balance:
   rarity: R2
@@ -52,32 +52,32 @@ telemetry:
   expected_pick_rate: 0.15
   spawn_weight: 0.22
 jobs_synergy:
-- Warden
-- Artificer
+  - Warden
+  - Artificer
 environment_affinity:
-  biome_class: badlands
+  biome_class: canyons_risonanti
   koppen:
-  - BSk
-  - BWk
+    - BSk
+    - BWk
   hazards_expected:
-  - tempeste_sabbia
-  - collassi di scarpate
-  - tempesta_sabbia_magnetica
-  - iron_shards
-  - magnetic_patches
+    - tempeste_sabbia
+    - collassi di scarpate
+    - tempesta_sabbia_magnetica
+    - iron_shards
+    - magnetic_patches
 derived_from_environment:
   suggested_traits:
-  - cute_resistente_sali
-  - enzimi_chelanti
-  - pelli_anti_ustione
-  - pigmenti_termici
+    - cute_resistente_sali
+    - enzimi_chelanti
+    - pelli_anti_ustione
+    - pigmenti_termici
   required_capabilities:
-  - build_cover
-  - dr_impact_cap
-  - non_metal_gear
-  - seal_vents
+    - build_cover
+    - dr_impact_cap
+    - non_metal_gear
+    - seal_vents
   jobs_bias:
-  - Vanguard
-  - Warden
+    - Vanguard
+    - Warden
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml
@@ -7,11 +7,11 @@ receipt:
 id: sand-burrower
 display_name: Sand Burrower
 biomes:
-- badlands
+  - canyons_risonanti
 role_trofico: erbivoro_primario
 functional_tags:
-- prede
-- detritivoro
+  - prede
+  - detritivoro
 morphotype: cursoriale_quadrupede
 flags:
   apex: false
@@ -30,42 +30,42 @@ vc:
   tilt: 0.3
 spawn_rules:
   orario:
-  - notte
+    - notte
   meteo:
-  - sereno_freddo
+    - sereno_freddo
   densita: high
 balance:
   rarity: R1
   threat_tier: T1
   encounter_role: minion
 environment_affinity:
-  biome_class: badlands
+  biome_class: canyons_risonanti
   koppen:
-  - BSk
-  - BWk
+    - BSk
+    - BWk
   hazards_expected:
-  - tempeste_sabbia
-  - collassi di scarpate
-  - tempesta_sabbia_magnetica
-  - iron_shards
-  - magnetic_patches
+    - tempeste_sabbia
+    - collassi di scarpate
+    - tempesta_sabbia_magnetica
+    - iron_shards
+    - magnetic_patches
 derived_from_environment:
   suggested_traits:
-  - cute_resistente_sali
-  - enzimi_chelanti
-  - pelli_anti_ustione
-  - pigmenti_termici
+    - cute_resistente_sali
+    - enzimi_chelanti
+    - pelli_anti_ustione
+    - pigmenti_termici
   required_capabilities:
-  - build_cover
-  - dr_impact_cap
-  - non_metal_gear
-  - seal_vents
+    - build_cover
+    - dr_impact_cap
+    - non_metal_gear
+    - seal_vents
   jobs_bias:
-  - Vanguard
-  - Warden
+    - Vanguard
+    - Warden
 telemetry:
-  expected_pick_rate: null
-  spawn_weight: null
+  expected_pick_rate:
+  spawn_weight:
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml
@@ -1,11 +1,11 @@
 id: aurora-gull
 display_name: Gabbiano d’Aurora
 biomes:
-- cryosteppe
+  - mezzanotte_orbitale
 role_trofico: dispersore_ponte
 functional_tags:
-- impollinatore
-- dispersore_semi
+  - impollinatore
+  - dispersore_semi
 morphotype: volatore_planatore
 flags:
   apex: false
@@ -19,9 +19,9 @@ pi_loadout:
   weight_budget: 12
   default_parts:
     locomotion:
-    - glide_wings
+      - glide_wings
     senses:
-    - echolocate
+      - echolocate
 vc:
   aggro: 0.2
   risk: 0.2
@@ -31,9 +31,9 @@ vc:
   tilt: 0.2
 spawn_rules:
   orario:
-  - diurno
+    - diurno
   meteo:
-  - sereno_freddo
+    - sereno_freddo
   densita: mid
 balance:
   rarity: R2
@@ -43,8 +43,8 @@ telemetry:
   expected_pick_rate: 0.16
   spawn_weight: 0.24
 jobs_synergy:
-- Skirmisher
-- Invoker
+  - Skirmisher
+  - Invoker
 schema_version: 1.7
 receipt:
   source: PTPF.v1.0
@@ -52,24 +52,24 @@ receipt:
   date: '2025-10-25'
   trace_hash: to-fill
 environment_affinity:
-  biome_class: cryosteppe
+  biome_class: mezzanotte_orbitale
   koppen:
-  - BSk
-  - Dfc
+    - BSk
+    - Dfc
 derived_from_environment:
   suggested_traits:
-  - cuticole_cerose
-  - grassi_termici
-  - pelli_cave
-  - pigmenti_aurorali
-  - proteine_shock_termico
-  - reti_capillari_radici
+    - cuticole_cerose
+    - grassi_termici
+    - pelli_cave
+    - pigmenti_aurorali
+    - proteine_shock_termico
+    - reti_capillari_radici
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+    - Skirmisher
+    - Vanguard
+    - Warden
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml
@@ -1,11 +1,11 @@
 id: cryo-lynx
 display_name: Cryo Lynx
 biomes:
-- cryosteppe
+  - mezzanotte_orbitale
 role_trofico: predatore_terziario_apex
 functional_tags:
-- predatore
-- specie_chiave
+  - predatore
+  - specie_chiave
 morphotype: cursoriale_quadrupede
 flags:
   apex: true
@@ -24,11 +24,11 @@ vc:
   tilt: 0.4
 spawn_rules:
   orario:
-  - notte
-  - crepuscolo
+    - notte
+    - crepuscolo
   meteo:
-  - whiteout
-  - whiteout_ionico
+    - whiteout
+    - whiteout_ionico
   densita: low
 balance:
   rarity: R3
@@ -41,27 +41,27 @@ receipt:
   date: '2025-10-25'
   trace_hash: to-fill
 environment_affinity:
-  biome_class: cryosteppe
+  biome_class: mezzanotte_orbitale
   koppen:
-  - BSk
-  - Dfc
+    - BSk
+    - Dfc
 derived_from_environment:
   suggested_traits:
-  - cuticole_cerose
-  - grassi_termici
-  - pelli_cave
-  - pigmenti_aurorali
-  - proteine_shock_termico
-  - reti_capillari_radici
+    - cuticole_cerose
+    - grassi_termici
+    - pelli_cave
+    - pigmenti_aurorali
+    - proteine_shock_termico
+    - reti_capillari_radici
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+    - Skirmisher
+    - Vanguard
+    - Warden
 telemetry:
-  expected_pick_rate: null
-  spawn_weight: null
+  expected_pick_rate:
+  spawn_weight:
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml
@@ -1,10 +1,10 @@
 id: evento-brinastorm
 display_name: 'Evento: Brina Tempestosa'
 biomes:
-- cryosteppe
+  - mezzanotte_orbitale
 role_trofico: evento_ecologico
 functional_tags:
-- pulse_climatico
+  - pulse_climatico
 morphotype: volatore_planatore
 flags:
   apex: false
@@ -23,16 +23,16 @@ vc:
   tilt: 0.95
 ecology:
   trigger:
-  - aria sovraraffreddata + nuclei ghiaccio
+    - aria sovraraffreddata + nuclei ghiaccio
   contromisure:
-  - rifugi neve compattata
-  - mantelli termici
+    - rifugi neve compattata
+    - mantelli termici
 spawn_rules:
   orario:
-  - notte
+    - notte
   meteo:
-  - whiteout
-  - whiteout_ionico
+    - whiteout
+    - whiteout_ionico
   densita: low
 balance:
   rarity: R5
@@ -45,27 +45,27 @@ receipt:
   date: '2025-10-25'
   trace_hash: to-fill
 environment_affinity:
-  biome_class: cryosteppe
+  biome_class: mezzanotte_orbitale
   koppen:
-  - BSk
-  - Dfc
+    - BSk
+    - Dfc
 derived_from_environment:
   suggested_traits:
-  - cuticole_cerose
-  - grassi_termici
-  - pelli_cave
-  - pigmenti_aurorali
-  - proteine_shock_termico
-  - reti_capillari_radici
+    - cuticole_cerose
+    - grassi_termici
+    - pelli_cave
+    - pigmenti_aurorali
+    - proteine_shock_termico
+    - reti_capillari_radici
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+    - Skirmisher
+    - Vanguard
+    - Warden
 telemetry:
-  expected_pick_rate: null
-  spawn_weight: null
+  expected_pick_rate:
+  spawn_weight:
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml
@@ -1,12 +1,12 @@
 id: steppe-bison-mini
 display_name: Bisonte Nano della Steppa
 biomes:
-- cryosteppe
+  - mezzanotte_orbitale
 role_trofico: ingegneri_ecosistema
 functional_tags:
-- ingegneri_ecosistema
-- specie_chiave
-- prede
+  - ingegneri_ecosistema
+  - specie_chiave
+  - prede
 morphotype: cursoriale_quadrupede
 flags:
   apex: false
@@ -20,7 +20,7 @@ pi_loadout:
   weight_budget: 12
   default_parts:
     defense:
-    - elastomer_skin
+      - elastomer_skin
     metabolism: burst_anaerobic
 vc:
   aggro: 0.3
@@ -30,14 +30,14 @@ vc:
   explore: 0.4
   tilt: 0.2
 services_links:
-- supporto:aree_brina_compatta
-- regolazione:riciclo_nutrienti_neve
+  - supporto:aree_brina_compatta
+  - regolazione:riciclo_nutrienti_neve
 spawn_rules:
   orario:
-  - diurno
+    - diurno
   meteo:
-  - sereno_freddo
-  - whiteout
+    - sereno_freddo
+    - whiteout
   densita: mid
 balance:
   rarity: R2
@@ -47,8 +47,8 @@ telemetry:
   expected_pick_rate: 0.15
   spawn_weight: 0.22
 jobs_synergy:
-- Warden
-- Vanguard
+  - Warden
+  - Vanguard
 schema_version: 1.7
 receipt:
   source: PTPF.v1.0
@@ -56,23 +56,23 @@ receipt:
   date: '2025-10-25'
   trace_hash: to-fill
 environment_affinity:
-  biome_class: cryosteppe
+  biome_class: mezzanotte_orbitale
   koppen:
-  - BSk
-  - Dfc
+    - BSk
+    - Dfc
 derived_from_environment:
   suggested_traits:
-  - cuticole_cerose
-  - grassi_termici
-  - pelli_cave
-  - pigmenti_aurorali
-  - proteine_shock_termico
-  - reti_capillari_radici
+    - cuticole_cerose
+    - grassi_termici
+    - pelli_cave
+    - pigmenti_aurorali
+    - proteine_shock_termico
+    - reti_capillari_radici
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+    - Skirmisher
+    - Vanguard
+    - Warden
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml
@@ -1,10 +1,10 @@
 id: thaw-rot
 display_name: Thaw Rot
 biomes:
-- cryosteppe
+  - mezzanotte_orbitale
 role_trofico: minaccia_microbica
 functional_tags:
-- patogeno
+  - patogeno
 morphotype: scavenger_corazzato
 flags:
   apex: false
@@ -23,16 +23,16 @@ vc:
   tilt: 0.8
 ecology:
   trigger:
-  - disgelo rapido + materiale organico
+    - disgelo rapido + materiale organico
   contromisure:
-  - bonifica criogenica
-  - barriere drenanti
+    - bonifica criogenica
+    - barriere drenanti
 spawn_rules:
   orario:
-  - continuo
+    - continuo
   meteo:
-  - whiteout_ionico
-  - sereno_freddo
+    - whiteout_ionico
+    - sereno_freddo
   densita: mid
 balance:
   rarity: R3
@@ -45,27 +45,27 @@ receipt:
   date: '2025-10-25'
   trace_hash: to-fill
 environment_affinity:
-  biome_class: cryosteppe
+  biome_class: mezzanotte_orbitale
   koppen:
-  - BSk
-  - Dfc
+    - BSk
+    - Dfc
 derived_from_environment:
   suggested_traits:
-  - cuticole_cerose
-  - grassi_termici
-  - pelli_cave
-  - pigmenti_aurorali
-  - proteine_shock_termico
-  - reti_capillari_radici
+    - cuticole_cerose
+    - grassi_termici
+    - pelli_cave
+    - pigmenti_aurorali
+    - proteine_shock_termico
+    - reti_capillari_radici
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+    - Skirmisher
+    - Vanguard
+    - Warden
 telemetry:
-  expected_pick_rate: null
-  spawn_weight: null
+  expected_pick_rate:
+  spawn_weight:
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml
+++ b/packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml
@@ -1,12 +1,12 @@
 id: cactus-weaver
 display_name: Cactus Weaver
 biomes:
-- deserto_caldo
+  - savana
 role_trofico: ingegneri_ecosistema
 functional_tags:
-- ingegneri_ecosistema
-- specie_chiave
-- detritivoro
+  - ingegneri_ecosistema
+  - specie_chiave
+  - detritivoro
 morphotype: ingegnere_radicante
 flags:
   apex: false
@@ -20,7 +20,7 @@ pi_loadout:
   weight_budget: 12
   default_parts:
     defense:
-    - elastomer_skin
+      - elastomer_skin
     metabolism: burst_anaerobic
 vc:
   aggro: 0.2
@@ -30,14 +30,14 @@ vc:
   explore: 0.5
   tilt: 0.2
 services_links:
-- supporto:stoccaggio_acqua
-- regolazione:ombreggiamento_microhabitat
+  - supporto:stoccaggio_acqua
+  - regolazione:ombreggiamento_microhabitat
 spawn_rules:
   orario:
-  - diurno
+    - diurno
   meteo:
-  - sereno_freddo
-  - caldo_pulsato
+    - sereno_freddo
+    - caldo_pulsato
   densita: mid
 balance:
   rarity: R2
@@ -47,8 +47,8 @@ telemetry:
   expected_pick_rate: 0.16
   spawn_weight: 0.24
 jobs_synergy:
-- Warden
-- Artificer
+  - Warden
+  - Artificer
 schema_version: 1.7
 receipt:
   source: PTPF.v1.0
@@ -56,25 +56,25 @@ receipt:
   date: '2025-10-25'
   trace_hash: to-fill
 environment_affinity:
-  biome_class: deserto_caldo
+  biome_class: savana
   koppen:
-  - BWh
-  - BSh
+    - BWh
+    - BSh
 derived_from_environment:
   suggested_traits:
-  - cuticole_cerose
-  - grassi_termici
-  - pelli_cave
-  - pigmenti_aurorali
-  - proteine_shock_termico
-  - reti_capillari_radici
+    - cuticole_cerose
+    - grassi_termici
+    - pelli_cave
+    - pigmenti_aurorali
+    - proteine_shock_termico
+    - reti_capillari_radici
   required_capabilities: []
   services_links:
-  - regolazione:ritenzione_idrica
-  - supporto:stabilizzazione_suolo
+    - regolazione:ritenzione_idrica
+    - supporto:stabilizzazione_suolo
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+    - Skirmisher
+    - Vanguard
+    - Warden
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml
+++ b/packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml
@@ -1,10 +1,10 @@
 id: evento-ondata-termica
 display_name: 'Evento: Ondata Termica Ionica'
 biomes:
-- deserto_caldo
+  - savana
 role_trofico: evento_ecologico
 functional_tags:
-- pulse_climatico
+  - pulse_climatico
 morphotype: volatore_planatore
 flags:
   apex: false
@@ -23,15 +23,15 @@ vc:
   tilt: 0.95
 ecology:
   trigger:
-  - anticiclone + carica ionica
+    - anticiclone + carica ionica
   contromisure:
-  - rifugi sotterranei
-  - rottura del contatto termico
+    - rifugi sotterranei
+    - rottura del contatto termico
 spawn_rules:
   orario:
-  - diurno
+    - diurno
   meteo:
-  - caldo_pulsato
+    - caldo_pulsato
   densita: low
 balance:
   rarity: R5
@@ -44,27 +44,27 @@ receipt:
   date: '2025-10-25'
   trace_hash: to-fill
 environment_affinity:
-  biome_class: deserto_caldo
+  biome_class: savana
   koppen:
-  - BWh
-  - BSh
+    - BWh
+    - BSh
 derived_from_environment:
   suggested_traits:
-  - cuticole_cerose
-  - grassi_termici
-  - pelli_cave
-  - pigmenti_aurorali
-  - proteine_shock_termico
-  - reti_capillari_radici
+    - cuticole_cerose
+    - grassi_termici
+    - pelli_cave
+    - pigmenti_aurorali
+    - proteine_shock_termico
+    - reti_capillari_radici
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+    - Skirmisher
+    - Vanguard
+    - Warden
 telemetry:
-  expected_pick_rate: null
-  spawn_weight: null
+  expected_pick_rate:
+  spawn_weight:
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml
+++ b/packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml
@@ -1,11 +1,11 @@
 id: noctule-termico
 display_name: Noctule Termico
 biomes:
-- deserto_caldo
+  - savana
 role_trofico: dispersore_ponte
 functional_tags:
-- impollinatore
-- dispersore_semi
+  - impollinatore
+  - dispersore_semi
 morphotype: volatore_planatore
 flags:
   apex: false
@@ -19,9 +19,9 @@ pi_loadout:
   weight_budget: 12
   default_parts:
     locomotion:
-    - glide_wings
+      - glide_wings
     senses:
-    - echolocate
+      - echolocate
 vc:
   aggro: 0.2
   risk: 0.2
@@ -31,9 +31,9 @@ vc:
   tilt: 0.2
 spawn_rules:
   orario:
-  - notte
+    - notte
   meteo:
-  - sereno_freddo
+    - sereno_freddo
   densita: mid
 balance:
   rarity: R2
@@ -43,8 +43,8 @@ telemetry:
   expected_pick_rate: 0.17
   spawn_weight: 0.23
 jobs_synergy:
-- Skirmisher
-- Invoker
+  - Skirmisher
+  - Invoker
 schema_version: 1.7
 receipt:
   source: PTPF.v1.0
@@ -52,24 +52,24 @@ receipt:
   date: '2025-10-25'
   trace_hash: to-fill
 environment_affinity:
-  biome_class: deserto_caldo
+  biome_class: savana
   koppen:
-  - BWh
-  - BSh
+    - BWh
+    - BSh
 derived_from_environment:
   suggested_traits:
-  - cuticole_cerose
-  - grassi_termici
-  - pelli_cave
-  - pigmenti_aurorali
-  - proteine_shock_termico
-  - reti_capillari_radici
+    - cuticole_cerose
+    - grassi_termici
+    - pelli_cave
+    - pigmenti_aurorali
+    - proteine_shock_termico
+    - reti_capillari_radici
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+    - Skirmisher
+    - Vanguard
+    - Warden
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml
+++ b/packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml
@@ -1,10 +1,10 @@
 id: silica-bloom
 display_name: Silica Bloom
 biomes:
-- deserto_caldo
+  - savana
 role_trofico: minaccia_microbica
 functional_tags:
-- patogeno
+  - patogeno
 morphotype: scavenger_corazzato
 flags:
   apex: false
@@ -23,16 +23,16 @@ vc:
   tilt: 0.8
 ecology:
   trigger:
-  - umidità notturna + silice
+    - umidità notturna + silice
   contromisure:
-  - tessuti protettivi
-  - riduzione polveri
+    - tessuti protettivi
+    - riduzione polveri
 spawn_rules:
   orario:
-  - notte
+    - notte
   meteo:
-  - foschia_ferrosa
-  - caldo_pulsato
+    - foschia_ferrosa
+    - caldo_pulsato
   densita: mid
 balance:
   rarity: R3
@@ -45,27 +45,27 @@ receipt:
   date: '2025-10-25'
   trace_hash: to-fill
 environment_affinity:
-  biome_class: deserto_caldo
+  biome_class: savana
   koppen:
-  - BWh
-  - BSh
+    - BWh
+    - BSh
 derived_from_environment:
   suggested_traits:
-  - cuticole_cerose
-  - grassi_termici
-  - pelli_cave
-  - pigmenti_aurorali
-  - proteine_shock_termico
-  - reti_capillari_radici
+    - cuticole_cerose
+    - grassi_termici
+    - pelli_cave
+    - pigmenti_aurorali
+    - proteine_shock_termico
+    - reti_capillari_radici
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+    - Skirmisher
+    - Vanguard
+    - Warden
 telemetry:
-  expected_pick_rate: null
-  spawn_weight: null
+  expected_pick_rate:
+  spawn_weight:
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml
+++ b/packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml
@@ -1,11 +1,11 @@
 id: thermo-raptor
 display_name: Thermo Raptor
 biomes:
-- deserto_caldo
+  - savana
 role_trofico: predatore_terziario_apex
 functional_tags:
-- predatore
-- specie_chiave
+  - predatore
+  - specie_chiave
 morphotype: cursoriale_quadrupede
 flags:
   apex: true
@@ -24,10 +24,10 @@ vc:
   tilt: 0.4
 spawn_rules:
   orario:
-  - notte
-  - crepuscolo
+    - notte
+    - crepuscolo
   meteo:
-  - caldo_pulsato
+    - caldo_pulsato
   densita: low
 balance:
   rarity: R3
@@ -40,27 +40,27 @@ receipt:
   date: '2025-10-25'
   trace_hash: to-fill
 environment_affinity:
-  biome_class: deserto_caldo
+  biome_class: savana
   koppen:
-  - BWh
-  - BSh
+    - BWh
+    - BSh
 derived_from_environment:
   suggested_traits:
-  - cuticole_cerose
-  - grassi_termici
-  - pelli_cave
-  - pigmenti_aurorali
-  - proteine_shock_termico
-  - reti_capillari_radici
+    - cuticole_cerose
+    - grassi_termici
+    - pelli_cave
+    - pigmenti_aurorali
+    - proteine_shock_termico
+    - reti_capillari_radici
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+    - Skirmisher
+    - Vanguard
+    - Warden
 telemetry:
-  expected_pick_rate: null
-  spawn_weight: null
+  expected_pick_rate:
+  spawn_weight:
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml
@@ -7,10 +7,10 @@ receipt:
 id: blight-micotico
 display_name: Blight Micotico
 biomes:
-- foresta_temperata
+  - foresta_miceliale
 role_trofico: minaccia_microbica
 functional_tags:
-- patogeno
+  - patogeno
 flags:
   apex: false
   keystone: false
@@ -28,15 +28,15 @@ vc:
   tilt: 0.6
 ecology:
   trigger:
-  - umidità_prolungata
+    - umidità_prolungata
   contromisure:
-  - bruciatura controllata
-  - barriere biologiche
+    - bruciatura controllata
+    - barriere biologiche
 spawn_rules:
   orario:
-  - continuo
+    - continuo
   meteo:
-  - whiteout
+    - whiteout
   densita: high
 balance:
   rarity: R3
@@ -45,16 +45,16 @@ balance:
 environment_affinity:
   biome_class: Foresta temperata umida
   koppen:
-  - Cfb
+    - Cfb
   hazards_expected:
-  - alluvioni lampo
-  - incendi sporadici
+    - alluvioni lampo
+    - incendi sporadici
 derived_from_environment:
   suggested_traits:
-  - pelli_fitte
+    - pelli_fitte
 telemetry:
-  expected_pick_rate: null
-  spawn_weight: null
+  expected_pick_rate:
+  spawn_weight:
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml
@@ -7,10 +7,10 @@ receipt:
 id: evento-seme-uragano
 display_name: 'Evento: Seme d''Uragano'
 biomes:
-- foresta_temperata
+  - foresta_miceliale
 role_trofico: evento_ecologico
 functional_tags:
-- pulse_climatico
+  - pulse_climatico
 flags:
   apex: false
   keystone: false
@@ -28,15 +28,15 @@ vc:
   tilt: 0.9
 ecology:
   trigger:
-  - ciclone_extra-tropicale
+    - ciclone_extra-tropicale
   contromisure:
-  - rifugi
-  - piani_emergenza
+    - rifugi
+    - piani_emergenza
 spawn_rules:
   orario:
-  - crepuscolo
+    - crepuscolo
   meteo:
-  - whiteout_ionico
+    - whiteout_ionico
   densita: low
 balance:
   rarity: R5
@@ -45,16 +45,16 @@ balance:
 environment_affinity:
   biome_class: Foresta temperata umida
   koppen:
-  - Cfb
+    - Cfb
   hazards_expected:
-  - alluvioni lampo
-  - incendi sporadici
+    - alluvioni lampo
+    - incendi sporadici
 derived_from_environment:
   suggested_traits:
-  - pelli_fitte
+    - pelli_fitte
 telemetry:
-  expected_pick_rate: null
-  spawn_weight: null
+  expected_pick_rate:
+  spawn_weight:
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml
@@ -7,10 +7,10 @@ receipt:
 id: lupus-temperatus
 display_name: Lupo della Foresta
 biomes:
-- foresta_temperata
+  - foresta_miceliale
 role_trofico: predatore_terziario_apex
 functional_tags:
-- specie_chiave
+  - specie_chiave
 flags:
   apex: true
   keystone: true
@@ -28,10 +28,10 @@ vc:
   tilt: 0.3
 spawn_rules:
   orario:
-  - crepuscolo
-  - notte
+    - crepuscolo
+    - notte
   meteo:
-  - sereno_freddo
+    - sereno_freddo
   densita: mid
 balance:
   rarity: R2
@@ -40,16 +40,16 @@ balance:
 environment_affinity:
   biome_class: Foresta temperata umida
   koppen:
-  - Cfb
+    - Cfb
   hazards_expected:
-  - alluvioni lampo
-  - incendi sporadici
+    - alluvioni lampo
+    - incendi sporadici
 derived_from_environment:
   suggested_traits:
-  - pelli_fitte
+    - pelli_fitte
 telemetry:
-  expected_pick_rate: null
-  spawn_weight: null
+  expected_pick_rate:
+  spawn_weight:
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml
@@ -7,10 +7,10 @@ receipt:
 id: sentinella-radice
 display_name: Sentinella Radice
 biomes:
-- foresta_temperata
+  - foresta_miceliale
 role_trofico: ingegneri_ecosistema
 functional_tags:
-- specie_chiave
+  - specie_chiave
 flags:
   apex: false
   keystone: true
@@ -24,9 +24,9 @@ pi_loadout:
   weight_budget: 12
   default_parts:
     senses:
-    - echolocate
+      - echolocate
     defense:
-    - elastomer_skin
+      - elastomer_skin
 vc:
   aggro: 0.3
   risk: 0.2
@@ -35,13 +35,13 @@ vc:
   explore: 0.4
   tilt: 0.2
 services_links:
-- supporto:formazione_suolo
-- regolazione:ritenzione_idrica
+  - supporto:formazione_suolo
+  - regolazione:ritenzione_idrica
 spawn_rules:
   orario:
-  - diurno
+    - diurno
   meteo:
-  - nebbia_ionica
+    - nebbia_ionica
   densita: low
 balance:
   rarity: R3
@@ -53,13 +53,13 @@ telemetry:
 environment_affinity:
   biome_class: Foresta temperata umida
   koppen:
-  - Cfb
+    - Cfb
   hazards_expected:
-  - alluvioni lampo
-  - incendi sporadici
+    - alluvioni lampo
+    - incendi sporadici
 derived_from_environment:
   suggested_traits:
-  - pelli_fitte
+    - pelli_fitte
 genetic_traits: []
 mate_synergy: []
 jobs_synergy: []


### PR DESCRIPTION
## Summary
- add a biome alias registry to bridge legacy identifiers to the new canon
- normalize biome identifiers in pack data and regenerate the species trait matrix with alias annotations
- extend tools/traits.py to resolve biome aliases and warn on unresolved identifiers

## Testing
- python tools/traits.py validate

------
https://chatgpt.com/codex/tasks/task_e_68ff51ecb8608332a3aa2db4355bccd3