### PR TITLE
Ensure deploy workflow installs python3 deps before CLI gates

### DIFF
--- a/.github/workflows/deploy-test-interface.yml
+++ b/.github/workflows/deploy-test-interface.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r tools/py/requirements.txt
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r tools/py/requirements.txt
 
       - name: Run CLI smoke suite
         run: ./scripts/cli_smoke.sh


### PR DESCRIPTION
## Summary
- use python3 -m pip for dependency installation in the deploy workflow so the CLI smoke and trait audit gates run after packages are present

## Testing
- not run (CI only)

------
https://chatgpt.com/codex/tasks/task_e_68ff669c65008332aef8bc8d1706b027