### PR TITLE
Improve workflow flag parsing and deploy build

### DIFF
--- a/.github/workflows/deploy-test-interface.yml
+++ b/.github/workflows/deploy-test-interface.yml
@@ -30,6 +30,14 @@ jobs:
           cache: "npm"
           cache-dependency-path: tools/ts/package-lock.json
 
+      - name: Install TypeScript tool dependencies
+        working-directory: tools/ts
+        run: npm ci --no-audit --no-fund
+
+      - name: Build TypeScript artifacts
+        working-directory: tools/ts
+        run: npm run build --if-present
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/hud.yml
+++ b/.github/workflows/hud.yml
@@ -24,20 +24,24 @@ jobs:
       - name: Risolvi flag smart alerts
         id: flags
         run: |
-          value=$(python - <<'PY'
-from pathlib import Path
+          set -euo pipefail
+          output_file="$(mktemp)"
+          python <<'PY' >"$output_file"
+          from pathlib import Path
 
-content = Path('config/cli/hud.yaml').read_text(encoding='utf-8')
-enabled = False
-for line in content.splitlines():
-    stripped = line.strip()
-    if stripped.startswith('default:'):
-        enabled = stripped.split(':', 1)[1].strip().lower() in {'true', 'yes', '1', 'on'}
-        break
-print(f"enabled={'true' if enabled else 'false'}")
-PY
-          )
-          echo "$value" >> "$GITHUB_OUTPUT"
+          content = Path("config/cli/hud.yaml").read_text(encoding="utf-8")
+          enabled = False
+          for line in content.splitlines():
+              stripped = line.strip()
+              if stripped.startswith("default:"):
+                  enabled = stripped.split(":", 1)[1].strip().lower() in {"true", "yes", "1", "on"}
+                  break
+
+          print("enabled=true" if enabled else "enabled=false")
+          PY
+          cat "$output_file"
+          cat "$output_file" >>"$GITHUB_OUTPUT"
+          rm -f "$output_file"
 
       - name: Imposta Node.js
         if: steps.flags.outputs.enabled == 'true'


### PR DESCRIPTION
## Summary
- rewrite the HUD canary smart alert flag step to run a readable heredoc Python helper and safely export the enabled flag
- install Node dependencies and build the TypeScript bundle during the deploy workflow so the validation script has the expected dist artifacts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ffc96e4d888332b26d582d65b4c40e