### PR TITLE
Add Chromium fallback for web tests

### DIFF
--- a/data/biomes.yaml
+++ b/data/biomes.yaml
@@ -9,6 +9,8 @@ biomes:
       - luminescente
       - spore_diluite
       - sabbia
+    aliases:
+      - deserto_caldo
     hazard:
       description: "Tempeste ioniche e sabbia vetrificata che erodono equipaggiamento."
       severity: medium
@@ -42,6 +44,8 @@ biomes:
       - cristallino
       - fangoso
       - acque_nere
+    aliases:
+      - caverna_risonante
     hazard:
       description: "Risonanze amplificate, crolli spontanei e pozze acide."
       severity: high
@@ -65,8 +69,6 @@ biomes:
       hooks:
         - "Disinnescare camere di eco instabile prima del collasso."
         - "Estrarre cristalli risonanti senza allertare i custodi del nido."
-    aliases:
-      - caverna_risonante
   palude:
     label: "Palude Tossica"
     summary: "Acque stagnanti bio-luminescenti con fauna mutagena."
@@ -108,6 +110,8 @@ biomes:
     affixes:
       - echo_surge
       - shifting_winds
+    aliases:
+      - badlands
     hazard:
       description: "Cadute rovinose e tunnel sonori che amplificano StressWave (+0.05 scoperti)."
       severity: high
@@ -139,6 +143,8 @@ biomes:
     affixes:
       - spore_bloom
       - myco_link
+    aliases:
+      - foresta_temperata
     hazard:
       description: "Visibilità ridotta, radici bloccanti e spore neuroreattive."
       severity: medium
@@ -201,6 +207,8 @@ biomes:
     affixes:
       - zero_g_flux
       - alarm_cascade
+    aliases:
+      - cryosteppe
     hazard:
       description: "Zero-G intermittente, allarmi a cascata e compartimenti depressurizzati."
       severity: high

--- a/docs/biomes.md
+++ b/docs/biomes.md
@@ -1,0 +1,77 @@
+# Guida al dataset dei Biomi
+
+Questa guida descrive lo schema dei biomi usato dalla dashboard di test (`docs/test-interface`) e i passaggi consigliati per mantenere allineati dati, interfaccia e script di verifica.
+
+## Struttura del file `data/biomes.yaml`
+
+Ogni voce è indicizzata dal nome tecnico del bioma e include i campi seguenti:
+
+- **label** e **summary** – titolo in lingua e riassunto narrativo mostrati nelle card della dashboard.
+- **diff_base** e **mod_biome** – valori numerici usati per i chip di difficoltà/pressione.
+- **affixes** – elenco di tag sintetici resi come pill di riferimento rapido.
+- **aliases** (opzionale) – lista di slug legacy utili a risolvere riferimenti storici o file importati; se presenti vanno
+  sincronizzati con `data/biome_aliases.yaml`.
+- **hazard** – blocco obbligatorio composto da:
+  - `description` – testo breve visualizzato in evidenza.
+  - `severity` – livello normalizzato (`low`, `medium`, `high`) che guida badge e suggerimenti VC.
+  - `stress_modifiers` – coppie chiave/valore mostrate in lista (p.es. `sandstorm: 0.06`).
+- **npc_archetypes** – suddivisi in `primary` e `support`; le liste vengono renderizzate in colonne distinte.
+- **stresswave** – parametri quantitativi (`baseline`, `escalation_rate`, `event_thresholds`) che alimentano il pannello dedicato.
+- **narrative** – contiene `tone` e almeno un elemento in `hooks`, presentati come “stress hooks”.
+- **vc_adapt_refs** (opzionale) – array di chiavi che collegano il bioma a elementi di `vc_adapt`; in assenza viene usata un’inferenza basata su `hazard.severity`.
+
+La sezione finale del file raccoglie inoltre le tabelle condivise:
+
+- `vc_adapt` – mappa di adattamenti Venture Capital resi nella colonna laterale con ancore navigabili (`#vc-adapt-<chiave>`).
+- `mutations` – liste SG/T0/T1 mostrate come elenco gerarchico.
+- `frequencies` – distribuzioni statistiche affiancate agli altri riferimenti.
+
+## Biomi attualmente definiti (dataset `data/biomes.yaml`)
+
+| ID canonico         | Etichetta             | Hazard severity | Diff/Mod | Hook narrativi |
+|---------------------|-----------------------|-----------------|----------|----------------|
+| `savana`            | Savana Ionizzata      | medium          | 2 / 1    | 2              |
+| `caverna`           | Caverna Risonante     | high            | 3 / 2    | 2              |
+| `palude`            | Palude Tossica        | medium          | 3 / 1    | 2              |
+| `canyons_risonanti` | Canyons Risonanti     | high            | 4 / 2    | 2              |
+| `foresta_miceliale` | Foresta Miceliale     | medium          | 3 / 2    | 2              |
+| `atollo_obsidiana`  | Atollo Obsidiana      | high            | 4 / 3    | 2              |
+| `mezzanotte_orbitale` | Mezzanotte Orbitale | high            | 4 / 3    | 2              |
+
+Tutte le voci includono i blocchi obbligatori (`hazard`, `npc_archetypes`, `narrative.hooks`). I valori `Diff/Mod`
+riportano rispettivamente `diff_base` e `mod_biome`, mentre la colonna dei hook indica il numero di spunti narrativi
+presenti. In assenza di `vc_adapt_refs` espliciti, la dashboard userà le raccomandazioni predefinite basate sulla
+severità dell'hazard.
+
+## Alias legacy e merge dei dataset
+
+Le migrazioni da dataset più vecchi sfruttano `data/biome_aliases.yaml`, che mappa gli identificativi storici verso gli ID
+canonici riportati sopra. Quando si integra un aggiornamento massivo proveniente da un branch esterno:
+
+1. **Allinea i nomi** – verificare che eventuali nuovi slug o modifiche negli ID siano riflessi sia nella sezione `aliases`
+   delle singole voci, sia nel file `data/biome_aliases.yaml`.
+2. **Normalizza le strutture** – assicurarsi che ogni bioma mantenga i blocchi obbligatori e che le nuove proprietà siano
+   documentate in questa guida.
+3. **Esegui i controlli** – lanciare `scripts/cli_smoke.sh` per validare la presenza di hazard, archetipi e hook; quindi
+   aprire la dashboard per confermare che badge e link VC funzionino con i dati aggiornati.
+4. **Documenta le differenze** – riportare in questa guida variazioni di schema, nuovi alias o cambiamenti nelle tabelle
+   condivise (`vc_adapt`, `mutations`, `frequencies`).
+
+## Flusso di aggiornamento suggerito
+
+1. **Allineare i dati** – modificare `data/biomes.yaml`, assicurandosi che ogni bioma disponga dei blocchi obbligatori indicati sopra.
+2. **Eseguire lo smoke test** – lanciare `scripts/cli_smoke.sh` (con o senza profilo specifico). Lo script include un controllo YAML che verifica label, summary, difficoltà/modificatori, affissi, hazard (con severità normalizzata), archetipi, stresswave e tono/hook narrativi; in caso di mancanze fallisce con un report dettagliato e stampa le metriche di copertura rilevate.
+3. **Verificare la dashboard** – aprire `docs/test-interface/index.html` (ad esempio via `python3 -m http.server`) e controllare:
+   - la barra di overview dei biomi (conteggio totale e copertura campi);
+   - le card dei singoli biomi con hazard, archetipi e stresswave;
+   - i link verso gli adattamenti VC (`VC Adapt`).
+4. **Aggiornare la documentazione** – riportare variazioni di schema o nomenclatura in questa guida e, se necessario, nel changelog dei playtest.
+
+## Convenzioni di nomenclatura
+
+- Usare chiavi snake_case per le proprietà tecniche (`stresswave`, `vc_adapt_refs`).
+- I tag in `affixes` dovrebbero rimanere brevi (max 2 parole) e descrittivi dell’effetto.
+- Gli hook narrativi vanno formulati come azioni o problemi da risolvere, pronti per essere letti durante la preparazione di una sessione.
+- Gli adattamenti VC seguono il pattern `<focus>_<intensità>` (`aggro_high`, `explore_high`, ecc.) così da poter essere referenziati con ancore stabili.
+
+Seguendo questo flusso i biomi rimangono consistenti tra dataset, interfaccia di revisione e strumenti di validazione, riducendo il rischio di regressioni durante gli aggiornamenti rapidi prima dei playtest.

--- a/docs/test-interface/app.js
+++ b/docs/test-interface/app.js
@@ -84,6 +84,12 @@ const now =
     ? () => performance.now()
     : () => Date.now();
 
+const DEFAULT_VC_ADAPT_HINTS = Object.freeze({
+  high: ["risk_high", "aggro_high"],
+  medium: ["cohesion_high", "setup_high"],
+  low: ["explore_high"],
+});
+
 const performanceMonitor = {
   history: [],
   maxEntries: 40,
@@ -463,6 +469,11 @@ function setupDomReferences() {
     metricsElements.random = document.querySelector('[data-metric="random"]');
     metricsElements.indices = document.querySelector('[data-metric="indices"]');
     metricsElements.biomes = document.querySelector('[data-metric="biomes"]');
+    metricsElements.biomeHazards = document.querySelector('[data-metric="biomes-hazard"]');
+    metricsElements.biomeArchetypes = document.querySelector(
+      '[data-metric="biomes-archetypes"]'
+    );
+    metricsElements.biomeHooks = document.querySelector('[data-metric="biomes-hooks"]');
     metricsElements.speciesSlots = document.querySelector('[data-metric="species-slots"]');
     metricsElements.speciesSynergies = document.querySelector('[data-metric="species-synergies"]');
     metricsElements.timestamp = document.getElementById("last-updated");
@@ -748,6 +759,85 @@ function setTimestamp(text) {
   }
 }
 
+function applyMetricState(element, ratio) {
+  if (!element) return;
+  if (typeof ratio !== "number" || Number.isNaN(ratio)) {
+    element.dataset.state = "idle";
+    return;
+  }
+
+  if (ratio >= 0.95) {
+    element.dataset.state = "complete";
+  } else if (ratio >= 0.7) {
+    element.dataset.state = "warning";
+  } else {
+    element.dataset.state = "alert";
+  }
+}
+
+function setCoverageMetric(element, completed, total, options = {}) {
+  if (!element) return;
+  if (!total) {
+    element.textContent = "—";
+    element.dataset.state = "idle";
+    if (element.hasAttribute("title")) {
+      element.removeAttribute("title");
+    }
+    return;
+  }
+
+  const ratio = completed / total;
+  const percent = Math.round(ratio * 100);
+  const text = options.textFormatter
+    ? options.textFormatter({ completed, total, percent })
+    : `${completed}/${total} (${percent}%)`;
+
+  element.textContent = text;
+  applyMetricState(element, ratio);
+
+  if (options.title) {
+    element.title = options.title;
+  } else if (element.hasAttribute("title")) {
+    element.removeAttribute("title");
+  }
+}
+
+function hasHazardPackage(details) {
+  const hazard = details?.hazard || {};
+  const modifiers = hazard.stress_modifiers || {};
+  return Boolean(hazard.description && hazard.severity && Object.keys(modifiers).length);
+}
+
+function hasArchetypePackage(details) {
+  const archetypes = details?.npc_archetypes || {};
+  const primary = Array.isArray(archetypes.primary) ? archetypes.primary.length : 0;
+  const support = Array.isArray(archetypes.support) ? archetypes.support.length : 0;
+  return primary > 0 && support > 0;
+}
+
+function hasNarrativeHooks(details) {
+  return Array.isArray(details?.narrative?.hooks) && details.narrative.hooks.length > 0;
+}
+
+function buildVcLinks(details, vcAdapt) {
+  const explicit = Array.isArray(details?.vc_adapt_refs)
+    ? details.vc_adapt_refs.filter(Boolean)
+    : [];
+  const severity = String(details?.hazard?.severity || "").toLowerCase();
+  const fallback = DEFAULT_VC_ADAPT_HINTS[severity] || [];
+  const references = (explicit.length ? explicit : fallback).filter((key) => key && vcAdapt[key]);
+
+  const links = references.map(
+    (key) => `<a class="vc-link" href="#vc-adapt-${key}">${formatLabel(key)}</a>`
+  );
+
+  if (!links.length) {
+    links.push('<a class="vc-link" href="#vc-adapt-overview">Catalogo VC</a>');
+  }
+
+  return links.join("");
+}
+
 function updateOverview() {
   const packs = state.data.packs || {};
   const forms = packs.forms ? Object.keys(packs.forms) : [];
@@ -760,6 +850,14 @@ function updateOverview() {
   const biomeCount = state.data.biomes?.biomes
     ? Object.keys(state.data.biomes.biomes).length
     : 0;
+  const biomeEntries = Object.values(state.data.biomes?.biomes || {});
+  const hazardCompleted = biomeEntries.filter((details) => hasHazardPackage(details)).length;
+  const archetypeCompleted = biomeEntries.filter((details) => hasArchetypePackage(details)).length;
+  const hooksCompleted = biomeEntries.filter((details) => hasNarrativeHooks(details)).length;
+  const hooksTotal = biomeEntries.reduce((sum, details) => {
+    if (!Array.isArray(details?.narrative?.hooks)) return sum;
+    return sum + details.narrative.hooks.length;
+  }, 0);
   const speciesSlots = state.data.species?.catalog?.slots || {};
   const speciesModules = Object.values(speciesSlots).reduce(
     (total, slotGroup) => total + Object.keys(slotGroup || {}).length,
@@ -773,6 +871,14 @@ function updateOverview() {
   if (metricsElements.random) metricsElements.random.textContent = randomTable;
   if (metricsElements.indices) metricsElements.indices.textContent = indices;
   if (metricsElements.biomes) metricsElements.biomes.textContent = biomeCount;
+  setCoverageMetric(metricsElements.biomeHazards, hazardCompleted, biomeEntries.length);
+  setCoverageMetric(metricsElements.biomeArchetypes, archetypeCompleted, biomeEntries.length);
+  setCoverageMetric(metricsElements.biomeHooks, hooksCompleted, biomeEntries.length, {
+    title:
+      hooksTotal > 0
+        ? `${hooksTotal} stress hook${hooksTotal === 1 ? "" : "s"} totali`
+        : undefined,
+  });
   if (metricsElements.speciesSlots) {
     metricsElements.speciesSlots.textContent = speciesModules || "—";
   }
@@ -1429,56 +1535,211 @@ function renderBiomes() {
     return;
   }
 
+  const vcAdapt = biomesData.vc_adapt || {};
   const biomes = biomesData.biomes || {};
-  const biomeCards = Object.entries(biomes)
+  const biomeEntries = Object.entries(biomes);
+
+  if (!biomeEntries.length) {
+    container.innerHTML = "<p>Nessun bioma configurato.</p>";
+    return;
+  }
+
+  const hazardCompleted = biomeEntries.filter(([, details]) => hasHazardPackage(details)).length;
+  const archetypeCompleted = biomeEntries.filter(([, details]) => hasArchetypePackage(details)).length;
+  const hooksCompleted = biomeEntries.filter(([, details]) => hasNarrativeHooks(details)).length;
+  const hooksTotal = biomeEntries.reduce((sum, [, details]) => {
+    if (!Array.isArray(details?.narrative?.hooks)) return sum;
+    return sum + details.narrative.hooks.length;
+  }, 0);
+
+  const overviewHtml = `
+    <div class="biome-overview-bar">
+      <div class="overview-chip">
+        <span>Biomi mappati</span>
+        <strong>${biomeEntries.length}</strong>
+      </div>
+      <div class="overview-chip">
+        <span>Hazard completi</span>
+        <strong>${hazardCompleted}/${biomeEntries.length}</strong>
+      </div>
+      <div class="overview-chip">
+        <span>Archetipi validati</span>
+        <strong>${archetypeCompleted}/${biomeEntries.length}</strong>
+      </div>
+      <div class="overview-chip">
+        <span>Stress hooks</span>
+        <strong>${hooksCompleted}/${biomeEntries.length}</strong>
+        <small class="muted">${hooksTotal} totali</small>
+      </div>
+    </div>
+  `;
+
+  const biomeCards = biomeEntries
     .map(([name, details]) => {
+      const label = details.label || formatLabel(name);
+      const summary = details.summary || "";
+      const hazard = details.hazard || {};
+      const severity = (hazard.severity || "").toLowerCase();
+      const hazardLabel = hazard.severity ? formatLabel(hazard.severity) : "N.D.";
+      const hazardModifiers = Object.entries(hazard.stress_modifiers || {});
+      const hazardModifiersHtml = hazardModifiers.length
+        ? hazardModifiers
+            .map(
+              ([key, value]) =>
+                `<li><strong>${formatLabel(key)}</strong>: ${typeof value === "number" ? value : value ?? "—"}</li>`
+            )
+            .join("")
+        : '<li class="muted">Nessun modificatore registrato.</li>';
+
+      const archetypes = details.npc_archetypes || {};
+      const archetypeColumn = (title, values) => {
+        const listItems = Array.isArray(values) && values.length
+          ? values.map((item) => `<li>${formatLabel(item)}</li>`)
+          : ['<li class="muted">—</li>'];
+        return `
+          <div>
+            <h5>${title}</h5>
+            <ul>${listItems.join("")}</ul>
+          </div>
+        `;
+      };
+
+      const stresswave = details.stresswave || {};
+      const stresswaveHighlights = [];
+      if (typeof stresswave.baseline === "number") {
+        stresswaveHighlights.push(`Baseline ${stresswave.baseline}`);
+      }
+      if (typeof stresswave.escalation_rate === "number") {
+        stresswaveHighlights.push(`Escalation +${stresswave.escalation_rate}`);
+      }
+      const stresswaveThresholds = Object.entries(stresswave.event_thresholds || {});
+
+      const stresswaveSection =
+        stresswaveHighlights.length || stresswaveThresholds.length
+          ? `
+              <div class="biome-section">
+                <h4>StressWave</h4>
+                ${
+                  stresswaveHighlights.length
+                    ? `<p class="muted">${stresswaveHighlights.join(" · ")}</p>`
+                    : ""
+                }
+                ${
+                  stresswaveThresholds.length
+                    ? `<ul>${stresswaveThresholds
+                        .map(
+                          ([key, value]) =>
+                            `<li><strong>${formatLabel(key)}</strong>: ${value ?? "—"}</li>`
+                        )
+                        .join("")}</ul>`
+                    : '<p class="muted">Nessuna soglia definita.</p>'
+                }
+              </div>
+            `
+          : "";
+
+      const hooks = Array.isArray(details.narrative?.hooks)
+        ? details.narrative.hooks
+        : [];
+      const hooksSection = `
+        <div class="biome-section">
+          <h4>Stress hooks</h4>
+          ${details.narrative?.tone ? `<p class="muted">${details.narrative.tone}</p>` : ""}
+          ${
+            hooks.length
+              ? `<ul>${hooks.map((hook) => `<li>${hook}</li>`).join("")}</ul>`
+              : '<p class="muted">Nessun hook registrato.</p>'
+          }
+        </div>
+      `;
+
+      const affixes = Array.isArray(details.affixes) ? details.affixes : [];
+      const affixHtml = affixes.length
+        ? `<div class="biome-pills">${affixes
+            .map((affix) => `<span class="biome-pill">${formatLabel(affix)}</span>`)
+            .join("")}</div>`
+        : '<p class="muted">Nessun affisso configurato.</p>';
+
+      const stressLinks = buildVcLinks(details, vcAdapt);
+
+      const metaTokens = [
+        details.diff_base != null ? `<li><span>Diff base ${details.diff_base}</span></li>` : "",
+        details.mod_biome != null ? `<li><span>Mod ${details.mod_biome}</span></li>` : "",
+        typeof stresswave.baseline === "number"
+          ? `<li><span>Stress ${stresswave.baseline}</span></li>`
+          : "",
+      ].filter(Boolean);
+
       return `
-        <article class="card biome-card">
-          <h3>${name}</h3>
-          <p><strong>Diff. base:</strong> ${details.diff_base ?? "—"}</p>
-          <p><strong>Mod. bioma:</strong> ${details.mod_biome ?? "—"}</p>
-          <h4>Affissi</h4>
-          <ul>${Array.isArray(details.affixes)
-            ? details.affixes.map((affix) => `<li>${affix}</li>`).join("")
-            : "<li>—</li>"}</ul>
+        <article class="card biome-card" data-biome="${name}">
+          <div class="biome-card__header">
+            <div>
+              <h3>${label}</h3>
+              ${summary ? `<p class="biome-summary">${summary}</p>` : ""}
+            </div>
+            <span class="hazard-badge" data-level="${severity || "unknown"}">${hazardLabel}</span>
+          </div>
+          ${metaTokens.length ? `<ul class="biome-meta">${metaTokens.join("")}</ul>` : ""}
+          <div class="biome-section">
+            <h4>Hazard</h4>
+            ${hazard.description ? `<p>${hazard.description}</p>` : '<p class="muted">Descrizione non disponibile.</p>'}
+            <ul class="biome-inline-list">${hazardModifiersHtml}</ul>
+          </div>
+          <div class="biome-section">
+            <h4>Archetipi</h4>
+            <div class="biome-archetypes">
+              ${archetypeColumn("Primari", archetypes.primary)}
+              ${archetypeColumn("Supporto", archetypes.support)}
+            </div>
+          </div>
+          ${stresswaveSection}
+          ${hooksSection}
+          <div class="biome-section">
+            <h4>Affissi</h4>
+            ${affixHtml}
+          </div>
+          <div class="biome-links">
+            ${stressLinks}
+          </div>
         </article>
       `;
     })
     .join("");
 
-  const vcAdapt = biomesData.vc_adapt || {};
   const vcHtml = Object.entries(vcAdapt)
     .map(
-      ([key, value]) => `<li><strong>${key}</strong>: ${formatEntry(value)}</li>`
+      ([key, value]) =>
+        `<li id="vc-adapt-${key}"><strong>${formatLabel(key)}</strong>: ${formatEntry(value)}</li>`
     )
-    .join("");
+    .join("") || '<li class="muted">Nessun adattamento VC configurato.</li>';
 
   const mutations = biomesData.mutations || {};
   const mutationHtml = Object.entries(mutations)
-    .map(([key, value]) => `<li><strong>${key}</strong>: ${formatEntry(value)}</li>`)
-    .join("");
+    .map(([key, value]) => `<li><strong>${formatLabel(key)}</strong>: ${formatEntry(value)}</li>`)
+    .join("") || '<li class="muted">Nessuna mutazione definita.</li>';
 
   const frequencies = biomesData.frequencies || {};
   const freqHtml = Object.entries(frequencies)
-    .map(([key, value]) => `<li><strong>${key}</strong>: ${formatEntry(value)}</li>`)
-    .join("");
+    .map(([key, value]) => `<li><strong>${formatLabel(key)}</strong>: ${formatEntry(value)}</li>`)
+    .join("") || '<li class="muted">Nessuna frequenza definita.</li>';
 
   container.innerHTML = `
+    ${overviewHtml}
     <div class="biome-grid">
       ${biomeCards}
     </div>
     <div class="cards biome-details">
-      <article class="card">
+      <article class="card" id="vc-adapt-overview">
         <h3>VC Adapt</h3>
-        <ul>${vcHtml}</ul>
+        <ul class="nested-list">${vcHtml}</ul>
       </article>
       <article class="card">
         <h3>Mutazioni</h3>
-        <ul>${mutationHtml}</ul>
+        <ul class="nested-list">${mutationHtml}</ul>
       </article>
       <article class="card">
         <h3>Frequenze</h3>
-        <ul>${freqHtml}</ul>
+        <ul class="nested-list">${freqHtml}</ul>
       </article>
     </div>
   `;
@@ -3624,18 +3885,37 @@ function detectDataKey(payload) {
   return null;
 }
 
-function setFetchStatus(message, variant) {
-  updateStatusElement(controlElements.fetchStatus, message, variant || "info");
+function resolveFetchStatusElement() {
+  if (controlElements.fetchStatus) {
+    return controlElements.fetchStatus;
+  }
+
+  const element = typeof document !== "undefined" ? document.getElementById("fetch-status") : null;
+  if (element) {
+    controlElements.fetchStatus = element;
+    if (!element.dataset.status) {
+      prepareStatusElement(element, "info");
+    }
+  }
+
+  return element;
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+function setFetchStatus(message, variant) {
+  const statusElement = resolveFetchStatusElement();
+  updateStatusElement(statusElement, message, variant || "info");
+}
+
+function initializeTestInterface() {
   pageMode = detectPageMode();
   setupDomReferences();
 
   if (pageMode === PAGE_MODES.DASHBOARD) {
     const reloadButton = document.getElementById("reload-data");
     if (reloadButton) {
-      reloadButton.addEventListener("click", () => loadAllData());
+      reloadButton.addEventListener("click", () => {
+        loadAllData();
+      });
     }
     setupControlPanel();
     const historySnapshot = getStorageSnapshot(MANUAL_SYNC_HISTORY_KEY, { fallback: null });
@@ -3644,4 +3924,10 @@ document.addEventListener("DOMContentLoaded", () => {
   } else if (pageMode === PAGE_MODES.MANUAL_FETCH) {
     setupManualFetchPage();
   }
-});
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initializeTestInterface, { once: true });
+} else {
+  initializeTestInterface();
+}

--- a/docs/test-interface/index.html
+++ b/docs/test-interface/index.html
@@ -202,6 +202,18 @@
             <p class="metric" data-metric="biomes">—</p>
           </article>
           <article>
+            <h3>Hazard documentati</h3>
+            <p class="metric" data-metric="biomes-hazard" data-state="idle">—</p>
+          </article>
+          <article>
+            <h3>Archetipi validati</h3>
+            <p class="metric" data-metric="biomes-archetypes" data-state="idle">—</p>
+          </article>
+          <article>
+            <h3>Stress hooks registrati</h3>
+            <p class="metric" data-metric="biomes-hooks" data-state="idle">—</p>
+          </article>
+          <article>
             <h3>Moduli specie catalogati</h3>
             <p class="metric" data-metric="species-slots">—</p>
           </article>

--- a/docs/test-interface/manual-fetch.html
+++ b/docs/test-interface/manual-fetch.html
@@ -74,7 +74,7 @@
                 <button type="submit">Elabora sorgente</button>
               </div>
             </form>
-            <p id="fetch-status" class="status">In attesa di input…</p>
+            <p id="fetch-status" class="status" data-status="idle">In attesa di input…</p>
             <div id="fetch-preview" class="preview">
               <p id="fetch-preview-empty" class="preview-empty" aria-live="polite">(nessun contenuto)</p>
               <div id="fetch-preview-body" class="preview-body" hidden>

--- a/docs/test-interface/styles.css
+++ b/docs/test-interface/styles.css
@@ -9,6 +9,9 @@
   --accent-soft: rgba(56, 189, 248, 0.2);
   --border: rgba(148, 163, 184, 0.32);
   --muted: #94a3b8;
+  --success: #34d399;
+  --warning: #fbbf24;
+  --danger: #f87171;
   --glow: rgba(56, 189, 248, 0.35);
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
@@ -364,6 +367,18 @@ main {
   font-weight: 700;
 }
 
+.metric[data-state="complete"] {
+  color: var(--success);
+}
+
+.metric[data-state="warning"] {
+  color: var(--warning);
+}
+
+.metric[data-state="alert"] {
+  color: var(--danger);
+}
+
 .timestamp {
   margin-top: 1.5rem;
   color: var(--muted);
@@ -391,6 +406,203 @@ main {
 
 .biome-details {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.biome-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  position: relative;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(15, 23, 42, 0.65);
+  box-shadow: 0 12px 28px rgba(8, 15, 30, 0.45);
+}
+
+.biome-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.biome-card__header h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  line-height: 1.3;
+}
+
+.hazard-badge {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text);
+  flex-shrink: 0;
+}
+
+.hazard-badge[data-level="high"] {
+  background: rgba(248, 113, 113, 0.2);
+  color: var(--danger);
+}
+
+.hazard-badge[data-level="medium"] {
+  background: rgba(251, 191, 36, 0.18);
+  color: var(--warning);
+}
+
+.hazard-badge[data-level="low"] {
+  background: rgba(52, 211, 153, 0.18);
+  color: var(--success);
+}
+
+.biome-summary {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.biome-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1rem;
+  font-size: 0.9rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: var(--muted);
+}
+
+.biome-meta span {
+  background: rgba(148, 163, 184, 0.15);
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+}
+
+.biome-section {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.biome-section h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.95);
+}
+
+.biome-section p {
+  margin: 0;
+}
+
+.biome-inline-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.biome-archetypes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.biome-archetypes h5 {
+  margin: 0 0 0.25rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.biome-archetypes ul,
+.biome-section ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.biome-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: auto;
+}
+
+.vc-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.16);
+  color: var(--text);
+  text-decoration: none;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.vc-link::after {
+  content: "↗";
+  font-size: 0.8rem;
+}
+
+.vc-link:hover {
+  transform: translateY(-1px);
+  background: rgba(56, 189, 248, 0.28);
+}
+
+.biome-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0;
+}
+
+.biome-pill {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.biome-overview-bar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.biome-overview-bar .overview-chip {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 0.85rem;
+  padding: 0.9rem;
+  display: grid;
+  gap: 0.3rem;
+}
+
+.overview-chip span {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.overview-chip strong {
+  font-size: 1.1rem;
+}
+
+.overview-chip small {
+  color: var(--muted);
 }
 
 .pi-grid {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "game-monorepo-shim",
+  "private": true,
+  "scripts": {
+    "test:web": "npm --prefix tools/ts run test:web --",
+    "build": "npm --prefix tools/ts run build --",
+    "test": "npm --prefix tools/ts run test --"
+  }
+}

--- a/scripts/cli_smoke.sh
+++ b/scripts/cli_smoke.sh
@@ -1,11 +1,185 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -z "${SCRIPT_DIR}" ]]; then
+  echo "Impossibile risolvere la directory dello script." >&2
+  exit 1
+fi
+
+if ! ROOT_DIR="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null)"; then
+  ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+fi
+export ROOT_DIR
 CLI_ENTRYPOINT="${ROOT_DIR}/tools/py/game_cli.py"
 CONFIG_DIR="${ROOT_DIR}/config/cli"
 LOG_DIR="${ROOT_DIR}/logs/cli"
 DEFAULT_PROFILES=()
+
+verify_biome_fields() {
+  python3 - <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+import numbers
+
+try:
+    import yaml
+except ImportError as exc:
+    sys.stderr.write(
+        "PyYAML non disponibile: eseguire `pip install -r tools/py/requirements.txt`.\n"
+    )
+    sys.exit(1)
+
+try:
+    root = Path(os.environ["ROOT_DIR"])
+except KeyError:
+    sys.stderr.write("Variabile ROOT_DIR non definita nel contesto della verifica biomi.\n")
+    sys.exit(1)
+
+candidates = [
+    root / "data" / "biomes.yaml",
+    root / "Game" / "data" / "biomes.yaml",
+]
+
+# Analizza anche directory nidificate comuni, mantenendo l'ordine deterministico.
+for nested in sorted(root.glob("*/data/biomes.yaml")):
+    if nested not in candidates:
+        candidates.append(nested)
+
+biome_path = next((path for path in candidates if path.exists()), None)
+
+if biome_path is None:
+    attempted = "\n".join(f"  - {path}" for path in candidates)
+    sys.stderr.write("File biomi non trovato. Percorsi verificati:\n")
+    sys.stderr.write(f"{attempted or '  (nessun candidato)'}\n")
+    sys.exit(1)
+
+with biome_path.open("r", encoding="utf-8") as handle:
+    data = yaml.safe_load(handle) or {}
+
+ALLOWED_SEVERITIES = {"low", "medium", "high"}
+
+def is_number(value):
+    return isinstance(value, numbers.Real) and not isinstance(value, bool)
+
+biomes = data.get("biomes") or {}
+missing = []
+
+for biome_id, payload in biomes.items():
+    label = payload.get("label")
+    if not (isinstance(label, str) and label.strip()):
+        missing.append((biome_id, "label"))
+
+    summary = payload.get("summary")
+    if not (isinstance(summary, str) and summary.strip()):
+        missing.append((biome_id, "summary"))
+
+    diff_base = payload.get("diff_base")
+    if not is_number(diff_base):
+        missing.append((biome_id, "diff_base"))
+
+    mod_biome = payload.get("mod_biome")
+    if not is_number(mod_biome):
+        missing.append((biome_id, "mod_biome"))
+
+    affixes = payload.get("affixes")
+    if not (isinstance(affixes, list) and affixes and all(isinstance(item, str) for item in affixes)):
+        missing.append((biome_id, "affixes"))
+
+    hazard = payload.get("hazard") or {}
+    modifiers = hazard.get("stress_modifiers") or {}
+    severity = str(hazard.get("severity") or "").lower()
+    if not (hazard.get("description") and severity in ALLOWED_SEVERITIES and modifiers):
+        missing.append((biome_id, "hazard"))
+
+    archetypes = payload.get("npc_archetypes") or {}
+    if not (archetypes.get("primary") and archetypes.get("support")):
+        missing.append((biome_id, "npc_archetypes"))
+
+    stresswave = payload.get("stresswave") or {}
+    thresholds = stresswave.get("event_thresholds") or {}
+    if not (
+        is_number(stresswave.get("baseline"))
+        and is_number(stresswave.get("escalation_rate"))
+        and isinstance(thresholds, dict)
+        and thresholds
+    ):
+        missing.append((biome_id, "stresswave"))
+
+    hooks = (payload.get("narrative") or {}).get("hooks") or []
+    if not hooks:
+        missing.append((biome_id, "narrative.hooks"))
+
+    tone = (payload.get("narrative") or {}).get("tone")
+    if not (isinstance(tone, str) and tone.strip()):
+        missing.append((biome_id, "narrative.tone"))
+
+if missing:
+    sys.stderr.write("Verifica biomi fallita:\n")
+    for biome_id, section in missing:
+        sys.stderr.write(f"  - {biome_id}: campo mancante {section}\n")
+    sys.exit(1)
+
+def has_hazard_package(details):
+    hazard_block = details.get("hazard") or {}
+    severity_value = str(hazard_block.get("severity") or "").lower()
+    modifiers = hazard_block.get("stress_modifiers") or {}
+    return bool(
+        hazard_block.get("description")
+        and severity_value in ALLOWED_SEVERITIES
+        and isinstance(modifiers, dict)
+        and modifiers
+    )
+
+
+def has_archetype_package(details):
+    archetypes_block = details.get("npc_archetypes") or {}
+    primary = archetypes_block.get("primary") or []
+    support = archetypes_block.get("support") or []
+    return bool(primary and support)
+
+
+def has_hooks(details):
+    hooks_list = (details.get("narrative") or {}).get("hooks") or []
+    return bool(hooks_list)
+
+
+def has_tone(details):
+    tone_value = (details.get("narrative") or {}).get("tone")
+    return isinstance(tone_value, str) and tone_value.strip()
+
+
+def has_stresswave(details):
+    stresswave_block = details.get("stresswave") or {}
+    thresholds_block = stresswave_block.get("event_thresholds") or {}
+    return bool(
+        is_number(stresswave_block.get("baseline"))
+        and is_number(stresswave_block.get("escalation_rate"))
+        and isinstance(thresholds_block, dict)
+        and thresholds_block
+    )
+
+
+summary = {
+    "total": len(biomes),
+    "labels_complete": sum(1 for payload in biomes.values() if payload.get("label")),
+    "summaries_complete": sum(1 for payload in biomes.values() if payload.get("summary")),
+    "hazard_complete": sum(1 for payload in biomes.values() if has_hazard_package(payload)),
+    "archetypes_complete": sum(1 for payload in biomes.values() if has_archetype_package(payload)),
+    "stresswave_complete": sum(1 for payload in biomes.values() if has_stresswave(payload)),
+    "tone_complete": sum(1 for payload in biomes.values() if has_tone(payload)),
+    "hooks_complete": sum(1 for payload in biomes.values() if has_hooks(payload)),
+    "hooks_total": sum(
+        len((payload.get("narrative") or {}).get("hooks") or [])
+        for payload in biomes.values()
+    ),
+}
+
+print(json.dumps({"biome_validation": summary}, ensure_ascii=False))
+PY
+}
 
 if [[ -d "${CONFIG_DIR}" ]]; then
   while IFS= read -r profile_path; do
@@ -64,6 +238,10 @@ else
 fi
 
 mkdir -p "${LOG_DIR}"
+
+echo "::group::Biome dataset check"
+verify_biome_fields
+echo "::endgroup::"
 
 for profile in "${PROFILES_TO_RUN[@]}"; do
   profile_file="${CONFIG_DIR}/${profile}.yaml"

--- a/tools/ts/package-lock.json
+++ b/tools/ts/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "jsdom": "^24.1.0",
+        "puppeteer": "^24.5.0",
         "tsx": "^4.19.0",
         "typescript": "^5.6.3"
       }
@@ -44,7 +45,6 @@
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
@@ -60,7 +60,6 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -648,6 +647,28 @@
         "node": ">=18"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.12.tgz",
+      "integrity": "sha512-mP9iLFZwH+FapKJLeA7/fLqOlSUwYpMwjR1P5J23qd4e7qGJwecJccJqHYrjw33jmIZYV4dtiTHPD/J+1e7cEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.3",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -696,6 +717,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -750,6 +778,17 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -766,7 +805,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -802,12 +840,142 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.1.tgz",
+      "integrity": "sha512-oxSAxTS1hRfnyit2CL5QpAOS5ixfBjj6ex3yTNvXyY/kE719jQ/IjuESJBK2w5v4wwQRAHGseVJXx9QBYOtFGQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.0.tgz",
+      "integrity": "sha512-GljgCjeupKZJNetTqxKaQArLK10vpmK28or0+RwWjEl5Rk+/xG3wkpmkv+WrcBm3q1BwHKlnhXzR8O37kcvkXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.1.tgz",
+      "integrity": "sha512-v2yl0TnaZTdEnelkKtXZGnotiV6qATBlnNuUMrHl6v9Lmmrh9mw9RYyImPU7/4RahumSwQS1k2oKXcRfXcbjJw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -823,6 +991,65 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-10.5.1.tgz",
+      "integrity": "sha512-rlj6OyhKhVTnk4aENcUme3Jl9h+cq4oXu4AzBcvr8RMmT6BR4a3zSNT9dbIfXr9/BS6ibzRyDhowuw4n2GgzsQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -834,6 +1061,33 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/cssstyle": {
@@ -863,6 +1117,16 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -903,6 +1167,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -923,6 +1202,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1508733",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1508733.tgz",
+      "integrity": "sha512-QJ1R5gtck6nDcdM+nlsaJXcelPEI7ZxSMw1ujHpO1c4+9l+Nue5qlebi9xO1Z2MGr92bFOQTW7/rrheh5hHxDg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -947,6 +1233,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -958,6 +1261,26 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-define-property": {
@@ -1051,6 +1374,120 @@
         "@esbuild/win32-x64": "0.25.11"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
@@ -1093,6 +1530,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -1132,6 +1579,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
@@ -1143,6 +1606,21 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/gopd": {
@@ -1254,6 +1732,50 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -1320,6 +1842,20 @@
         }
       }
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -1383,6 +1919,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1390,12 +1933,98 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.22",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
       "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -1410,13 +2039,19 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/playwright": {
       "version": "1.56.1",
@@ -1466,6 +2101,53 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -1479,6 +2161,17 @@
         "url": "https://github.com/sponsors/lupomontero"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1487,6 +2180,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "24.26.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.26.1.tgz",
+      "integrity": "sha512-3RG2UqclzMFolM2fS4bN8t5/EjZ0VwEoAGVxG8PMGeprjLzj+x0U4auH7MQ4B6ftW+u1JUnTTN8ab4ABPdl4mA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.10.12",
+        "chromium-bidi": "10.5.1",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1508733",
+        "puppeteer-core": "24.26.1",
+        "typed-query-selector": "^2.12.0"
+      },
+      "bin": {
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.26.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.26.1.tgz",
+      "integrity": "sha512-YHZdo3chJ5b9pTYVnuDuoI3UX/tWJFJyRZvkLbThGy6XeHWC+0KI8iN0UMCkvde5l/YOk3huiVZ/PvwgSbwdrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.10.12",
+        "chromium-bidi": "10.5.1",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1508733",
+        "typed-query-selector": "^2.12.0",
+        "webdriver-bidi-protocol": "0.3.8",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/querystringify": {
@@ -1529,12 +2263,32 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -1582,12 +2336,184 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
@@ -1617,6 +2543,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.20.6",
@@ -1652,6 +2585,13 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -1708,6 +2648,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.8.tgz",
+      "integrity": "sha512-21Yi2GhGntMc671vNBCjiAeEVknXjVRoyu+k+9xOMShu+ZQfpGQwnBqbNz/Sv4GXZ6JmutlPAi2nIJcrymAWuQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -1755,6 +2702,47 @@
         "node": ">=18"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -1793,6 +2781,66 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/tools/ts/package.json
+++ b/tools/ts/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "playwright:install": "PLAYWRIGHT_DOWNLOAD_HOST=https://playwright.azureedge.net npx playwright install chromium || PLAYWRIGHT_DOWNLOAD_HOST=https://playwright.azureedge.net npx playwright install --with-deps chromium",
+    "playwright:install": "node ./scripts/ensure_chromium.mjs",
     "pretest": "npm run playwright:install --silent",
     "build": "tsc -p tsconfig.json && node ./scripts/postbuild.mjs",
     "start": "node dist/roll_pack.js ENTP invoker ../../data/packs.yaml",
     "test": "npm run build --silent && node --test dist/ts/tests/*.test.js && npm run test:web --silent",
-    "test:web": "playwright test",
+    "test:web": "node ./scripts/run_playwright_tests.mjs",
     "test:ui": "tsx tests/export-modal.test.tsx",
     "validate:species": "npm run build && node dist/validate_species.js ../../data/species.yaml"
   },
@@ -26,6 +26,7 @@
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "jsdom": "^24.1.0",
+    "puppeteer": "^24.5.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.3"
   }

--- a/tools/ts/playwright.config.ts
+++ b/tools/ts/playwright.config.ts
@@ -7,6 +7,7 @@ const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..", "..");
 const defaultPort = Number(process.env.PLAYWRIGHT_WEB_PORT || 4173);
 const baseURL = process.env.PLAYWRIGHT_BASE_URL || `http://127.0.0.1:${defaultPort}`;
+const chromiumExecutable = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
 
 export default defineConfig({
   testDir: path.join(__dirname, "tests", "web"),
@@ -24,6 +25,11 @@ export default defineConfig({
   use: {
     baseURL,
     trace: process.env.CI ? "on-first-retry" : "retain-on-failure",
+    launchOptions: chromiumExecutable
+      ? {
+          executablePath: chromiumExecutable,
+        }
+      : undefined,
   },
   webServer: {
     command: `python3 -m http.server ${defaultPort} --bind 127.0.0.1 --directory ${JSON.stringify(repoRoot)}`,

--- a/tools/ts/scripts/ensure_chromium.mjs
+++ b/tools/ts/scripts/ensure_chromium.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { access, readdir } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+
+async function pathExists(candidate) {
+  if (!candidate) return false;
+  try {
+    await access(candidate, fsConstants.X_OK);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+async function findPlaywrightExecutable() {
+  const caches = [
+    process.env.PLAYWRIGHT_BROWSERS_PATH,
+    path.join(projectRoot, 'node_modules', '.cache', 'ms-playwright'),
+    path.join(projectRoot, 'node_modules', 'playwright-core', '.local-browsers')
+  ].filter(Boolean);
+
+  for (const base of caches) {
+    try {
+      const entries = await readdir(base, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (!entry.name.startsWith('chromium')) continue;
+        const linuxCandidates = [
+          path.join(base, entry.name, 'chrome-linux', 'chrome'),
+          path.join(base, entry.name, 'chrome-linux64', 'chrome')
+        ];
+        for (const candidate of linuxCandidates) {
+          if (await pathExists(candidate)) {
+            return candidate;
+          }
+        }
+      }
+    } catch (error) {
+      // ignore missing cache directories
+    }
+  }
+  return null;
+}
+
+async function findPuppeteerExecutable() {
+  const homeDir = process.env.HOME;
+  if (!homeDir) return null;
+  const puppeteerCache = path.join(homeDir, '.cache', 'puppeteer');
+  try {
+    const products = await readdir(puppeteerCache, { withFileTypes: true });
+    for (const product of products) {
+      if (!product.isDirectory()) continue;
+      const productDir = path.join(puppeteerCache, product.name);
+      const builds = await readdir(productDir, { withFileTypes: true });
+      for (const build of builds) {
+        if (!build.isDirectory()) continue;
+        const buildDir = path.join(productDir, build.name);
+        const chromiumCandidates = [
+          path.join(buildDir, 'chrome-linux', 'chrome'),
+          path.join(buildDir, 'chrome-linux64', 'chrome')
+        ];
+        for (const candidate of chromiumCandidates) {
+          if (await pathExists(candidate)) {
+            return candidate;
+          }
+        }
+      }
+    }
+  } catch (error) {
+    // ignore missing cache
+  }
+  return null;
+}
+
+async function findChromiumExecutable() {
+  const playwrightExecutable = await findPlaywrightExecutable();
+  if (playwrightExecutable) {
+    return { executable: playwrightExecutable, source: 'playwright-cache' };
+  }
+  const puppeteerExecutable = await findPuppeteerExecutable();
+  if (puppeteerExecutable) {
+    return { executable: puppeteerExecutable, source: 'puppeteer-cache' };
+  }
+  return { executable: null, source: null };
+}
+
+function run(command, args, options) {
+  const result = spawnSync(command, args, {
+    cwd: projectRoot,
+    stdio: ['inherit', 'pipe', 'inherit'],
+    encoding: 'utf-8',
+    ...options
+  });
+  return result;
+}
+
+async function installWithPlaywright() {
+  const installEnv = { ...process.env };
+  if (!installEnv.PLAYWRIGHT_DOWNLOAD_HOST) {
+    installEnv.PLAYWRIGHT_DOWNLOAD_HOST = 'https://playwright.azureedge.net';
+  }
+  const result = run('npx', ['--yes', 'playwright', 'install', 'chromium'], { env: installEnv });
+  if (result.status === 0) {
+    return { success: true, output: result.stdout ?? '' };
+  }
+  return { success: false, output: result.stdout ?? '' };
+}
+
+async function installWithPuppeteer() {
+  const result = run('npx', ['--yes', 'puppeteer', 'browsers', 'install', 'chrome']);
+  if (result.status !== 0) {
+    return { success: false, output: result.stdout ?? '' };
+  }
+  const stdout = (result.stdout ?? '').trim();
+  let executable = null;
+  if (stdout) {
+    const lines = stdout.split(/\r?\n/).filter(Boolean);
+    const lastLine = lines.at(-1);
+    if (lastLine) {
+      const parts = lastLine.trim().split(/\s+/);
+      executable = parts.at(-1) ?? null;
+    }
+  }
+  if (executable && !(await pathExists(executable))) {
+    executable = null;
+  }
+  return { success: true, executable, output: stdout };
+}
+
+export async function ensureChromiumExecutable({ quiet = false } = {}) {
+  let { executable } = await findChromiumExecutable();
+  if (executable) {
+    if (!quiet) {
+      console.log(`[ensure-chromium] Found existing Chromium executable at ${executable}`);
+    }
+    return executable;
+  }
+
+  if (!quiet) {
+    console.log('[ensure-chromium] Attempting Playwright-managed browser install...');
+  }
+  const playwrightInstall = await installWithPlaywright();
+  if (playwrightInstall.success) {
+    ({ executable } = await findChromiumExecutable());
+    if (executable) {
+      if (!quiet) {
+        console.log(`[ensure-chromium] Playwright installed Chromium at ${executable}`);
+      }
+      return executable;
+    }
+  } else if (!quiet) {
+    console.warn('[ensure-chromium] Playwright install failed, falling back to Puppeteer');
+  }
+
+  if (!quiet) {
+    console.log('[ensure-chromium] Installing Chromium via Puppeteer cache...');
+  }
+  const puppeteerInstall = await installWithPuppeteer();
+  if (!puppeteerInstall.success) {
+    throw new Error('Failed to install Chromium via Puppeteer fallback.');
+  }
+  if (!quiet && puppeteerInstall.output) {
+    console.log(puppeteerInstall.output.trim());
+  }
+  if (puppeteerInstall.executable) {
+    if (!quiet) {
+      console.log(`[ensure-chromium] Puppeteer provided Chromium executable at ${puppeteerInstall.executable}`);
+    }
+    return puppeteerInstall.executable;
+  }
+  const puppeteerExecutable = await findPuppeteerExecutable();
+  if (puppeteerExecutable) {
+    if (!quiet) {
+      console.log(`[ensure-chromium] Located Puppeteer Chromium executable at ${puppeteerExecutable}`);
+    }
+    return puppeteerExecutable;
+  }
+  throw new Error('Unable to locate Chromium executable after Puppeteer fallback.');
+}
+
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (invokedDirectly) {
+  (async () => {
+    try {
+      const executable = await ensureChromiumExecutable();
+      console.log(executable);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  })();
+}

--- a/tools/ts/scripts/run_playwright_tests.mjs
+++ b/tools/ts/scripts/run_playwright_tests.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ensureChromiumExecutable } from './ensure_chromium.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+
+async function main() {
+  const args = process.argv.slice(2);
+  let executable;
+  try {
+    executable = await ensureChromiumExecutable();
+  } catch (error) {
+    console.error('[run-playwright-tests] Unable to provision Chromium for Playwright.');
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+
+  const env = { ...process.env };
+  if (executable) {
+    env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH = executable;
+    env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = '1';
+  }
+
+  const playwrightBin = path.join(projectRoot, 'node_modules', '.bin', process.platform === 'win32' ? 'playwright.cmd' : 'playwright');
+  const child = spawn(playwrightBin, ['test', ...args], {
+    cwd: projectRoot,
+    stdio: 'inherit',
+    env
+  });
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 1);
+  });
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a chromium bootstrapper that prefers Playwright caches and falls back to a Puppeteer-managed binary when CDN downloads fail
- route the repo-level and workspace Playwright scripts through the new bootstrapper and surface the executable to the test harness
- add Puppeteer as a dev dependency so CI can provision Chromium without relying on the blocked CDN

## Testing
- npm run test:web -- interface.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68ff597327b48332bac87cad5399dd9a