### PR TITLE
Adjust report incoming script to honor stdout mode

### DIFF
--- a/scripts/report_incoming.sh
+++ b/scripts/report_incoming.sh
@@ -7,4 +7,28 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 cd "${PROJECT_ROOT}"
 
-python3 tools/py/game_cli.py investigate incoming --recursive --json --html "$@"
+args=("$@")
+destination=""
+
+for i in "${!args[@]}"; do
+    arg="${args[$i]}"
+    case "$arg" in
+        --destination)
+            next_index=$((i + 1))
+            if (( next_index < ${#args[@]} )); then
+                destination="${args[$next_index]}"
+            fi
+            ;;
+        --destination=*)
+            destination="${arg#*=}"
+            ;;
+    esac
+done
+
+html_args=(--html)
+normalized_destination="${destination//[[:space:]]/}"
+if [[ "$normalized_destination" == "-" ]]; then
+    html_args=()
+fi
+
+python3 tools/py/game_cli.py investigate incoming --recursive --json "${html_args[@]}" "${args[@]}"


### PR DESCRIPTION
## Summary
- conditionally skip the `--html` flag when `--destination -` is provided
- allow the report_incoming helper to support stdout-only runs without errors

## Testing
- ./scripts/report_incoming.sh --destination - > /tmp/report.json

------
https://chatgpt.com/codex/tasks/task_e_6901780a44cc83328b2ac74895a02df8