### PR TITLE
Prevent Playwright web server reuse from blocking deploy checks

### DIFF
--- a/tools/ts/playwright.config.ts
+++ b/tools/ts/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
   webServer: {
     command: `python3 -m http.server ${defaultPort} --bind 127.0.0.1 --directory ${JSON.stringify(repoRoot)}`,
     url: `${baseURL}/docs/test-interface/index.html`,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: process.env.PLAYWRIGHT_REUSE_SERVER === "1",
     stdout: "pipe",
     stderr: "pipe",
     timeout: 30_000,


### PR DESCRIPTION
## Summary
- ensure the Playwright-driven HTTP server shuts down after tests by default
- allow opting back into persistent reuse via the PLAYWRIGHT_REUSE_SERVER flag

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ffb869ee708332b8c7e9b7d51feff2