### PR TITLE
Rework Idea Engine taxonomy for biomes and ecosystems

### DIFF
--- a/README_IDEAS.md
+++ b/README_IDEAS.md
@@ -36,10 +36,13 @@ Questa cartella aggiunge **docs/ideas/** con un widget (JS) per inserire idee.
 ## Campi del Reminder
 IDEA: <titolo breve>
 SOMMARIO: <2-4 righe secche>
-CATEGORIA: Narrativa | Meccaniche | Tooling | Arte | VTT | Repo | Docs | Personaggi | Divinità | Enneagramma | Sistema | Altro
+CATEGORIA: Biomi | Ecosistemi | Specie | Tratti & Mutazioni | Missioni & Stage | Telemetria & HUD | Tooling & Pipeline | Documentazione & Lore | Progressione & Economia | Altro
 TAGS: #tag1 #tag2 #tag3
-MODULE: <es. NR04, Fangwood, Torneo Cremesi, Master DD core>
-ENTITÀ: <PG/NPC/divinità/luoghi/oggetti separati da virgola>
+BIOMI: <lista ID da data/biomes.yaml>
+ECOSISTEMI: <meta-nodi o pack collegati>
+SPECIE: <slug specie da data/species.yaml>
+TRATTI: <mutazioni/trait da data/traits/>
+FUNZIONI_GIOCO: <telemetria_vc, mating_nido, progressione_pe…>
 PRIORITÀ: P0 | P1 | P2 | P3
 AZIONI_NEXT: - [ ] azione 1  - [ ] azione 2
 LINK_DRIVE: <URL se esiste>

--- a/docs/ideas/index.html
+++ b/docs/ideas/index.html
@@ -40,11 +40,11 @@
       <ul class="idea-intake__steps">
         <li>
           <span class="idea-intake__step-label">1.</span>
-          Prepara i tag e scegli la categoria più adatta (Narrativa, Meccaniche, Tooling…).
+          Prepara i tag e scegli la categoria coerente con il repository (Biomi, Ecosistemi, Specie, Tratti, Funzioni…).
         </li>
         <li>
           <span class="idea-intake__step-label">2.</span>
-          Inserisci modulo, entità collegate e priorità così il reminder resta coerente con la roadmap.
+          Mappa biomi, ecosistemi, specie, tratti e funzioni di gioco: il reminder resterà allineato con i dataset del repo.
         </li>
         <li>
           <span class="idea-intake__step-label">3.</span>
@@ -74,15 +74,27 @@
           <dl>
             <div>
               <dt>Categoria</dt>
-              <dd>Narrativa · Meccaniche · Tooling · Arte · VTT · Repo · Docs · Personaggi · Divinità · Enneagramma · Sistema · Altro</dd>
+              <dd>Biomi · Ecosistemi · Specie · Tratti &amp; Mutazioni · Missioni &amp; Stage · Telemetria &amp; HUD · Tooling &amp; Pipeline · Documentazione &amp; Lore · Progressione &amp; Economia · Altro</dd>
             </div>
             <div>
               <dt>Tags</dt>
               <dd>Usa <code>#</code> davanti alle keyword. Esempio: <code>#mission</code> <code>#telemetria</code></dd>
             </div>
             <div>
-              <dt>Module</dt>
-              <dd>Identifica pacchetto o arco: <em>NR04, Fangwood, Torneo Cremesi…</em></dd>
+              <dt>Biomi</dt>
+              <dd>Elenca gli ID ufficiali da <code>data/biomes.yaml</code>. Usa virgole o nuove righe.</dd>
+            </div>
+            <div>
+              <dt>Ecosistemi</dt>
+              <dd>Meta-nodi o pack: <em>ecosistema_alpha</em>, <em>fangwood_cluster</em>, ecc.</dd>
+            </div>
+            <div>
+              <dt>Specie &amp; Tratti</dt>
+              <dd>Specie da <code>data/species.yaml</code> e tratti/mutazioni da <code>data/traits/</code>.</dd>
+            </div>
+            <div>
+              <dt>Funzioni di gioco</dt>
+              <dd>Telemetria, mating, progressione, HUD… usa slug coerenti con <code>docs/</code> e <code>packs/</code>.</dd>
             </div>
             <div>
               <dt>Priorità</dt>
@@ -104,7 +116,7 @@
           </p>
           <ul>
             <li>Inserisci <code>?apiBase=https://server</code> e <code>?apiToken=XXX</code> nell'URL per override rapido.</li>
-            <li>Imposta il <em>default module</em> con <code>?module=NR04-Fangwood</code> e la priorità con <code>?priority=P1</code>.</li>
+            <li>Prefiltra i campi con <code>?biomes=foresta_temperata</code>, <code>?ecosystems=ecosistema_alpha</code>, <code>?species=cervo_bianco</code> o <code>?traits=muta_respiratoria</code>; la priorità resta configurabile con <code>?priority=P1</code>.</li>
             <li>Salva il file Markdown esportato in <code>ideas/</code>: il workflow aggiorna <code>IDEAS_INDEX.md</code>.</li>
           </ul>
         </article>
@@ -112,14 +124,19 @@
     </main>
 
     <footer class="idea-intake__footer">
-      Idea Intake widget — v1.2 · Compatibile con export offline e backend Node/Express con catalogo persistente.
+      Idea Intake widget — v2.0 · Allineato ai dataset biomi/ecosistemi/specie e compatibile con export offline o backend Node/Express.
     </footer>
 
     <script>
       window.IDEA_WIDGET_CONFIG = {
         apiBase: "",
         apiToken: "",
-        defaultModule: "NR04-Fangwood",
+        defaultModule: "",
+        defaultBiomes: "",
+        defaultEcosystems: "",
+        defaultSpecies: "",
+        defaultTraits: "",
+        defaultFunctions: "",
         defaultPriority: "P2",
       };
 
@@ -132,7 +149,16 @@
           const params = new URLSearchParams(window.location.search);
           if (params.has("apiBase")) window.IDEA_WIDGET_CONFIG.apiBase = params.get("apiBase") || "";
           if (params.has("apiToken")) window.IDEA_WIDGET_CONFIG.apiToken = params.get("apiToken") || "";
-          if (params.has("module")) window.IDEA_WIDGET_CONFIG.defaultModule = params.get("module") || "";
+          if (params.has("module")) {
+            const value = params.get("module") || "";
+            window.IDEA_WIDGET_CONFIG.defaultModule = value;
+            window.IDEA_WIDGET_CONFIG.defaultEcosystems = value;
+          }
+          if (params.has("biomes")) window.IDEA_WIDGET_CONFIG.defaultBiomes = params.get("biomes") || "";
+          if (params.has("ecosystems")) window.IDEA_WIDGET_CONFIG.defaultEcosystems = params.get("ecosystems") || "";
+          if (params.has("species")) window.IDEA_WIDGET_CONFIG.defaultSpecies = params.get("species") || "";
+          if (params.has("traits")) window.IDEA_WIDGET_CONFIG.defaultTraits = params.get("traits") || "";
+          if (params.has("functions")) window.IDEA_WIDGET_CONFIG.defaultFunctions = params.get("functions") || "";
           if (params.has("priority")) window.IDEA_WIDGET_CONFIG.defaultPriority = params.get("priority") || "P2";
         } catch (error) {
           console.warn("Impossibile applicare gli override del widget", error);

--- a/server/report.js
+++ b/server/report.js
@@ -5,6 +5,11 @@ function formatTags(tags) {
     .join(' ');
 }
 
+function formatList(items) {
+  if (!items || !items.length) return '-';
+  return items.join(', ');
+}
+
 function formatChecklist(actions) {
   if (!actions) return '-';
   const rows = actions
@@ -27,8 +32,11 @@ function reminderBlock(idea) {
     ['SOMMARIO', idea.summary],
     ['CATEGORIA', idea.category],
     ['TAGS', formatTags(idea.tags)],
-    ['MODULE', idea.module],
-    ['ENTITÀ', idea.entities],
+    ['BIOMI', formatList(idea.biomes)],
+    ['ECOSISTEMI', formatList(idea.ecosystems)],
+    ['SPECIE', formatList(idea.species)],
+    ['TRATTI', formatList(idea.traits)],
+    ['FUNZIONI_GIOCO', formatList(idea.game_functions)],
     ['PRIORITÀ', idea.priority],
     ['AZIONI_NEXT', idea.actions_next],
     ['LINK_DRIVE', idea.link_drive],
@@ -45,15 +53,22 @@ function repoTouchpoints(idea) {
   if (idea.github) {
     paths.push(`- Existing reference: ${idea.github}`);
   }
-  if (idea.module) {
-    const moduleSlug = idea.module.replace(/\s+/g, '-').toLowerCase();
-    const ideaFile = idea.id ? `${moduleSlug}-${String(idea.id).padStart(3, '0')}.md` : `${moduleSlug}-idea.md`;
-    paths.push(`- Module focus: ${idea.module}`);
-    paths.push(`- Suggested doc stub: docs/modules/${moduleSlug}/README.md`);
-    paths.push(`- Suggested idea file: ideas/${ideaFile}`);
-  } else {
-    paths.push('- Suggested idea file: ideas/new-idea.md');
+  if (idea.biomes && idea.biomes.length) {
+    paths.push(`- Biomi da aggiornare: ${idea.biomes.join(', ')} (data/biomes.yaml, docs/evo-tactics-pack/)`);
   }
+  if (idea.ecosystems && idea.ecosystems.length) {
+    paths.push(`- Ecosistemi/metanodi: ${idea.ecosystems.join(', ')} (docs/evo-tactics-pack/)`);
+  }
+  if (idea.species && idea.species.length) {
+    paths.push(`- Specie coinvolte: ${idea.species.join(', ')} (data/species.yaml, docs/catalog/)`);
+  }
+  if (idea.traits && idea.traits.length) {
+    paths.push(`- Tratti/Morph: ${idea.traits.join(', ')} (data/traits/, docs/catalog/species_trait_matrix.json)`);
+  }
+  if (idea.game_functions && idea.game_functions.length) {
+    paths.push(`- Funzioni di gioco: ${idea.game_functions.join(', ')} (docs/telemetria, packs/, tools/)`);
+  }
+  paths.push('- Suggested idea file: ideas/new-idea.md');
   paths.push('- Sync index: README_IDEAS.md and IDEAS_INDEX.md');
   return paths.join('\n');
 }
@@ -65,10 +80,12 @@ function buildIncrementalPlan(idea) {
     '- Audit existing lore and mechanics impacted by the idea.',
     '- Confirm assets and references listed below are reachable.',
     '- Align keywords with `/config/project_index.json` taxonomy.',
+    '- Verifica che biomi/ecosistemi siano presenti in `data/biomes.yaml` e negli export `docs/evo-tactics-pack/`.',
+    '- Allinea specie e tratti con `data/species.yaml`, `data/traits/` e `docs/catalog/species_trait_matrix.json`.',
     '',
     '### Phase 2 · Implementation Draft',
     '- Implement gameplay changes incrementally in dedicated branches.',
-    '- Update rules text and supporting data in `/packs` or `/appendici` as needed.',
+    '- Update rules text and supporting data in `/packs`, `/docs`, `/data` as needed.',
     '- Produce playtest hooks or sample encounters under `/data/playtests`.',
     '',
     '### Phase 3 · Playtest & Integration',
@@ -76,6 +93,9 @@ function buildIncrementalPlan(idea) {
     '- Capture adjustments in `/logs/design-journal`. ',
     '- Merge once documentation and checklists below are satisfied.',
   ];
+  if (idea.game_functions && idea.game_functions.length) {
+    plan.splice(6, 0, `- Coordina le funzioni di gioco (${formatList(idea.game_functions)}) con docs/telemetria, tools/ e packs/ pertinenti.`);
+  }
   if (checklist !== '-') {
     plan.push('', '### Next Actions (from intake)', checklist);
   }
@@ -96,8 +116,11 @@ function buildCodexReport(idea) {
     `- **Category:** ${idea.category}`,
     `- **Priority:** ${idea.priority || 'P2'}`,
     `- **Tags:** ${formatTags(idea.tags)}`,
-    `- **Module / Arc:** ${idea.module || '-'}`,
-    `- **Key Entities:** ${idea.entities || '-'}`,
+    `- **Biomi:** ${formatList(idea.biomes)}`,
+    `- **Ecosistemi:** ${formatList(idea.ecosystems)}`,
+    `- **Specie:** ${formatList(idea.species)}`,
+    `- **Tratti:** ${formatList(idea.traits)}`,
+    `- **Funzioni di gioco:** ${formatList(idea.game_functions)}`,
     '',
     '## Repository Touchpoints',
     repoTouchpoints(idea),

--- a/server/storage.js
+++ b/server/storage.js
@@ -16,6 +16,20 @@ function normaliseTags(input) {
   return [];
 }
 
+function normaliseList(input) {
+  if (!input) return [];
+  if (Array.isArray(input)) {
+    return input.map((item) => String(item).trim()).filter(Boolean);
+  }
+  if (typeof input === 'string') {
+    return input
+      .split(/[\n,;]+/)
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
 function timestamp() {
   return new Date().toISOString();
 }
@@ -47,8 +61,11 @@ class IdeaRepository {
       summary: doc.summary || '',
       category: doc.category,
       tags: Array.isArray(doc.tags) ? doc.tags : [],
-      module: doc.module || '',
-      entities: doc.entities || '',
+      biomes: Array.isArray(doc.biomes) ? doc.biomes : [],
+      ecosystems: Array.isArray(doc.ecosystems) ? doc.ecosystems : [],
+      species: Array.isArray(doc.species) ? doc.species : [],
+      traits: Array.isArray(doc.traits) ? doc.traits : [],
+      game_functions: Array.isArray(doc.game_functions) ? doc.game_functions : [],
       priority: doc.priority || '',
       actions_next: doc.actions_next || '',
       link_drive: doc.link_drive || '',
@@ -79,8 +96,11 @@ class IdeaRepository {
       summary: String(payload.summary || '').trim(),
       category: String(payload.category || '').trim(),
       tags: normaliseTags(payload.tags),
-      module: String(payload.module || '').trim(),
-      entities: String(payload.entities || '').trim(),
+      biomes: normaliseList(payload.biomes),
+      ecosystems: normaliseList(payload.ecosystems),
+      species: normaliseList(payload.species),
+      traits: normaliseList(payload.traits),
+      game_functions: normaliseList(payload.game_functions),
       priority: String(payload.priority || '').trim() || 'P2',
       actions_next: String(payload.actions_next || '').trim(),
       link_drive: String(payload.link_drive || '').trim(),
@@ -111,4 +131,5 @@ class IdeaRepository {
 module.exports = {
   IdeaRepository,
   normaliseTags,
+  normaliseList,
 };

--- a/tests/api/idea-engine.test.js
+++ b/tests/api/idea-engine.test.js
@@ -22,14 +22,17 @@ test('POST /api/ideas salva nel database e genera il report Codex', async (t) =>
   const payload = {
     title: 'Nuova idea Playtest',
     summary: 'Dungeon modulare con telemetria',
-    category: 'Meccaniche',
+    category: 'Biomi',
     tags: ['#playtest', 'telemetria'],
-    module: 'NR04 Fangwood',
-    entities: 'Cervo Bianco',
+    biomes: ['foresta_temperata'],
+    ecosystems: ['ecosistema_alpha'],
+    species: ['cervo_bianco'],
+    traits: ['muta_respiratoria'],
+    game_functions: ['telemetria_vc'],
     priority: 'P1',
     actions_next: '- [ ] Stendere schema incontri',
     link_drive: 'https://drive.google.com/test',
-    github: 'docs/modules/fangwood.md',
+    github: 'docs/biomes/foresta_temperata.md',
     note: 'Richiede confronto con bilanciamento VTT',
   };
 
@@ -39,7 +42,10 @@ test('POST /api/ideas salva nel database e genera il report Codex', async (t) =>
     .expect(201);
 
   assert.ok(response.body.idea.id, 'l\'idea deve avere un id');
-  assert.equal(response.body.idea.category, 'Meccaniche');
+  assert.equal(response.body.idea.category, 'Biomi');
+  assert.deepEqual(response.body.idea.biomes, ['foresta_temperata']);
+  assert.deepEqual(response.body.idea.ecosystems, ['ecosistema_alpha']);
+  assert.deepEqual(response.body.idea.game_functions, ['telemetria_vc']);
   assert.equal(response.body.idea.tags.length, 2);
   assert.ok(response.body.report.includes('Codex GPT Integration Brief'));
 
@@ -47,6 +53,9 @@ test('POST /api/ideas salva nel database e genera il report Codex', async (t) =>
   assert.ok(stored, 'l\'idea deve essere salvata nel database');
   assert.equal(stored.summary, payload.summary);
   assert.equal(stored.priority, 'P1');
+  assert.deepEqual(stored.biomes, payload.biomes);
+  assert.deepEqual(stored.species, payload.species);
+  assert.deepEqual(stored.traits, payload.traits);
 });
 
 test('GET /api/ideas/:id/report restituisce il report salvato', async (t) => {

--- a/tools/ts/tests/web/idea-engine.spec.ts
+++ b/tools/ts/tests/web/idea-engine.spec.ts
@@ -24,8 +24,11 @@ test("permette export markdown offline", async ({ page }) => {
   await page.fill("#title", "Idea offline Playwright");
   await page.fill("#summary", "Verifica del flusso di export in modalità offline.");
   await page.fill("#tags", "#playwright #offline");
-  await page.fill("#module", "NR-Test");
-  await page.fill("#entities", "Alpha, Beta");
+  await page.fill("#biomes", "foresta_temperata");
+  await page.fill("#ecosystems", "ecosistema_alpha");
+  await page.fill("#species", "cervo_bianco");
+  await page.fill("#traits", "muta_respiratoria");
+  await page.fill("#game_functions", "telemetria_vc");
   await page.fill("#actions_next", "- [ ] valida export\n- [ ] sincronizza reminder");
 
   await page.getByRole("button", { name: "Anteprima / Export .md" }).click();
@@ -33,9 +36,12 @@ test("permette export markdown offline", async ({ page }) => {
   const preview = page.locator("#result pre.preview");
   await expect(preview).toContainText("IDEA: Idea offline Playwright");
   await expect(preview).toContainText("## Suggested Next Actions");
+  await expect(preview).toContainText("- **Biomi:** foresta_temperata");
 
   const reminder = page.locator("#result pre.preview");
   await expect(reminder).toContainText("TAGS: #playwright #offline");
+  await expect(reminder).toContainText("BIOMI: foresta_temperata");
+  await expect(reminder).toContainText("ECOSISTEMI: ecosistema_alpha");
 
   const note = page.locator("#result .note.small");
   await expect(note).toContainText("Metti il file in  /ideas");


### PR DESCRIPTION
## Summary
- align the Idea Engine widget and documentation with biome/ecosystem/species driven categories and guidance
- persist the new taxonomy fields in the Node backend and regenerate Codex reports with biome, ecosystem, species, and trait data
- refresh API coverage to exercise the updated payload structure

## Testing
- npm run test:api

------
https://chatgpt.com/codex/tasks/task_e_69014e5727cc8332846a6241f0542db2