### PR TITLE
Sync idea engine categories from shared taxonomy

### DIFF
--- a/README_IDEAS.md
+++ b/README_IDEAS.md
@@ -36,7 +36,7 @@ Questa cartella aggiunge **docs/ideas/** con un widget (JS) per inserire idee.
 ## Campi del Reminder
 IDEA: <titolo breve>
 SOMMARIO: <2-4 righe secche>
-CATEGORIA: Biomi | Ecosistemi | Specie | Tratti & Mutazioni | Missioni & Stage | Telemetria & HUD | Tooling & Pipeline | Documentazione & Lore | Progressione & Economia | Altro
+CATEGORIA: vedi `config/idea_engine_taxonomy.json`
 TAGS: #tag1 #tag2 #tag3
 BIOMI: <lista ID da data/biomes.yaml>
 ECOSISTEMI: <meta-nodi o pack collegati>
@@ -48,3 +48,8 @@ AZIONI_NEXT: - [ ] azione 1  - [ ] azione 2
 LINK_DRIVE: <URL se esiste>
 GITHUB: <repo/percorso o URL se esiste>
 NOTE: <altro>
+
+## Tassonomia categorie Idea Engine
+- La lista ufficiale delle categorie è definita in [`config/idea_engine_taxonomy.json`](config/idea_engine_taxonomy.json) e viene caricata sia dal backend Node (`server/app.js`) sia dal widget (`docs/public/embed.js`).
+- Quando aggiorni la tassonomia modifica il file JSON (mantieni la struttura `{ "categories": [] }`) e fai commit.
+- Per la versione pubblicata su GitHub Pages imposta `window.IDEA_WIDGET_CONFIG.categoriesUrl` verso l'asset JSON servito (esempio: `https://raw.githubusercontent.com/<org>/<repo>/main/config/idea_engine_taxonomy.json`). In locale puoi lasciare il valore di default `../config/idea_engine_taxonomy.json`.

--- a/config/idea_engine_taxonomy.json
+++ b/config/idea_engine_taxonomy.json
@@ -1,0 +1,15 @@
+{
+  "updated_at": "2025-01-12T00:00:00Z",
+  "categories": [
+    "Biomi",
+    "Ecosistemi",
+    "Specie",
+    "Tratti & Mutazioni",
+    "Missioni & Stage",
+    "Telemetria & HUD",
+    "Tooling & Pipeline",
+    "Documentazione & Lore",
+    "Progressione & Economia",
+    "Altro"
+  ]
+}

--- a/docs/ideas/index.html
+++ b/docs/ideas/index.html
@@ -74,7 +74,7 @@
           <dl>
             <div>
               <dt>Categoria</dt>
-              <dd>Biomi · Ecosistemi · Specie · Tratti &amp; Mutazioni · Missioni &amp; Stage · Telemetria &amp; HUD · Tooling &amp; Pipeline · Documentazione &amp; Lore · Progressione &amp; Economia · Altro</dd>
+              <dd id="idea-categories-list">Caricamento tassonomia…</dd>
             </div>
             <div>
               <dt>Tags</dt>
@@ -138,6 +138,7 @@
         defaultTraits: "",
         defaultFunctions: "",
         defaultPriority: "P2",
+        categoriesUrl: "../config/idea_engine_taxonomy.json",
       };
 
       if (!window.IDEA_WIDGET_CONFIG.apiBase && window.location.hostname === "localhost") {
@@ -160,6 +161,7 @@
           if (params.has("traits")) window.IDEA_WIDGET_CONFIG.defaultTraits = params.get("traits") || "";
           if (params.has("functions")) window.IDEA_WIDGET_CONFIG.defaultFunctions = params.get("functions") || "";
           if (params.has("priority")) window.IDEA_WIDGET_CONFIG.defaultPriority = params.get("priority") || "P2";
+          if (params.has("categoriesUrl")) window.IDEA_WIDGET_CONFIG.categoriesUrl = params.get("categoriesUrl") || "";
         } catch (error) {
           console.warn("Impossibile applicare gli override del widget", error);
         }
@@ -171,7 +173,20 @@
         const container = document.querySelector("#idea-widget");
         if (!container) return;
         if (window.IdeaWidget && typeof window.IdeaWidget.mount === "function") {
-          window.IdeaWidget.mount("#idea-widget", window.IDEA_WIDGET_CONFIG);
+          window.IdeaWidget
+            .mount("#idea-widget", window.IDEA_WIDGET_CONFIG)
+            .then((categories) => {
+              const list = document.getElementById("idea-categories-list");
+              if (list && Array.isArray(categories) && categories.length) {
+                list.textContent = categories.join(" · ");
+              }
+            })
+            .catch(() => {
+              const list = document.getElementById("idea-categories-list");
+              if (list) {
+                list.textContent = window.IdeaWidget.DEFAULT_CATEGORIES.join(" · ");
+              }
+            });
         } else {
           container.innerHTML =
             "<p class='err'>Impossibile caricare il widget (controlla <code>docs/public/embed.js</code>).</p>";

--- a/server/app.js
+++ b/server/app.js
@@ -3,6 +3,9 @@ const cors = require('cors');
 const path = require('node:path');
 const { IdeaRepository } = require('./storage');
 const { buildCodexReport } = require('./report');
+const ideaTaxonomy = require('../config/idea_engine_taxonomy.json');
+
+const IDEA_CATEGORIES = new Set((ideaTaxonomy && Array.isArray(ideaTaxonomy.categories)) ? ideaTaxonomy.categories : []);
 
 function validateIdeaPayload(payload) {
   if (!payload || typeof payload !== 'object') {
@@ -14,6 +17,11 @@ function validateIdeaPayload(payload) {
   if (!payload.category || !payload.category.trim()) {
     return 'Categoria richiesta';
   }
+  const normalizedCategory = payload.category.trim();
+  if (IDEA_CATEGORIES.size > 0 && !IDEA_CATEGORIES.has(normalizedCategory)) {
+    return 'Categoria non valida';
+  }
+  payload.category = normalizedCategory;
   return '';
 }
 

--- a/tests/api/idea-engine.test.js
+++ b/tests/api/idea-engine.test.js
@@ -99,3 +99,23 @@ test('POST /api/ideas valida i campi obbligatori', async (t) => {
 
   assert.equal(res.body.error, 'Titolo richiesto');
 });
+
+test('POST /api/ideas rifiuta categorie non in tassonomia', async (t) => {
+  const databasePath = createTempDbPath();
+  const { app, repo } = createApp({ databasePath });
+  await repo.ready;
+  t.after(() => {
+    // no-op
+  });
+
+  const res = await request(app)
+    .post('/api/ideas')
+    .send({
+      title: 'Idea senza categoria valida',
+      summary: 'Test categoria',
+      category: 'Non Esiste'
+    })
+    .expect(400);
+
+  assert.equal(res.body.error, 'Categoria non valida');
+});


### PR DESCRIPTION
## Summary
- add config/idea_engine_taxonomy.json as the single source for Idea Engine categories
- update the public widget and Ideas page to load categories dynamically from the shared taxonomy
- validate categories on the API using the taxonomy and document the update flow in README_IDEAS

## Testing
- npm run test:api

------
https://chatgpt.com/codex/tasks/task_e_69015594872c8332a8df52965d6fee22