### PR TITLE
Add Idea Engine changelog reminders and feedback CTA

### DIFF
--- a/.github/workflows/idea-intake-index.yml
+++ b/.github/workflows/idea-intake-index.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Build ideas index
         run: |
           echo "# Ideas Index" > IDEAS_INDEX.md
@@ -19,6 +21,15 @@ jobs:
             done
           else
             echo "_(nessuna idea ancora)_" >> IDEAS_INDEX.md
+          fi
+      - name: Reminder changelog widget/backend
+        run: |
+          set -euo pipefail
+          CHANGED=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" -- 'docs/ideas/**' 'docs/public/**' 'server/**' || true)
+          if [ -n "$CHANGED" ]; then
+            echo "::warning::Sono stati modificati file del widget/backend (${CHANGED//$'\n'/, }). Aggiorna README.md, README_IDEAS.md e docs/ideas/changelog.md con le note di rilascio."
+          else
+            echo "Nessun file widget/backend in modifica, nessun promemoria changelog.";
           fi
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/README.md
+++ b/README.md
@@ -116,14 +116,30 @@ python3 generate_encounter.py savana
 
 ## Idea Engine Updates & Feedback
 
+### Novità rapide — 2025-12-01
+- **CTA unificata per il feedback** — Il report Codex ora si chiude con un richiamo diretto al modulo immediato per raccogliere
+  le impressioni a caldo su widget e backend.
+- **Changelog dedicato** — Le note di rilascio vivono nel nuovo file [`docs/ideas/changelog.md`](docs/ideas/changelog.md) così
+  da poter allegare rapidamente gli highlight di ogni sprint.
+
 ### Changelog
+- Consulta [`docs/ideas/changelog.md`](docs/ideas/changelog.md) per la cronologia completa.
 - **2025-10-29** — Il widget `docs/public/embed.js` mostra un modulo "Feedback" dopo l'invio delle idee e il backend accetta
   `POST /api/ideas/:id/feedback` per archiviare i commenti accanto alla proposta, includendoli nel report Codex.
 
-### Come inviare feedback
-- **Modulo rapido** — Compila il campo feedback direttamente nel widget dopo il submit per registrare note contestuali.
-- **Template strutturato** — Duplica [`docs/ideas/feedback.md`](docs/ideas/feedback.md) quando hai bisogno di un resoconto
-  completo (allega il file oppure apri un ticket con label `idea-engine-feedback`).
+### Procedura feedback
+1. **Segnala subito** — Compila il [modulo feedback immediato](https://forms.gle/evoTacticsIdeaFeedback) per registrare l'esito
+   dei test su widget/back-end entro poche ore dal rilascio.
+2. **Approfondisci nel widget** — Usa il campo feedback integrato dopo l'invio dell'idea per allegare note contestuali che
+   finiranno nel report Codex.
+3. **Formalizza se serve** — Duplica [`docs/ideas/feedback.md`](docs/ideas/feedback.md) o apri un ticket con label
+   `idea-engine-feedback` quando servono follow-up estesi.
+
+### Link rapidi
+- [Modulo feedback immediato](https://forms.gle/evoTacticsIdeaFeedback)
+- [Changelog Idea Engine](docs/ideas/changelog.md)
+- [Indice idee generato dalla CI](IDEAS_INDEX.md)
+- [Support Hub Idea Engine](docs/ideas/index.html)
 
 ## Pacchetto ecosistemi (Evo-Tactics Pack v1.7)
 - Contenuto in `packs/evo_tactics_pack/` con struttura autosufficiente (`data/`, `docs/`, `tools/`, `out/`).

--- a/README_IDEAS.md
+++ b/README_IDEAS.md
@@ -2,6 +2,25 @@
 
 Questa cartella aggiunge **docs/ideas/** con un widget (JS) per inserire idee.
 
+## Novità widget & backend — 2025-12-01
+- **Richiamo feedback immediato** — Il report Codex pubblicato dal backend include una call to action verso il modulo espresso
+  così da raccogliere rapidamente le note post-rilascio.
+- **Registro cambi dedicato** — I rilasci di widget/backend confluiscono in [`docs/ideas/changelog.md`](docs/ideas/changelog.md)
+  per avere uno storico unico da citare in release note e retrospettive.
+
+## Procedura feedback Idea Engine
+1. **Compila il modulo espresso** — Segnala regressioni o highlight dal playtest tramite il [modulo feedback immediato](https://forms.gle/evoTacticsIdeaFeedback).
+2. **Aggiungi note contestuali** — Usa il campo feedback mostrato dal widget dopo l'invio per collegare i commenti alla singola
+   idea; l'informazione verrà riportata nel report Codex.
+3. **Apri follow-up strutturati** — Duplica [`docs/ideas/feedback.md`](docs/ideas/feedback.md) o apri un ticket con label
+   `idea-engine-feedback` per raccolte più ampie.
+
+## Link rapidi
+- [Modulo feedback immediato](https://forms.gle/evoTacticsIdeaFeedback)
+- [Changelog widget/backend](docs/ideas/changelog.md)
+- [Indice idee generato dalla CI](IDEAS_INDEX.md)
+- [Support Hub Idea Engine](docs/ideas/index.html)
+
 ## Setup
 1. Copia tutto nella **radice del repo** (mantieni i percorsi).
 2. Apri `docs/ideas/index.html` e imposta:

--- a/docs/ideas/changelog.md
+++ b/docs/ideas/changelog.md
@@ -1,0 +1,22 @@
+# Idea Engine — Changelog rilasci
+
+> Aggiorna questo file ad ogni promozione di widget/backend per mantenere una traccia unica delle novità. Duplica lo scheletro
+> qui sotto e collega sempre PR, issue o log operativi utili al review.
+
+## 2025-12-01 · Feedback sprint
+- Introdotta la call to action finale nel report Codex con link diretto al modulo di feedback immediato.
+- Allineati i README principali con procedura e link rapidi per l'ingestione del feedback.
+
+## 2025-10-29 · Feedback nel widget
+- Il widget `docs/public/embed.js` mostra un modulo "Feedback" post-submit per raccogliere commenti contestuali.
+- Il backend accetta `POST /api/ideas/:id/feedback` e salva le note accanto alla proposta, includendole nel report Codex.
+
+---
+
+### Template per il prossimo rilascio
+```
+## AAAA-MM-GG · Nome rilascio
+- Punto 1
+- Punto 2
+- Collegamenti utili: PR #, log, ticket
+```

--- a/server/report.js
+++ b/server/report.js
@@ -140,6 +140,8 @@ function buildIncrementalPlan(idea) {
   return plan.join('\n');
 }
 
+const IMMEDIATE_FEEDBACK_FORM_URL = 'https://forms.gle/evoTacticsIdeaFeedback';
+
 function buildCodexReport(idea) {
   const createdAt = idea.created_at || new Date().toISOString();
   const report = [
@@ -189,10 +191,16 @@ function buildCodexReport(idea) {
   if (idea.feedback && idea.feedback.length) {
     report.push('', '## Intake Feedback', formatFeedbackEntries(idea.feedback));
   }
+  report.push(
+    '',
+    '## Share Immediate Feedback',
+    `Compila il modulo espresso per segnalare risultati o regressioni a caldo: [Modulo feedback immediato](${IMMEDIATE_FEEDBACK_FORM_URL}).`,
+  );
   return report.join('\n');
 }
 
 module.exports = {
   buildCodexReport,
   formatFeedbackEntries,
+  IMMEDIATE_FEEDBACK_FORM_URL,
 };


### PR DESCRIPTION
## Summary
- document the new Idea Engine release highlights, feedback process, and quick links in the README files
- add a dedicated changelog page for widget/backend releases and expose a feedback CTA in the Codex report
- update the idea-intake workflow to remind maintainers to refresh changelog notes when relevant files change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69016ceb0fb08332b0f8ed5b04f108eb