### PR TITLE
Align Evo-Tactics cross events with available network edges

### DIFF
--- a/packs/evo_tactics_pack/data/ecosystems/network/cross_events.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/network/cross_events.yaml
@@ -24,7 +24,7 @@ events:
       - CRYOSTEPPE
     propagate_via:
       - seasonal_bridge
-      - corridor
+      - trophic_spillover
     to_nodes:
       - FORESTA_TEMPERATA
       - BADLANDS

--- a/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
@@ -50,12 +50,24 @@ network:
       resistance: 0.5
       seasonality: estate
       notes: canali wadi → dune mobili
+    - from: DESERTO_CALDO
+      to: BADLANDS
+      type: corridor
+      resistance: 0.55
+      seasonality: estate
+      notes: ritorno di corridoi aeolici verso canyon ombrosi
     - from: FORESTA_TEMPERATA
       to: CRYOSTEPPE
       type: seasonal_bridge
       resistance: 0.6
       seasonality: inverno
       notes: valichi nevosi con copertura forestale rada
+    - from: CRYOSTEPPE
+      to: FORESTA_TEMPERATA
+      type: seasonal_bridge
+      resistance: 0.65
+      seasonality: inverno
+      notes: discese glaciali verso vallate temperate tramite gallerie di ghiaccio
     - from: CRYOSTEPPE
       to: BADLANDS
       type: trophic_spillover


### PR DESCRIPTION
## Summary
- add reverse corridor and seasonal bridge edges so Evo-Tactics cross-events can resolve against the meta-network
- update the brinastorm event propagation modes to match the available network connections

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff64fab5cc833299a3290163038783