### PR TITLE
Fix standalone bootstrap for species validator CLI

### DIFF
--- a/packs/evo_tactics_pack/tools/py/validate_species_v1_7.py
+++ b/packs/evo_tactics_pack/tools/py/validate_species_v1_7.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import sys
 from pathlib import Path
 from typing import Iterable
@@ -12,6 +13,9 @@ import yaml
 def _ensure_repo_root_on_path() -> None:
     """Make the repository root (containing the ``packs`` package) importable."""
 
+    if importlib.util.find_spec("packs") is not None:
+        return
+
     repo_root: Path | None = None
     for candidate in Path(__file__).resolve().parents:
         if (candidate / "packs").is_dir():
@@ -19,6 +23,8 @@ def _ensure_repo_root_on_path() -> None:
             break
 
     if repo_root is None:
+        if importlib.util.find_spec("packs") is not None:
+            return
         raise RuntimeError(
             "Unable to locate the repository root containing the 'packs' package"
         )


### PR DESCRIPTION
## Summary
- ensure the species validator CLI locates the repository root dynamically before importing pack modules
- raise a clear error when the packs package cannot be located while preserving standalone execution

## Testing
- python packs/evo_tactics_pack/tools/py/validate_species_v1_7.py --help

------
https://chatgpt.com/codex/tasks/task_e_6901788901d08332b67bbe4694c5c306