### PR TITLE
Replace rsync with Python static site builder

### DIFF
--- a/.github/workflows/deploy-test-interface.yml
+++ b/.github/workflows/deploy-test-interface.yml
@@ -54,16 +54,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Prepare static site
-        run: |
-          rm -rf dist
-          mkdir -p dist
-          rsync -av --delete \
-            --exclude '*.md' \
-            --exclude 'chatgpt_changes/' \
-            --exclude 'checklist/' \
-            --exclude 'Canvas/' \
-            docs/ dist/
-          cp -r data dist/data
+        run: python scripts/prepare_static_site.py
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/scripts/prepare_static_site.py
+++ b/scripts/prepare_static_site.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Utility to assemble the static site artifact for deployment."""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS_DIR = ROOT / "docs"
+DATA_DIR = ROOT / "data"
+DIST_DIR = ROOT / "dist"
+
+# Directories inside `docs/` that should not be published as part of the static site.
+EXCLUDED_DIRECTORIES = {"chatgpt_changes", "checklist", "Canvas"}
+# File patterns we do not want to publish from `docs/`.
+EXCLUDED_PATTERNS = ["*.md"]
+
+
+def ensure_directory(path: Path) -> None:
+    """Remove the directory if it exists and (re)create it empty."""
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def docs_ignore_patterns():
+    """Create the ignore pattern callable for copytree."""
+    return shutil.ignore_patterns(*(EXCLUDED_PATTERNS + list(EXCLUDED_DIRECTORIES)))
+
+
+def copy_docs() -> None:
+    if not DOCS_DIR.is_dir():
+        raise SystemExit(f"Docs directory not found: {DOCS_DIR}")
+
+    ignore = docs_ignore_patterns()
+    # `copytree` expects the destination not to exist.
+    shutil.copytree(DOCS_DIR, DIST_DIR, ignore=ignore, dirs_exist_ok=True)
+
+
+def copy_data() -> None:
+    if not DATA_DIR.is_dir():
+        raise SystemExit(f"Data directory not found: {DATA_DIR}")
+
+    destination = DIST_DIR / "data"
+    shutil.copytree(DATA_DIR, destination, dirs_exist_ok=True)
+
+
+def main() -> None:
+    ensure_directory(DIST_DIR)
+    copy_docs()
+    copy_data()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace the rsync-based static site preparation step with a Python helper script
- add scripts/prepare_static_site.py to assemble the deployable artifact with the desired exclusions

## Testing
- python scripts/prepare_static_site.py

------
https://chatgpt.com/codex/tasks/task_e_68ff8ddd37f0833289c71db9fe1c55bf