### PR TITLE
feat: orchestrate webapp generator flow UI

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -1,0 +1,169 @@
+<template>
+  <div class="flow-shell">
+    <header class="flow-shell__header">
+      <FlowBreadcrumb :steps="breadcrumb" :current="currentStep" @navigate="goToStep" />
+      <ProgressTracker :steps="steps" :summary="summary" @navigate="goToStep" />
+    </header>
+
+    <main class="flow-shell__main">
+      <component :is="activeView" v-bind="activeProps" />
+    </main>
+
+    <footer class="flow-shell__footer">
+      <button type="button" class="flow-shell__nav" :disabled="!canGoBack" @click="goPrevious">
+        ← Indietro
+      </button>
+      <span class="flow-shell__step-indicator">{{ currentStep.index + 1 }} / {{ steps.length }}</span>
+      <button type="button" class="flow-shell__nav" :disabled="!canGoForward" @click="goNext">
+        Avanti →
+      </button>
+    </footer>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import FlowBreadcrumb from './components/layout/FlowBreadcrumb.vue';
+import ProgressTracker from './components/layout/ProgressTracker.vue';
+import { useGeneratorFlow } from './state/flowMachine.js';
+import {
+  demoSpecies,
+  demoBiomes,
+  demoEncounter,
+  orchestratorSnapshot,
+  globalTimeline,
+} from './state/demoOrchestration.js';
+import OverviewView from './views/OverviewView.vue';
+import SpeciesView from './views/SpeciesView.vue';
+import BiomesView from './views/BiomesView.vue';
+import EncounterView from './views/EncounterView.vue';
+import PublishingView from './views/PublishingView.vue';
+
+const flow = useGeneratorFlow();
+
+flow.updateMetrics('overview', {
+  completed: orchestratorSnapshot.overview.completion.completed,
+  total: orchestratorSnapshot.overview.completion.total,
+  label: 'Milestone',
+});
+
+flow.updateMetrics('species', {
+  completed: orchestratorSnapshot.species.curated,
+  total: orchestratorSnapshot.species.total,
+  label: 'Specie',
+});
+
+flow.updateMetrics('biomes', {
+  completed: orchestratorSnapshot.biomes.validated,
+  total: orchestratorSnapshot.biomes.validated + orchestratorSnapshot.biomes.pending,
+  label: 'Biomi',
+});
+
+flow.updateMetrics('encounter', {
+  completed: orchestratorSnapshot.encounter.variants,
+  total: orchestratorSnapshot.encounter.variants + orchestratorSnapshot.encounter.seeds,
+  label: 'Varianti',
+});
+
+flow.updateMetrics('publishing', {
+  completed: orchestratorSnapshot.publishing.artifactsReady,
+  total: orchestratorSnapshot.publishing.totalArtifacts,
+  label: 'Artefatti',
+});
+
+const steps = flow.steps;
+const breadcrumb = flow.breadcrumb;
+const currentStep = flow.currentStep;
+const summary = flow.summary;
+
+const viewMap = {
+  overview: OverviewView,
+  species: SpeciesView,
+  biomes: BiomesView,
+  encounter: EncounterView,
+  publishing: PublishingView,
+};
+
+const activeView = computed(() => viewMap[currentStep.value.id] || OverviewView);
+
+const activeProps = computed(() => {
+  const id = currentStep.value.id;
+  if (id === 'overview') {
+    return { overview: orchestratorSnapshot.overview, timeline: globalTimeline.value };
+  }
+  if (id === 'species') {
+    return { species: demoSpecies, status: orchestratorSnapshot.species };
+  }
+  if (id === 'biomes') {
+    return { biomes: demoBiomes };
+  }
+  if (id === 'encounter') {
+    return { encounter: demoEncounter, summary: orchestratorSnapshot.encounter };
+  }
+  if (id === 'publishing') {
+    return { publishing: orchestratorSnapshot.publishing };
+  }
+  return {};
+});
+
+const canGoBack = computed(() => currentStep.value.index > 0);
+const canGoForward = computed(() => currentStep.value.index < steps.length - 1);
+
+const goToStep = (stepId) => flow.goTo(stepId);
+const goNext = () => flow.next();
+const goPrevious = () => flow.previous();
+</script>
+
+<style scoped>
+.flow-shell {
+  display: grid;
+  gap: 1.5rem;
+  padding: 2rem;
+  background: radial-gradient(circle at top left, rgba(96, 213, 255, 0.08), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(159, 123, 255, 0.08), transparent 45%),
+    #05080d;
+  min-height: 100vh;
+  color: #f0f4ff;
+}
+
+.flow-shell__header {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.flow-shell__main {
+  display: grid;
+}
+
+.flow-shell__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.flow-shell__nav {
+  background: rgba(9, 14, 20, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  padding: 0.6rem 1.1rem;
+  color: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.flow-shell__nav:hover:enabled {
+  border-color: rgba(96, 213, 255, 0.6);
+  transform: translateY(-1px);
+}
+
+.flow-shell__nav:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.flow-shell__step-indicator {
+  font-size: 0.95rem;
+  color: rgba(240, 244, 255, 0.7);
+}
+</style>

--- a/webapp/src/components/layout/FlowBreadcrumb.vue
+++ b/webapp/src/components/layout/FlowBreadcrumb.vue
@@ -1,0 +1,101 @@
+<template>
+  <nav class="flow-breadcrumb" aria-label="Percorso di generazione">
+    <ol class="flow-breadcrumb__list">
+      <li
+        v-for="step in steps"
+        :key="step.id"
+        class="flow-breadcrumb__item"
+      >
+        <button
+          type="button"
+          class="flow-breadcrumb__link"
+          :class="{
+            'flow-breadcrumb__link--active': step.id === current?.id,
+          }"
+          :disabled="step.id === current?.id"
+          @click="$emit('navigate', step.id)"
+        >
+          <span class="flow-breadcrumb__index">{{ step.index + 1 }}</span>
+          <span class="flow-breadcrumb__label">{{ step.title }}</span>
+        </button>
+      </li>
+    </ol>
+  </nav>
+</template>
+
+<script setup>
+import { toRefs } from 'vue';
+
+const props = defineProps({
+  steps: {
+    type: Array,
+    default: () => [],
+  },
+  current: {
+    type: Object,
+    default: null,
+  },
+});
+
+const { steps, current } = toRefs(props);
+
+defineEmits(['navigate']);
+</script>
+
+<style scoped>
+.flow-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: rgba(240, 244, 255, 0.7);
+}
+
+.flow-breadcrumb__list {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.flow-breadcrumb__item {
+  display: flex;
+}
+
+.flow-breadcrumb__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(15, 21, 32, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  color: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.flow-breadcrumb__link--active,
+.flow-breadcrumb__link:disabled {
+  cursor: default;
+  border-color: rgba(96, 213, 255, 0.65);
+  color: #ffffff;
+  background: rgba(96, 213, 255, 0.18);
+}
+
+.flow-breadcrumb__link:not(:disabled):hover {
+  border-color: rgba(96, 213, 255, 0.55);
+  color: #ffffff;
+}
+
+.flow-breadcrumb__index {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.flow-breadcrumb__label {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+</style>

--- a/webapp/src/components/layout/ProgressTracker.vue
+++ b/webapp/src/components/layout/ProgressTracker.vue
@@ -1,0 +1,270 @@
+<template>
+  <section class="progress-tracker">
+    <header class="progress-tracker__header">
+      <div>
+        <h1 class="progress-tracker__title">Orchestrazione generazione</h1>
+        <p class="progress-tracker__subtitle">
+          Stato globale · {{ summary.completedSteps }} / {{ summary.totalSteps }} fasi completate
+        </p>
+      </div>
+      <div class="progress-tracker__chip">
+        <span class="progress-tracker__chip-label">{{ summary.active?.title }}</span>
+        <span class="progress-tracker__chip-value">{{ summary.percent }}%</span>
+      </div>
+    </header>
+
+    <div
+      class="progress-tracker__bar"
+      role="progressbar"
+      :aria-valuenow="summary.percent"
+      aria-valuemin="0"
+      aria-valuemax="100"
+    >
+      <div class="progress-tracker__bar-fill" :style="{ width: `${summary.percent}%` }"></div>
+    </div>
+
+    <div class="progress-tracker__cards">
+      <article
+        v-for="step in steps"
+        :key="step.id"
+        class="progress-card"
+        :class="[
+          `progress-card--${step.status}`,
+          { 'progress-card--active': step.id === summary.active?.id },
+        ]"
+      >
+        <header class="progress-card__header">
+          <div>
+            <p class="progress-card__caption">{{ step.caption }}</p>
+            <h2 class="progress-card__title">{{ step.title }}</h2>
+          </div>
+          <button type="button" class="progress-card__status" @click="$emit('navigate', step.id)">
+            <span>{{ statusLabel(step.status) }}</span>
+            <span class="progress-card__index">#{{ step.index + 1 }}</span>
+          </button>
+        </header>
+        <p class="progress-card__description">{{ step.description }}</p>
+        <dl v-if="step.metrics.total" class="progress-card__metrics">
+          <div>
+            <dt>{{ step.metrics.label || 'Elementi' }}</dt>
+            <dd>{{ step.metrics.completed }} / {{ step.metrics.total }}</dd>
+          </div>
+          <div>
+            <dt>Completezza</dt>
+            <dd>{{ completionPercent(step.metrics) }}%</dd>
+          </div>
+        </dl>
+      </article>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { toRefs } from 'vue';
+
+const props = defineProps({
+  steps: {
+    type: Array,
+    default: () => [],
+  },
+  summary: {
+    type: Object,
+    default: () => ({ totalSteps: 0, completedSteps: 0, percent: 0, active: null }),
+  },
+});
+
+const { steps, summary } = toRefs(props);
+
+defineEmits(['navigate']);
+
+const statusMap = {
+  done: 'Completo',
+  current: 'In corso',
+  pending: 'In attesa',
+  blocked: 'Bloccato',
+};
+
+const statusLabel = (status) => statusMap[status] || statusMap.pending;
+
+const completionPercent = (metrics) => {
+  const total = Number.isFinite(metrics.total) ? metrics.total : 0;
+  const completed = Number.isFinite(metrics.completed) ? metrics.completed : 0;
+  if (!total) {
+    return 0;
+  }
+  return Math.min(100, Math.round((completed / total) * 100));
+};
+</script>
+
+<style scoped>
+.progress-tracker {
+  background: rgba(6, 11, 18, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.25rem;
+  color: #f0f4ff;
+}
+
+.progress-tracker__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.progress-tracker__title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+}
+
+.progress-tracker__subtitle {
+  margin: 0.35rem 0 0;
+  color: rgba(240, 244, 255, 0.7);
+  font-size: 0.95rem;
+}
+
+.progress-tracker__chip {
+  background: rgba(96, 213, 255, 0.15);
+  border: 1px solid rgba(96, 213, 255, 0.4);
+  border-radius: 12px;
+  padding: 0.5rem 0.9rem;
+  display: grid;
+  gap: 0.25rem;
+  justify-items: end;
+  min-width: 140px;
+}
+
+.progress-tracker__chip-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.progress-tracker__chip-value {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.progress-tracker__bar {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 999px;
+  overflow: hidden;
+  height: 0.75rem;
+  position: relative;
+}
+
+.progress-tracker__bar-fill {
+  background: linear-gradient(90deg, #61d5ff 0%, #9f7bff 100%);
+  height: 100%;
+  border-radius: inherit;
+  transition: width 0.3s ease;
+}
+
+.progress-tracker__cards {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.progress-card {
+  background: rgba(10, 15, 22, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  min-height: 180px;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.progress-card--active {
+  border-color: rgba(96, 213, 255, 0.7);
+  transform: translateY(-2px);
+}
+
+.progress-card--done {
+  border-color: rgba(87, 202, 138, 0.6);
+}
+
+.progress-card--blocked {
+  border-color: rgba(244, 96, 96, 0.6);
+}
+
+.progress-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.progress-card__caption {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(240, 244, 255, 0.65);
+}
+
+.progress-card__title {
+  margin: 0.25rem 0 0;
+  font-size: 1.1rem;
+}
+
+.progress-card__status {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.2rem;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.85rem;
+  text-align: right;
+}
+
+.progress-card__status:hover {
+  color: #ffffff;
+}
+
+.progress-card__index {
+  font-size: 0.7rem;
+  opacity: 0.6;
+}
+
+.progress-card__description {
+  margin: 0;
+  color: rgba(240, 244, 255, 0.7);
+  font-size: 0.9rem;
+}
+
+.progress-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem 1rem;
+  margin: 0;
+}
+
+.progress-card__metrics div {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 10px;
+  padding: 0.6rem;
+}
+
+.progress-card__metrics dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0 0 0.25rem;
+  color: rgba(240, 244, 255, 0.6);
+}
+
+.progress-card__metrics dd {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+</style>

--- a/webapp/src/main.js
+++ b/webapp/src/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#app');

--- a/webapp/src/state/demoOrchestration.js
+++ b/webapp/src/state/demoOrchestration.js
@@ -1,0 +1,160 @@
+import { computed, reactive } from 'vue';
+
+export const demoSpecies = reactive({
+  id: 'lupus-nebulis',
+  display_name: 'Lupo delle Nebbie',
+  summary: 'Predatore d\'élite che sfrutta condensazioni luminose per disorientare gli intrusi.',
+  description:
+    'Questa variante evolutiva è stata selezionata per operare in squadre coordinate, sfruttando la nebbia fotoreattiva del bioma per creare imboscate multi-angolo.',
+  traits: {
+    core: ['Coordinazione di branco', 'Visione spettrale', 'Fase di camuffamento'],
+    derived: ['Risonanza ululante', 'Scatto fulmineo'],
+  },
+  morphology: {
+    adaptations: ['Membrane respiratorie anti-nebbia', 'Vibrisse fotocromatiche', 'Artigli polifasici'],
+  },
+  behavior: {
+    tags: ['Predatore sinergico', 'Agguato opportunistico', 'Reazione a stimoli luminosi'],
+  },
+  statistics: {
+    threat_tier: 'T2',
+    rarity: 'Rara',
+    energy_profile: 'Alta intensità',
+    synergy_score: 0.62,
+  },
+});
+
+export const demoBiomes = reactive([
+  {
+    id: 'twilight-marsh',
+    name: 'Paludi del Crepuscolo',
+    climate: 'Umido temperato',
+    risk: 'Moderato',
+    focus: 'Nebbia fotonica pulsante',
+    opportunities: ['Creare corridoi acustici', 'Reindirizzare i riflettori naturali'],
+    readiness: 3,
+    total: 5,
+  },
+  {
+    id: 'obsidian-ridge',
+    name: 'Cresta di Ossidiana',
+    climate: 'Freddo secco',
+    risk: 'Elevato',
+    focus: 'Canaloni lavici cristallizzati',
+    opportunities: ['Proiezioni sonore a lunga distanza', 'Nascondigli naturali multilivello'],
+    readiness: 2,
+    total: 4,
+  },
+]);
+
+export const demoEncounter = reactive({
+  templateName: 'Assalto Nella Nebbia',
+  biomeName: 'Paludi del Crepuscolo',
+  parameterLabels: {
+    density: 'Densità del branco',
+    cadence: 'Cadenza offensiva',
+  },
+  variants: [
+    {
+      id: 'strike-team',
+      summary: 'Intercettazione rapida con due nuclei coordinati.',
+      description:
+        'La squadra entra dal fronte orientale sfruttando micro-lampi per disgregare la formazione nemica mentre il branco primario chiude da nord.',
+      parameters: {
+        density: { label: 'Compatta', value: 'compact' },
+        cadence: { label: 'Impulsi rapidi', value: 'burst' },
+      },
+      slots: [
+        {
+          id: 'alpha',
+          title: 'Alfa nebulare',
+          quantity: 1,
+          species: [demoSpecies],
+        },
+        {
+          id: 'stalker',
+          title: 'Predatori di supporto',
+          quantity: 3,
+          species: [
+            { ...demoSpecies, id: 'support-1', display_name: 'Lupo delle Nebbie - Scout' },
+            { ...demoSpecies, id: 'support-2', display_name: 'Lupo delle Nebbie - Distruttore' },
+          ],
+        },
+      ],
+      metrics: {
+        threat: { tier: 'T2' },
+      },
+      warnings: [
+        { code: 'ATTENTION_SPIKES', slot: 'stalker' },
+      ],
+    },
+    {
+      id: 'stealth',
+      summary: 'Pattuglia silente con cariche differite.',
+      description:
+        'Una squadra distaccata prepara i rifugi mentre il branco principale attiva le trappole di luce in sequenza.',
+      parameters: {
+        density: { label: 'Diluita', value: 'spread' },
+        cadence: { label: 'Sincronizzata', value: 'sync' },
+      },
+      slots: [
+        {
+          id: 'alpha',
+          title: 'Alfa nebulare',
+          quantity: 1,
+          species: [demoSpecies],
+        },
+        {
+          id: 'saboteur',
+          title: 'Sabotatori luminescenti',
+          quantity: 2,
+          species: [
+            { ...demoSpecies, id: 'saboteur-1', display_name: 'Sabotatore Prismico' },
+            { ...demoSpecies, id: 'saboteur-2', display_name: 'Sabotatore Obscura' },
+          ],
+        },
+      ],
+      metrics: {
+        threat: { tier: 'T3' },
+      },
+      warnings: [],
+    },
+  ],
+});
+
+export const orchestratorSnapshot = reactive({
+  overview: {
+    objectives: ['Stabilire punto di vista narrativo', 'Definire palette emozionale', 'Vincolare escalation a 12 minuti'],
+    blockers: ['In attesa di conferma sul canale di distribuzione'],
+    completion: { completed: 3, total: 4 },
+  },
+  species: {
+    curated: 8,
+    total: 12,
+    shortlist: ['Lupo delle Nebbie', 'Cefalo Prisma', 'Draco delle Tife'],
+  },
+  biomes: {
+    validated: 2,
+    pending: 1,
+  },
+  encounter: {
+    seeds: 2,
+    variants: 4,
+    warnings: 1,
+  },
+  publishing: {
+    artifactsReady: 2,
+    totalArtifacts: 5,
+    channels: ['Compendio digitale', 'Brief video'],
+  },
+});
+
+export const globalTimeline = computed(() => {
+  const totalSteps = orchestratorSnapshot.overview.completion.total;
+  const completed = orchestratorSnapshot.overview.completion.completed;
+  const percent = totalSteps === 0 ? 0 : Math.round((completed / totalSteps) * 100);
+  return {
+    label: `Sincronizzazione ${percent}%`,
+    percent,
+  };
+});

--- a/webapp/src/state/flowMachine.js
+++ b/webapp/src/state/flowMachine.js
@@ -1,0 +1,158 @@
+import { computed, reactive } from 'vue';
+
+const BASE_STEPS = [
+  {
+    id: 'overview',
+    title: 'Overview',
+    caption: 'Panoramica del progetto',
+    description: 'Riepilogo degli obiettivi e dei vincoli di generazione.',
+  },
+  {
+    id: 'species',
+    title: 'Specie',
+    caption: 'Curazione faunistica',
+    description: 'Selezione e revisione delle specie protagoniste.',
+  },
+  {
+    id: 'biomes',
+    title: 'Biomi',
+    caption: 'Scenari ecologici',
+    description: 'Biomi candidati e condizioni ambientali principali.',
+  },
+  {
+    id: 'encounter',
+    title: 'Encounter',
+    caption: 'Configurazioni di scontro',
+    description: 'Seed, varianti e parametri del combattimento.',
+  },
+  {
+    id: 'publishing',
+    title: 'Publishing',
+    caption: 'Preparazione artefatti',
+    description: 'Pacchetti finali e consegna dei deliverable.',
+  },
+];
+
+function applyActiveStep(steps, targetIndex) {
+  const clamped = Math.max(0, Math.min(targetIndex, steps.length - 1));
+  steps.forEach((step, index) => {
+    if (index < clamped) {
+      step.status = step.status === 'blocked' ? 'blocked' : 'done';
+    } else if (index === clamped) {
+      step.status = step.status === 'blocked' ? 'blocked' : 'current';
+    } else {
+      step.status = step.status === 'blocked' ? 'blocked' : 'pending';
+    }
+  });
+  return clamped;
+}
+
+export function useGeneratorFlow(options = {}) {
+  const { initial = 'overview', stepOverrides = {} } = options;
+
+  const steps = reactive(
+    BASE_STEPS.map((step, index) => {
+      const override = stepOverrides[step.id] || {};
+      const metrics = {
+        completed: 0,
+        total: 0,
+        label: 'Elementi',
+        ...override.metrics,
+      };
+      return {
+        ...step,
+        ...override,
+        index,
+        status: 'pending',
+        metrics,
+        completed: Boolean(metrics.total && metrics.completed >= metrics.total),
+        locked: Boolean(override.locked),
+      };
+    })
+  );
+
+  const initialIndex = steps.findIndex((step) => step.id === initial);
+  const state = reactive({
+    currentIndex: applyActiveStep(steps, initialIndex === -1 ? 0 : initialIndex),
+  });
+
+  const currentStep = computed(() => steps[state.currentIndex] || steps[0]);
+
+  const breadcrumb = computed(() => steps.slice(0, state.currentIndex + 1));
+
+  const summary = computed(() => {
+    const totalSteps = steps.length;
+    const completedSteps = steps.filter((step) => step.status === 'done').length;
+    const percent = totalSteps === 0 ? 0 : Math.round((completedSteps / totalSteps) * 100);
+    return {
+      totalSteps,
+      completedSteps,
+      percent,
+      active: currentStep.value,
+    };
+  });
+
+  function goTo(stepId) {
+    const index = steps.findIndex((step) => step.id === stepId);
+    if (index !== -1) {
+      state.currentIndex = applyActiveStep(steps, index);
+    }
+  }
+
+  function next() {
+    if (state.currentIndex < steps.length - 1) {
+      state.currentIndex = applyActiveStep(steps, state.currentIndex + 1);
+    }
+  }
+
+  function previous() {
+    if (state.currentIndex > 0) {
+      state.currentIndex = applyActiveStep(steps, state.currentIndex - 1);
+    }
+  }
+
+  function updateMetrics(stepId, metrics = {}) {
+    const step = steps.find((item) => item.id === stepId);
+    if (!step) {
+      return;
+    }
+    const nextMetrics = {
+      ...step.metrics,
+      ...metrics,
+    };
+    step.metrics = nextMetrics;
+    const total = Number.isFinite(nextMetrics.total) ? nextMetrics.total : 0;
+    const completed = Number.isFinite(nextMetrics.completed) ? nextMetrics.completed : 0;
+    if (total > 0 && completed >= total) {
+      step.completed = true;
+      if (steps[state.currentIndex].id !== step.id) {
+        step.status = 'done';
+      }
+    }
+  }
+
+  function mark(stepId, status) {
+    const step = steps.find((item) => item.id === stepId);
+    if (!step) {
+      return;
+    }
+    step.status = status;
+    if (status === 'done') {
+      step.completed = true;
+    }
+  }
+
+  return {
+    steps,
+    currentStep,
+    breadcrumb,
+    summary,
+    goTo,
+    next,
+    previous,
+    updateMetrics,
+    mark,
+  };
+}
+
+export const FLOW_STEPS = BASE_STEPS.map((step) => ({ ...step }));

--- a/webapp/src/views/BiomesView.vue
+++ b/webapp/src/views/BiomesView.vue
@@ -1,0 +1,130 @@
+<template>
+  <section class="flow-view">
+    <header class="flow-view__header">
+      <h2>Biomi candidati</h2>
+      <p>Panoramica degli ambienti approvati e del grado di prontezza.</p>
+    </header>
+    <div class="flow-view__grid">
+      <article class="biome-card" v-for="biome in biomes" :key="biome.id">
+        <header>
+          <h3>{{ biome.name }}</h3>
+          <span class="biome-card__badge">{{ biome.climate }}</span>
+        </header>
+        <p class="biome-card__focus">{{ biome.focus }}</p>
+        <ul>
+          <li v-for="item in biome.opportunities" :key="item">{{ item }}</li>
+        </ul>
+        <footer>
+          <div class="biome-card__meter">
+            <div class="biome-card__meter-fill" :style="{ width: `${readinessPercent(biome)}%` }"></div>
+          </div>
+          <small>Readiness {{ biome.readiness }} / {{ biome.total }} · Rischio {{ biome.risk }}</small>
+        </footer>
+      </article>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { toRefs } from 'vue';
+
+const props = defineProps({
+  biomes: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const { biomes } = toRefs(props);
+
+const readinessPercent = (biome) => {
+  const total = Number.isFinite(biome.total) ? biome.total : 0;
+  const readiness = Number.isFinite(biome.readiness) ? biome.readiness : 0;
+  if (!total) {
+    return 0;
+  }
+  return Math.min(100, Math.round((readiness / total) * 100));
+};
+</script>
+
+<style scoped>
+.flow-view {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.flow-view__header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.flow-view__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(240, 244, 255, 0.7);
+}
+
+.flow-view__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.biome-card {
+  background: rgba(9, 14, 20, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.biome-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.biome-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.biome-card__badge {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(96, 213, 255, 0.15);
+  border: 1px solid rgba(96, 213, 255, 0.4);
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+}
+
+.biome-card__focus {
+  margin: 0;
+  color: rgba(240, 244, 255, 0.75);
+}
+
+.biome-card ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: rgba(240, 244, 255, 0.85);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.biome-card__meter {
+  height: 0.45rem;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.biome-card__meter-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #57ca8a 0%, #61d5ff 100%);
+}
+
+small {
+  color: rgba(240, 244, 255, 0.6);
+}
+</style>

--- a/webapp/src/views/EncounterView.vue
+++ b/webapp/src/views/EncounterView.vue
@@ -1,0 +1,101 @@
+<template>
+  <section class="flow-view">
+    <header class="flow-view__header">
+      <h2>Encounter selezionato</h2>
+      <p>Seed, varianti e parametri tattici generati finora.</p>
+    </header>
+    <div class="flow-view__content">
+      <EncounterPanel :encounter="encounter" />
+      <aside class="flow-view__sidebar">
+        <div class="sidebar-card">
+          <h3>Metriche</h3>
+          <ul>
+            <li><strong>{{ summary.seeds }}</strong> seed generati</li>
+            <li><strong>{{ summary.variants }}</strong> varianti attive</li>
+            <li><strong>{{ summary.warnings }}</strong> warning aperti</li>
+          </ul>
+        </div>
+        <div class="sidebar-card">
+          <h3>Prossimi trigger</h3>
+          <p>Convalida parametri minaccia e sincronizzazione con canale Publishing.</p>
+        </div>
+      </aside>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { toRefs } from 'vue';
+import EncounterPanel from '../components/EncounterPanel.vue';
+
+const props = defineProps({
+  encounter: {
+    type: Object,
+    required: true,
+  },
+  summary: {
+    type: Object,
+    required: true,
+  },
+});
+
+const { encounter, summary } = toRefs(props);
+</script>
+
+<style scoped>
+.flow-view {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.flow-view__header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.flow-view__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(240, 244, 255, 0.7);
+}
+
+.flow-view__content {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(220px, 1fr);
+  gap: 1.25rem;
+}
+
+.flow-view__sidebar {
+  display: grid;
+  gap: 1rem;
+}
+
+.sidebar-card {
+  background: rgba(9, 14, 20, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.sidebar-card h3 {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(240, 244, 255, 0.7);
+}
+
+.sidebar-card ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.35rem;
+  color: rgba(240, 244, 255, 0.85);
+}
+
+.sidebar-card p {
+  margin: 0;
+  color: rgba(240, 244, 255, 0.75);
+}
+</style>

--- a/webapp/src/views/OverviewView.vue
+++ b/webapp/src/views/OverviewView.vue
@@ -1,0 +1,117 @@
+<template>
+  <section class="flow-view">
+    <header class="flow-view__header">
+      <h2>Snapshot operativo</h2>
+      <p>Coordinamento attuale del workflow narrativo.</p>
+    </header>
+    <div class="flow-view__grid">
+      <article class="flow-card" v-for="objective in objectives" :key="objective">
+        <h3 class="flow-card__title">Obiettivo</h3>
+        <p class="flow-card__body">{{ objective }}</p>
+      </article>
+      <article class="flow-card flow-card--warning" v-for="blocker in blockers" :key="blocker">
+        <h3 class="flow-card__title">Bloccante</h3>
+        <p class="flow-card__body">{{ blocker }}</p>
+      </article>
+      <article class="flow-card flow-card--progress">
+        <h3 class="flow-card__title">Allineamento timeline</h3>
+        <p class="flow-card__body">{{ timeline.label }}</p>
+        <div class="flow-card__progress">
+          <div class="flow-card__progress-bar" :style="{ width: `${timeline.percent}%` }"></div>
+        </div>
+        <small>{{ completion.completed }} su {{ completion.total }} milestone confermate</small>
+      </article>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, toRefs } from 'vue';
+
+const props = defineProps({
+  overview: {
+    type: Object,
+    required: true,
+  },
+  timeline: {
+    type: Object,
+    required: true,
+  },
+});
+
+const { overview, timeline } = toRefs(props);
+const completion = computed(() => overview.value.completion || { completed: 0, total: 0 });
+const blockers = computed(() => overview.value.blockers || []);
+const objectives = computed(() => overview.value.objectives || []);
+</script>
+
+<style scoped>
+.flow-view {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.flow-view__header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.flow-view__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(240, 244, 255, 0.7);
+}
+
+.flow-view__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.flow-card {
+  background: rgba(9, 14, 20, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.flow-card--warning {
+  border-color: rgba(244, 196, 96, 0.55);
+  background: rgba(244, 196, 96, 0.12);
+}
+
+.flow-card--progress {
+  border-color: rgba(96, 213, 255, 0.4);
+}
+
+.flow-card__title {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  color: rgba(240, 244, 255, 0.65);
+}
+
+.flow-card__body {
+  margin: 0;
+  font-size: 1rem;
+  color: #f0f4ff;
+}
+
+.flow-card__progress {
+  height: 0.5rem;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.flow-card__progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, #61d5ff 0%, #9f7bff 100%);
+}
+
+small {
+  color: rgba(240, 244, 255, 0.6);
+}
+</style>

--- a/webapp/src/views/PublishingView.vue
+++ b/webapp/src/views/PublishingView.vue
@@ -1,0 +1,97 @@
+<template>
+  <section class="flow-view">
+    <header class="flow-view__header">
+      <h2>Publishing & Deliverable</h2>
+      <p>Stato di confezionamento dei materiali e canali di uscita.</p>
+    </header>
+    <div class="flow-view__grid">
+      <article class="flow-card">
+        <h3 class="flow-card__title">Artefatti</h3>
+        <p class="flow-card__body">
+          {{ publishing.artifactsReady }} asset pronti su {{ publishing.totalArtifacts }} previsti.
+        </p>
+      </article>
+      <article class="flow-card">
+        <h3 class="flow-card__title">Canali</h3>
+        <ul>
+          <li v-for="channel in publishing.channels" :key="channel">{{ channel }}</li>
+        </ul>
+      </article>
+      <article class="flow-card flow-card--action">
+        <h3 class="flow-card__title">Prossime azioni</h3>
+        <p class="flow-card__body">Coordinare il QA narrativo e validare la sincronizzazione media.</p>
+      </article>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { toRefs } from 'vue';
+
+const props = defineProps({
+  publishing: {
+    type: Object,
+    required: true,
+  },
+});
+
+const { publishing } = toRefs(props);
+</script>
+
+<style scoped>
+.flow-view {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.flow-view__header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.flow-view__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(240, 244, 255, 0.7);
+}
+
+.flow-view__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.flow-card {
+  background: rgba(9, 14, 20, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.flow-card--action {
+  border-color: rgba(87, 202, 138, 0.55);
+}
+
+.flow-card__title {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  color: rgba(240, 244, 255, 0.65);
+}
+
+.flow-card__body {
+  margin: 0;
+  font-size: 1rem;
+  color: #f0f4ff;
+}
+
+.flow-card ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: rgba(240, 244, 255, 0.85);
+  display: grid;
+  gap: 0.25rem;
+}
+</style>

--- a/webapp/src/views/SpeciesView.vue
+++ b/webapp/src/views/SpeciesView.vue
@@ -1,0 +1,102 @@
+<template>
+  <section class="flow-view">
+    <header class="flow-view__header">
+      <h2>Specie prioritario</h2>
+      <p>Curazione attuale e shortlist degli organismi selezionati.</p>
+    </header>
+    <div class="flow-view__content">
+      <SpeciesPanel :species="species" />
+      <aside class="flow-view__sidebar">
+        <div class="sidebar-card">
+          <h3>Stato curazione</h3>
+          <p><strong>{{ curated }}</strong> specie curate su <strong>{{ total }}</strong> candidate.</p>
+        </div>
+        <div class="sidebar-card">
+          <h3>Shortlist</h3>
+          <ul>
+            <li v-for="item in shortlist" :key="item">{{ item }}</li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, toRefs } from 'vue';
+import SpeciesPanel from '../components/SpeciesPanel.vue';
+
+const props = defineProps({
+  species: {
+    type: Object,
+    required: true,
+  },
+  status: {
+    type: Object,
+    required: true,
+  },
+});
+
+const { species, status } = toRefs(props);
+const curated = computed(() => status.value.curated || 0);
+const total = computed(() => status.value.total || 0);
+const shortlist = computed(() => status.value.shortlist || []);
+</script>
+
+<style scoped>
+.flow-view {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.flow-view__header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.flow-view__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(240, 244, 255, 0.7);
+}
+
+.flow-view__content {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(220px, 1fr);
+  gap: 1.25rem;
+}
+
+.flow-view__sidebar {
+  display: grid;
+  gap: 1rem;
+}
+
+.sidebar-card {
+  background: rgba(9, 14, 20, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.sidebar-card h3 {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(240, 244, 255, 0.7);
+}
+
+.sidebar-card p {
+  margin: 0;
+  color: #f0f4ff;
+}
+
+.sidebar-card ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: rgba(240, 244, 255, 0.8);
+  display: grid;
+  gap: 0.25rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- introduce a generator flow state machine with demo data to drive the orchestrated workflow
- add breadcrumb and progress tracker components with card-based status metrics for each step
- render dedicated Overview, Specie, Biomi, Encounter, and Publishing views inside the new application shell

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690181a99f0c83328f1f40a966c4f23b