### PR TITLE
Stop forcing legacy Playwright mirror in deploy checks

### DIFF
--- a/scripts/run_deploy_checks.sh
+++ b/scripts/run_deploy_checks.sh
@@ -13,10 +13,19 @@ pushd "$ROOT_DIR/tools/ts" >/dev/null
 npm ci
 
 log "Installing Playwright browsers"
-PLAYWRIGHT_DOWNLOAD_HOST="https://playwright.azureedge.net"
-if ! PLAYWRIGHT_DOWNLOAD_HOST="$PLAYWRIGHT_DOWNLOAD_HOST" npx playwright install chromium; then
-  log "Playwright download failed via $PLAYWRIGHT_DOWNLOAD_HOST; retrying with --with-deps"
-  PLAYWRIGHT_DOWNLOAD_HOST="$PLAYWRIGHT_DOWNLOAD_HOST" npx playwright install --with-deps chromium
+PLAYWRIGHT_ENV=()
+PLAYWRIGHT_MIRROR=${PLAYWRIGHT_DOWNLOAD_HOST:-}
+if [ -n "$PLAYWRIGHT_MIRROR" ]; then
+  log "Using custom Playwright mirror at $PLAYWRIGHT_MIRROR"
+  PLAYWRIGHT_ENV=("PLAYWRIGHT_DOWNLOAD_HOST=$PLAYWRIGHT_MIRROR")
+fi
+if ! "${PLAYWRIGHT_ENV[@]}" npx playwright install chromium; then
+  if [ -n "$PLAYWRIGHT_MIRROR" ]; then
+    log "Playwright download failed via $PLAYWRIGHT_MIRROR; retrying with --with-deps"
+  else
+    log "Playwright download failed; retrying with --with-deps"
+  fi
+  "${PLAYWRIGHT_ENV[@]}" npx playwright install --with-deps chromium
 fi
 
 log "Running TypeScript and web regression test suite"

--- a/tools/ts/package.json
+++ b/tools/ts/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "playwright:install": "PLAYWRIGHT_DOWNLOAD_HOST=https://playwright.azureedge.net npx playwright install chromium || PLAYWRIGHT_DOWNLOAD_HOST=https://playwright.azureedge.net npx playwright install --with-deps chromium",
+    "playwright:install": "npx playwright install chromium || npx playwright install --with-deps chromium",
     "pretest": "npm run playwright:install --silent",
     "build": "tsc -p tsconfig.json && node ./scripts/postbuild.mjs",
     "start": "node dist/roll_pack.js ENTP invoker ../../data/packs.yaml",


### PR DESCRIPTION
## Summary
- stop hardcoding the legacy Azure mirror in `run_deploy_checks.sh` so Playwright can use its built-in CDN rotation, while still allowing custom overrides via `PLAYWRIGHT_DOWNLOAD_HOST`
- update the `tools/ts` Playwright install npm script to rely on the same default behaviour

## Testing
- npm --prefix tools/ts run playwright:install
- scripts/run_deploy_checks.sh *(fails: Playwright tests expect dashboard metrics that were not produced)*

------
https://chatgpt.com/codex/tasks/task_e_68ff680b34e08332aa24fcd4de0dd2cf