### PR TITLE
Add ADR for CLI refactor motivations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,9 @@ Questi file sono scheletri collegati ai **Canvas** già creati in ChatGPT. Copia
 ## Procedure post-ottobre 2025
 Dal ciclo VC-2025-10 in avanti utilizziamo un flusso documentale condiviso con Support/QA e Telemetria. Con l'estensione di novembre 2025 il refactor della CLI introduce anche un percorso di approvazione per i profili `playtest`, `telemetry` e `support`.
 
+### Decisioni architetturali
+- **ADR-XXX — Refactor CLI, determinismo e pipeline HUD**: `docs/adr/ADR-XXX-refactor-cli.md` raccoglie le motivazioni fornite dal team lead e formalizza le opzioni valutate, gli impatti sugli strumenti (`roll_pack`, `hud_alerts.ts`) e i follow-up richiesti.
+
 1. **Sync settimanale (martedì, 15:00 CET)** — raccogli log telemetrici e note playtest in `docs/chatgpt_changes/` (`sync-<AAAAMMGG>.md`) e annota la versione CLI attiva (`game-cli version --json`).
 2. **Aggiornamento checklist** — segna in `docs/checklist/` lo stato milestone, collega la sessione Git (`logs/playtests/<data>-vc`) e aggiungi il link al log CLI giornaliero (`logs/cli/<data>.log`).
 3. **Validazione profili CLI** — verifica che gli script profilati siano allineati alle configurazioni in `config/cli/` (commit hash, token rotazioni, flags `--telemetry-upload`) e registra eventuali differenze in `docs/chatgpt_sync_status.md`.

--- a/docs/adr/ADR-XXX-refactor-cli.md
+++ b/docs/adr/ADR-XXX-refactor-cli.md
@@ -1,0 +1,38 @@
+# ADR-XXX: Motivazioni refactor CLI e allineamento toolchain
+
+- **Data**: 2025-11-20
+- **Stato**: Accettato
+- **Owner**: Team Lead Tools
+- **Stakeholder**: Team Platform, HUD/UX, Support, QA
+
+## Contesto
+Durante il ciclo VC-2025-10 il refactor della CLI (`game-cli`) ha introdotto entrypoint modulare e profili di esecuzione condivisi. Il team lead ha richiesto una decisione formale che preservi: (1) determinismo sugli output, (2) parità tra implementazioni TypeScript e Python e (3) continuità della pipeline HUD che consuma gli eventi CLI.
+
+## Motivazioni raccolte dal team lead
+1. **Determinismo riproducibile** — ogni comando deve accettare `--seed` e loggare gli input in modo da poter riprodurre un encounter o un pacchetto partendo dagli stessi dati.
+2. **Allineamento TS/Python** — `roll_pack` e gli altri tool devono condividere lo stesso set di sorgenti YAML e la stessa logica di calcolo per evitare regressioni quando i team cambiano linguaggio di riferimento.
+3. **Pipeline HUD** — gli aggiornamenti `hud_alerts.ts` devono ricevere stream coerenti dagli script CLI, evitando divergenze sui formati telemetry (`ema.update`) e mantenendo i tag missione configurabili.
+
+## Opzioni valutate
+- **A. Mantenere doppia CLI separata (status quo pre-refactor)**: lasciare gli script Python e TypeScript indipendenti con logiche duplicate.
+- **B. Centralizzare tutto in TypeScript**: spostare la generazione dei pacchetti e encounter in TS e deprecare i wrapper Python.
+- **C. Stabilire un contratto di reference implementation**: definire moduli condivisi (schema YAML, seed handling, normalizzazione log) e test cross-language obbligatori.
+
+## Decisione
+Adottare l'opzione **C**. Il refactor CLI rimane modulare, ma tutti i comandi devono validare seed e schema dati contro la reference TypeScript, con test di parità che girano sia in `tools/ts` sia in `tools/py` ad ogni modifica.
+
+## Impatti sugli strumenti
+- **`tools/py/roll_pack.py`**: mantiene supporto come wrapper di compatibilità. I test di parità con `tools/ts/dist/roll_pack.js` devono essere schedulati nelle pipeline e documentati nei log giornalieri.
+- **`tools/ts/hud_alerts.ts`**: riceve gli output normalizzati del comando `game-cli telemetry stream`. Il refactor impone mapping esplicito dei campi `missionId`, `risk.indices.weighted_index` e `risk.indices.time_low_hp_turns`, oltre a controlli sui tag missione forniti dal CLI profile.
+- **Pipeline HUD**: la CLI diventa la fonte autorevole per gli eventi `ema.update`; gli adapter HUD devono ascoltare il bus CLI e rispettare il formato JSON deciso qui.
+
+## Conseguenze
+- Gli script Python vengono trattati come implementazione di riferimento secondaria ma con parità garantita tramite test comparativi.
+- La documentazione operativa deve descrivere come usare i seed condivisi e dove reperire i log (`logs/cli/<data>.log`).
+- HUD/UX può anticipare regressioni monitorando i tag missione e gli alert generati dal nuovo flusso CLI.
+
+## Azioni di follow-up
+- [x] Aggiornare i test di parità CLI TS/Python (`npm test` in `tools/ts`, `pytest tests/test_tools_modules.py`).
+- [ ] Automatizzare l'esecuzione giornaliera dei test di parità nella pipeline CI (`scripts/cli_smoke.sh`).
+- [ ] Estendere la documentazione HUD con esempi di alert generati dalla CLI (`docs/tools/hud.md`).
+- [ ] Verificare con Support/QA la disponibilità dei log CLI nel drive condiviso.

--- a/docs/checklist/project-setup-todo.md
+++ b/docs/checklist/project-setup-todo.md
@@ -81,7 +81,7 @@ ogni esecuzione importante, annotando data, esito e note operative.
 
 ## 11. Knowledge sharing e onboarding
 - [x] Aggiornare `docs/README.md` e le guide in `docs/piani/` con le nuove procedure adottate. _Completato con il riepilogo post-ottobre 2025 e l'integrazione dei Canvas specializzati._【F:docs/README.md†L1-L38】【F:docs/piani/roadmap.md†L1-L60】
-- [ ] Documentare le decisioni architetturali in un ADR (`docs/adr/ADR-<numero>-<titolo>.md`) quando necessario. _Prossimo ADR pianificato dopo refactor CLI (owner: Lead Dev)._
+- [x] Documentare le decisioni architetturali in un ADR (`docs/adr/ADR-<numero>-<titolo>.md`) quando necessario. _ADR-XXX refactor CLI pubblicato il 2025-11-20 (owner: Lead Dev Tools) con focus su determinismo, parità TS/Python e pipeline HUD._
 - [x] Programmare sessioni di onboarding per nuovi membri e registrare le call per consultazione futura. _Registrazioni archiviate in `docs/presentations/2025-11-onboarding-recordings.md`._【F:docs/presentations/2025-11-onboarding-recordings.md†L1-L9】
 - [x] Creare FAQ interne su `docs/faq.md` con le domande più ricorrenti ricevute dal team. _Sezione post-onboarding aggiornata con owner e follow-up._【F:docs/faq.md†L1-L80】
 


### PR DESCRIPTION
## Summary
- capture the team lead's rationale for the CLI refactor in a new ADR focused on determinism, TS/Python parity, and HUD pipeline alignment
- reference the ADR from the shared knowledge doc so teams can discover it quickly
- mark the project setup checklist item about documenting architecture decisions as completed with the new ADR details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff5b502b788332aa4d091c2417737a