### PR TITLE
Normalize biome references to canonical ids

### DIFF
--- a/packs/evo_tactics_pack/data/ecosistemi/cross_events.yaml
+++ b/packs/evo_tactics_pack/data/ecosistemi/cross_events.yaml
@@ -2,30 +2,30 @@ schema_version: 1.0
 events:
   - species_id: evento-tempesta-ferrosa
     from_nodes:
-      - canyons_risonanti
+      - BADLANDS
     propagate_via:
       - corridor
       - seasonal_bridge
     to_nodes:
-      - foresta_miceliale
-      - savana
+      - FORESTA_TEMPERATA
+      - DESERTO_CALDO
     effect: polveri ferrose e carica magnetica, penalità visibilità/gear 
       metallico
   - species_id: evento-ondata-termica
     from_nodes:
-      - savana
+      - DESERTO_CALDO
     propagate_via:
       - corridor
     to_nodes:
-      - canyons_risonanti
+      - BADLANDS
     effect: ondata di calore e ionizzazione, stress termico esteso
   - species_id: evento-brinastorm
     from_nodes:
-      - mezzanotte_orbitale
+      - CRYOSTEPPE
     propagate_via:
       - seasonal_bridge
       - corridor
     to_nodes:
-      - foresta_miceliale
-      - canyons_risonanti
+      - FORESTA_TEMPERATA
+      - BADLANDS
     effect: ghiaccio fine in sospensione, visibilità ridotta e attrito aumentato

--- a/packs/evo_tactics_pack/data/ecosystems/network/cross_events.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/network/cross_events.yaml
@@ -2,30 +2,30 @@ schema_version: 1.0
 events:
   - species_id: evento-tempesta-ferrosa
     from_nodes:
-      - canyons_risonanti
+      - BADLANDS
     propagate_via:
       - corridor
       - seasonal_bridge
     to_nodes:
-      - foresta_miceliale
-      - savana
+      - FORESTA_TEMPERATA
+      - DESERTO_CALDO
     effect: polveri ferrose e carica magnetica, penalità visibilità/gear 
       metallico
   - species_id: evento-ondata-termica
     from_nodes:
-      - savana
+      - DESERTO_CALDO
     propagate_via:
       - corridor
     to_nodes:
-      - canyons_risonanti
+      - BADLANDS
     effect: ondata di calore e ionizzazione, stress termico esteso
   - species_id: evento-brinastorm
     from_nodes:
-      - mezzanotte_orbitale
+      - CRYOSTEPPE
     propagate_via:
       - seasonal_bridge
       - corridor
     to_nodes:
-      - foresta_miceliale
-      - canyons_risonanti
+      - FORESTA_TEMPERATA
+      - BADLANDS
     effect: ghiaccio fine in sospensione, visibilità ridotta e attrito aumentato


### PR DESCRIPTION
## Summary
- add a biome alias registry to bridge legacy identifiers to the new canon
- normalize biome identifiers in pack data and regenerate the species trait matrix with alias annotations
- extend tools/traits.py to resolve biome aliases and warn on unresolved identifiers
- restore Evo-Tactics cross-event definitions to use the meta-network node IDs so edges resolve correctly

## Testing
- python tools/traits.py validate

------
https://chatgpt.com/codex/tasks/task_e_68ff5982c0f48332a59253b5258500e8