### PR TITLE
feat: add species builder pipeline and species panel UI

### DIFF
--- a/docs/catalog/catalog_data.json
+++ b/docs/catalog/catalog_data.json
@@ -1,0 +1,1960 @@
+{
+  "generated_at": null,
+  "sources": {
+    "inventory": "docs/catalog/traits_inventory.json",
+    "trait_glossary": "data/traits/glossary.json",
+    "trait_matrix": "docs/catalog/species_trait_matrix.json",
+    "trait_reference": "packs/evo_tactics_pack/docs/catalog/trait_reference.json"
+  },
+  "traits": {
+    "artigli_sette_vie": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Locomotorio",
+        "Prensile"
+      ],
+      "id": "artigli_sette_vie",
+      "label": "Artigli a Sette Vie",
+      "mutation": "Dita lunghe e segmentate con punte a uncino multiplo.",
+      "selective_drive": "Arrampicarsi su pareti rocciose o vegetazione densa.",
+      "synergies": [
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Afferrare superfici irregolari o oggetti multipli.",
+      "usage_map": {
+        "core": [
+          "dune-stalker",
+          "dune_stalker",
+          "magneto-ridge-hunter"
+        ],
+        "optional": [],
+        "synergy": []
+      },
+      "weakness": "Angoli di presa limitati se la superficie è perfettamente liscia."
+    },
+    "carapace_fase_variabile": {
+      "conflicts": [
+        "struttura_elastica_amorfa"
+      ],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Alto (Richiede energia per il cambio di fase)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Strutturale",
+        "Difensivo"
+      ],
+      "id": "carapace_fase_variabile",
+      "label": "Carapace a Variazione di Fase",
+      "mutation": "Strutture minerali a legame reversibile o micro-strutture a rigidità controllata.",
+      "selective_drive": "Alternanza tra ambienti con attacchi cinetici pesanti e ambienti che richiedono velocità.",
+      "synergies": [],
+      "tier": "T1",
+      "usage": "Durezza/densità del guscio modificabile rapidamente.",
+      "usage_map": {
+        "core": [],
+        "optional": [
+          "nano-rust-bloom",
+          "sand-burrower"
+        ],
+        "synergy": []
+      },
+      "weakness": "Debolezza strutturale durante la transizione tra le fasi di durezza."
+    },
+    "coda_frusta_cinetica": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Mantenimento dell'energia accumulata)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Locomotorio",
+        "Difensivo"
+      ],
+      "id": "coda_frusta_cinetica",
+      "label": "Coda a Frusta Cinetica",
+      "mutation": "Muscolatura della coda densa con tendini e fibre che agiscono come molle.",
+      "selective_drive": "Necessità di un attacco di \"sfondamento\" dopo movimento preparatorio.",
+      "synergies": [
+        "artigli_sette_vie"
+      ],
+      "tier": "T1",
+      "usage": "Immagazzinare energia da ogni movimento per un colpo finale potente.",
+      "usage_map": {
+        "core": [
+          "dune-stalker",
+          "magneto-ridge-hunter",
+          "slag-veil-ambusher"
+        ],
+        "optional": [
+          "dune_stalker"
+        ],
+        "synergy": []
+      },
+      "weakness": "Richiede un periodo di inattività o movimento preparatorio per massimizzare il danno."
+    },
+    "criostasi_adattiva": {
+      "conflicts": [
+        "sangue_piroforico",
+        "sacche_galleggianti_ascensoriali"
+      ],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Alto (Fase di risveglio/inizio) / Basso (Fase Criostasi).",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Metabolico",
+        "Difensivo"
+      ],
+      "id": "criostasi_adattiva",
+      "label": "Criostasi",
+      "mutation": "Sviluppo di enzimi crioprotettivi e tessuto adiposo isolante.",
+      "selective_drive": "Inverni prolungati o lunghi periodi di scarsità di cibo.",
+      "synergies": [],
+      "tier": "T1",
+      "usage": "Sopravvivenza a condizioni ambientali estreme.",
+      "usage_map": {
+        "core": [],
+        "optional": [
+          "dune_stalker"
+        ],
+        "synergy": []
+      },
+      "weakness": "Vulnerabilità estrema agli attacchi chimici (veleni) in fase Criostasi."
+    },
+    "eco_interno_riflesso": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Emissioni e ricezione continua)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Sensoriale",
+        "Nervoso"
+      ],
+      "id": "eco_interno_riflesso",
+      "label": "Riflesso dell'Eco Interno",
+      "mutation": "Organi interni che emettono ultrasuoni e li captano tramite lo scheletro.",
+      "selective_drive": "Orientamento in ambienti completamente privi di luce.",
+      "synergies": [
+        "olfatto_risonanza_magnetica"
+      ],
+      "tier": "T1",
+      "usage": "Utilizzo di onde sonore emesse internamente per mappare l'ambiente.",
+      "usage_map": {
+        "core": [
+          "aurora-bridge-runner",
+          "echo-wing",
+          "zephyr-spore-courier"
+        ],
+        "optional": [],
+        "synergy": []
+      },
+      "weakness": "Estremamente disorientato da suoni o vibrazioni esterne forti e continue."
+    },
+    "empatia_coordinativa": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Feedback costante dai compagni)",
+      "environments": [],
+      "families": [
+        "Supporto",
+        "Empatico"
+      ],
+      "id": "empatia_coordinativa",
+      "label": "Empatia Coordinativa",
+      "mutation": "Circuiti sensorio-emotivi collegati al feed HUD PI.",
+      "selective_drive": "Turni lunghi con rischio alto in cui serve mitigare tilt e HP critici.",
+      "synergies": [],
+      "tier": "T1",
+      "usage": "Collega cooldown difensivi e cura quando la squadra entra in finestra rischio.",
+      "usage_map": {
+        "core": [
+          "glowcap-weaver",
+          "myco-spire-warden"
+        ],
+        "optional": [],
+        "synergy": [
+          "aurora-bridge-runner",
+          "zephyr-spore-courier"
+        ]
+      },
+      "weakness": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende."
+    },
+    "filamenti_digestivi_compattanti": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Digestivo",
+        "Escretorio"
+      ],
+      "id": "filamenti_digestivi_compattanti",
+      "label": "Filamento materiali digeriti",
+      "mutation": "Muscolatura rettale ipertrofica e organo appendice dedicato.",
+      "selective_drive": "Necessità di mantenere la pulizia del territorio/nido.",
+      "synergies": [
+        "ventriglio_gastroliti"
+      ],
+      "tier": "T1",
+      "usage": "Espulsione compatta e ordinata di scorie.",
+      "usage_map": {
+        "core": [
+          "glowcap-weaver",
+          "myco-spire-warden",
+          "nano-rust-bloom",
+          "rust-scavenger"
+        ],
+        "optional": [],
+        "synergy": []
+      },
+      "weakness": "Blocco intestinale se la dieta è priva di materiale 'legante'."
+    },
+    "focus_frazionato": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Dividere l'attenzione su più canali)",
+      "environments": [],
+      "families": [
+        "Tattico",
+        "Controllo"
+      ],
+      "id": "focus_frazionato",
+      "label": "Focus Frazionato",
+      "mutation": "Processore di priorità multi-thread per bersagli e obiettivi.",
+      "selective_drive": "Comunicazioni piatte dove occorre coprire minacce su più fronti.",
+      "synergies": [],
+      "tier": "T1",
+      "usage": "Permette di gestire due ingaggi paralleli senza perdere efficienza.",
+      "usage_map": {
+        "core": [],
+        "optional": [
+          "glowcap-weaver",
+          "myco-spire-warden"
+        ],
+        "synergy": [
+          "dune_stalker"
+        ]
+      },
+      "weakness": "Rischio di overload mentale se tilt e aggro salgono oltre le soglie HUD."
+    },
+    "ghiandola_caustica": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Produzione reagenti)",
+      "environments": [],
+      "families": [
+        "Offensivo",
+        "Chimico"
+      ],
+      "id": "ghiandola_caustica",
+      "label": "Ghiandola Caustica",
+      "mutation": "Sintesi rapida di composti caustici nei moduli d'attacco.",
+      "selective_drive": "Squadre che devono rispondere a guardie situazionali al turno 1-2.",
+      "synergies": [],
+      "tier": "T1",
+      "usage": "Sblocco early di danni da acido per rompere armature leggere.",
+      "usage_map": {
+        "core": [],
+        "optional": [
+          "slag-veil-ambusher"
+        ],
+        "synergy": []
+      },
+      "weakness": "Gestione accurata delle riserve per non calare sotto i budget PE previsto."
+    },
+    "lingua_tattile_trama": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Sensoriale",
+        "Alimentare"
+      ],
+      "id": "lingua_tattile_trama",
+      "label": "Lingua Tattile Trama-Sensibile",
+      "mutation": "Lingua sottile con papille tattili e meccanocettori avanzati.",
+      "selective_drive": "Individuare movimenti sismici o cibi sepolti.",
+      "synergies": [
+        "olfatto_risonanza_magnetica"
+      ],
+      "tier": "T1",
+      "usage": "\"Leggere\" la tessitura delle superfici per vibrazioni o micro-fratture.",
+      "usage_map": {
+        "core": [],
+        "optional": [
+          "aurora-bridge-runner",
+          "echo-wing",
+          "ferrocolonia-magnetotattica",
+          "glowcap-weaver",
+          "zephyr-spore-courier"
+        ],
+        "synergy": []
+      },
+      "weakness": "Estrema vulnerabilità della lingua a contaminanti chimici o acidi."
+    },
+    "mimetismo_cromatico_passivo": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Fase passiva)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "id": "mimetismo_cromatico_passivo",
+      "label": "Ghiandole di Mimetismo Cromatico Passivo",
+      "mutation": "Cromatofori che richiedono un input tattile prolungato per la ricarica.",
+      "selective_drive": "Ambiente con pattern cromatici molto variabili che cambiano lentamente.",
+      "synergies": [
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Assorbire e replicare il colore dell'ambiente circostante dopo contatto.",
+      "usage_map": {
+        "core": [
+          "aurora-bridge-runner",
+          "ferrocolonia-magnetotattica",
+          "zephyr-spore-courier"
+        ],
+        "optional": [],
+        "synergy": []
+      },
+      "weakness": "La colorazione è fissa finché non c'è un nuovo contatto prolungato."
+    },
+    "nucleo_ovomotore_rotante": {
+      "conflicts": [
+        "secrezione_rallentante_palmi"
+      ],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Alto (Rotolamento)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Riproduttivo",
+        "Locomotorio"
+      ],
+      "id": "nucleo_ovomotore_rotante",
+      "label": "Uovo rotaia, uovo grande e uova piccole dentro...",
+      "mutation": "Massa globulare rigida con giunto sferico al centro del petto.",
+      "selective_drive": "Necessità di spostarsi rapidamente su terreni uniformi in assenza di arti.",
+      "synergies": [],
+      "tier": "T1",
+      "usage": "Organo Motorio Rotante: usato come 'ruota' centrale per il rotolamento.",
+      "usage_map": {
+        "core": [
+          "sand-burrower"
+        ],
+        "optional": [
+          "rust-scavenger"
+        ],
+        "synergy": []
+      },
+      "weakness": "Impossibilità di muoversi su superfici irregolari o in salita ripida."
+    },
+    "occhi_infrarosso_composti": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Sensoriale",
+        "Visivo"
+      ],
+      "id": "occhi_infrarosso_composti",
+      "label": "Occhi Composti ad Infrarosso",
+      "mutation": "Sviluppo di un secondo strato retinico sensibile all'infrarosso.",
+      "selective_drive": "Caccia notturna o nell'oscurità totale basata sul gradiente termico.",
+      "synergies": [
+        "sonno_emisferico_alternato"
+      ],
+      "tier": "T1",
+      "usage": "Vista specializzata che percepisce il calore corporeo.",
+      "usage_map": {
+        "core": [
+          "echo-wing"
+        ],
+        "optional": [
+          "aurora-bridge-runner",
+          "zephyr-spore-courier"
+        ],
+        "synergy": []
+      },
+      "weakness": "Accecamento temporaneo da fonti di calore intenso e concentrato."
+    },
+    "olfatto_risonanza_magnetica": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Elaborazione sensoriale costante)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Sensoriale",
+        "Nervoso"
+      ],
+      "id": "olfatto_risonanza_magnetica",
+      "label": "Olfatto di Risonanza Magnetica",
+      "mutation": "Organi sensoriali elettrorecettori concentrati su muso o antenne.",
+      "selective_drive": "Orientamento in ambienti sotterranei senza luce o caccia a prede metallifere.",
+      "synergies": [
+        "eco_interno_riflesso"
+      ],
+      "tier": "T1",
+      "usage": "Percepire la direzione e la composizione di metalli o campi energetici.",
+      "usage_map": {
+        "core": [
+          "slag-veil-ambusher"
+        ],
+        "optional": [
+          "dune-stalker",
+          "magneto-ridge-hunter"
+        ],
+        "synergy": []
+      },
+      "weakness": "Sensibilità a forti interferenze elettromagnetiche (es. fulmini o minerali magnetici)."
+    },
+    "pathfinder": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Sincronizzazione con HUD di esplorazione)",
+      "environments": [],
+      "families": [
+        "Esplorazione",
+        "Tattico"
+      ],
+      "id": "pathfinder",
+      "label": "Pathfinder",
+      "mutation": "Suite sensoriale orientata a scouting e lettura minacce.",
+      "selective_drive": "Missioni con indice explore alto e opzioni opzionali da capitalizzare.",
+      "synergies": [],
+      "tier": "T1",
+      "usage": "Ottimizza esplorazione e controllo mappe multi-bioma.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": [
+          "glowcap-weaver",
+          "myco-spire-warden"
+        ]
+      },
+      "weakness": "Valore ridotto in scenari a corridoio o con tilt già stabilizzato."
+    },
+    "pianificatore": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Analisi continua di stato squadre)",
+      "environments": [],
+      "families": [
+        "Strategico",
+        "Comando"
+      ],
+      "id": "pianificatore",
+      "label": "Pianificatore",
+      "mutation": "Protocollo decisionale adattivo con buffer informativi dedicati.",
+      "selective_drive": "Squadre che devono mantenere priorità multiple su turni lunghi.",
+      "synergies": [],
+      "tier": "T1",
+      "usage": "Coordina finestre di danno e difesa, mantenendo la squadra allineata al piano PI.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": [
+          "glowcap-weaver",
+          "myco-spire-warden"
+        ]
+      },
+      "weakness": "Rigidità tattica se gli input di telemetria arrivano in ritardo."
+    },
+    "random": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Variabile (Dipende dal tratto estratto)",
+      "environments": [],
+      "families": [
+        "Flessibile",
+        "Generico"
+      ],
+      "id": "random",
+      "label": "Trait Random",
+      "mutation": "Selezione casuale da pool controllata per esperimenti di build.",
+      "selective_drive": "Draft rapidi o recuperi quando il tavolo necessita sorprese adattive.",
+      "synergies": [],
+      "tier": "T1",
+      "usage": "Slot jolly per testing o pareggiare budget PI quando serve varietà.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "weakness": "Bassa affidabilità: richiede slot aggiuntivi per mitigare risultati sfavorevoli."
+    },
+    "respiro_a_scoppio": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Alto (Richiede ricarica polmonare)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Respiratorio",
+        "Propulsivo"
+      ],
+      "id": "respiro_a_scoppio",
+      "label": "Respiro a scoppio",
+      "mutation": "Polmoni o sacche aeree ad alta pressione con valvole di rilascio rapide.",
+      "selective_drive": "Spostamento rapido tramite getto d'aria in ambienti a bassa resistenza.",
+      "synergies": [
+        "sacche_galleggianti_ascensoriali"
+      ],
+      "tier": "T1",
+      "usage": "Rilasciare grandi quantità d'aria o energia in un getto potente.",
+      "usage_map": {
+        "core": [
+          "rust-scavenger"
+        ],
+        "optional": [
+          "dune-stalker",
+          "magneto-ridge-hunter",
+          "slag-veil-ambusher"
+        ],
+        "synergy": []
+      },
+      "weakness": "Vulnerabilità respiratoria subito dopo l'utilizzo (tempo di ricarica)."
+    },
+    "risonanza_di_branco": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Richiede mantenimento empatico)",
+      "environments": [],
+      "families": [
+        "Supporto",
+        "Armonico"
+      ],
+      "id": "risonanza_di_branco",
+      "label": "Risonanza di Branco",
+      "mutation": "Reticolo empatico che collega i canali PI cooperativi.",
+      "selective_drive": "Forme che eccellono in difesa coordinata e scudi sovrapposti.",
+      "synergies": [],
+      "tier": "T1",
+      "usage": "Amplifica buff condivisi sincronizzando i timer di squadra.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": [
+          "aurora-bridge-runner",
+          "dune_stalker",
+          "zephyr-spore-courier"
+        ]
+      },
+      "weakness": "Stress elevato se la coesione cala sotto i target di telemetria."
+    },
+    "sacche_galleggianti_ascensoriali": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Per il controllo della pressione)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Idrostatico",
+        "Locomotorio"
+      ],
+      "id": "sacche_galleggianti_ascensoriali",
+      "label": "Sacche galleggianti ascensoriali",
+      "mutation": "Sacche ripiene di gas leggeri con pompe muscolari.",
+      "selective_drive": "Vivere in un ambiente acquatico con forti correnti verticali.",
+      "synergies": [
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Controllo preciso della profondità e del movimento verticale.",
+      "usage_map": {
+        "core": [
+          "aurora-bridge-runner",
+          "sand-burrower",
+          "zephyr-spore-courier"
+        ],
+        "optional": [
+          "dune_stalker",
+          "echo-wing"
+        ],
+        "synergy": []
+      },
+      "weakness": "Rischio di barotrauma se la pressione esterna cambia troppo rapidamente."
+    },
+    "sangue_piroforico": {
+      "conflicts": [
+        "criostasi_adattiva",
+        "scheletro_idro_regolante"
+      ],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Sintesi dei composti)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Circolatorio",
+        "Difensivo"
+      ],
+      "id": "sangue_piroforico",
+      "label": "Sangue che prende fuoco a contatto con l'ossigeno",
+      "mutation": "Presenza di composti piroforici nel sangue.",
+      "selective_drive": "Difesa contro predatori che tentano di estrarre fluidi corporei.",
+      "synergies": [],
+      "tier": "T1",
+      "usage": "Meccanismo di difesa termico o chimico che si attiva con l'aria.",
+      "usage_map": {
+        "core": [
+          "ferrocolonia-magnetotattica"
+        ],
+        "optional": [
+          "nano-rust-bloom"
+        ],
+        "synergy": []
+      },
+      "weakness": "Rischio di auto-combustione in caso di ferita profonda in atmosfera ricca di ossigeno."
+    },
+    "scheletro_idro_regolante": {
+      "conflicts": [
+        "sangue_piroforico"
+      ],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Scambio rapido di fluidi)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Strutturale",
+        "Omeostatico"
+      ],
+      "id": "scheletro_idro_regolante",
+      "label": "Scheletro Idro-Regolante",
+      "mutation": "Struttura ossea porosa capace di scambio rapido di fluidi.",
+      "selective_drive": "Alternare vita terrestre e vita acquatica/aerea.",
+      "synergies": [
+        "sacche_galleggianti_ascensoriali"
+      ],
+      "tier": "T1",
+      "usage": "Assorbire o espellere rapidamente acqua dai tessuti ossei per modificare il peso.",
+      "usage_map": {
+        "core": [
+          "dune-stalker",
+          "dune_stalker",
+          "magneto-ridge-hunter",
+          "nano-rust-bloom",
+          "sand-burrower"
+        ],
+        "optional": [
+          "rust-scavenger"
+        ],
+        "synergy": [
+          "slag-veil-ambusher"
+        ]
+      },
+      "weakness": "Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio."
+    },
+    "secrezione_rallentante_palmi": {
+      "conflicts": [
+        "carapace_fase_variabile",
+        "nucleo_ovomotore_rotante"
+      ],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Produzione del liquido)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "id": "secrezione_rallentante_palmi",
+      "label": "Mani secernano liquido rallentante",
+      "mutation": "Ghiandole mucose modificate sulle superfici prensili.",
+      "selective_drive": "Cattura di prede veloci o difesa da aggressori corpo a corpo.",
+      "synergies": [],
+      "tier": "T1",
+      "usage": "Neutralizzare o immobilizzare prede/nemici.",
+      "usage_map": {
+        "core": [
+          "ferrocolonia-magnetotattica"
+        ],
+        "optional": [],
+        "synergy": []
+      },
+      "weakness": "Esaurimento rapido delle riserve di liquido con tempo di ricarica prolungato."
+    },
+    "sonno_emisferico_alternato": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Mantenimento attivo di metà cervello)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Nervoso",
+        "Omeostatico"
+      ],
+      "id": "sonno_emisferico_alternato",
+      "label": "Dormire con solo metà cervello alla volta",
+      "mutation": "Encefalizzazione asimmetrica o due lobi cerebrali separati.",
+      "selective_drive": "Monitoraggio costante dei predatori in ambienti ad alto rischio.",
+      "synergies": [
+        "occhi_infrarosso_composti"
+      ],
+      "tier": "T1",
+      "usage": "Vigilanza continua pur garantendo riposo.",
+      "usage_map": {
+        "core": [
+          "echo-wing"
+        ],
+        "optional": [],
+        "synergy": []
+      },
+      "weakness": "Vulnerabilità a suoni/stimoli che colpiscono entrambi i lobi contemporaneamente."
+    },
+    "spore_psichiche_silenziate": {
+      "conflicts": [
+        "respiro_a_scoppio"
+      ],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Alto (Produzione e rilascio)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Escretorio",
+        "Psichico"
+      ],
+      "id": "spore_psichiche_silenziate",
+      "label": "Spora Psichica Silenziosa",
+      "mutation": "Pori che rilasciano nano-particelle attive chimicamente o psichicamente.",
+      "selective_drive": "Neutralizzare gruppi di prede o predatori senza impegnare in combattimento.",
+      "synergies": [],
+      "tier": "T1",
+      "usage": "Indurre uno stato di confusione o letargia negli individui vicini.",
+      "usage_map": {
+        "core": [
+          "nano-rust-bloom"
+        ],
+        "optional": [
+          "myco-spire-warden"
+        ],
+        "synergy": []
+      },
+      "weakness": "Funzionalità ridotta in presenza di vento forte o umidità elevata."
+    },
+    "struttura_elastica_amorfa": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Strutturale",
+        "Locomotorio"
+      ],
+      "id": "struttura_elastica_amorfa",
+      "label": "Struttura elastica, allungabile, amorfa, retrattile",
+      "mutation": "Tessuto con matrice di proteine elastiche iper-modificate.",
+      "selective_drive": "Fuga rapida da predatori in spazi confinati.",
+      "synergies": [
+        "scheletro_idro_regolante"
+      ],
+      "tier": "T1",
+      "usage": "Flessibilità estrema e capacità di assumere forme diverse.",
+      "usage_map": {
+        "core": [
+          "dune-stalker",
+          "dune_stalker",
+          "glowcap-weaver",
+          "myco-spire-warden",
+          "slag-veil-ambusher"
+        ],
+        "optional": [],
+        "synergy": [
+          "magneto-ridge-hunter"
+        ]
+      },
+      "weakness": "Vulnerabilità a danni da taglio o perforazione (difficile cauterizzazione)."
+    },
+    "tattiche_di_branco": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Broadcast continuo di segnali)",
+      "environments": [],
+      "families": [
+        "Strategico",
+        "Supporto"
+      ],
+      "id": "tattiche_di_branco",
+      "label": "Tattiche di Branco",
+      "mutation": "Canale condiviso per marcature e ingaggi simultanei.",
+      "selective_drive": "Squadre che puntano a style bonus tramite assist e controllo spazio.",
+      "synergies": [],
+      "tier": "T1",
+      "usage": "Coordina prese e focus bersaglio condividendo segnali di priorità.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": [
+          "dune_stalker",
+          "magneto-ridge-hunter",
+          "slag-veil-ambusher"
+        ]
+      },
+      "weakness": "Richiede formazione stabile; cala se la coesione precipita sotto il target."
+    },
+    "ventriglio_gastroliti": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Contrazione muscolare costante)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Digestivo",
+        "Alimentare"
+      ],
+      "id": "ventriglio_gastroliti",
+      "label": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
+      "mutation": "Sviluppo di un organo muscolare (ventriglio) con gastroliti.",
+      "selective_drive": "Dieta basata su semi, conchiglie o insetti corazzati.",
+      "synergies": [
+        "filamenti_digestivi_compattanti"
+      ],
+      "tier": "T1",
+      "usage": "Macinazione di cibo duro all'interno di un ventriglio.",
+      "usage_map": {
+        "core": [
+          "rust-scavenger"
+        ],
+        "optional": [
+          "ferrocolonia-magnetotattica"
+        ],
+        "synergy": []
+      },
+      "weakness": "Usura e rottura del ventriglio se i gastroliti sono esauriti o troppo lisci."
+    },
+    "zampe_a_molla": {
+      "conflicts": [],
+      "dataset_sources": [
+        "data/analysis/trait_baseline.yaml",
+        "data/analysis/trait_coverage_matrix.csv",
+        "data/analysis/trait_coverage_report.json",
+        "data/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/species.yaml",
+        "data/telemetry.yaml",
+        "data/traits/glossary.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Carica elastica a turni alterni)",
+      "environments": [],
+      "families": [
+        "Mobilità",
+        "Cinetico"
+      ],
+      "id": "zampe_a_molla",
+      "label": "Zampe a Molla",
+      "mutation": "Arti potenziati con ammortizzatori ad alta compressione.",
+      "selective_drive": "Metagame con forte pressione di aggro e necessità di riposizionamento.",
+      "synergies": [],
+      "tier": "T1",
+      "usage": "Dash esplosivi per mantenere il ritmo di ingaggio o disimpegno.",
+      "usage_map": {
+        "core": [],
+        "optional": [
+          "sand-burrower"
+        ],
+        "synergy": []
+      },
+      "weakness": "Perdita di valore su mappe con spazi stretti o controllo setup elevato."
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "test:web": "npm --prefix tools/ts run test:web --",
     "build": "npm --prefix tools/ts run build --",
-    "test": "npm run test:api && npm --prefix tools/ts run test --",
+    "test": "npm run test:api && npm --prefix tools/ts run test -- && npm --prefix webapp run test",
     "test:api": "node --test tests/api/*.test.js",
     "start:api": "node server/index.js",
     "build:idea-taxonomy": "node scripts/build-idea-taxonomy.js"

--- a/services/generation/speciesBuilder.js
+++ b/services/generation/speciesBuilder.js
@@ -1,0 +1,312 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const DEFAULT_CATALOG_PATH = path.resolve(__dirname, '..', '..', 'docs', 'catalog', 'catalog_data.json');
+
+const FAMILY_KEYWORDS = new Map([
+  ['locomotorio', 'locomotor'],
+  ['prensile', 'prehensile'],
+  ['strutturale', 'structural'],
+  ['difensivo', 'defensive'],
+  ['sensoriale', 'sensorial'],
+  ['nervoso', 'neural'],
+  ['metabolico', 'metabolic'],
+  ['supporto', 'support'],
+  ['empatico', 'social'],
+  ['cognitivo', 'cognitive'],
+  ['offensivo', 'offensive'],
+  ['biotico', 'biotic'],
+]);
+
+const BEHAVIOUR_KEYWORDS = new Map([
+  ['coordin', 'coordinated'],
+  ['pred', 'predatory'],
+  ['difes', 'defensive'],
+  ['support', 'supportive'],
+  ['simbi', 'symbiotic'],
+  ['migraz', 'migratory'],
+  ['arramp', 'climber'],
+  ['vol', 'aerial'],
+  ['echo', 'echolocator'],
+  ['dispers', 'disperser'],
+  ['scav', 'scavenger'],
+]);
+
+const ENERGY_ORDER = ['basso', 'medio', 'alto', 'estremo'];
+
+function normaliseList(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    return value.trim() ? [value.trim()] : [];
+  }
+  return [];
+}
+
+function uniqueSorted(values) {
+  return Array.from(new Set(values.filter(Boolean))).sort();
+}
+
+function normaliseEnergy(value) {
+  if (!value) return null;
+  const lowered = value.toLowerCase();
+  for (const token of ENERGY_ORDER) {
+    if (lowered.includes(token)) {
+      return token;
+    }
+  }
+  return lowered.trim() || null;
+}
+
+function scoreEnergy(values) {
+  let picked = null;
+  for (const value of values) {
+    const normalised = normaliseEnergy(value);
+    if (!normalised) continue;
+    if (!picked) {
+      picked = normalised;
+      continue;
+    }
+    if (ENERGY_ORDER.indexOf(normalised) > ENERGY_ORDER.indexOf(picked)) {
+      picked = normalised;
+    }
+  }
+  return picked;
+}
+
+function tierValue(tier) {
+  if (!tier) return null;
+  if (typeof tier === 'number') return tier;
+  const str = String(tier);
+  if (/^[Tt]\d+/.test(str)) {
+    return Number.parseInt(str.slice(1), 10);
+  }
+  const num = Number.parseInt(str, 10);
+  return Number.isFinite(num) ? num : null;
+}
+
+function rarityFromTraits(traits) {
+  const highTiers = traits.reduce((count, trait) => {
+    const value = tierValue(trait.tier);
+    return value && value >= 3 ? count + 1 : count;
+  }, 0);
+  if (highTiers >= 3) return 'R4';
+  if (highTiers === 2) return 'R3';
+  if (highTiers === 1) return 'R2';
+  return 'R1';
+}
+
+function threatFromTraits(traits) {
+  const values = traits
+    .map((trait) => tierValue(trait.tier))
+    .filter((value) => Number.isFinite(value));
+  if (!values.length) return 'T1';
+  const avg = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const tier = Math.max(1, Math.min(5, Math.round(avg)));
+  return `T${tier}`;
+}
+
+function synergyScore(traits) {
+  if (!traits.length) return 0;
+  let total = 0;
+  traits.forEach((trait) => {
+    const overlap = traits.filter((candidate) => trait.synergies.includes(candidate.id)).length;
+    total += overlap;
+  });
+  return Math.round((total / (traits.length * Math.max(traits.length - 1, 1))) * 1000) / 1000;
+}
+
+function deriveMorphology(traits) {
+  const families = [];
+  const adaptations = [];
+  const environments = new Set();
+
+  traits.forEach((trait) => {
+    (trait.families || []).forEach((family) => {
+      const lowered = family.toLowerCase();
+      for (const [token, mapped] of FAMILY_KEYWORDS.entries()) {
+        if (lowered.includes(token)) {
+          families.push(mapped);
+          return;
+        }
+      }
+      families.push(lowered);
+    });
+    if (trait.mutation) {
+      adaptations.push(trait.mutation);
+    }
+    if (trait.weakness) {
+      adaptations.push(`Precauzione: ${trait.weakness}`);
+    }
+    (trait.environments || []).forEach((env) => environments.add(env));
+  });
+
+  return {
+    families: uniqueSorted(families),
+    adaptations,
+    environments: uniqueSorted(Array.from(environments)),
+  };
+}
+
+function deriveBehaviour(traits) {
+  const tags = new Set();
+  const drives = [];
+
+  traits.forEach((trait) => {
+    [trait.usage, trait.selective_drive].forEach((field) => {
+      if (!field) return;
+      drives.push(field);
+      const lowered = field.toLowerCase();
+      for (const [token, label] of BEHAVIOUR_KEYWORDS.entries()) {
+        if (lowered.includes(token)) {
+          tags.add(label);
+        }
+      }
+    });
+  });
+
+  return { tags: Array.from(tags), drives };
+}
+
+function composeSummary(traits) {
+  return traits.slice(0, 3).map((trait) => trait.label).join(', ');
+}
+
+function composeDescription(traits, morphology, behaviour) {
+  if (!traits.length) {
+    return 'Specie sintetica generata da trait sconosciuti.';
+  }
+  let lead = `Sintesi genetica focalizzata su ${traits[0].label}`;
+  if (traits.length > 1) {
+    lead += ` e ${traits[1].label}`;
+  }
+  const families = morphology.families || [];
+  const tags = behaviour.tags || [];
+  const environments = morphology.environments || [];
+  let morpho = '';
+  if (families.length) {
+    morpho = ` con impronta morfologica ${families.join(', ')}`;
+  }
+  if (tags.length) {
+    morpho += `; comportamento ${tags.join(', ')}`;
+  }
+  const envPart = environments.length
+    ? ` Ottimizzata per biomi: ${environments.join(', ')}.`
+    : ' Ottimizzata per biomi vari.';
+  return `${lead}${morpho}.${envPart}`;
+}
+
+async function loadCatalog(catalogPath = DEFAULT_CATALOG_PATH) {
+  const buffer = await fs.readFile(catalogPath, 'utf8');
+  const payload = JSON.parse(buffer);
+  const entries = payload?.traits || {};
+  const traits = new Map();
+  Object.entries(entries).forEach(([traitId, raw]) => {
+    traits.set(traitId, {
+      id: traitId,
+      label: raw.label || traitId,
+      tier: raw.tier || null,
+      families: normaliseList(raw.families),
+      energy_profile: raw.energy_profile || null,
+      usage: raw.usage || null,
+      selective_drive: raw.selective_drive || null,
+      mutation: raw.mutation || null,
+      synergies: normaliseList(raw.synergies),
+      conflicts: normaliseList(raw.conflicts),
+      environments: normaliseList(raw.environments),
+      weakness: raw.weakness || null,
+    });
+  });
+  return traits;
+}
+
+function createSpeciesBuilder(options = {}) {
+  const catalogPath = options.catalogPath || DEFAULT_CATALOG_PATH;
+  let traitCatalog = null;
+  let loading = null;
+
+  async function ensureCatalog() {
+    if (traitCatalog) return traitCatalog;
+    if (!loading) {
+      loading = loadCatalog(catalogPath).then((map) => {
+        traitCatalog = map;
+        return map;
+      });
+    }
+    return loading;
+  }
+
+  async function buildProfile(traitIds, buildOptions = {}) {
+    if (!Array.isArray(traitIds) || !traitIds.length) {
+      throw new Error('Impossibile generare specie: nessun tratto fornito');
+    }
+    const catalog = await ensureCatalog();
+    const traits = traitIds
+      .map((traitId) => catalog.get(traitId))
+      .filter(Boolean);
+    if (!traits.length) {
+      throw new Error('Impossibile generare specie: tratti sconosciuti');
+    }
+    const rng = buildOptions.random || Math.random;
+    const morphology = deriveMorphology(traits);
+    const behaviour = deriveBehaviour(traits);
+    const energy = scoreEnergy(traits.map((trait) => trait.energy_profile));
+    const threat = threatFromTraits(traits);
+    const rarity = rarityFromTraits(traits);
+    const synergy = synergyScore(traits);
+    const summary = composeSummary(traits);
+    const description = composeDescription(traits, morphology, behaviour);
+
+    const baseName = buildOptions.baseName || traits[0].label;
+    let displayName = baseName;
+    if (traits.length > 1) {
+      const alternate = traits[Math.floor(rng() * (traits.length - 1)) + 1]?.label;
+      if (alternate) {
+        displayName = `${displayName} / ${alternate}`;
+      }
+    }
+
+    const derived = uniqueSorted(
+      traits.flatMap((trait) => trait.synergies || [])
+    );
+    const conflicts = uniqueSorted(
+      traits.flatMap((trait) => trait.conflicts || [])
+    );
+    const identifierSeed = `${displayName}-${threat}-${rarity}-${rng().toFixed(4)}`;
+    const digest = Buffer.from(identifierSeed).toString('base64').replace(/[^a-z0-9]/gi, '').slice(0, 10);
+    const identifier = `synthetic-${digest || '0000000000'}`;
+
+    return {
+      id: identifier,
+      display_name: displayName,
+      summary,
+      description,
+      morphology,
+      behavior: behaviour,
+      statistics: {
+        threat_tier: threat,
+        rarity,
+        energy_profile: energy,
+        synergy_score: synergy,
+      },
+      traits: {
+        core: traits.map((trait) => trait.id),
+        derived,
+        conflicts,
+      },
+    };
+  }
+
+  return {
+    buildProfile,
+    ensureCatalog,
+  };
+}
+
+module.exports = {
+  createSpeciesBuilder,
+};

--- a/tests/snapshots/species_builder_predatore.json
+++ b/tests/snapshots/species_builder_predatore.json
@@ -1,0 +1,60 @@
+{
+  "id": "synthetic-1d37afd07a",
+  "display_name": "Predatore / Coda a Frusta Cinetica",
+  "summary": "Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante",
+  "description": "Sintesi genetica focalizzata su Artigli a Sette Vie e Coda a Frusta Cinetica con impronta morfologica defensive, locomotor, omeostatico, prehensile, structural; comportamento climber. Ottimizzata per biomi: caverna_risonante.",
+  "morphology": {
+    "families": [
+      "defensive",
+      "locomotor",
+      "omeostatico",
+      "prehensile",
+      "structural"
+    ],
+    "adaptations": [
+      "Dita lunghe e segmentate con punte a uncino multiplo.",
+      "Precauzione: Angoli di presa limitati se la superficie è perfettamente liscia.",
+      "Muscolatura della coda densa con tendini e fibre che agiscono come molle.",
+      "Precauzione: Richiede un periodo di inattività o movimento preparatorio per massimizzare il danno.",
+      "Struttura ossea porosa capace di scambio rapido di fluidi.",
+      "Precauzione: Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio."
+    ],
+    "environments": [
+      "caverna_risonante"
+    ]
+  },
+  "behavior": {
+    "tags": [
+      "climber"
+    ],
+    "drives": [
+      "Afferrare superfici irregolari o oggetti multipli.",
+      "Arrampicarsi su pareti rocciose o vegetazione densa.",
+      "Immagazzinare energia da ogni movimento per un colpo finale potente.",
+      "Necessità di un attacco di \"sfondamento\" dopo movimento preparatorio.",
+      "Assorbire o espellere rapidamente acqua dai tessuti ossei per modificare il peso.",
+      "Alternare vita terrestre e vita acquatica/aerea."
+    ]
+  },
+  "statistics": {
+    "threat_tier": "T1",
+    "rarity": "R1",
+    "energy_profile": "medio",
+    "synergy_score": 0.167
+  },
+  "traits": {
+    "core": [
+      "artigli_sette_vie",
+      "coda_frusta_cinetica",
+      "scheletro_idro_regolante"
+    ],
+    "derived": [
+      "artigli_sette_vie",
+      "sacche_galleggianti_ascensoriali",
+      "struttura_elastica_amorfa"
+    ],
+    "conflicts": [
+      "sangue_piroforico"
+    ]
+  }
+}

--- a/tests/test_species_builder.py
+++ b/tests/test_species_builder.py
@@ -1,0 +1,38 @@
+import json
+import unittest
+from pathlib import Path
+
+from services.generation.species_builder import SpeciesBuilder, TraitCatalog
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SNAPSHOT_PATH = REPO_ROOT / "tests" / "snapshots" / "species_builder_predatore.json"
+
+
+class SpeciesBuilderTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.catalog = TraitCatalog.load()
+        self.builder = SpeciesBuilder(self.catalog)
+
+    def test_catalog_contains_core_trait_metadata(self) -> None:
+        trait = self.catalog.require("artigli_sette_vie")
+        self.assertEqual(trait.label, "Artigli a Sette Vie")
+        self.assertIn("Locomotorio", " ".join(trait.families) or trait.usage or "")
+        self.assertIn("data/traits/glossary.json", trait.dataset_sources)
+        self.assertIn("caverna_risonante", trait.environments)
+
+    def test_species_blueprint_matches_snapshot(self) -> None:
+        profile = self.builder.build(
+            [
+                "artigli_sette_vie",
+                "coda_frusta_cinetica",
+                "scheletro_idro_regolante",
+            ],
+            seed=42,
+            base_name="Predatore",
+        )
+        snapshot = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+        self.assertDictEqual(profile, snapshot)
+
+
+if __name__ == "__main__":  # pragma: no cover - esecuzione manuale
+    unittest.main()

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,0 +1,3062 @@
+{
+  "name": "idea-engine-webapp",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "idea-engine-webapp",
+      "dependencies": {
+        "vue": "^3.5.11"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-vue": "^5.1.4",
+        "@vue/test-utils": "^2.4.6",
+        "jsdom": "^24.1.0",
+        "vitest": "^2.1.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
+      "integrity": "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.5.tgz",
+      "integrity": "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz",
+      "integrity": "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.5.tgz",
+      "integrity": "sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.5.tgz",
+      "integrity": "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.5.tgz",
+      "integrity": "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.5.tgz",
+      "integrity": "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.5.tgz",
+      "integrity": "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.5.tgz",
+      "integrity": "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.5.tgz",
+      "integrity": "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.5.tgz",
+      "integrity": "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.5.tgz",
+      "integrity": "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.5.tgz",
+      "integrity": "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.5.tgz",
+      "integrity": "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.5.tgz",
+      "integrity": "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz",
+      "integrity": "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.5.tgz",
+      "integrity": "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.5.tgz",
+      "integrity": "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.5.tgz",
+      "integrity": "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
+      "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.22.tgz",
+      "integrity": "sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.4",
+        "@vue/shared": "3.5.22",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.22.tgz",
+      "integrity": "sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.22",
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.22.tgz",
+      "integrity": "sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.4",
+        "@vue/compiler-core": "3.5.22",
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/compiler-ssr": "3.5.22",
+        "@vue/shared": "3.5.22",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.19",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.22.tgz",
+      "integrity": "sha512-GdgyLvg4R+7T8Nk2Mlighx7XGxq/fJf9jaVofc3IL0EPesTE86cP/8DD1lT3h1JeZr2ySBvyqKQJgbS54IX1Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.22.tgz",
+      "integrity": "sha512-f2Wux4v/Z2pqc9+4SmgZC1p73Z53fyD90NFWXiX9AKVnVBEvLFOWCEgJD3GdGnlxPZt01PSlfmLqbLYzY/Fw4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.22.tgz",
+      "integrity": "sha512-EHo4W/eiYeAzRTN5PCextDUZ0dMs9I8mQ2Fy+OkzvRPUYQEyK9yAjbasrMCXbLNhF7P0OUyivLjIy0yc6VrLJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.22",
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.22.tgz",
+      "integrity": "sha512-Av60jsryAkI023PlN7LsqrfPvwfxOd2yAwtReCjeuugTJTkgrksYJJstg1e12qle0NarkfhfFu1ox2D+cQotww==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.22",
+        "@vue/runtime-core": "3.5.22",
+        "@vue/shared": "3.5.22",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.22.tgz",
+      "integrity": "sha512-gXjo+ao0oHYTSswF+a3KRHZ1WszxIqO7u6XwNHqcqb9JfyIL/pbWrrh/xLv7jeDqla9u+LK7yfZKHih1e1RKAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.22",
+        "@vue/shared": "3.5.22"
+      },
+      "peerDependencies": {
+        "vue": "3.5.22"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.22.tgz",
+      "integrity": "sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
+      "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^2.0.0"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
+      "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
+      "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.5",
+        "@rollup/rollup-android-arm64": "4.52.5",
+        "@rollup/rollup-darwin-arm64": "4.52.5",
+        "@rollup/rollup-darwin-x64": "4.52.5",
+        "@rollup/rollup-freebsd-arm64": "4.52.5",
+        "@rollup/rollup-freebsd-x64": "4.52.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.5",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.5",
+        "@rollup/rollup-linux-arm64-musl": "4.52.5",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.5",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.5",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-musl": "4.52.5",
+        "@rollup/rollup-openharmony-arm64": "4.52.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.5",
+        "@rollup/rollup-win32-x64-gnu": "4.52.5",
+        "@rollup/rollup-win32-x64-msvc": "4.52.5",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.22.tgz",
+      "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/compiler-sfc": "3.5.22",
+        "@vue/runtime-dom": "3.5.22",
+        "@vue/server-renderer": "3.5.22",
+        "@vue/shared": "3.5.22"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
+      "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "idea-engine-webapp",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "vue": "^3.5.11"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.1.4",
+    "@vue/test-utils": "^2.4.6",
+    "jsdom": "^24.1.0",
+    "vitest": "^2.1.1"
+  }
+}

--- a/webapp/src/components/SpeciesPanel.vue
+++ b/webapp/src/components/SpeciesPanel.vue
@@ -1,0 +1,198 @@
+<template>
+  <section class="species-panel" v-if="species">
+    <header class="species-panel__header">
+      <h2 class="species-panel__title">{{ species.display_name || species.id }}</h2>
+      <p class="species-panel__summary" v-if="summary">{{ summary }}</p>
+    </header>
+
+    <article class="species-panel__description">
+      <p>{{ description }}</p>
+    </article>
+
+    <section class="species-panel__traits">
+      <h3>Tratti fondamentali</h3>
+      <ul class="species-panel__trait-list">
+        <li v-for="trait in coreTraits" :key="trait">{{ trait }}</li>
+      </ul>
+    </section>
+
+    <section class="species-panel__traits" v-if="derivedTraits.length">
+      <h3>Tratti derivati</h3>
+      <ul class="species-panel__trait-list species-panel__trait-list--derived">
+        <li v-for="trait in derivedTraits" :key="trait">{{ trait }}</li>
+      </ul>
+    </section>
+
+    <section class="species-panel__adaptations" v-if="adaptations.length">
+      <h3>Adattamenti</h3>
+      <ul>
+        <li v-for="adaptation in adaptations" :key="adaptation">{{ adaptation }}</li>
+      </ul>
+    </section>
+
+    <section class="species-panel__behavior" v-if="behaviourTags.length">
+      <h3>Comportamento</h3>
+      <p>{{ behaviourTags.join(', ') }}</p>
+    </section>
+
+    <section class="species-panel__statistics">
+      <h3>Statistiche</h3>
+      <dl>
+        <div class="species-panel__stat">
+          <dt>Minaccia</dt>
+          <dd>{{ statistics.threat_tier }}</dd>
+        </div>
+        <div class="species-panel__stat">
+          <dt>Rarità</dt>
+          <dd>{{ statistics.rarity || 'R?' }}</dd>
+        </div>
+        <div class="species-panel__stat">
+          <dt>Energia</dt>
+          <dd>{{ statistics.energy_profile || 'n/d' }}</dd>
+        </div>
+        <div class="species-panel__stat">
+          <dt>Sinergia</dt>
+          <dd>{{ formattedSynergy }}</dd>
+        </div>
+      </dl>
+    </section>
+  </section>
+  <section v-else class="species-panel species-panel--empty">
+    <p>Nessuna specie selezionata.</p>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  species: {
+    type: Object,
+    default: null,
+  },
+});
+
+const summary = computed(() => props.species?.summary || null);
+const description = computed(() => props.species?.description || props.species?.summary || '');
+const traits = computed(() => props.species?.traits || {});
+const coreTraits = computed(() => traits.value.core || []);
+const derivedTraits = computed(() => traits.value.derived || props.species?.derived_traits || []);
+const morphology = computed(() => props.species?.morphology || {});
+const adaptations = computed(() => morphology.value.adaptations || []);
+const behaviour = computed(() => props.species?.behavior || props.species?.behavior_profile || {});
+const behaviourTags = computed(() => behaviour.value.tags || behaviour.value.behaviourTags || []);
+const statistics = computed(() => props.species?.statistics || { threat_tier: props.species?.balance?.threat_tier });
+const formattedSynergy = computed(() => {
+  const value = statistics.value?.synergy_score;
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return `${Math.round(value * 100)}%`;
+  }
+  return 'n/d';
+});
+</script>
+
+<style scoped>
+.species-panel {
+  background: #0a0d12;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 1.5rem;
+  color: #f0f4ff;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.species-panel__header {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding-bottom: 0.75rem;
+}
+
+.species-panel__title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.species-panel__summary {
+  margin: 0.25rem 0 0;
+  color: rgba(240, 244, 255, 0.82);
+  font-size: 1rem;
+}
+
+.species-panel__description p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.species-panel__traits,
+.species-panel__adaptations,
+.species-panel__behavior,
+.species-panel__statistics {
+  background: rgba(10, 15, 22, 0.6);
+  padding: 1rem;
+  border-radius: 10px;
+}
+
+.species-panel__traits h3,
+.species-panel__adaptations h3,
+.species-panel__behavior h3,
+.species-panel__statistics h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.species-panel__trait-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.species-panel__trait-list li {
+  background: rgba(39, 121, 255, 0.18);
+  border: 1px solid rgba(39, 121, 255, 0.32);
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.species-panel__trait-list--derived li {
+  background: rgba(180, 94, 255, 0.18);
+  border-color: rgba(180, 94, 255, 0.32);
+}
+
+.species-panel__adaptations ul {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.species-panel__statistics dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem 1rem;
+  margin: 0;
+}
+
+.species-panel__stat dt {
+  font-weight: 600;
+  margin-bottom: 0.1rem;
+  color: rgba(240, 244, 255, 0.75);
+}
+
+.species-panel__stat dd {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.species-panel--empty {
+  text-align: center;
+  color: rgba(240, 244, 255, 0.6);
+  border: 1px dashed rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+  padding: 2rem;
+}
+</style>

--- a/webapp/tests/SpeciesPanel.spec.ts
+++ b/webapp/tests/SpeciesPanel.spec.ts
@@ -1,0 +1,43 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import SpeciesPanel from '../src/components/SpeciesPanel.vue';
+
+const BASE_SPECIES = {
+  id: 'synthetic-1d37afd07a',
+  display_name: 'Predatore / Coda a Frusta Cinetica',
+  summary: 'Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante',
+  description:
+    'Sintesi genetica focalizzata su Artigli a Sette Vie e Coda a Frusta Cinetica con impronta morfologica defensive, locomotor, omeostatico, prehensile, structural; comportamento climber. Ottimizzata per biomi: caverna_risonante.',
+  traits: {
+    core: ['Artigli a Sette Vie', 'Coda a Frusta Cinetica', 'Scheletro Idro-Regolante'],
+    derived: ['struttura_elastica_amorfa', 'sacche_galleggianti_ascensoriali'],
+  },
+  morphology: {
+    adaptations: ['Dita lunghe', 'Precauzione: vulnerabile ai veleni'],
+  },
+  behavior_profile: {
+    tags: ['climber'],
+  },
+  statistics: {
+    threat_tier: 'T3',
+    rarity: 'R2',
+    energy_profile: 'medio',
+    synergy_score: 0.42,
+  },
+};
+
+describe('SpeciesPanel', () => {
+  it('renders species narrative and mechanics', () => {
+    const wrapper = mount(SpeciesPanel, {
+      props: { species: BASE_SPECIES },
+    });
+    expect(wrapper.text()).toContain('Predatore / Coda a Frusta Cinetica');
+    expect(wrapper.text()).toContain('Tratti derivati');
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders placeholder when missing species', () => {
+    const wrapper = mount(SpeciesPanel);
+    expect(wrapper.text()).toContain('Nessuna specie selezionata');
+  });
+});

--- a/webapp/tests/__snapshots__/SpeciesPanel.spec.ts.snap
+++ b/webapp/tests/__snapshots__/SpeciesPanel.spec.ts.snap
@@ -1,0 +1,60 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`SpeciesPanel > renders species narrative and mechanics 1`] = `
+"<section data-v-73eb6eb5="" class="species-panel">
+  <header data-v-73eb6eb5="" class="species-panel__header">
+    <h2 data-v-73eb6eb5="" class="species-panel__title">Predatore / Coda a Frusta Cinetica</h2>
+    <p data-v-73eb6eb5="" class="species-panel__summary">Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante</p>
+  </header>
+  <article data-v-73eb6eb5="" class="species-panel__description">
+    <p data-v-73eb6eb5="">Sintesi genetica focalizzata su Artigli a Sette Vie e Coda a Frusta Cinetica con impronta morfologica defensive, locomotor, omeostatico, prehensile, structural; comportamento climber. Ottimizzata per biomi: caverna_risonante.</p>
+  </article>
+  <section data-v-73eb6eb5="" class="species-panel__traits">
+    <h3 data-v-73eb6eb5="">Tratti fondamentali</h3>
+    <ul data-v-73eb6eb5="" class="species-panel__trait-list">
+      <li data-v-73eb6eb5="">Artigli a Sette Vie</li>
+      <li data-v-73eb6eb5="">Coda a Frusta Cinetica</li>
+      <li data-v-73eb6eb5="">Scheletro Idro-Regolante</li>
+    </ul>
+  </section>
+  <section data-v-73eb6eb5="" class="species-panel__traits">
+    <h3 data-v-73eb6eb5="">Tratti derivati</h3>
+    <ul data-v-73eb6eb5="" class="species-panel__trait-list species-panel__trait-list--derived">
+      <li data-v-73eb6eb5="">struttura_elastica_amorfa</li>
+      <li data-v-73eb6eb5="">sacche_galleggianti_ascensoriali</li>
+    </ul>
+  </section>
+  <section data-v-73eb6eb5="" class="species-panel__adaptations">
+    <h3 data-v-73eb6eb5="">Adattamenti</h3>
+    <ul data-v-73eb6eb5="">
+      <li data-v-73eb6eb5="">Dita lunghe</li>
+      <li data-v-73eb6eb5="">Precauzione: vulnerabile ai veleni</li>
+    </ul>
+  </section>
+  <section data-v-73eb6eb5="" class="species-panel__behavior">
+    <h3 data-v-73eb6eb5="">Comportamento</h3>
+    <p data-v-73eb6eb5="">climber</p>
+  </section>
+  <section data-v-73eb6eb5="" class="species-panel__statistics">
+    <h3 data-v-73eb6eb5="">Statistiche</h3>
+    <dl data-v-73eb6eb5="">
+      <div data-v-73eb6eb5="" class="species-panel__stat">
+        <dt data-v-73eb6eb5="">Minaccia</dt>
+        <dd data-v-73eb6eb5="">T3</dd>
+      </div>
+      <div data-v-73eb6eb5="" class="species-panel__stat">
+        <dt data-v-73eb6eb5="">Rarità</dt>
+        <dd data-v-73eb6eb5="">R2</dd>
+      </div>
+      <div data-v-73eb6eb5="" class="species-panel__stat">
+        <dt data-v-73eb6eb5="">Energia</dt>
+        <dd data-v-73eb6eb5="">medio</dd>
+      </div>
+      <div data-v-73eb6eb5="" class="species-panel__stat">
+        <dt data-v-73eb6eb5="">Sinergia</dt>
+        <dd data-v-73eb6eb5="">42%</dd>
+      </div>
+    </dl>
+  </section>
+</section>"
+`;

--- a/webapp/vitest.config.ts
+++ b/webapp/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- aggregate trait metadata into the shared catalog and expose a Python species builder for deterministic blueprints
- integrate the builder across the biome synthesizer and hybrid generator, replacing the Neo-Variant fallback with narrative-rich profiles
- add a Vue SpeciesPanel component with vitest snapshot coverage to surface derived traits, adaptations and dynamic statistics

## Testing
- python -m unittest tests/test_species_builder.py
- npm --prefix webapp run test -- --run
- npm test *(fails: Chromium missing libatk-1.0.so.0 in Playwright runner)*

------
https://chatgpt.com/codex/tasks/task_e_69016794c3548332805e55cbfb05614b