### PR TITLE
Document trait inventory checks in web release pipeline

### DIFF
--- a/docs/DesignDoc-Overview.md
+++ b/docs/DesignDoc-Overview.md
@@ -32,7 +32,7 @@
 
 ## Job & Trait di base
 - **Famiglie Job**: Vanguard, Skirmisher, Warden, Artificer, Invoker, Harvester — ciascuna con bias di pack (`job_bias`) e abilità signature documentate in `data/packs.yaml`.【F:data/packs.yaml†L21-L90】
-- **Tratti**: `trait_T1`/`T2`/`T3` alimentano combo PI, sinergie e costi `pi_shop`; i validatori assicurano coerenza tra dataset e CLI (`tools/py` e `tools/ts`).【F:data/packs.yaml†L1-L20】【F:docs/20-SPECIE_E_PARTI.md†L5-L10】
+- **Tratti**: `trait_T1`/`T2`/`T3` alimentano combo PI, sinergie e costi `pi_shop`; i validatori assicurano coerenza tra dataset e CLI (`tools/py` e `tools/ts`) e dipendono dall'inventario centralizzato (`docs/catalog/traits_inventory.json`) che viene aggiornato ad ogni commit.【F:data/packs.yaml†L1-L20】【F:docs/20-SPECIE_E_PARTI.md†L5-L10】【F:docs/catalog/traits_inventory.json†L1-L120】
 - **Prestigio/Mutazioni**: progressioni Forma sbloccano nuove combinazioni di parti e tratti, con telemetria MBTI/Ennea a supporto del seed temperamentale.【F:data/telemetry.yaml†L41-L73】【F:docs/22-FORME_BASE_16.md†L1-L6】
 
 ## Workflow tratti end-to-end
@@ -43,6 +43,8 @@
 5. **Validare naming** — usa `python tools/py/validate_registry_naming.py --trait-glossary data/traits/glossary.json` per controllare slug, mapping biomi/hazard/morphotype e coerenza del glossario referenziato in `config/project_index.json`.【F:tools/py/validate_registry_naming.py†L1-L270】【F:config/project_index.json†L1-L91】
 6. **Copertura & diff** — genera il report matriciale con `python tools/py/report_trait_coverage.py --out-json data/analysis/trait_coverage_report.json --out-csv data/analysis/trait_coverage_matrix.csv` per confrontare biomi↔forme mappati dalle regole con quelli realmente assegnati alle specie.【F:tools/py/report_trait_coverage.py†L1-L85】【F:tools/py/game_utils/trait_coverage.py†L1-L249】
 7. **QA interattivo** — ricarica il catalogo nel generator (`docs/evo-tactics-pack/generator.js`) per ottenere label dal glossario centralizzato e visualizzare i nuovi suggerimenti in UI senza duplicare stringhe.【F:docs/evo-tactics-pack/generator.js†L360-L449】【F:docs/evo-tactics-pack/generator.js†L666-L760】
+8. **Inventario & log** — aggiungi o aggiorna l'entry dedicata in `docs/catalog/traits_inventory.json` e lancia `python tools/py/traits_validator.py` per registrare il run in `logs/traits_tracking.md`, garantendo che baseline e specie citate rimangano sincronizzate.【F:docs/catalog/traits_inventory.json†L1-L120】【F:tools/py/traits_validator.py†L1-L200】【F:logs/traits_tracking.md†L1-L40】
+9. **Gate CI & deploy** — conferma che `scripts/run_deploy_checks.sh` e il workflow `deploy-test-interface.yml` ereditino gli stessi controlli (inventario, registri generatore, audit) prima della pubblicazione web, così da mantenere allineati generator, dataset e bundle pubblico.【F:scripts/run_deploy_checks.sh†L1-L80】【F:.github/workflows/deploy-test-interface.yml†L1-L200】
 
 ## Quality Gates
 - **Audit tratti ↔ ambienti** — consulta `docs/reports/trait-env-alignment.md` per verificare coperture, lacune e note di bilanciamento tra tratti PI e regole ambientali; usalo prima dei playtest per pianificare i pick consigliati e dopo per registrare gap emersi.【F:docs/reports/trait-env-alignment.md†L1-L80】

--- a/docs/process/traits_checklist.md
+++ b/docs/process/traits_checklist.md
@@ -10,6 +10,8 @@ seguendo step incrementali che coprono revisione design, QA e telemetria.
       requisiti ambientali, includendo eventuali note di bilanciamento.
 - [ ] Aggiornare `docs/catalog/species_trait_matrix.json` con le nuove
       associazioni Forma↔bioma e indicare l'owner del tratto nelle note.
+- [ ] Registrare l'asset nell'inventario `docs/catalog/traits_inventory.json`
+      specificando stato (`core/mock`), owner e fonti di riferimento.
 
 ## 2. Revisione e QA automatizzato
 - [ ] Eseguire `python tools/traits.py validate --matrix docs/catalog/species_trait_matrix.json`
@@ -18,6 +20,9 @@ seguendo step incrementali che coprono revisione design, QA e telemetria.
       `report_trait_coverage.py`) per aggiornare `data/analysis/*.yaml|csv`.
 - [ ] Lanciare `python tools/py/validate_registry_naming.py` per verificare
       coerenza slug e traduzioni condivise.
+- [ ] Eseguire `python tools/py/traits_validator.py --inventory
+      docs/catalog/traits_inventory.json` (opzionale `--no-log` in locale)
+      per verificare che tutte le risorse citate siano presenti e aggiornate.
 - [ ] Eseguire `scripts/cli_smoke.sh` filtrando il profilo rilevante
       (`CLI_PROFILES="playtest telemetry"`) e annotare eventuali regressioni.
 
@@ -41,7 +46,26 @@ seguendo step incrementali che coprono revisione design, QA e telemetria.
 - [ ] Preparare la nota di rilascio o l'aggiornamento del canvas con i link a
       report, matrici e telemetria.
 
-## 5. Verifica sito e promozione pipeline web
+## 5. Manutenzione file trait & integrazione CI
+
+- [ ] Quando si crea un nuovo file specie/evento in `packs/evo_tactics_pack/data/species/**`,
+      rigenerare la matrice con `python tools/traits.py matrix --out
+      docs/catalog/species_trait_matrix.json` per importare i nuovi trait nel
+      generator e prevenire regressioni sugli ID.
+- [ ] Aggiornare l'inventario `docs/catalog/traits_inventory.json` con il nuovo path,
+      eseguendo `python tools/py/traits_validator.py` per registrare il run in
+      `logs/traits_tracking.md`.
+- [ ] Verificare che `scripts/run_deploy_checks.sh` passi senza errori: lo script
+      viene richiamato sia da CI sia dal workflow `deploy-test-interface.yml` e
+      blocca la pubblicazione se l'inventario o i registri del generatore non sono
+      coerenti.
+- [ ] Collegare il nuovo file alle procedure di audit lanciando `python
+      tools/py/validate_registry_naming.py --trait-glossary data/traits/glossary.json`
+      e archiviare gli output nella cartella `logs/traits/` (se assente, crearla).
+- [ ] Annotare nelle note del PR i gate superati (validator inventario, naming,
+      `scripts/trait_audit.py --check`) per rendere tracciabile il ciclo di QA.
+
+## 6. Verifica sito e promozione pipeline web
 
 ### Stato corrente
 

--- a/docs/process/web_pipeline.md
+++ b/docs/process/web_pipeline.md
@@ -4,9 +4,11 @@ Questa procedura definisce il percorso end-to-end per promuovere la web experien
 
 ## Panoramica del flusso
 
-1. **Validazione continua automatica** – ogni push/PR esegue `ci.yml`, che include build TS/Python, suite CLI, audit dei tratti e `scripts/run_deploy_checks.sh`.
-2. **Validazione staging manuale/programmata** – prima di rilasciare, eseguire manualmente gli script di gating nello stesso ordine usato da CI per catturare regressioni ambientali.
-3. **Promozione e pubblicazione** – il workflow `deploy-test-interface.yml` ripete i gate (CLI smoke, audit tratti, deploy checks) e, solo in caso di esito positivo, carica l'artifact su GitHub Pages.
+1. **Inventario & trait readiness** – ogni PR deve aggiornare `docs/catalog/traits_inventory.json` tramite `python tools/py/traits_validator.py --inventory docs/catalog/traits_inventory.json` per assicurare che dataset (`data/analysis/*`, `packs/evo_tactics_pack/data/species/*`) siano allineati. Il report viene archiviato da CI in `logs/traits_tracking.md` e segnala risorse mancanti o obsolete.
+2. **Configurazione generatore** – il workflow esegue `python tools/py/validate_registry_naming.py` per garantire che i registri del generatore (`packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml`, `packs/evo_tactics_pack/docs/catalog/trait_reference.json`, `docs/catalog/species_trait_matrix.json`) e il glossario siano coerenti; eventuali mismatch bloccano la pipeline prima della build web.
+3. **Validazione continua automatica** – ogni push/PR esegue `ci.yml`, che include build TS/Python, suite CLI, audit dei tratti e `scripts/run_deploy_checks.sh` (il quale richiama il validator dell'inventario e la verifica dei registri del generatore).
+4. **Validazione staging manuale/programmata** – prima di rilasciare, eseguire manualmente gli script di gating nello stesso ordine usato da CI per catturare regressioni ambientali.
+5. **Promozione e pubblicazione** – il workflow `deploy-test-interface.yml` ripete i gate (inventario, configurazione generatore, CLI smoke, audit tratti, deploy checks) e, solo in caso di esito positivo, carica l'artifact su GitHub Pages.
 
 ## Run di staging passo–passo
 
@@ -28,7 +30,17 @@ Questa procedura definisce il percorso end-to-end per promuovere la web experien
    python3 scripts/trait_audit.py --check
    ```
    Garantisce che il catalogo tratti sia coerente con dataset e regole correnti.
-4. **Deploy checks**
+4. **Inventario trait**
+   ```bash
+   python3 tools/py/traits_validator.py --inventory docs/catalog/traits_inventory.json
+   ```
+   Convalida che tutte le risorse elencate nell'inventario siano presenti, aggiornate e linkate ai report analitici (`data/analysis/*`). In caso di nuove specie/biomi, verificare che le note riportino owner e data di allineamento.
+5. **Configurazione generatore**
+   ```bash
+   python3 tools/py/validate_registry_naming.py --trait-glossary data/traits/glossary.json
+   ```
+   Esegue i controlli incrociati su registri (`env_to_traits.yaml`, `hazards.yaml`, `biome_classes.yaml`), trait reference e matrici specie, assicurando che i preset diffusi via web riflettano il glossario condiviso e che i morphotype elencati abbiano mapping aggiornati.
+6. **Deploy checks**
    ```bash
    DEPLOY_DATA_DIR="$(pwd)/data" scripts/run_deploy_checks.sh
    ```
@@ -42,6 +54,8 @@ Se uno dei passaggi fallisce (es. Playwright non riesce a scaricare Chromium, co
 - [ ] CI `Deploy site` (workflow `deploy-test-interface.yml`) verde nell'ultima esecuzione manuale/programmata.
 - [ ] Output CLI smoke privo di errori (solo avvisi noti ammessi, da documentare in `logs/cli/`).
 - [ ] `python3 scripts/trait_audit.py --check` restituisce "nessuna regressione".
+- [ ] `python3 tools/py/traits_validator.py --inventory docs/catalog/traits_inventory.json` senza errori e con log aggiornato in `logs/traits_tracking.md`.
+- [ ] `python3 tools/py/validate_registry_naming.py --trait-glossary data/traits/glossary.json` conferma la coerenza dei registri generator e del glossario.
 - [ ] `scripts/run_deploy_checks.sh` termina con `exit 0` e aggiorna `logs/web_status.md` con esito ✅.
 - [ ] Bundle statico generato (`dist/` in workflow o directory temporanea riportata dallo script) aperto in browser locale senza errori console critici.
 - [ ] Tutti gli eventuali problemi Playwright/UI risolti o tracciati con ticket bloccante.


### PR DESCRIPTION
## Summary
- clarify the web pipeline flow with explicit trait inventory validation and generator registry checks
- document trait inventory dependencies and gating in the design overview
- extend the trait process checklist with inventory updates and CI maintenance guidelines for new trait files

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_69013065f208833284829e0ec8c19eb6