### PR TITLE
Guard idea payload validation against non-string values

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -5,12 +5,11 @@ const { IdeaRepository } = require('./storage');
 const { buildCodexReport } = require('./report');
 
 function sanitizeTextField(value) {
-  if (value === undefined || value === null) {
+  if (typeof value !== 'string') {
     return { sanitized: '', isValid: false };
   }
 
-  const coerced = typeof value === 'string' ? value : String(value);
-  const sanitized = coerced.trim();
+  const sanitized = value.trim();
 
   return { sanitized, isValid: sanitized.length > 0 };
 }


### PR DESCRIPTION
## Summary
- ensure sanitizeTextField rejects non-string inputs instead of coercing them
- keep idea validation requiring textual title and category values

## Testing
- npm run test:api *(fails: missing dev dependency `supertest` in environment)*

------
https://chatgpt.com/codex/tasks/task_e_690150e9a0408332b91804a11a4c3662