### PR TITLE
fix: enforce approved assets token requirement

### DIFF
--- a/scripts/driveSync.gs
+++ b/scripts/driveSync.gs
@@ -1054,7 +1054,7 @@ function resolveRequestToken_(event, payload) {
 function authorizeApprovedAssetsRequest_(token) {
   const expected = scriptProps.getProperty('DRIVE_SYNC_APPROVED_ASSETS_TOKEN');
   if (!expected) {
-    return true;
+    return false;
   }
   return String(token || '') === String(expected);
 }


### PR DESCRIPTION
## Summary
- fail closed when the DRIVE_SYNC_APPROVED_ASSETS_TOKEN script property is not configured
- ensure the approved assets update endpoint cannot be invoked without the token

## Testing
- node --test tools/tests/driveSync.test.js

------
https://chatgpt.com/codex/tasks/task_e_69017dd178448332a3626389f13f68fa