### PR TITLE
Fix syntax error in test interface script

### DIFF
--- a/docs/test-interface/app.js
+++ b/docs/test-interface/app.js
@@ -1894,8 +1894,7 @@ function renderBiomes(targetContainer = sectionElements.biomes || document.getEl
         <ul class="nested-list">${freqHtml}</ul>
       </article>
     </div>
-  `
-  );
+  `;
 }
 
 function renderSpeciesShowcase(targetContainer = sectionElements.species || document.getElementById("species-showcase")) {


### PR DESCRIPTION
## Summary
- remove a stray closing parenthesis in `docs/test-interface/app.js` so the dashboard script executes without syntax errors

## Testing
- npm run test:web -- tests/web/interface.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68ff751107f08332bc8292301655c2b8