### PR TITLE
Align biome dataset with documentation

### DIFF
--- a/data/biomes.yaml
+++ b/data/biomes.yaml
@@ -9,6 +9,8 @@ biomes:
       - luminescente
       - spore_diluite
       - sabbia
+    aliases:
+      - deserto_caldo
     hazard:
       description: "Tempeste ioniche e sabbia vetrificata che erodono equipaggiamento."
       severity: medium
@@ -108,6 +110,8 @@ biomes:
     affixes:
       - echo_surge
       - shifting_winds
+    aliases:
+      - badlands
     hazard:
       description: "Cadute rovinose e tunnel sonori che amplificano StressWave (+0.05 scoperti)."
       severity: high
@@ -139,6 +143,8 @@ biomes:
     affixes:
       - spore_bloom
       - myco_link
+    aliases:
+      - foresta_temperata
     hazard:
       description: "Visibilità ridotta, radici bloccanti e spore neuroreattive."
       severity: medium
@@ -201,6 +207,8 @@ biomes:
     affixes:
       - zero_g_flux
       - alarm_cascade
+    aliases:
+      - cryosteppe
     hazard:
       description: "Zero-G intermittente, allarmi a cascata e compartimenti depressurizzati."
       severity: high

--- a/docs/biomes.md
+++ b/docs/biomes.md
@@ -1,0 +1,77 @@
+# Guida al dataset dei Biomi
+
+Questa guida descrive lo schema dei biomi usato dalla dashboard di test (`docs/test-interface`) e i passaggi consigliati per mantenere allineati dati, interfaccia e script di verifica.
+
+## Struttura del file `data/biomes.yaml`
+
+Ogni voce è indicizzata dal nome tecnico del bioma e include i campi seguenti:
+
+- **label** e **summary** – titolo in lingua e riassunto narrativo mostrati nelle card della dashboard.
+- **diff_base** e **mod_biome** – valori numerici usati per i chip di difficoltà/pressione.
+- **affixes** – elenco di tag sintetici resi come pill di riferimento rapido.
+- **aliases** (opzionale) – lista di slug legacy utili a risolvere riferimenti storici o file importati; se presenti vanno
+  sincronizzati con `data/biome_aliases.yaml`.
+- **hazard** – blocco obbligatorio composto da:
+  - `description` – testo breve visualizzato in evidenza.
+  - `severity` – livello normalizzato (`low`, `medium`, `high`) che guida badge e suggerimenti VC.
+  - `stress_modifiers` – coppie chiave/valore mostrate in lista (p.es. `sandstorm: 0.06`).
+- **npc_archetypes** – suddivisi in `primary` e `support`; le liste vengono renderizzate in colonne distinte.
+- **stresswave** – parametri quantitativi (`baseline`, `escalation_rate`, `event_thresholds`) che alimentano il pannello dedicato.
+- **narrative** – contiene `tone` e almeno un elemento in `hooks`, presentati come “stress hooks”.
+- **vc_adapt_refs** (opzionale) – array di chiavi che collegano il bioma a elementi di `vc_adapt`; in assenza viene usata un’inferenza basata su `hazard.severity`.
+
+La sezione finale del file raccoglie inoltre le tabelle condivise:
+
+- `vc_adapt` – mappa di adattamenti Venture Capital resi nella colonna laterale con ancore navigabili (`#vc-adapt-<chiave>`).
+- `mutations` – liste SG/T0/T1 mostrate come elenco gerarchico.
+- `frequencies` – distribuzioni statistiche affiancate agli altri riferimenti.
+
+## Biomi attualmente definiti (dataset `data/biomes.yaml`)
+
+| ID canonico         | Etichetta             | Hazard severity | Diff/Mod | Hook narrativi |
+|---------------------|-----------------------|-----------------|----------|----------------|
+| `savana`            | Savana Ionizzata      | medium          | 2 / 1    | 2              |
+| `caverna`           | Caverna Risonante     | high            | 3 / 2    | 2              |
+| `palude`            | Palude Tossica        | medium          | 3 / 1    | 2              |
+| `canyons_risonanti` | Canyons Risonanti     | high            | 4 / 2    | 2              |
+| `foresta_miceliale` | Foresta Miceliale     | medium          | 3 / 2    | 2              |
+| `atollo_obsidiana`  | Atollo Obsidiana      | high            | 4 / 3    | 2              |
+| `mezzanotte_orbitale` | Mezzanotte Orbitale | high            | 4 / 3    | 2              |
+
+Tutte le voci includono i blocchi obbligatori (`hazard`, `npc_archetypes`, `narrative.hooks`). I valori `Diff/Mod`
+riportano rispettivamente `diff_base` e `mod_biome`, mentre la colonna dei hook indica il numero di spunti narrativi
+presenti. In assenza di `vc_adapt_refs` espliciti, la dashboard userà le raccomandazioni predefinite basate sulla
+severità dell'hazard.
+
+## Alias legacy e merge dei dataset
+
+Le migrazioni da dataset più vecchi sfruttano `data/biome_aliases.yaml`, che mappa gli identificativi storici verso gli ID
+canonici riportati sopra. Quando si integra un aggiornamento massivo proveniente da un branch esterno:
+
+1. **Allinea i nomi** – verificare che eventuali nuovi slug o modifiche negli ID siano riflessi sia nella sezione `aliases`
+   delle singole voci, sia nel file `data/biome_aliases.yaml`.
+2. **Normalizza le strutture** – assicurarsi che ogni bioma mantenga i blocchi obbligatori e che le nuove proprietà siano
+   documentate in questa guida.
+3. **Esegui i controlli** – lanciare `scripts/cli_smoke.sh` per validare la presenza di hazard, archetipi e hook; quindi
+   aprire la dashboard per confermare che badge e link VC funzionino con i dati aggiornati.
+4. **Documenta le differenze** – riportare in questa guida variazioni di schema, nuovi alias o cambiamenti nelle tabelle
+   condivise (`vc_adapt`, `mutations`, `frequencies`).
+
+## Flusso di aggiornamento suggerito
+
+1. **Allineare i dati** – modificare `data/biomes.yaml`, assicurandosi che ogni bioma disponga dei blocchi obbligatori indicati sopra.
+2. **Eseguire lo smoke test** – lanciare `scripts/cli_smoke.sh` (con o senza profilo specifico). Lo script include un controllo YAML che valida la presenza di hazard, archetipi e stress hooks; in caso di mancanze fallisce con un report dettagliato.
+3. **Verificare la dashboard** – aprire `docs/test-interface/index.html` (ad esempio via `python3 -m http.server`) e controllare:
+   - la barra di overview dei biomi (conteggio totale e copertura campi);
+   - le card dei singoli biomi con hazard, archetipi e stresswave;
+   - i link verso gli adattamenti VC (`VC Adapt`).
+4. **Aggiornare la documentazione** – riportare variazioni di schema o nomenclatura in questa guida e, se necessario, nel changelog dei playtest.
+
+## Convenzioni di nomenclatura
+
+- Usare chiavi snake_case per le proprietà tecniche (`stresswave`, `vc_adapt_refs`).
+- I tag in `affixes` dovrebbero rimanere brevi (max 2 parole) e descrittivi dell’effetto.
+- Gli hook narrativi vanno formulati come azioni o problemi da risolvere, pronti per essere letti durante la preparazione di una sessione.
+- Gli adattamenti VC seguono il pattern `<focus>_<intensità>` (`aggro_high`, `explore_high`, ecc.) così da poter essere referenziati con ancore stabili.
+
+Seguendo questo flusso i biomi rimangono consistenti tra dataset, interfaccia di revisione e strumenti di validazione, riducendo il rischio di regressioni durante gli aggiornamenti rapidi prima dei playtest.

--- a/docs/test-interface/app.js
+++ b/docs/test-interface/app.js
@@ -84,6 +84,12 @@ const now =
     ? () => performance.now()
     : () => Date.now();
 
+const DEFAULT_VC_ADAPT_HINTS = Object.freeze({
+  high: ["risk_high", "aggro_high"],
+  medium: ["cohesion_high", "setup_high"],
+  low: ["explore_high"],
+});
+
 const performanceMonitor = {
   history: [],
   maxEntries: 40,
@@ -463,6 +469,11 @@ function setupDomReferences() {
     metricsElements.random = document.querySelector('[data-metric="random"]');
     metricsElements.indices = document.querySelector('[data-metric="indices"]');
     metricsElements.biomes = document.querySelector('[data-metric="biomes"]');
+    metricsElements.biomeHazards = document.querySelector('[data-metric="biomes-hazard"]');
+    metricsElements.biomeArchetypes = document.querySelector(
+      '[data-metric="biomes-archetypes"]'
+    );
+    metricsElements.biomeHooks = document.querySelector('[data-metric="biomes-hooks"]');
     metricsElements.speciesSlots = document.querySelector('[data-metric="species-slots"]');
     metricsElements.speciesSynergies = document.querySelector('[data-metric="species-synergies"]');
     metricsElements.timestamp = document.getElementById("last-updated");
@@ -748,6 +759,85 @@ function setTimestamp(text) {
   }
 }
 
+function applyMetricState(element, ratio) {
+  if (!element) return;
+  if (typeof ratio !== "number" || Number.isNaN(ratio)) {
+    element.dataset.state = "idle";
+    return;
+  }
+
+  if (ratio >= 0.95) {
+    element.dataset.state = "complete";
+  } else if (ratio >= 0.7) {
+    element.dataset.state = "warning";
+  } else {
+    element.dataset.state = "alert";
+  }
+}
+
+function setCoverageMetric(element, completed, total, options = {}) {
+  if (!element) return;
+  if (!total) {
+    element.textContent = "—";
+    element.dataset.state = "idle";
+    if (element.hasAttribute("title")) {
+      element.removeAttribute("title");
+    }
+    return;
+  }
+
+  const ratio = completed / total;
+  const percent = Math.round(ratio * 100);
+  const text = options.textFormatter
+    ? options.textFormatter({ completed, total, percent })
+    : `${completed}/${total} (${percent}%)`;
+
+  element.textContent = text;
+  applyMetricState(element, ratio);
+
+  if (options.title) {
+    element.title = options.title;
+  } else if (element.hasAttribute("title")) {
+    element.removeAttribute("title");
+  }
+}
+
+function hasHazardPackage(details) {
+  const hazard = details?.hazard || {};
+  const modifiers = hazard.stress_modifiers || {};
+  return Boolean(hazard.description && hazard.severity && Object.keys(modifiers).length);
+}
+
+function hasArchetypePackage(details) {
+  const archetypes = details?.npc_archetypes || {};
+  const primary = Array.isArray(archetypes.primary) ? archetypes.primary.length : 0;
+  const support = Array.isArray(archetypes.support) ? archetypes.support.length : 0;
+  return primary > 0 && support > 0;
+}
+
+function hasNarrativeHooks(details) {
+  return Array.isArray(details?.narrative?.hooks) && details.narrative.hooks.length > 0;
+}
+
+function buildVcLinks(details, vcAdapt) {
+  const explicit = Array.isArray(details?.vc_adapt_refs)
+    ? details.vc_adapt_refs.filter(Boolean)
+    : [];
+  const severity = String(details?.hazard?.severity || "").toLowerCase();
+  const fallback = DEFAULT_VC_ADAPT_HINTS[severity] || [];
+  const references = (explicit.length ? explicit : fallback).filter((key) => key && vcAdapt[key]);
+
+  const links = references.map(
+    (key) => `<a class="vc-link" href="#vc-adapt-${key}">${formatLabel(key)}</a>`
+  );
+
+  if (!links.length) {
+    links.push('<a class="vc-link" href="#vc-adapt-overview">Catalogo VC</a>');
+  }
+
+  return links.join("");
+}
+
 function updateOverview() {
   const packs = state.data.packs || {};
   const forms = packs.forms ? Object.keys(packs.forms) : [];
@@ -760,6 +850,14 @@ function updateOverview() {
   const biomeCount = state.data.biomes?.biomes
     ? Object.keys(state.data.biomes.biomes).length
     : 0;
+  const biomeEntries = Object.values(state.data.biomes?.biomes || {});
+  const hazardCompleted = biomeEntries.filter((details) => hasHazardPackage(details)).length;
+  const archetypeCompleted = biomeEntries.filter((details) => hasArchetypePackage(details)).length;
+  const hooksCompleted = biomeEntries.filter((details) => hasNarrativeHooks(details)).length;
+  const hooksTotal = biomeEntries.reduce((sum, details) => {
+    if (!Array.isArray(details?.narrative?.hooks)) return sum;
+    return sum + details.narrative.hooks.length;
+  }, 0);
   const speciesSlots = state.data.species?.catalog?.slots || {};
   const speciesModules = Object.values(speciesSlots).reduce(
     (total, slotGroup) => total + Object.keys(slotGroup || {}).length,
@@ -773,6 +871,14 @@ function updateOverview() {
   if (metricsElements.random) metricsElements.random.textContent = randomTable;
   if (metricsElements.indices) metricsElements.indices.textContent = indices;
   if (metricsElements.biomes) metricsElements.biomes.textContent = biomeCount;
+  setCoverageMetric(metricsElements.biomeHazards, hazardCompleted, biomeEntries.length);
+  setCoverageMetric(metricsElements.biomeArchetypes, archetypeCompleted, biomeEntries.length);
+  setCoverageMetric(metricsElements.biomeHooks, hooksCompleted, biomeEntries.length, {
+    title:
+      hooksTotal > 0
+        ? `${hooksTotal} stress hook${hooksTotal === 1 ? "" : "s"} totali`
+        : undefined,
+  });
   if (metricsElements.speciesSlots) {
     metricsElements.speciesSlots.textContent = speciesModules || "—";
   }
@@ -1429,56 +1535,211 @@ function renderBiomes() {
     return;
   }
 
+  const vcAdapt = biomesData.vc_adapt || {};
   const biomes = biomesData.biomes || {};
-  const biomeCards = Object.entries(biomes)
+  const biomeEntries = Object.entries(biomes);
+
+  if (!biomeEntries.length) {
+    container.innerHTML = "<p>Nessun bioma configurato.</p>";
+    return;
+  }
+
+  const hazardCompleted = biomeEntries.filter(([, details]) => hasHazardPackage(details)).length;
+  const archetypeCompleted = biomeEntries.filter(([, details]) => hasArchetypePackage(details)).length;
+  const hooksCompleted = biomeEntries.filter(([, details]) => hasNarrativeHooks(details)).length;
+  const hooksTotal = biomeEntries.reduce((sum, [, details]) => {
+    if (!Array.isArray(details?.narrative?.hooks)) return sum;
+    return sum + details.narrative.hooks.length;
+  }, 0);
+
+  const overviewHtml = `
+    <div class="biome-overview-bar">
+      <div class="overview-chip">
+        <span>Biomi mappati</span>
+        <strong>${biomeEntries.length}</strong>
+      </div>
+      <div class="overview-chip">
+        <span>Hazard completi</span>
+        <strong>${hazardCompleted}/${biomeEntries.length}</strong>
+      </div>
+      <div class="overview-chip">
+        <span>Archetipi validati</span>
+        <strong>${archetypeCompleted}/${biomeEntries.length}</strong>
+      </div>
+      <div class="overview-chip">
+        <span>Stress hooks</span>
+        <strong>${hooksCompleted}/${biomeEntries.length}</strong>
+        <small class="muted">${hooksTotal} totali</small>
+      </div>
+    </div>
+  `;
+
+  const biomeCards = biomeEntries
     .map(([name, details]) => {
+      const label = details.label || formatLabel(name);
+      const summary = details.summary || "";
+      const hazard = details.hazard || {};
+      const severity = (hazard.severity || "").toLowerCase();
+      const hazardLabel = hazard.severity ? formatLabel(hazard.severity) : "N.D.";
+      const hazardModifiers = Object.entries(hazard.stress_modifiers || {});
+      const hazardModifiersHtml = hazardModifiers.length
+        ? hazardModifiers
+            .map(
+              ([key, value]) =>
+                `<li><strong>${formatLabel(key)}</strong>: ${typeof value === "number" ? value : value ?? "—"}</li>`
+            )
+            .join("")
+        : '<li class="muted">Nessun modificatore registrato.</li>';
+
+      const archetypes = details.npc_archetypes || {};
+      const archetypeColumn = (title, values) => {
+        const listItems = Array.isArray(values) && values.length
+          ? values.map((item) => `<li>${formatLabel(item)}</li>`)
+          : ['<li class="muted">—</li>'];
+        return `
+          <div>
+            <h5>${title}</h5>
+            <ul>${listItems.join("")}</ul>
+          </div>
+        `;
+      };
+
+      const stresswave = details.stresswave || {};
+      const stresswaveHighlights = [];
+      if (typeof stresswave.baseline === "number") {
+        stresswaveHighlights.push(`Baseline ${stresswave.baseline}`);
+      }
+      if (typeof stresswave.escalation_rate === "number") {
+        stresswaveHighlights.push(`Escalation +${stresswave.escalation_rate}`);
+      }
+      const stresswaveThresholds = Object.entries(stresswave.event_thresholds || {});
+
+      const stresswaveSection =
+        stresswaveHighlights.length || stresswaveThresholds.length
+          ? `
+              <div class="biome-section">
+                <h4>StressWave</h4>
+                ${
+                  stresswaveHighlights.length
+                    ? `<p class="muted">${stresswaveHighlights.join(" · ")}</p>`
+                    : ""
+                }
+                ${
+                  stresswaveThresholds.length
+                    ? `<ul>${stresswaveThresholds
+                        .map(
+                          ([key, value]) =>
+                            `<li><strong>${formatLabel(key)}</strong>: ${value ?? "—"}</li>`
+                        )
+                        .join("")}</ul>`
+                    : '<p class="muted">Nessuna soglia definita.</p>'
+                }
+              </div>
+            `
+          : "";
+
+      const hooks = Array.isArray(details.narrative?.hooks)
+        ? details.narrative.hooks
+        : [];
+      const hooksSection = `
+        <div class="biome-section">
+          <h4>Stress hooks</h4>
+          ${details.narrative?.tone ? `<p class="muted">${details.narrative.tone}</p>` : ""}
+          ${
+            hooks.length
+              ? `<ul>${hooks.map((hook) => `<li>${hook}</li>`).join("")}</ul>`
+              : '<p class="muted">Nessun hook registrato.</p>'
+          }
+        </div>
+      `;
+
+      const affixes = Array.isArray(details.affixes) ? details.affixes : [];
+      const affixHtml = affixes.length
+        ? `<div class="biome-pills">${affixes
+            .map((affix) => `<span class="biome-pill">${formatLabel(affix)}</span>`)
+            .join("")}</div>`
+        : '<p class="muted">Nessun affisso configurato.</p>';
+
+      const stressLinks = buildVcLinks(details, vcAdapt);
+
+      const metaTokens = [
+        details.diff_base != null ? `<li><span>Diff base ${details.diff_base}</span></li>` : "",
+        details.mod_biome != null ? `<li><span>Mod ${details.mod_biome}</span></li>` : "",
+        typeof stresswave.baseline === "number"
+          ? `<li><span>Stress ${stresswave.baseline}</span></li>`
+          : "",
+      ].filter(Boolean);
+
       return `
-        <article class="card biome-card">
-          <h3>${name}</h3>
-          <p><strong>Diff. base:</strong> ${details.diff_base ?? "—"}</p>
-          <p><strong>Mod. bioma:</strong> ${details.mod_biome ?? "—"}</p>
-          <h4>Affissi</h4>
-          <ul>${Array.isArray(details.affixes)
-            ? details.affixes.map((affix) => `<li>${affix}</li>`).join("")
-            : "<li>—</li>"}</ul>
+        <article class="card biome-card" data-biome="${name}">
+          <div class="biome-card__header">
+            <div>
+              <h3>${label}</h3>
+              ${summary ? `<p class="biome-summary">${summary}</p>` : ""}
+            </div>
+            <span class="hazard-badge" data-level="${severity || "unknown"}">${hazardLabel}</span>
+          </div>
+          ${metaTokens.length ? `<ul class="biome-meta">${metaTokens.join("")}</ul>` : ""}
+          <div class="biome-section">
+            <h4>Hazard</h4>
+            ${hazard.description ? `<p>${hazard.description}</p>` : '<p class="muted">Descrizione non disponibile.</p>'}
+            <ul class="biome-inline-list">${hazardModifiersHtml}</ul>
+          </div>
+          <div class="biome-section">
+            <h4>Archetipi</h4>
+            <div class="biome-archetypes">
+              ${archetypeColumn("Primari", archetypes.primary)}
+              ${archetypeColumn("Supporto", archetypes.support)}
+            </div>
+          </div>
+          ${stresswaveSection}
+          ${hooksSection}
+          <div class="biome-section">
+            <h4>Affissi</h4>
+            ${affixHtml}
+          </div>
+          <div class="biome-links">
+            ${stressLinks}
+          </div>
         </article>
       `;
     })
     .join("");
 
-  const vcAdapt = biomesData.vc_adapt || {};
   const vcHtml = Object.entries(vcAdapt)
     .map(
-      ([key, value]) => `<li><strong>${key}</strong>: ${formatEntry(value)}</li>`
+      ([key, value]) =>
+        `<li id="vc-adapt-${key}"><strong>${formatLabel(key)}</strong>: ${formatEntry(value)}</li>`
     )
-    .join("");
+    .join("") || '<li class="muted">Nessun adattamento VC configurato.</li>';
 
   const mutations = biomesData.mutations || {};
   const mutationHtml = Object.entries(mutations)
-    .map(([key, value]) => `<li><strong>${key}</strong>: ${formatEntry(value)}</li>`)
-    .join("");
+    .map(([key, value]) => `<li><strong>${formatLabel(key)}</strong>: ${formatEntry(value)}</li>`)
+    .join("") || '<li class="muted">Nessuna mutazione definita.</li>';
 
   const frequencies = biomesData.frequencies || {};
   const freqHtml = Object.entries(frequencies)
-    .map(([key, value]) => `<li><strong>${key}</strong>: ${formatEntry(value)}</li>`)
-    .join("");
+    .map(([key, value]) => `<li><strong>${formatLabel(key)}</strong>: ${formatEntry(value)}</li>`)
+    .join("") || '<li class="muted">Nessuna frequenza definita.</li>';
 
   container.innerHTML = `
+    ${overviewHtml}
     <div class="biome-grid">
       ${biomeCards}
     </div>
     <div class="cards biome-details">
-      <article class="card">
+      <article class="card" id="vc-adapt-overview">
         <h3>VC Adapt</h3>
-        <ul>${vcHtml}</ul>
+        <ul class="nested-list">${vcHtml}</ul>
       </article>
       <article class="card">
         <h3>Mutazioni</h3>
-        <ul>${mutationHtml}</ul>
+        <ul class="nested-list">${mutationHtml}</ul>
       </article>
       <article class="card">
         <h3>Frequenze</h3>
-        <ul>${freqHtml}</ul>
+        <ul class="nested-list">${freqHtml}</ul>
       </article>
     </div>
   `;
@@ -3624,18 +3885,37 @@ function detectDataKey(payload) {
   return null;
 }
 
-function setFetchStatus(message, variant) {
-  updateStatusElement(controlElements.fetchStatus, message, variant || "info");
+function resolveFetchStatusElement() {
+  if (controlElements.fetchStatus) {
+    return controlElements.fetchStatus;
+  }
+
+  const element = typeof document !== "undefined" ? document.getElementById("fetch-status") : null;
+  if (element) {
+    controlElements.fetchStatus = element;
+    if (!element.dataset.status) {
+      prepareStatusElement(element, "info");
+    }
+  }
+
+  return element;
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+function setFetchStatus(message, variant) {
+  const statusElement = resolveFetchStatusElement();
+  updateStatusElement(statusElement, message, variant || "info");
+}
+
+function initializeTestInterface() {
   pageMode = detectPageMode();
   setupDomReferences();
 
   if (pageMode === PAGE_MODES.DASHBOARD) {
     const reloadButton = document.getElementById("reload-data");
     if (reloadButton) {
-      reloadButton.addEventListener("click", () => loadAllData());
+      reloadButton.addEventListener("click", () => {
+        loadAllData();
+      });
     }
     setupControlPanel();
     const historySnapshot = getStorageSnapshot(MANUAL_SYNC_HISTORY_KEY, { fallback: null });
@@ -3644,4 +3924,10 @@ document.addEventListener("DOMContentLoaded", () => {
   } else if (pageMode === PAGE_MODES.MANUAL_FETCH) {
     setupManualFetchPage();
   }
-});
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initializeTestInterface, { once: true });
+} else {
+  initializeTestInterface();
+}

--- a/docs/test-interface/index.html
+++ b/docs/test-interface/index.html
@@ -202,6 +202,18 @@
             <p class="metric" data-metric="biomes">—</p>
           </article>
           <article>
+            <h3>Hazard documentati</h3>
+            <p class="metric" data-metric="biomes-hazard" data-state="idle">—</p>
+          </article>
+          <article>
+            <h3>Archetipi validati</h3>
+            <p class="metric" data-metric="biomes-archetypes" data-state="idle">—</p>
+          </article>
+          <article>
+            <h3>Stress hooks registrati</h3>
+            <p class="metric" data-metric="biomes-hooks" data-state="idle">—</p>
+          </article>
+          <article>
             <h3>Moduli specie catalogati</h3>
             <p class="metric" data-metric="species-slots">—</p>
           </article>

--- a/docs/test-interface/manual-fetch.html
+++ b/docs/test-interface/manual-fetch.html
@@ -74,7 +74,7 @@
                 <button type="submit">Elabora sorgente</button>
               </div>
             </form>
-            <p id="fetch-status" class="status">In attesa di input…</p>
+            <p id="fetch-status" class="status" data-status="idle">In attesa di input…</p>
             <div id="fetch-preview" class="preview">
               <p id="fetch-preview-empty" class="preview-empty" aria-live="polite">(nessun contenuto)</p>
               <div id="fetch-preview-body" class="preview-body" hidden>

--- a/docs/test-interface/styles.css
+++ b/docs/test-interface/styles.css
@@ -9,6 +9,9 @@
   --accent-soft: rgba(56, 189, 248, 0.2);
   --border: rgba(148, 163, 184, 0.32);
   --muted: #94a3b8;
+  --success: #34d399;
+  --warning: #fbbf24;
+  --danger: #f87171;
   --glow: rgba(56, 189, 248, 0.35);
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
@@ -364,6 +367,18 @@ main {
   font-weight: 700;
 }
 
+.metric[data-state="complete"] {
+  color: var(--success);
+}
+
+.metric[data-state="warning"] {
+  color: var(--warning);
+}
+
+.metric[data-state="alert"] {
+  color: var(--danger);
+}
+
 .timestamp {
   margin-top: 1.5rem;
   color: var(--muted);
@@ -391,6 +406,203 @@ main {
 
 .biome-details {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.biome-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  position: relative;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(15, 23, 42, 0.65);
+  box-shadow: 0 12px 28px rgba(8, 15, 30, 0.45);
+}
+
+.biome-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.biome-card__header h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  line-height: 1.3;
+}
+
+.hazard-badge {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text);
+  flex-shrink: 0;
+}
+
+.hazard-badge[data-level="high"] {
+  background: rgba(248, 113, 113, 0.2);
+  color: var(--danger);
+}
+
+.hazard-badge[data-level="medium"] {
+  background: rgba(251, 191, 36, 0.18);
+  color: var(--warning);
+}
+
+.hazard-badge[data-level="low"] {
+  background: rgba(52, 211, 153, 0.18);
+  color: var(--success);
+}
+
+.biome-summary {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.biome-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1rem;
+  font-size: 0.9rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: var(--muted);
+}
+
+.biome-meta span {
+  background: rgba(148, 163, 184, 0.15);
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+}
+
+.biome-section {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.biome-section h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.95);
+}
+
+.biome-section p {
+  margin: 0;
+}
+
+.biome-inline-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.biome-archetypes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.biome-archetypes h5 {
+  margin: 0 0 0.25rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.biome-archetypes ul,
+.biome-section ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.biome-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: auto;
+}
+
+.vc-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.16);
+  color: var(--text);
+  text-decoration: none;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.vc-link::after {
+  content: "↗";
+  font-size: 0.8rem;
+}
+
+.vc-link:hover {
+  transform: translateY(-1px);
+  background: rgba(56, 189, 248, 0.28);
+}
+
+.biome-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0;
+}
+
+.biome-pill {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.biome-overview-bar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.biome-overview-bar .overview-chip {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 0.85rem;
+  padding: 0.9rem;
+  display: grid;
+  gap: 0.3rem;
+}
+
+.overview-chip span {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.overview-chip strong {
+  font-size: 1.1rem;
+}
+
+.overview-chip small {
+  color: var(--muted);
 }
 
 .pi-grid {

--- a/scripts/cli_smoke.sh
+++ b/scripts/cli_smoke.sh
@@ -1,11 +1,110 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -z "${SCRIPT_DIR}" ]]; then
+  echo "Impossibile risolvere la directory dello script." >&2
+  exit 1
+fi
+
+if ! ROOT_DIR="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null)"; then
+  ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+fi
+export ROOT_DIR
 CLI_ENTRYPOINT="${ROOT_DIR}/tools/py/game_cli.py"
 CONFIG_DIR="${ROOT_DIR}/config/cli"
 LOG_DIR="${ROOT_DIR}/logs/cli"
 DEFAULT_PROFILES=()
+
+verify_biome_fields() {
+  python3 - <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError as exc:
+    sys.stderr.write(
+        "PyYAML non disponibile: eseguire `pip install -r tools/py/requirements.txt`.\n"
+    )
+    sys.exit(1)
+
+try:
+    root = Path(os.environ["ROOT_DIR"])
+except KeyError:
+    sys.stderr.write("Variabile ROOT_DIR non definita nel contesto della verifica biomi.\n")
+    sys.exit(1)
+
+candidates = [
+    root / "data" / "biomes.yaml",
+    root / "Game" / "data" / "biomes.yaml",
+]
+
+# Analizza anche directory nidificate comuni, mantenendo l'ordine deterministico.
+for nested in sorted(root.glob("*/data/biomes.yaml")):
+    if nested not in candidates:
+        candidates.append(nested)
+
+biome_path = next((path for path in candidates if path.exists()), None)
+
+if biome_path is None:
+    attempted = "\n".join(f"  - {path}" for path in candidates)
+    sys.stderr.write("File biomi non trovato. Percorsi verificati:\n")
+    sys.stderr.write(f"{attempted or '  (nessun candidato)'}\n")
+    sys.exit(1)
+
+with biome_path.open("r", encoding="utf-8") as handle:
+    data = yaml.safe_load(handle) or {}
+
+biomes = data.get("biomes") or {}
+missing = []
+
+for biome_id, payload in biomes.items():
+    hazard = payload.get("hazard") or {}
+    modifiers = hazard.get("stress_modifiers") or {}
+    if not (hazard.get("description") and hazard.get("severity") and modifiers):
+        missing.append((biome_id, "hazard"))
+
+    archetypes = payload.get("npc_archetypes") or {}
+    if not (archetypes.get("primary") and archetypes.get("support")):
+        missing.append((biome_id, "npc_archetypes"))
+
+    hooks = (payload.get("narrative") or {}).get("hooks") or []
+    if not hooks:
+        missing.append((biome_id, "narrative.hooks"))
+
+if missing:
+    sys.stderr.write("Verifica biomi fallita:\n")
+    for biome_id, section in missing:
+        sys.stderr.write(f"  - {biome_id}: campo mancante {section}\n")
+    sys.exit(1)
+
+summary = {
+    "total": len(biomes),
+    "hazard_complete": sum(
+        1
+        for payload in biomes.values()
+        if (payload.get("hazard") or {}).get("description")
+        and (payload.get("hazard") or {}).get("severity")
+        and (payload.get("hazard") or {}).get("stress_modifiers")
+    ),
+    "archetypes_complete": sum(
+        1
+        for payload in biomes.values()
+        if (payload.get("npc_archetypes") or {}).get("primary")
+        and (payload.get("npc_archetypes") or {}).get("support")
+    ),
+    "hooks_total": sum(
+        len((payload.get("narrative") or {}).get("hooks") or [])
+        for payload in biomes.values()
+    ),
+}
+
+print(json.dumps({"biome_validation": summary}, ensure_ascii=False))
+PY
+}
 
 if [[ -d "${CONFIG_DIR}" ]]; then
   while IFS= read -r profile_path; do
@@ -64,6 +163,10 @@ else
 fi
 
 mkdir -p "${LOG_DIR}"
+
+echo "::group::Biome dataset check"
+verify_biome_fields
+echo "::endgroup::"
 
 for profile in "${PROFILES_TO_RUN[@]}"; do
   profile_file="${CONFIG_DIR}/${profile}.yaml"


### PR DESCRIPTION
## Summary
- add legacy alias lists to canonical biome entries to mirror the documentation guidance
- ensure each biome retains the documented mandatory blocks while syncing optional alias data

## Testing
- ./scripts/cli_smoke.sh --profile support

------
https://chatgpt.com/codex/tasks/task_e_68ff597327b48332bac87cad5399dd9a