### PR TITLE
feat(webapp): add encounter generator templates and UI

### DIFF
--- a/webapp/src/components/EncounterPanel.vue
+++ b/webapp/src/components/EncounterPanel.vue
@@ -1,0 +1,333 @@
+<template>
+  <section class="encounter-panel" v-if="encounter">
+    <header class="encounter-panel__header">
+      <div class="encounter-panel__title-block">
+        <h2 class="encounter-panel__title">{{ encounter.templateName }}</h2>
+        <p class="encounter-panel__summary">{{ activeSeed.summary }}</p>
+      </div>
+      <div class="encounter-panel__meta">
+        <span class="encounter-panel__badge">{{ activeSeed.metrics.threat.tier }}</span>
+        <span class="encounter-panel__biome">{{ encounter.biomeName }}</span>
+      </div>
+    </header>
+
+    <div v-if="hasVariants" class="encounter-panel__variant-selector">
+      <label class="encounter-panel__variant-label" for="encounter-variant">Scenario</label>
+      <select
+        id="encounter-variant"
+        class="encounter-panel__variant-select"
+        v-model="selectedVariant"
+        data-testid="variant-select"
+      >
+        <option v-for="(variant, index) in encounter.variants" :key="variant.id" :value="index">
+          {{ variantLabel(variant, index) }}
+        </option>
+      </select>
+    </div>
+
+    <article class="encounter-panel__description">
+      <p>{{ activeSeed.description }}</p>
+    </article>
+
+    <section class="encounter-panel__slots">
+      <h3>Composizione</h3>
+      <ul class="encounter-panel__slot-list">
+        <li v-for="slot in activeSeed.slots" :key="slot.id" class="encounter-panel__slot">
+          <header>
+            <h4>{{ slot.title }} <span class="encounter-panel__slot-qty">× {{ slot.quantity }}</span></h4>
+          </header>
+          <ul class="encounter-panel__specimen-list">
+            <li v-for="specimen in slot.species" :key="specimen.id">
+              <span class="encounter-panel__specimen-name">{{ specimen.display_name }}</span>
+              <small class="encounter-panel__specimen-role">{{ specimen.role_trofico }}</small>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </section>
+
+    <section v-if="activeSeed.parametersList.length" class="encounter-panel__parameters">
+      <h3>Parametri</h3>
+      <dl>
+        <div v-for="parameter in activeSeed.parametersList" :key="parameter.id">
+          <dt>{{ parameter.label }}</dt>
+          <dd>{{ parameter.value.label }}</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section v-if="activeSeed.warnings.length" class="encounter-panel__warnings">
+      <h3>Avvisi</h3>
+      <ul>
+        <li v-for="warning in activeSeed.warnings" :key="warning.code + warning.slot">
+          {{ formatWarning(warning) }}
+        </li>
+      </ul>
+    </section>
+  </section>
+  <section v-else class="encounter-panel encounter-panel--empty">
+    <p>Nessun encounter generato.</p>
+  </section>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue';
+
+const props = defineProps({
+  encounter: {
+    type: Object,
+    default: null,
+  },
+  initialVariant: {
+    type: Number,
+    default: 0,
+  },
+});
+
+const selectedVariant = ref(props.initialVariant);
+
+watch(
+  () => props.encounter,
+  () => {
+    selectedVariant.value = props.initialVariant;
+  }
+);
+
+watch(
+  () => props.initialVariant,
+  (value) => {
+    selectedVariant.value = value;
+  }
+);
+
+const hasVariants = computed(() => (props.encounter?.variants?.length || 0) > 1);
+
+const normalizedVariants = computed(() => {
+  if (!props.encounter) {
+    return [];
+  }
+  const base = props.encounter.variants || [props.encounter.seed || props.encounter];
+  return base.map((variant) => ({
+    ...variant,
+    metrics: variant.metrics || { threat: { tier: 'T?' } },
+    parametersList: Object.entries(variant.parameters || {}).map(([id, value]) => ({
+      id,
+      label: props.encounter.parameterLabels?.[id] || id,
+      value,
+    })),
+    warnings: variant.warnings || [],
+  }));
+});
+
+const activeSeed = computed(() => {
+  const index = Math.min(Math.max(selectedVariant.value, 0), normalizedVariants.value.length - 1);
+  return normalizedVariants.value[index] || {
+    summary: '',
+    description: '',
+    slots: [],
+    metrics: { threat: { tier: 'T?' } },
+    parametersList: [],
+    warnings: [],
+  };
+});
+
+const encounter = computed(() => {
+  if (!props.encounter) {
+    return null;
+  }
+  return {
+    templateName: props.encounter.templateName || props.encounter.template_id || 'Encounter',
+    biomeName: props.encounter.biomeName || props.encounter.biome?.name || props.encounter.biome?.id || 'Biome sconosciuto',
+    variants: normalizedVariants.value,
+  };
+});
+
+function variantLabel(variant, index) {
+  const parameterText = variant.parametersList
+    .map((item) => `${item.label}: ${item.value.label}`)
+    .join(' · ');
+  if (parameterText) {
+    return `${index + 1}. ${parameterText}`;
+  }
+  return `${index + 1}. Configurazione`;
+}
+
+function formatWarning(warning) {
+  if (warning.slot) {
+    return `${warning.code} (${warning.slot})`;
+  }
+  return warning.code;
+}
+</script>
+
+<style scoped>
+.encounter-panel {
+  background: #0a0d12;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 1.5rem;
+  color: #f0f4ff;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.encounter-panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding-bottom: 0.75rem;
+}
+
+.encounter-panel__title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.encounter-panel__summary {
+  margin: 0.25rem 0 0;
+  color: rgba(240, 244, 255, 0.82);
+}
+
+.encounter-panel__meta {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.encounter-panel__badge {
+  background: rgba(231, 76, 60, 0.2);
+  border: 1px solid rgba(231, 76, 60, 0.4);
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.encounter-panel__biome {
+  color: rgba(240, 244, 255, 0.75);
+  font-size: 0.9rem;
+}
+
+.encounter-panel__variant-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.encounter-panel__variant-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: rgba(240, 244, 255, 0.65);
+}
+
+.encounter-panel__variant-select {
+  background: rgba(10, 15, 22, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  color: inherit;
+  padding: 0.4rem 0.6rem;
+}
+
+.encounter-panel__description p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.encounter-panel__slots {
+  background: rgba(10, 15, 22, 0.6);
+  padding: 1rem;
+  border-radius: 10px;
+}
+
+.encounter-panel__slots h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.encounter-panel__slot-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.encounter-panel__slot h4 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.encounter-panel__slot-qty {
+  font-size: 0.9rem;
+  color: rgba(240, 244, 255, 0.7);
+}
+
+.encounter-panel__specimen-list {
+  margin: 0.35rem 0 0;
+  padding-left: 1.1rem;
+  color: rgba(240, 244, 255, 0.85);
+  display: grid;
+  gap: 0.15rem;
+}
+
+.encounter-panel__specimen-name {
+  font-weight: 600;
+}
+
+.encounter-panel__specimen-role {
+  margin-left: 0.35rem;
+  color: rgba(240, 244, 255, 0.6);
+}
+
+.encounter-panel__parameters,
+.encounter-panel__warnings {
+  background: rgba(10, 15, 22, 0.6);
+  padding: 1rem;
+  border-radius: 10px;
+}
+
+.encounter-panel__parameters h3,
+.encounter-panel__warnings h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.encounter-panel__parameters dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.5rem 1rem;
+  margin: 0;
+}
+
+.encounter-panel__parameters dt {
+  font-weight: 600;
+  color: rgba(240, 244, 255, 0.75);
+}
+
+.encounter-panel__parameters dd {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.encounter-panel__warnings ul {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.encounter-panel--empty {
+  text-align: center;
+  color: rgba(240, 244, 255, 0.6);
+  border: 1px dashed rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+  padding: 2rem;
+}
+</style>

--- a/webapp/src/state/generator/encounterGenerator.js
+++ b/webapp/src/state/generator/encounterGenerator.js
@@ -1,0 +1,350 @@
+import { ENCOUNTER_BLUEPRINTS, getEncounterTemplate, getDefaultEncounterCopy } from './encounters.js';
+
+function normalizeBiome(input) {
+  if (!input) {
+    return { id: 'unknown', name: 'Biome sconosciuto' };
+  }
+  if (typeof input === 'string') {
+    return { id: input, name: input };
+  }
+  const name = input.display_name || input.name || input.id;
+  return { id: input.id || name || 'unknown', name: name || 'Biome sconosciuto' };
+}
+
+function normalizeParameters(template, overrides = {}) {
+  const parameters = {};
+  for (const parameter of template.parameters || []) {
+    const defaultValue = overrides[parameter.id] || parameter.default || parameter.values[0].value;
+    const selected = parameter.values.find((value) => value.value === defaultValue) || parameter.values[0];
+    parameters[parameter.id] = {
+      value: selected.value,
+      label: selected.label || selected.value,
+      summary: selected.summary || '',
+      description: selected.description || '',
+    };
+  }
+  return parameters;
+}
+
+function applyVariantQuantity(baseQuantity, variantQuantity) {
+  if (variantQuantity == null) {
+    return baseQuantity;
+  }
+  if (typeof variantQuantity === 'number') {
+    return variantQuantity;
+  }
+  return {
+    min: variantQuantity.min ?? (typeof baseQuantity === 'object' ? baseQuantity.min : variantQuantity.max ?? 0),
+    max: variantQuantity.max ?? (typeof baseQuantity === 'object' ? baseQuantity.max : variantQuantity.min ?? 0),
+  };
+}
+
+function resolveQuantity(quantity, random) {
+  if (typeof quantity === 'number') {
+    return Math.max(0, Math.floor(quantity));
+  }
+  const min = Math.max(0, Math.floor(quantity.min));
+  const max = Math.max(min, Math.floor(quantity.max));
+  if (min === max) {
+    return min;
+  }
+  const roll = typeof random === 'function' ? random() : Math.random();
+  const clamped = Math.max(0, Math.min(1, roll));
+  return Math.round(min + clamped * (max - min));
+}
+
+function adjustQuantityForVariants(slot, parameters) {
+  let quantity = slot.quantity;
+  if (slot.variants) {
+    for (const [parameterId, options] of Object.entries(slot.variants)) {
+      const selected = parameters[parameterId];
+      if (selected && options[selected.value]) {
+        quantity = applyVariantQuantity(quantity, options[selected.value].quantity);
+      }
+    }
+  }
+  return quantity;
+}
+
+function matchesSlotFilters(species, slotFilters, biomeId) {
+  if (!species) {
+    return false;
+  }
+  if (!slotFilters.roles.some((role) => role === species.role_trofico || role === species.role || role === species.roleId)) {
+    return false;
+  }
+  if (slotFilters.tags && slotFilters.tags.length) {
+    const speciesTags = new Set(
+      ([])
+        .concat(species.tags || [])
+        .concat(species.functional_tags || [])
+        .concat(species.behavior_profile?.tags || species.behavior?.tags || [])
+    );
+    for (const tag of slotFilters.tags) {
+      if (!speciesTags.has(tag)) {
+        return false;
+      }
+    }
+  }
+  if (slotFilters.rarity && slotFilters.rarity.length) {
+    const rarity = species.statistics?.rarity || species.rarity;
+    if (!rarity || !slotFilters.rarity.includes(rarity)) {
+      return false;
+    }
+  }
+  if (biomeId) {
+    const biomes = new Set([].concat(species.biomes || []).concat(species.spawn_rules?.biomes || []));
+    if (biomes.size && !biomes.has(biomeId)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function pickSpeciesForSlot(speciesPool, quantity, random) {
+  if (quantity <= 0 || speciesPool.length === 0) {
+    return [];
+  }
+  const sorted = speciesPool.slice().sort((a, b) => {
+    const rarityA = a.statistics?.rarity || '';
+    const rarityB = b.statistics?.rarity || '';
+    if (rarityA === rarityB) {
+      return (a.display_name || a.id).localeCompare(b.display_name || b.id);
+    }
+    return rarityA.localeCompare(rarityB);
+  });
+  const result = [];
+  for (let i = 0; i < quantity; i += 1) {
+    if (!sorted.length) {
+      break;
+    }
+    const index = Math.floor((typeof random === 'function' ? random() : Math.random()) * sorted.length);
+    result.push(sorted.splice(index, 1)[0]);
+  }
+  return result;
+}
+
+function parseThreatTier(value) {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const match = value.match(/(\d+(?:\.\d+)?)/);
+    if (match) {
+      return parseFloat(match[1]);
+    }
+  }
+  return 1;
+}
+
+function computeThreat(template, parameters, slotAssignments) {
+  const threatConfig = template.dynamics?.threat || {};
+  const slotWeight = threatConfig.slotWeight || {};
+  let score = threatConfig.base ?? 0;
+  for (const assignment of slotAssignments) {
+    const weight = slotWeight[assignment.slot.id] ?? slotWeight.default ?? 1;
+    const slotThreat = assignment.species.reduce((acc, specimen) => {
+      const tier = parseThreatTier(specimen.statistics?.threat_tier || specimen.balance?.threat_tier);
+      return acc + tier;
+    }, 0);
+    score += slotThreat * weight;
+  }
+  if (threatConfig.parameterMultipliers) {
+    for (const [parameterId, multipliers] of Object.entries(threatConfig.parameterMultipliers)) {
+      const selected = parameters[parameterId];
+      if (selected && typeof multipliers[selected.value] === 'number') {
+        score *= multipliers[selected.value];
+      }
+    }
+  }
+  const tier = Math.max(1, Math.round(score));
+  return {
+    score: Number(score.toFixed(2)),
+    tier: `T${tier}`,
+  };
+}
+
+function buildContext({ biome, template, parameters, assignments, threat }) {
+  const slots = {};
+  for (const assignment of assignments) {
+    const primary = assignment.species[0] || null;
+    slots[assignment.slot.id] = {
+      quantity: assignment.quantity,
+      species: assignment.species,
+      primary,
+      names: assignment.species.map((specimen) => specimen.display_name || specimen.id).join(', '),
+    };
+  }
+  return {
+    biome,
+    template,
+    parameters,
+    slots,
+    metrics: { threat },
+  };
+}
+
+function resolvePath(target, path) {
+  return path.split('.').reduce((acc, segment) => {
+    if (acc == null) {
+      return undefined;
+    }
+    if (segment.endsWith(']')) {
+      const [key, indexPart] = segment.split('[');
+      const index = Number.parseInt(indexPart.slice(0, -1), 10);
+      const container = acc[key];
+      return Array.isArray(container) ? container[index] : undefined;
+    }
+    return acc[segment];
+  }, target);
+}
+
+function renderTemplateCopy(templateString, context) {
+  if (!templateString) {
+    return '';
+  }
+  return templateString.replace(/\{\{\s*([^{}]+?)\s*\}\}/g, (_, path) => {
+    const value = resolvePath(context, path.trim());
+    if (value == null) {
+      return '';
+    }
+    if (typeof value === 'object') {
+      if ('label' in value && typeof value.label === 'string') {
+        return value.label;
+      }
+      return JSON.stringify(value);
+    }
+    return String(value);
+  });
+}
+
+function buildLinks(template, biome) {
+  return {
+    template_id: template.id,
+    biome_id: biome.id,
+    category: template.category,
+  };
+}
+
+export function generateEncounterSeed({
+  templateId,
+  biome,
+  speciesPool,
+  parameterSelections = {},
+  random,
+}) {
+  const template = typeof templateId === 'string' ? getEncounterTemplate(templateId) : templateId;
+  if (!template) {
+    throw new Error(`Encounter template "${templateId}" not found`);
+  }
+  const normalizedBiome = normalizeBiome(biome);
+  const parameters = normalizeParameters(template, parameterSelections);
+  const assignments = [];
+  const warnings = [];
+  for (const slot of template.slots) {
+    const quantityConfig = adjustQuantityForVariants(slot, parameters);
+    const quantity = resolveQuantity(quantityConfig, random);
+    if (quantity <= 0 && !slot.optional) {
+      warnings.push({ code: 'encounter.slot.empty', slot: slot.id });
+      continue;
+    }
+    const matches = speciesPool.filter((specimen) =>
+      matchesSlotFilters(specimen, slot.filters, normalizedBiome.id)
+    );
+    if (!matches.length) {
+      if (!slot.optional) {
+        warnings.push({ code: 'encounter.slot.unfilled', slot: slot.id });
+      }
+      continue;
+    }
+    const selected = pickSpeciesForSlot(matches, quantity, random);
+    if (!selected.length && !slot.optional) {
+      warnings.push({ code: 'encounter.slot.unfilled', slot: slot.id });
+      continue;
+    }
+    assignments.push({ slot, quantity, species: selected });
+  }
+  const threat = computeThreat(template, parameters, assignments);
+  const context = buildContext({
+    biome: normalizedBiome,
+    template,
+    parameters,
+    assignments,
+    threat,
+  });
+  const copy = getDefaultEncounterCopy(template);
+  const summary = renderTemplateCopy(copy.summary, context);
+  const description = renderTemplateCopy(copy.description, context);
+  const payload = {
+    id: `${template.id}:${normalizedBiome.id}:${parametersHash(parameters)}`,
+    template_id: template.id,
+    biome: normalizedBiome,
+    parameters,
+    slots: assignments.map((assignment) => ({
+      id: assignment.slot.id,
+      title: assignment.slot.title,
+      quantity: assignment.quantity,
+      species: assignment.species.map((specimen) => ({
+        id: specimen.id,
+        display_name: specimen.display_name || specimen.name || specimen.id,
+        role_trofico: specimen.role_trofico || specimen.role || specimen.roleId,
+        rarity: specimen.statistics?.rarity || null,
+        threat_tier: specimen.statistics?.threat_tier || specimen.balance?.threat_tier || null,
+      })),
+    })),
+    metrics: {
+      threat,
+      pacing: template.dynamics?.pacing?.base || null,
+    },
+    summary,
+    description,
+    links: buildLinks(template, normalizedBiome),
+    warnings,
+  };
+  return payload;
+}
+
+function parametersHash(parameters) {
+  const entries = Object.entries(parameters)
+    .map(([key, value]) => `${key}=${value.value}`)
+    .sort();
+  return entries.join('|') || 'default';
+}
+
+export function generateEncounterSeedsForBiome({
+  biome,
+  species,
+  templateIds,
+  variantsByTemplate = {},
+  random,
+}) {
+  const normalizedBiome = normalizeBiome(biome);
+  const templates = (templateIds || ENCOUNTER_BLUEPRINTS.map((template) => template.id))
+    .map((id) => getEncounterTemplate(id))
+    .filter((template) => template && template.biomes.includes(normalizedBiome.id));
+  const seeds = [];
+  for (const template of templates) {
+    const variantList = variantsByTemplate[template.id] || [{}];
+    for (const selection of variantList) {
+      const seed = generateEncounterSeed({
+        templateId: template,
+        biome: normalizedBiome,
+        speciesPool: species,
+        parameterSelections: selection,
+        random,
+      });
+      seeds.push(seed);
+    }
+  }
+  return seeds;
+}
+
+export function summarizeSeed(seed) {
+  return {
+    id: seed.id,
+    summary: seed.summary,
+    threatTier: seed.metrics?.threat?.tier || 'T?',
+    biome: seed.biome?.name || seed.biome?.id,
+    template: seed.template_id,
+  };
+}

--- a/webapp/src/state/generator/encounters.js
+++ b/webapp/src/state/generator/encounters.js
@@ -1,0 +1,404 @@
+/**
+ * Encounter template registry and schema definition.
+ *
+ * The DSL is deliberately JSON-schema compatible so that the server-side
+ * validators for the Evo Tactics pack can ingest the same payload without
+ * additional translation. Templates describe the tactical role of each slot
+ * together with biome availability, configurable parameters and derived
+ * metrics.
+ */
+
+export const EncounterTemplateSchema = Object.freeze({
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'com.meridian.encounters/EncounterTemplate.json',
+  type: 'object',
+  additionalProperties: false,
+  required: ['id', 'name', 'category', 'biomes', 'slots', 'summary', 'description'],
+  properties: {
+    id: { type: 'string' },
+    name: { type: 'string' },
+    category: { enum: ['skirmish', 'siege', 'hazard', 'story'] },
+    tags: {
+      type: 'array',
+      items: { type: 'string' },
+      uniqueItems: true,
+      default: [],
+    },
+    biomes: {
+      type: 'array',
+      items: { type: 'string' },
+      minItems: 1,
+      uniqueItems: true,
+    },
+    summary: { type: 'string' },
+    description: { type: 'string' },
+    parameters: {
+      type: 'array',
+      default: [],
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['id', 'type', 'values'],
+        properties: {
+          id: { type: 'string' },
+          type: { enum: ['enum'] },
+          default: { type: 'string' },
+          label: { type: 'string' },
+          values: {
+            type: 'array',
+            minItems: 1,
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              required: ['value'],
+              properties: {
+                value: { type: 'string' },
+                label: { type: 'string' },
+                summary: { type: 'string' },
+                description: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    },
+    slots: {
+      type: 'array',
+      minItems: 1,
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['id', 'title', 'quantity', 'filters'],
+        properties: {
+          id: { type: 'string' },
+          title: { type: 'string' },
+          quantity: {
+            anyOf: [
+              { type: 'integer', minimum: 0 },
+              {
+                type: 'object',
+                additionalProperties: false,
+                required: ['min', 'max'],
+                properties: {
+                  min: { type: 'integer', minimum: 0 },
+                  max: { type: 'integer', minimum: 0 },
+                },
+              },
+            ],
+          },
+          optional: { type: 'boolean', default: false },
+          filters: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['roles'],
+            properties: {
+              roles: {
+                type: 'array',
+                minItems: 1,
+                items: { type: 'string' },
+              },
+              tags: {
+                type: 'array',
+                items: { type: 'string' },
+                default: [],
+              },
+              rarity: {
+                type: 'array',
+                items: { type: 'string' },
+                default: [],
+              },
+            },
+          },
+          variants: {
+            type: 'object',
+            additionalProperties: {
+              type: 'object',
+              additionalProperties: {
+                type: 'object',
+                properties: {
+                  quantity: {
+                    anyOf: [
+                      { type: 'integer', minimum: 0 },
+                      {
+                        type: 'object',
+                        additionalProperties: false,
+                        required: ['min', 'max'],
+                        properties: {
+                          min: { type: 'integer', minimum: 0 },
+                          max: { type: 'integer', minimum: 0 },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    dynamics: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        threat: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            base: { type: 'number', default: 0 },
+            slotWeight: {
+              type: 'object',
+              additionalProperties: { type: 'number' },
+            },
+            parameterMultipliers: {
+              type: 'object',
+              additionalProperties: {
+                type: 'object',
+                additionalProperties: { type: 'number' },
+              },
+            },
+          },
+        },
+        pacing: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            base: { type: 'string' },
+          },
+        },
+      },
+    },
+  },
+});
+
+const DEFAULT_SUMMARY = 'Schieramento {{template.name}} nel biome {{biome.name}}';
+const DEFAULT_DESCRIPTION =
+  'Configurazione standard: {{slots.leader.primary.display_name || "specie ignota"}} guida {{slots.support.names || "nessun supporto"}}.';
+
+export const ENCOUNTER_BLUEPRINTS = Object.freeze([
+  {
+    id: 'dune-patrol',
+    name: 'Pattuglia Termomagnetica',
+    category: 'skirmish',
+    tags: ['patrol', 'mobile'],
+    biomes: ['badlands', 'deserto_caldo'],
+    summary: 'Pattuglia {{parameters.intensity.label}} tra le dune di {{biome.name}}',
+    description:
+      'Il comandante {{slots.leader.primary.display_name}} coordina {{slots.outrider.names || "nessun esploratore"}} con supporto {{slots.support.names || "limitato"}}.',
+    parameters: [
+      {
+        id: 'intensity',
+        type: 'enum',
+        default: 'standard',
+        label: 'Intensità tattica',
+        values: [
+          { value: 'low', label: 'cauta', summary: 'Riduce pattugliamenti di contatto.' },
+          { value: 'standard', label: 'standard', summary: 'Comportamento di pattuglia regolare.' },
+          { value: 'high', label: 'aggressiva', summary: 'Ricerca attiva di bersagli ad alto rischio.' },
+        ],
+      },
+    ],
+    slots: [
+      {
+        id: 'leader',
+        title: 'Predatore alfa',
+        quantity: 1,
+        filters: {
+          roles: ['predatore_apice_badlands', 'predatore_apice_deserto_caldo'],
+          tags: ['predatore'],
+        },
+      },
+      {
+        id: 'outrider',
+        title: 'Esploratori sinaptici',
+        quantity: { min: 1, max: 2 },
+        filters: {
+          roles: ['predatore_specialista_badlands', 'predatore_specialista_deserto_caldo'],
+          tags: ['ricognizione', 'trappola'],
+        },
+        variants: {
+          intensity: {
+            low: { quantity: { min: 1, max: 1 } },
+            high: { quantity: { min: 2, max: 3 } },
+          },
+        },
+      },
+      {
+        id: 'support',
+        title: 'Supporto bio-ingegneristico',
+        quantity: { min: 0, max: 2 },
+        optional: true,
+        filters: {
+          roles: ['ingegnere_ecologico_badlands', 'ingegnere_ecologico_deserto_caldo'],
+          tags: ['supporto', 'catalizzatore'],
+        },
+        variants: {
+          intensity: {
+            high: { quantity: { min: 1, max: 2 } },
+          },
+        },
+      },
+    ],
+    dynamics: {
+      threat: {
+        base: 2.5,
+        slotWeight: { default: 0.9, leader: 1.4 },
+        parameterMultipliers: {
+          intensity: { low: 0.85, standard: 1, high: 1.25 },
+        },
+      },
+      pacing: { base: 'dinamica' },
+    },
+  },
+  {
+    id: 'glacier-ambush',
+    name: 'Agguato dei Ponti di Ghiaccio',
+    category: 'skirmish',
+    tags: ['imboscata', 'furtiva'],
+    biomes: ['cryosteppe'],
+    summary: 'Emboscata {{parameters.trigger.label}} nella {{biome.name}}',
+    description:
+      'Le unità di presa {{slots.vanguard.names}} chiudono i flussi mentre {{slots.sapper.names || "nessun sabotatore"}} preparano il terreno.',
+    parameters: [
+      {
+        id: 'trigger',
+        type: 'enum',
+        default: 'standard',
+        label: 'Trigger',
+        values: [
+          { value: 'standard', label: 'a contatto' },
+          { value: 'delayed', label: 'a ritardo' },
+        ],
+      },
+    ],
+    slots: [
+      {
+        id: 'vanguard',
+        title: 'Linea di chiusura',
+        quantity: { min: 2, max: 3 },
+        filters: {
+          roles: ['predatore_assalitore_cryosteppe', 'guardiano_cryosteppe'],
+          tags: ['controllo'],
+        },
+      },
+      {
+        id: 'sapper',
+        title: 'Sabotatori ambientali',
+        quantity: { min: 0, max: 2 },
+        optional: true,
+        filters: {
+          roles: ['ingegnere_ecologico_cryosteppe', 'supporto_cryosteppe'],
+          tags: ['area_effect'],
+        },
+        variants: {
+          trigger: {
+            delayed: { quantity: { min: 1, max: 2 } },
+          },
+        },
+      },
+      {
+        id: 'overwatch',
+        title: 'Contenimento a distanza',
+        quantity: { min: 1, max: 1 },
+        filters: {
+          roles: ['predatore_ranged_cryosteppe'],
+          tags: ['precisione'],
+        },
+      },
+    ],
+    dynamics: {
+      threat: {
+        base: 2,
+        slotWeight: { default: 0.8, overwatch: 1.3 },
+        parameterMultipliers: {
+          trigger: { delayed: 1.1, standard: 1 },
+        },
+      },
+      pacing: { base: 'tesa' },
+    },
+  },
+  {
+    id: 'temperate-bloom',
+    name: 'Sinfonia Micotica',
+    category: 'story',
+    tags: ['evento', 'ambientale'],
+    biomes: ['foresta_temperata'],
+    summary: 'Evento {{parameters.expression.label}} nella {{biome.name}}',
+    description:
+      'Le colonie {{slots.conductor.names}} orchestrano un bloom che attira {{slots.sentinel.names}} e può mutare in {{slots.emergent.names || "esiti imprevedibili"}}.',
+    parameters: [
+      {
+        id: 'expression',
+        type: 'enum',
+        default: 'placida',
+        label: 'Espressione del bloom',
+        values: [
+          { value: 'placida', label: 'placida', description: 'Integrazione simbiotica con il bosco.' },
+          { value: 'sinergica', label: 'sinergica', description: 'Richiede manutenzione biotica costante.' },
+        ],
+      },
+    ],
+    slots: [
+      {
+        id: 'conductor',
+        title: 'Colonie direttrici',
+        quantity: { min: 1, max: 2 },
+        filters: {
+          roles: ['ingegnere_ecologico_foresta_temperata'],
+          tags: ['micelio', 'rete'],
+        },
+      },
+      {
+        id: 'sentinel',
+        title: 'Sentinelle',
+        quantity: { min: 1, max: 2 },
+        filters: {
+          roles: ['guardiano_foresta_temperata', 'predatore_specialista_foresta_temperata'],
+          tags: ['difesa'],
+        },
+      },
+      {
+        id: 'emergent',
+        title: 'Forme emergenti',
+        quantity: { min: 0, max: 1 },
+        optional: true,
+        filters: {
+          roles: ['anomalia_ecologica_foresta_temperata'],
+        },
+        variants: {
+          expression: {
+            sinergica: { quantity: { min: 1, max: 2 } },
+          },
+        },
+      },
+    ],
+    dynamics: {
+      threat: {
+        base: 1.2,
+        slotWeight: { default: 0.6, sentinel: 0.9 },
+        parameterMultipliers: {
+          expression: { placida: 0.9, sinergica: 1.1 },
+        },
+      },
+      pacing: { base: 'rituale' },
+    },
+  },
+]);
+
+export function listEncounterBlueprints() {
+  return ENCOUNTER_BLUEPRINTS.slice();
+}
+
+export function getEncounterTemplate(templateId) {
+  return ENCOUNTER_BLUEPRINTS.find((template) => template.id === templateId) || null;
+}
+
+export function getDefaultEncounterCopy(template) {
+  if (!template) {
+    return { summary: DEFAULT_SUMMARY, description: DEFAULT_DESCRIPTION };
+  }
+  return {
+    summary: template.summary || DEFAULT_SUMMARY,
+    description: template.description || DEFAULT_DESCRIPTION,
+  };
+}

--- a/webapp/tests/EncounterGenerator.spec.ts
+++ b/webapp/tests/EncounterGenerator.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { generateEncounterSeed, generateEncounterSeedsForBiome } from '../src/state/generator/encounterGenerator.js';
+import { getEncounterTemplate } from '../src/state/generator/encounters.js';
+
+const BASE_SPECIES = [
+  {
+    id: 'alpha-hunter',
+    display_name: 'Thermo Raptor',
+    role_trofico: 'predatore_apice_deserto_caldo',
+    biomes: ['deserto_caldo'],
+    tags: ['predatore'],
+    functional_tags: ['predatore'],
+    statistics: { threat_tier: 'T4', rarity: 'R3' },
+  },
+  {
+    id: 'sand-scout-1',
+    display_name: 'Scopritore di Dune',
+    role_trofico: 'predatore_specialista_deserto_caldo',
+    biomes: ['deserto_caldo'],
+    tags: ['ricognizione', 'trappola'],
+    functional_tags: ['ricognizione'],
+    statistics: { threat_tier: 'T2', rarity: 'R2' },
+  },
+  {
+    id: 'sand-scout-2',
+    display_name: 'Cuneo Magnetico',
+    role_trofico: 'predatore_specialista_badlands',
+    biomes: ['badlands'],
+    tags: ['ricognizione', 'trappola'],
+    functional_tags: ['ricognizione'],
+    statistics: { threat_tier: 'T2', rarity: 'R1' },
+  },
+  {
+    id: 'bio-engineer',
+    display_name: 'Catalizzatore Ferroflore',
+    role_trofico: 'ingegnere_ecologico_deserto_caldo',
+    biomes: ['deserto_caldo'],
+    tags: ['supporto', 'catalizzatore'],
+    functional_tags: ['supporto'],
+    statistics: { threat_tier: 'T1', rarity: 'R2' },
+  },
+];
+
+describe('Encounter generation', () => {
+  it('creates a seed with dynamic description for dune patrol', () => {
+    const template = getEncounterTemplate('dune-patrol');
+    if (!template) throw new Error('Template missing');
+    const seed = generateEncounterSeed({
+      templateId: template,
+      biome: { id: 'deserto_caldo', display_name: 'Deserto Caldo' },
+      speciesPool: BASE_SPECIES,
+      parameterSelections: { intensity: 'high' },
+      random: () => 0,
+    });
+    expect(seed.summary).toContain('Deserto Caldo');
+    expect(seed.description).toContain('Thermo Raptor');
+    expect(seed.metrics.threat.tier).toMatch(/^T/);
+    const outriderSlot = seed.slots.find((slot) => slot.id === 'outrider');
+    expect(outriderSlot?.quantity).toBeGreaterThanOrEqual(2);
+    expect(seed.parameters.intensity.value).toBe('high');
+    expect(seed.links.biome_id).toBe('deserto_caldo');
+    expect(seed.warnings).toHaveLength(0);
+  });
+
+  it('skips optional slots when no species match', () => {
+    const template = getEncounterTemplate('glacier-ambush');
+    if (!template) throw new Error('Template missing');
+    const seed = generateEncounterSeed({
+      templateId: template,
+      biome: { id: 'cryosteppe', display_name: 'Cryosteppe' },
+      speciesPool: BASE_SPECIES,
+      random: () => 0.3,
+    });
+    expect(seed.warnings.some((warning) => warning.slot === 'vanguard')).toBe(true);
+    expect(seed.slots.some((slot) => slot.id === 'sapper')).toBe(false);
+  });
+
+  it('generates seeds only for templates compatible with the biome', () => {
+    const seeds = generateEncounterSeedsForBiome({
+      biome: { id: 'deserto_caldo', display_name: 'Deserto Caldo' },
+      species: BASE_SPECIES,
+      variantsByTemplate: {
+        'dune-patrol': [{ intensity: 'low' }, { intensity: 'standard' }],
+      },
+      random: () => 0.1,
+    });
+    expect(seeds.length).toBeGreaterThan(0);
+    expect(seeds.every((seed) => seed.biome.id === 'deserto_caldo')).toBe(true);
+    const templateIds = new Set(seeds.map((seed) => seed.template_id));
+    expect(templateIds.has('dune-patrol')).toBe(true);
+    expect(templateIds.has('glacier-ambush')).toBe(false);
+  });
+});

--- a/webapp/tests/EncounterPanel.spec.ts
+++ b/webapp/tests/EncounterPanel.spec.ts
@@ -1,0 +1,71 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import EncounterPanel from '../src/components/EncounterPanel.vue';
+
+const BASE_SEED = {
+  id: 'dune-patrol:deserto_caldo:default',
+  templateName: 'Pattuglia Termomagnetica',
+  biomeName: 'Deserto Caldo',
+  summary: 'Pattuglia standard tra le dune di Deserto Caldo',
+  description: 'Il comandante Thermo Raptor coordina Scopritore di Dune con supporto limitato.',
+  metrics: { threat: { tier: 'T4' } },
+  parameters: {
+    intensity: { value: 'standard', label: 'standard' },
+  },
+  slots: [
+    {
+      id: 'leader',
+      title: 'Predatore alfa',
+      quantity: 1,
+      species: [
+        { id: 'alpha-hunter', display_name: 'Thermo Raptor', role_trofico: 'predatore_apice_deserto_caldo' },
+      ],
+    },
+    {
+      id: 'outrider',
+      title: 'Esploratori sinaptici',
+      quantity: 2,
+      species: [
+        { id: 'sand-scout-1', display_name: 'Scopritore di Dune', role_trofico: 'predatore_specialista_deserto_caldo' },
+        { id: 'sand-scout-2', display_name: 'Cuneo Magnetico', role_trofico: 'predatore_specialista_badlands' },
+      ],
+    },
+  ],
+  warnings: [],
+};
+
+describe('EncounterPanel', () => {
+  it('renders encounter information with variants', async () => {
+    const encounter = {
+      templateName: BASE_SEED.templateName,
+      biomeName: BASE_SEED.biomeName,
+      variants: [
+        BASE_SEED,
+        {
+          ...BASE_SEED,
+          id: 'dune-patrol:deserto_caldo:high',
+          summary: 'Pattuglia aggressiva tra le dune di Deserto Caldo',
+          description: 'Versione aggressiva.',
+          parameters: { intensity: { value: 'high', label: 'aggressiva' } },
+        },
+      ],
+      parameterLabels: { intensity: 'Intensità tattica' },
+    };
+    const wrapper = mount(EncounterPanel, {
+      props: { encounter },
+    });
+
+    expect(wrapper.text()).toContain('Pattuglia Termomagnetica');
+    expect(wrapper.text()).toContain('Thermo Raptor');
+    expect(wrapper.find('[data-testid="variant-select"]').exists()).toBe(true);
+
+    await wrapper.find('[data-testid="variant-select"]').setValue('1');
+    expect(wrapper.text()).toContain('Versione aggressiva.');
+    expect(wrapper.text()).toContain('aggressiva');
+  });
+
+  it('renders placeholder when encounter is missing', () => {
+    const wrapper = mount(EncounterPanel);
+    expect(wrapper.text()).toContain('Nessun encounter generato');
+  });
+});


### PR DESCRIPTION
## Summary
- define a JSON-schema driven DSL for encounter templates and register three starter blueprints
- implement encounter seed generation utilities that resolve template variants and compute threat metrics
- add an EncounterPanel UI with variant selection plus Vitest coverage for generator and panel behaviour

## Testing
- npm --prefix webapp run test

------
https://chatgpt.com/codex/tasks/task_e_69017a40f6ec83328cc7957ba5318b5b