### PR TITLE
fix: align encounter slot quantity with selected species

### DIFF
--- a/webapp/src/state/generator/encounterGenerator.js
+++ b/webapp/src/state/generator/encounterGenerator.js
@@ -262,7 +262,11 @@ export function generateEncounterSeed({
       warnings.push({ code: 'encounter.slot.unfilled', slot: slot.id });
       continue;
     }
-    assignments.push({ slot, quantity, species: selected });
+    const fulfilledQuantity = Math.min(quantity, selected.length);
+    if (fulfilledQuantity < quantity && !slot.optional) {
+      warnings.push({ code: 'encounter.slot.unfilled', slot: slot.id });
+    }
+    assignments.push({ slot, quantity: fulfilledQuantity, species: selected });
   }
   const threat = computeThreat(template, parameters, assignments);
   const context = buildContext({

--- a/webapp/tests/EncounterGenerator.spec.ts
+++ b/webapp/tests/EncounterGenerator.spec.ts
@@ -56,10 +56,15 @@ describe('Encounter generation', () => {
     expect(seed.description).toContain('Thermo Raptor');
     expect(seed.metrics.threat.tier).toMatch(/^T/);
     const outriderSlot = seed.slots.find((slot) => slot.id === 'outrider');
-    expect(outriderSlot?.quantity).toBeGreaterThanOrEqual(2);
+    expect(outriderSlot?.species.length).toBe(1);
+    expect(outriderSlot?.quantity).toBe(outriderSlot?.species.length);
     expect(seed.parameters.intensity.value).toBe('high');
     expect(seed.links.biome_id).toBe('deserto_caldo');
-    expect(seed.warnings).toHaveLength(0);
+    expect(
+      seed.warnings.some(
+        (warning) => warning.code === 'encounter.slot.unfilled' && warning.slot === 'outrider'
+      )
+    ).toBe(true);
   });
 
   it('skips optional slots when no species match', () => {


### PR DESCRIPTION
## Summary
- adjust encounter slot assignment to cap quantity at the number of selected specimens and emit a warning when required slots are under-filled
- update encounter generator test expectations to assert slot quantities track selected species and report warnings

## Testing
- npm --prefix webapp run test

------
https://chatgpt.com/codex/tasks/task_e_69017dc5fba88332b88feea2c0bd67e0