### PR TITLE
Fix HUD canary workflow Python heredoc syntax

### DIFF
--- a/.github/workflows/hud.yml
+++ b/.github/workflows/hud.yml
@@ -24,19 +24,7 @@ jobs:
       - name: Risolvi flag smart alerts
         id: flags
         run: |
-          value=$(python - <<'PY'
-from pathlib import Path
-
-content = Path('config/cli/hud.yaml').read_text(encoding='utf-8')
-enabled = False
-for line in content.splitlines():
-    stripped = line.strip()
-    if stripped.startswith('default:'):
-        enabled = stripped.split(':', 1)[1].strip().lower() in {'true', 'yes', '1', 'on'}
-        break
-print(f"enabled={'true' if enabled else 'false'}")
-PY
-          )
+          value=$(python -c 'from pathlib import Path; content = Path("config/cli/hud.yaml").read_text(encoding="utf-8"); enabled = next((line.split(":", 1)[1].strip().lower() in {"true", "yes", "1", "on"} for line in content.splitlines() if line.strip().startswith("default:")), False); print("enabled=true" if enabled else "enabled=false")')
           echo "$value" >> "$GITHUB_OUTPUT"
 
       - name: Imposta Node.js


### PR DESCRIPTION
## Summary
- replace the heredoc-based Python snippet in the HUD canary workflow with a single-line python -c invocation to avoid YAML parsing issues
- keep writing the computed smart alert flag status to GITHUB_OUTPUT for downstream steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ffc96e4d888332b26d582d65b4c40e