### PR TITLE
Follow-up: prevent telemetry duplication from export modal toggles

### DIFF
--- a/public/analytics/export/ExportModal.tsx
+++ b/public/analytics/export/ExportModal.tsx
@@ -212,28 +212,42 @@ const ExportModal: React.FC<ExportModalProps> = ({
   }
 
   const toggleGroup = (groupId: string) => {
-    const exists = selectedGroups.includes(groupId);
-    const nextGroups = exists
-      ? selectedGroups.filter(item => item !== groupId)
-      : [...selectedGroups, groupId];
+    let nextGroups: string[] = selectedGroups;
+    let action: 'added' | 'removed' = 'added';
 
-    setSelectedGroups(nextGroups);
+    setSelectedGroups(current => {
+      const exists = current.includes(groupId);
+      action = exists ? 'removed' : 'added';
+      nextGroups = exists
+        ? current.filter(item => item !== groupId)
+        : [...current, groupId];
+
+      return nextGroups;
+    });
+
     logFiltersTelemetry('analytics.export.recipient_toggle', nextGroups, selectedStatuses, onlyWithinSchedule, {
       groupId,
-      action: exists ? 'removed' : 'added'
+      action
     });
   };
 
   const toggleStatus = (status: string) => {
-    const exists = selectedStatuses.includes(status);
-    const nextStatuses = exists
-      ? selectedStatuses.filter(item => item !== status)
-      : [...selectedStatuses, status];
+    let nextStatuses: string[] = selectedStatuses;
+    let action: 'added' | 'removed' = 'added';
 
-    setSelectedStatuses(nextStatuses);
+    setSelectedStatuses(current => {
+      const exists = current.includes(status);
+      action = exists ? 'removed' : 'added';
+      nextStatuses = exists
+        ? current.filter(item => item !== status)
+        : [...current, status];
+
+      return nextStatuses;
+    });
+
     logFiltersTelemetry('analytics.export.status_toggle', selectedGroups, nextStatuses, onlyWithinSchedule, {
       status,
-      action: exists ? 'removed' : 'added'
+      action
     });
   };
 


### PR DESCRIPTION
## Summary
- restore functional state updaters for recipient group and status toggles so batched invocations always see the latest selections
- keep telemetry logging outside the updater while using the computed action for context

## Testing
- npx --prefix tools/ts tsx tools/ts/tests/export-modal.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_69012832b9dc8332a6d82c8fe19b575f