### PR TITLE
feat: manage drive sync approved assets

### DIFF
--- a/config/drive/approved_asset_sources.json
+++ b/config/drive/approved_asset_sources.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "sources": [
+    {
+      "id": "playtest-telemetry",
+      "driveSourceId": "vc-logs",
+      "description": "Dataset di telemetria dei playtest VC sincronizzati da driveSync.",
+      "root": "logs/playtests",
+      "extensions": [".yaml", ".yml"],
+      "include": ["session-metrics\\.ya?ml$"]
+    },
+    {
+      "id": "drive-dryrun",
+      "description": "Output dry-run generati localmente per validare il mapping verso Google Sheets.",
+      "root": "logs/drive",
+      "extensions": [".json", ".yaml", ".yml"]
+    },
+    {
+      "id": "drive-config",
+      "description": "File di configurazione condivisi dal workflow driveSync.",
+      "root": "config/drive",
+      "extensions": [".json", ".yaml", ".yml"]
+    }
+  ]
+}

--- a/data/drive/approved_assets.json
+++ b/data/drive/approved_assets.json
@@ -1,0 +1,135 @@
+{
+  "version": 1,
+  "generatedAt": "2025-10-29T02:27:02.344Z",
+  "config": {
+    "path": "config/drive/approved_asset_sources.json",
+    "version": 1
+  },
+  "totals": {
+    "assets": 11
+  },
+  "summary": [
+    {
+      "id": "playtest-telemetry",
+      "root": "logs/playtests",
+      "status": "ok",
+      "total": 8,
+      "skipped": 12
+    },
+    {
+      "id": "drive-dryrun",
+      "root": "logs/drive",
+      "status": "ok",
+      "total": 1,
+      "skipped": 0
+    },
+    {
+      "id": "drive-config",
+      "root": "config/drive",
+      "status": "ok",
+      "total": 2,
+      "skipped": 0
+    }
+  ],
+  "assets": [
+    {
+      "sourceId": "drive-config",
+      "driveSourceId": null,
+      "fileName": "approved_asset_sources.json",
+      "path": "config/drive/approved_asset_sources.json",
+      "size": 745,
+      "sha256": "5cb1261d2ac53c0e333a0f21c4af77a2ab8b4bc4906852dfd59e795b9811bb30",
+      "mtime": "2025-10-29T02:26:56.111Z"
+    },
+    {
+      "sourceId": "drive-config",
+      "driveSourceId": null,
+      "fileName": "recipients.yaml",
+      "path": "config/drive/recipients.yaml",
+      "size": 2322,
+      "sha256": "a80b9bfe65ae1e7cd68158d61815c326c4456ea501d19596a0b65f20dd255364",
+      "mtime": "2025-10-29T01:36:51.553Z"
+    },
+    {
+      "sourceId": "drive-dryrun",
+      "driveSourceId": null,
+      "fileName": "2025-11-XX-dryrun.json",
+      "path": "logs/drive/2025-11-XX-dryrun.json",
+      "size": 514,
+      "sha256": "cab8d1f335ab02193ba520e1a6f9ff773002968f51b2ddc6cfad434bada1ea63",
+      "mtime": "2025-10-29T01:36:51.577Z"
+    },
+    {
+      "sourceId": "playtest-telemetry",
+      "driveSourceId": "vc-logs",
+      "fileName": "session-metrics.yaml",
+      "path": "logs/playtests/2025-02-15-vc/session-metrics.yaml",
+      "size": 4084,
+      "sha256": "2d8d22da398c03a201880b9e6e62c961e62239555e4cc49034ee377fa61574f0",
+      "mtime": "2025-10-29T01:36:51.581Z"
+    },
+    {
+      "sourceId": "playtest-telemetry",
+      "driveSourceId": "vc-logs",
+      "fileName": "session-metrics.yaml",
+      "path": "logs/playtests/2025-02-26/session-metrics.yaml",
+      "size": 1507,
+      "sha256": "cf9f8264db3465d8f93b2214195b4eedcba2c665106128e4fb845443a4d4df01",
+      "mtime": "2025-10-29T01:36:51.581Z"
+    },
+    {
+      "sourceId": "playtest-telemetry",
+      "driveSourceId": "vc-logs",
+      "fileName": "session-metrics.yaml",
+      "path": "logs/playtests/2025-02-27-vc/session-metrics.yaml",
+      "size": 1021,
+      "sha256": "5365a7b2f5e6219a740264a784c6c076ede02433610835e8feeafc9a481e9b6e",
+      "mtime": "2025-10-29T01:36:51.581Z"
+    },
+    {
+      "sourceId": "playtest-telemetry",
+      "driveSourceId": "vc-logs",
+      "fileName": "session-metrics.yaml",
+      "path": "logs/playtests/2025-10-24-vc/session-metrics.yaml",
+      "size": 2756,
+      "sha256": "e064670eeacdb09cd4ed63cb44c12c41c1a219e4a177c94b99116ac4ba1100fd",
+      "mtime": "2025-10-29T01:36:51.581Z"
+    },
+    {
+      "sourceId": "playtest-telemetry",
+      "driveSourceId": "vc-logs",
+      "fileName": "session-metrics.yaml",
+      "path": "logs/playtests/2025-11-01-vc/session-metrics.yaml",
+      "size": 1459,
+      "sha256": "2cf6c4a7fe28ea507e20aa2f85817bbb6bc80fa22dc2af36b350745e6c03f3b1",
+      "mtime": "2025-10-29T01:36:51.581Z"
+    },
+    {
+      "sourceId": "playtest-telemetry",
+      "driveSourceId": "vc-logs",
+      "fileName": "session-metrics.yaml",
+      "path": "logs/playtests/2025-11-05-vc/session-metrics.yaml",
+      "size": 3538,
+      "sha256": "bfc7af8563caa68feeb69cce051ba7ba27430234bc046ee90721708cabf51014",
+      "mtime": "2025-10-29T01:36:51.581Z"
+    },
+    {
+      "sourceId": "playtest-telemetry",
+      "driveSourceId": "vc-logs",
+      "fileName": "session-metrics.yaml",
+      "path": "logs/playtests/2025-11-06-vc/session-metrics.yaml",
+      "size": 509,
+      "sha256": "6bd44cdba85c2632d985d02b730f310d140b58d81e6155ae21c300589b942bf1",
+      "mtime": "2025-10-29T01:36:51.581Z"
+    },
+    {
+      "sourceId": "playtest-telemetry",
+      "driveSourceId": "vc-logs",
+      "fileName": "session-metrics.yaml",
+      "path": "logs/playtests/2025-11-07-vc/session-metrics.yaml",
+      "size": 820,
+      "sha256": "16be0ea0ce08bff22fb1efb535729beafe83a34cd1d8c32a1949ea8f1ac95472",
+      "mtime": "2025-10-29T01:36:51.581Z"
+    }
+  ]
+}

--- a/docs/workflows/drive_sync.md
+++ b/docs/workflows/drive_sync.md
@@ -1,0 +1,65 @@
+# Workflow driveSync — approvazione asset
+
+Questa procedura descrive come generare l'elenco di asset approvati da sincronizzare
+con `scripts/driveSync.gs`, inviarlo all'Apps Script e documentare i trigger e le
+credenziali necessari.
+
+## 1. Generare il manifest degli asset approvati
+
+1. Aggiorna le sorgenti in [`config/drive/approved_asset_sources.json`](../../config/drive/approved_asset_sources.json)
+   se servono nuove directory o pattern. Ogni voce può indicare l'ID della sorgente
+   Apps Script (`driveSourceId`) per collegare l'asset al relativo mapping
+   (`vc-logs`, `hub-ops`, ecc.).
+2. Esegui il generatore locale:
+   ```bash
+   npm run drive:generate-approved
+   ```
+   Il comando produce/aggiorna `data/drive/approved_assets.json` includendo nome file,
+   hash SHA-256, sorgente e driveSourceId per l'incrocio con `driveSync.gs`.
+3. Verifica il riepilogo stampato a console: il manifest riporta il numero totale di
+   asset approvati e gli eventuali file scartati da ciascuna sorgente.
+
+## 2. Invio all'Apps Script `driveSync.gs`
+
+1. Distribuisci `scripts/driveSync.gs` come Web App (Deploy → *Web App*) e annota
+   l'URL pubblicato, oppure configura l'Execution API se preferisci invocare la
+   funzione `updateApprovedAssets` direttamente.
+2. Definisci nelle Script Properties:
+   - `DRIVE_SYNC_APPROVED_ASSETS_TOKEN`: token condiviso da fornire al Web App per
+     autorizzare l'aggiornamento della whitelist.
+   - (Opzionale) `DRIVE_SYNC_APPROVED_ASSETS`: verrà sovrascritto dallo script con il
+     JSON generato al passaggio successivo.
+3. Esegui lo script di invio:
+   ```bash
+   npm run drive:push-approved -- \
+     --url "https://script.google.com/macros/s/ID_DEPLOY/exec" \
+     --token "<TOKEN>"
+   ```
+   Parametri utili:
+   - `--token-location query|header|body` per scegliere dove passare il token
+     (default: body JSON).
+   - `--dry-run` per ispezionare il payload senza effettuare chiamate.
+
+Lo script invia il manifest al Web App usando l'azione `updateApprovedAssets`; lo
+script Apps Script salva il JSON nelle Script Properties e ricarica la whitelist in
+memoria. Solo i file elencati (per sorgente) verranno poi processati dai run di
+`convertYamlToSheets`.
+
+## 3. Trigger e credenziali
+
+- **Trigger time-driven**: esegui `ensureAutoSyncTrigger()` in Apps Script per
+  installare il trigger ogni 6 ore (`ClockTrigger` → handler `convertYamlToSheets`).
+  Questo è il flusso consigliato per mantenere allineati i dataset principali.
+- **Trigger manuale**: `convertYamlToSheets()` può essere avviato on-demand per
+  validare cambi rapidi o dopo aver aggiornato la whitelist.
+- **Credenziali richieste**:
+  - Account `ops.drive-sync@game-dev.internal` (o equivalente con permessi sulla
+    cartella Drive e sul progetto Apps Script) per creare trigger e gestire le
+    Script Properties.
+  - Accesso al Web App protetto dal token configurato in `DRIVE_SYNC_APPROVED_ASSETS_TOKEN`.
+  - Variabili localmente (`DRIVE_SYNC_WEBAPP_URL`, `DRIVE_SYNC_WEBAPP_TOKEN`) utili
+    per automatizzare `push-approved-assets` senza passare parametri espliciti.
+
+Tutte le configurazioni e i dettagli operativi di `driveSync.gs` restano descritti in
+[`docs/drive-sync.md`](../drive-sync.md); questo documento aggiunge la sezione di
+approvazione asset e la relativa automazione.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "npm run test:api && npm --prefix tools/ts run test -- && npm --prefix webapp run test",
     "test:api": "node --test tests/api/*.test.js",
     "start:api": "node server/index.js",
-    "build:idea-taxonomy": "node scripts/build-idea-taxonomy.js"
+    "build:idea-taxonomy": "node scripts/build-idea-taxonomy.js",
+    "drive:generate-approved": "node tools/drive/generate-approved-assets.mjs",
+    "drive:push-approved": "node tools/drive/push-approved-assets.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/tools/drive/generate-approved-assets.mjs
+++ b/tools/drive/generate-approved-assets.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  const repoRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)), '..');
+  const configPath = path.resolve(repoRoot, args.config || 'config/drive/approved_asset_sources.json');
+  const outputPath = path.resolve(repoRoot, args.output || 'data/drive/approved_assets.json');
+
+  let config;
+  try {
+    const configRaw = await readFile(configPath, 'utf8');
+    config = JSON.parse(configRaw);
+  } catch (error) {
+    console.error(`Impossibile leggere la configurazione ${configPath}:`, error.message || error);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!Array.isArray(config.sources)) {
+    console.error('La configurazione deve contenere una proprietà "sources" con una lista di sorgenti.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const summary = [];
+  const assets = [];
+
+  for (const source of config.sources) {
+    const normalized = normalizeSource(source);
+    const rootPath = path.resolve(repoRoot, normalized.root);
+    let rootStat;
+    try {
+      rootStat = await stat(rootPath);
+    } catch (error) {
+      summary.push({
+        id: normalized.id,
+        root: normalized.root,
+        status: 'missing',
+        reason: `Directory non trovata: ${normalized.root}`
+      });
+      continue;
+    }
+
+    if (!rootStat.isDirectory()) {
+      summary.push({
+        id: normalized.id,
+        root: normalized.root,
+        status: 'skipped',
+        reason: 'Il percorso configurato non è una directory'
+      });
+      continue;
+    }
+
+    const collected = await collectAssetsFromSource({
+      repoRoot,
+      rootPath,
+      source: normalized
+    });
+
+    assets.push(...collected.assets);
+    summary.push({
+      id: normalized.id,
+      root: normalized.root,
+      status: 'ok',
+      total: collected.assets.length,
+      skipped: collected.skipped
+    });
+  }
+
+  assets.sort((a, b) => a.path.localeCompare(b.path));
+
+  const manifest = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    config: {
+      path: toPosix(path.relative(repoRoot, configPath)),
+      version: config.version ?? null
+    },
+    totals: {
+      assets: assets.length
+    },
+    summary,
+    assets
+  };
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
+
+  if (!args.quiet) {
+    console.log(`Manifest generato: ${path.relative(repoRoot, outputPath)} (${assets.length} asset approvati)`);
+  }
+}
+
+function parseArgs(argv) {
+  const args = { quiet: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--help' || token === '-h') {
+      args.help = true;
+      return args;
+    }
+    if (token === '--quiet') {
+      args.quiet = true;
+      continue;
+    }
+    const [key, value] = token.split('=', 2);
+    if (key === '--config') {
+      if (value !== undefined) {
+        args.config = value;
+      } else {
+        args.config = argv[++i];
+      }
+      continue;
+    }
+    if (key === '--output') {
+      if (value !== undefined) {
+        args.output = value;
+      } else {
+        args.output = argv[++i];
+      }
+      continue;
+    }
+    console.error(`Argomento non riconosciuto: ${token}`);
+    args.help = true;
+    break;
+  }
+  return args;
+}
+
+function printUsage() {
+  console.log(`Uso: generate-approved-assets [--config <path>] [--output <path>] [--quiet]\n\n` +
+    'Genera un manifest JSON con l\'elenco degli asset approvati da sincronizzare tramite driveSync.');
+}
+
+function normalizeSource(source) {
+  if (!source || typeof source !== 'object') {
+    return {
+      id: null,
+      root: '',
+      extensions: [],
+      include: [],
+      exclude: []
+    };
+  }
+  const toRegexList = entries =>
+    (Array.isArray(entries) ? entries : [])
+      .map(pattern => {
+        try {
+          return new RegExp(pattern, 'i');
+        } catch (error) {
+          console.warn(`Pattern regex non valido ignorato (${pattern}):`, error.message || error);
+          return null;
+        }
+      })
+      .filter(Boolean);
+
+  const extensions = Array.isArray(source.extensions)
+    ? source.extensions.map(ext => String(ext || '').toLowerCase())
+    : [];
+
+  return {
+    id: source.id || null,
+    description: source.description || null,
+    root: source.root || '',
+    driveSourceId: source.driveSourceId || null,
+    extensions,
+    include: toRegexList(source.include),
+    exclude: toRegexList(source.exclude)
+  };
+}
+
+async function collectAssetsFromSource({ repoRoot, rootPath, source }) {
+  const assets = [];
+  let skipped = 0;
+
+  async function walk(currentPath) {
+    const entries = await readdir(currentPath, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        await walk(entryPath);
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+
+      const relPathFromRoot = toPosix(path.relative(rootPath, entryPath));
+      const relPathFromRepo = toPosix(path.relative(repoRoot, entryPath));
+      if (!shouldIncludeFile(relPathFromRoot, entryPath, source)) {
+        skipped += 1;
+        continue;
+      }
+
+      const info = await stat(entryPath);
+      const sha256 = await hashFile(entryPath);
+      assets.push({
+        sourceId: source.id,
+        driveSourceId: source.driveSourceId,
+        fileName: path.basename(entryPath),
+        path: relPathFromRepo,
+        size: info.size,
+        sha256,
+        mtime: new Date(info.mtimeMs).toISOString()
+      });
+    }
+  }
+
+  await walk(rootPath);
+  return { assets, skipped };
+}
+
+function shouldIncludeFile(relativePath, absolutePath, source) {
+  const ext = path.extname(absolutePath).toLowerCase();
+  if (source.extensions.length && !source.extensions.includes(ext)) {
+    return false;
+  }
+  if (source.exclude.length && source.exclude.some(regex => regex.test(relativePath))) {
+    return false;
+  }
+  if (source.include.length && !source.include.some(regex => regex.test(relativePath))) {
+    return false;
+  }
+  return true;
+}
+
+async function hashFile(filePath) {
+  const hash = createHash('sha256');
+  const file = await readFile(filePath);
+  hash.update(file);
+  return hash.digest('hex');
+}
+
+function toPosix(value) {
+  return value.split(path.sep).join('/');
+}
+
+main().catch(error => {
+  console.error('Errore non gestito durante la generazione del manifest:', error);
+  process.exitCode = 1;
+});

--- a/tools/drive/push-approved-assets.mjs
+++ b/tools/drive/push-approved-assets.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  const repoRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)), '..');
+  const manifestPath = path.resolve(repoRoot, args.manifest || 'data/drive/approved_assets.json');
+  const manifest = await loadManifest(manifestPath);
+
+  const url = args.url || process.env.DRIVE_SYNC_WEBAPP_URL;
+  if (!url) {
+    console.error('Specifica l\'URL del WebApp Apps Script tramite --url o variabile DRIVE_SYNC_WEBAPP_URL.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const token = args.token || process.env.DRIVE_SYNC_WEBAPP_TOKEN || '';
+  const payload = {
+    action: 'updateApprovedAssets',
+    manifest
+  };
+
+  let requestUrl = url;
+  const headers = { 'content-type': 'application/json' };
+
+  if (token) {
+    if (args.tokenLocation === 'query') {
+      const separator = requestUrl.includes('?') ? '&' : '?';
+      requestUrl = `${requestUrl}${separator}token=${encodeURIComponent(token)}`;
+    } else if (args.tokenLocation === 'header') {
+      headers.Authorization = `Bearer ${token}`;
+    } else {
+      payload.token = token;
+    }
+  }
+
+  if (args.dryRun) {
+    console.log('DRY-RUN: non invio nulla. Payload generato:');
+    console.log(JSON.stringify({ url: requestUrl, headers, payload }, null, 2));
+    return;
+  }
+
+  try {
+    const response = await fetch(requestUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload)
+    });
+    const text = await response.text();
+    const json = safeParseJson(text);
+    if (!response.ok) {
+      console.error(`Errore HTTP ${response.status}: ${text}`);
+      process.exitCode = 1;
+      return;
+    }
+    if (!json || json.ok !== true) {
+      console.error('La risposta del WebApp indica un errore:', text);
+      process.exitCode = 1;
+      return;
+    }
+    const result = json.result || {};
+    console.log(
+      `Manifest approvato inviato con successo (${result.assets || manifest.assets?.length || 0} asset, timestamp ${result.generatedAt || manifest.generatedAt}).`
+    );
+  } catch (error) {
+    console.error('Invio fallito:', error.message || error);
+    process.exitCode = 1;
+  }
+}
+
+function parseArgs(argv) {
+  const args = { tokenLocation: 'body', dryRun: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--help' || token === '-h') {
+      args.help = true;
+      return args;
+    }
+    if (token === '--dry-run') {
+      args.dryRun = true;
+      continue;
+    }
+    const [key, value] = token.split('=', 2);
+    if (key === '--manifest') {
+      args.manifest = value !== undefined ? value : argv[++i];
+      continue;
+    }
+    if (key === '--url') {
+      args.url = value !== undefined ? value : argv[++i];
+      continue;
+    }
+    if (key === '--token') {
+      args.token = value !== undefined ? value : argv[++i];
+      continue;
+    }
+    if (key === '--token-location') {
+      const location = (value !== undefined ? value : argv[++i]) || 'body';
+      if (!['body', 'query', 'header'].includes(location)) {
+        console.error('Valore non valido per --token-location: usa body, query o header.');
+        args.help = true;
+        return args;
+      }
+      args.tokenLocation = location;
+      continue;
+    }
+    console.error(`Argomento non riconosciuto: ${token}`);
+    args.help = true;
+    return args;
+  }
+  return args;
+}
+
+async function loadManifest(manifestPath) {
+  try {
+    const raw = await readFile(manifestPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error('Il manifest non contiene un JSON valido.');
+    }
+    return parsed;
+  } catch (error) {
+    console.error(`Impossibile leggere il manifest ${manifestPath}:`, error.message || error);
+    process.exitCode = 1;
+    throw error;
+  }
+}
+
+function safeParseJson(raw) {
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    return null;
+  }
+}
+
+function printUsage() {
+  console.log(`Uso: push-approved-assets [--manifest <path>] [--url <webapp>] [--token <value>] [--token-location body|query|header] [--dry-run]\n\n` +
+    'Invia l\'elenco degli asset approvati al WebApp Apps Script driveSync.');
+}
+
+main().catch(error => {
+  console.error('Errore inatteso:', error);
+  process.exitCode = 1;
+});

--- a/tools/tests/driveSync.test.js
+++ b/tools/tests/driveSync.test.js
@@ -150,3 +150,31 @@ test('dispatchLogs_ rispetta il livello di log', () => {
   ]);
   assert.equal(logs.length, 2);
 });
+
+test('isYamlCandidate_ rispetta la whitelist di asset approvati', () => {
+  const sandbox = createSandbox();
+  sandbox.updateApprovedAssets({
+    version: 1,
+    generatedAt: '2025-10-29T00:00:00Z',
+    assets: [
+      {
+        driveSourceId: 'vc-logs',
+        fileName: 'session-metrics.yaml'
+      }
+    ]
+  });
+
+  const source = sandbox.normalizeSourceConfig_(
+    { id: 'vc-logs' },
+    { folderId: 'folder', destinationFolderId: 'folder', sheetNamePrefix: '' }
+  );
+
+  assert.equal(sandbox.isYamlCandidate_('session-metrics.yaml', source), true);
+  assert.equal(sandbox.isYamlCandidate_('other.yaml', source), false);
+
+  const hubSource = sandbox.normalizeSourceConfig_(
+    { id: 'hub-ops' },
+    { folderId: 'folder', destinationFolderId: 'folder', sheetNamePrefix: '' }
+  );
+  assert.equal(sandbox.isYamlCandidate_('session-metrics.yaml', hubSource), false);
+});


### PR DESCRIPTION
## Summary
- add drive asset source configuration and generator that produces an approved manifest for driveSync
- extend driveSync.gs with an updateApprovedAssets API, whitelist support, and new CLI to push manifests
- document the asset approval workflow, triggers, and required credentials

## Testing
- `node --test tools/tests/driveSync.test.js`


------
https://chatgpt.com/codex/tasks/task_e_69017a6857848332a960919bf56aefce