### PR TITLE
Refactor species panel and add batch generation previews

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -295,6 +295,17 @@ function createApp(options = {}) {
     }
   });
 
+  app.post('/api/generation/species/batch', async (req, res) => {
+    const payload = req.body || {};
+    try {
+      const result = await generationOrchestrator.generateSpeciesBatch(payload);
+      res.json(result);
+    } catch (error) {
+      const status = error && error.message && error.message.includes('trait_ids') ? 400 : 500;
+      res.status(status).json({ error: error.message || 'Errore generazione batch specie' });
+    }
+  });
+
   return { app, repo };
 }
 

--- a/tests/test_generation_orchestrator.py
+++ b/tests/test_generation_orchestrator.py
@@ -3,9 +3,16 @@ import logging
 
 import pytest
 
+import json
+import logging
+
+import pytest
+
 from services.generation.orchestrator import (
+    GenerationBatchResult,
     GenerationError,
     GenerationOrchestrator,
+    SpeciesBatchRequest,
     SpeciesGenerationRequest,
     StructuredLogger,
 )
@@ -71,3 +78,20 @@ def test_generate_species_raises_on_missing_traits() -> None:
 
     with pytest.raises(GenerationError):
         orchestrator.generate_species(request)
+
+
+def test_generate_species_batch_returns_results_and_errors() -> None:
+    orchestrator = GenerationOrchestrator()
+    batch_request = SpeciesBatchRequest(
+        entries=[
+            build_request(seed=1),
+            build_request(trait_ids=['sconosciuto_trait'], fallback_trait_ids=['artigli_sette_vie'], seed=2),
+        ]
+    )
+
+    result = orchestrator.generate_species_batch(batch_request.entries)
+
+    payload = result.to_payload()
+    assert isinstance(result, GenerationBatchResult)
+    assert len(payload['results']) >= 1
+    assert isinstance(payload['errors'], list)

--- a/webapp/src/components/species/SpeciesBiology.vue
+++ b/webapp/src/components/species/SpeciesBiology.vue
@@ -1,0 +1,119 @@
+<template>
+  <section class="species-biology">
+    <div class="species-biology__section">
+      <header class="species-biology__header">
+        <h3>Tratti fondamentali</h3>
+        <slot name="filters"></slot>
+      </header>
+      <ul class="species-biology__trait-list" data-testid="core-traits">
+        <li v-for="trait in coreTraits" :key="trait">{{ trait }}</li>
+      </ul>
+    </div>
+
+    <div v-if="derivedTraits.length" class="species-biology__section">
+      <h3>Tratti derivati</h3>
+      <ul class="species-biology__trait-list species-biology__trait-list--derived" data-testid="derived-traits">
+        <li v-for="trait in derivedTraits" :key="trait">{{ trait }}</li>
+      </ul>
+    </div>
+
+    <div v-if="adaptations.length" class="species-biology__section">
+      <h3>Adattamenti</h3>
+      <ul class="species-biology__list">
+        <li v-for="adaptation in adaptations" :key="adaptation">{{ adaptation }}</li>
+      </ul>
+    </div>
+
+    <div v-if="behaviourTags.length || drives.length" class="species-biology__section">
+      <h3>Comportamento</h3>
+      <p v-if="behaviourTags.length" class="species-biology__behaviour-tags">{{ behaviourTags.join(', ') }}</p>
+      <ul v-if="drives.length" class="species-biology__list">
+        <li v-for="drive in drives" :key="drive">{{ drive }}</li>
+      </ul>
+    </div>
+  </section>
+</template>
+
+<script setup>
+defineProps({
+  coreTraits: {
+    type: Array,
+    default: () => [],
+  },
+  derivedTraits: {
+    type: Array,
+    default: () => [],
+  },
+  adaptations: {
+    type: Array,
+    default: () => [],
+  },
+  behaviourTags: {
+    type: Array,
+    default: () => [],
+  },
+  drives: {
+    type: Array,
+    default: () => [],
+  },
+});
+</script>
+
+<style scoped>
+.species-biology {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.species-biology__section {
+  background: rgba(10, 15, 22, 0.6);
+  padding: 1rem;
+  border-radius: 10px;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.species-biology__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.species-biology__header h3 {
+  margin: 0;
+}
+
+.species-biology__trait-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.species-biology__trait-list li {
+  background: rgba(39, 121, 255, 0.18);
+  border: 1px solid rgba(39, 121, 255, 0.32);
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.species-biology__trait-list--derived li {
+  background: rgba(180, 94, 255, 0.18);
+  border-color: rgba(180, 94, 255, 0.32);
+}
+
+.species-biology__list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.species-biology__behaviour-tags {
+  margin: 0;
+}
+</style>

--- a/webapp/src/components/species/SpeciesOverview.vue
+++ b/webapp/src/components/species/SpeciesOverview.vue
@@ -1,0 +1,53 @@
+<template>
+  <header class="species-overview">
+    <div class="species-overview__heading">
+      <h2 class="species-overview__title">{{ name }}</h2>
+      <p v-if="summary" class="species-overview__summary">{{ summary }}</p>
+    </div>
+    <p v-if="description" class="species-overview__description">{{ description }}</p>
+    <slot name="actions"></slot>
+  </header>
+</template>
+
+<script setup>
+defineProps({
+  name: {
+    type: String,
+    default: '',
+  },
+  summary: {
+    type: String,
+    default: '',
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+});
+</script>
+
+<style scoped>
+.species-overview {
+  display: grid;
+  gap: 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding-bottom: 1rem;
+}
+
+.species-overview__title {
+  margin: 0;
+  font-size: 1.85rem;
+  font-weight: 700;
+}
+
+.species-overview__summary {
+  margin: 0.25rem 0 0;
+  color: rgba(240, 244, 255, 0.82);
+  font-size: 1rem;
+}
+
+.species-overview__description {
+  margin: 0;
+  line-height: 1.5;
+}
+</style>

--- a/webapp/src/components/species/SpeciesPreviewGrid.vue
+++ b/webapp/src/components/species/SpeciesPreviewGrid.vue
@@ -1,0 +1,147 @@
+<template>
+  <section class="species-preview-grid">
+    <header class="species-preview-grid__header">
+      <h3>Anteprime sintetiche</h3>
+      <slot name="filters"></slot>
+    </header>
+    <p v-if="error" class="species-preview-grid__error">{{ error }}</p>
+    <p v-else-if="loading" class="species-preview-grid__loading">Generazione in corso...</p>
+    <div v-else-if="previews.length" class="species-preview-grid__cards">
+      <article
+        v-for="preview in previews"
+        :key="preview.blueprint?.id || preview.meta?.request_id"
+        class="species-preview-card"
+      >
+        <header class="species-preview-card__header">
+          <h4>{{ preview.blueprint?.display_name || preview.blueprint?.id }}</h4>
+          <span class="species-preview-card__badge">{{ preview.blueprint?.statistics?.threat_tier || 'T?' }}</span>
+        </header>
+        <p class="species-preview-card__summary">{{ preview.blueprint?.summary }}</p>
+        <dl class="species-preview-card__stats">
+          <div>
+            <dt>Energia</dt>
+            <dd>{{ preview.blueprint?.statistics?.energy_profile || 'n/d' }}</dd>
+          </div>
+          <div>
+            <dt>Rarità</dt>
+            <dd>{{ preview.blueprint?.statistics?.rarity || 'R?' }}</dd>
+          </div>
+        </dl>
+        <p v-if="preview.blueprint?.traits?.core?.length" class="species-preview-card__traits">
+          {{ preview.blueprint.traits.core.join(', ') }}
+        </p>
+      </article>
+    </div>
+    <p v-else class="species-preview-grid__empty">Nessuna anteprima disponibile.</p>
+  </section>
+</template>
+
+<script setup>
+defineProps({
+  previews: {
+    type: Array,
+    default: () => [],
+  },
+  loading: {
+    type: Boolean,
+    default: false,
+  },
+  error: {
+    type: String,
+    default: '',
+  },
+});
+</script>
+
+<style scoped>
+.species-preview-grid {
+  background: rgba(10, 15, 22, 0.6);
+  padding: 1rem;
+  border-radius: 10px;
+  display: grid;
+  gap: 1rem;
+}
+
+.species-preview-grid__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.species-preview-grid__header h3 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.species-preview-grid__cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.species-preview-card {
+  background: rgba(9, 12, 18, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.species-preview-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.species-preview-card__badge {
+  background: rgba(39, 121, 255, 0.35);
+  border-radius: 6px;
+  padding: 0.1rem 0.45rem;
+  font-size: 0.75rem;
+}
+
+.species-preview-card__summary {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.species-preview-card__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 0.35rem 0.75rem;
+  margin: 0;
+}
+
+.species-preview-card__stats dt {
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: rgba(240, 244, 255, 0.75);
+}
+
+.species-preview-card__stats dd {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.species-preview-card__traits {
+  margin: 0;
+  font-size: 0.75rem;
+  opacity: 0.75;
+}
+
+.species-preview-grid__error {
+  color: #ff6070;
+  margin: 0;
+}
+
+.species-preview-grid__loading,
+.species-preview-grid__empty {
+  margin: 0;
+  color: rgba(240, 244, 255, 0.75);
+}
+</style>

--- a/webapp/src/components/species/SpeciesQuickActions.vue
+++ b/webapp/src/components/species/SpeciesQuickActions.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="species-quick-actions">
+    <button type="button" class="species-quick-actions__button" @click="$emit('export')">
+      Esporta scheda
+    </button>
+    <button type="button" class="species-quick-actions__button species-quick-actions__button--secondary" @click="$emit('save')">
+      Salva nel pack
+    </button>
+  </div>
+</template>
+
+<script setup>
+defineEmits(['export', 'save']);
+</script>
+
+<style scoped>
+.species-quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.species-quick-actions__button {
+  background: linear-gradient(135deg, rgba(39, 121, 255, 0.35), rgba(39, 121, 255, 0.6));
+  border: 1px solid rgba(39, 121, 255, 0.6);
+  color: #f0f4ff;
+  border-radius: 8px;
+  padding: 0.6rem 1.1rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.species-quick-actions__button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(39, 121, 255, 0.25);
+}
+
+.species-quick-actions__button--secondary {
+  background: transparent;
+  border-color: rgba(240, 244, 255, 0.35);
+}
+</style>

--- a/webapp/src/components/species/SpeciesRevisionTimeline.vue
+++ b/webapp/src/components/species/SpeciesRevisionTimeline.vue
@@ -1,0 +1,81 @@
+<template>
+  <section class="species-timeline" v-if="entries.length">
+    <h3>Revisioni validate</h3>
+    <ol class="species-timeline__list">
+      <li v-for="entry in entries" :key="entry.id" :class="['species-timeline__entry', `species-timeline__entry--${entry.level}`]">
+        <header>
+          <strong>{{ entry.title }}</strong>
+          <span class="species-timeline__code">{{ entry.code }}</span>
+        </header>
+        <p>{{ entry.message }}</p>
+      </li>
+    </ol>
+  </section>
+</template>
+
+<script setup>
+defineProps({
+  entries: {
+    type: Array,
+    default: () => [],
+  },
+});
+</script>
+
+<style scoped>
+.species-timeline {
+  background: rgba(10, 15, 22, 0.6);
+  padding: 1rem;
+  border-radius: 10px;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.species-timeline h3 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.species-timeline__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.species-timeline__entry {
+  padding: 0.65rem 0.75rem;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.species-timeline__entry header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.species-timeline__entry--warning {
+  border-color: rgba(255, 184, 76, 0.5);
+}
+
+.species-timeline__entry--error {
+  border-color: rgba(255, 96, 104, 0.6);
+}
+
+.species-timeline__code {
+  font-size: 0.75rem;
+  opacity: 0.75;
+}
+
+.species-timeline__entry p {
+  margin: 0;
+  line-height: 1.4;
+}
+</style>

--- a/webapp/src/components/species/SpeciesStatistics.vue
+++ b/webapp/src/components/species/SpeciesStatistics.vue
@@ -1,0 +1,71 @@
+<template>
+  <section class="species-statistics">
+    <h3>Statistiche</h3>
+    <dl class="species-statistics__grid">
+      <div class="species-statistics__stat">
+        <dt>Minaccia</dt>
+        <dd>{{ statistics.threat_tier || 'T?' }}</dd>
+      </div>
+      <div class="species-statistics__stat">
+        <dt>Rarità</dt>
+        <dd>{{ statistics.rarity || 'R?' }}</dd>
+      </div>
+      <div class="species-statistics__stat">
+        <dt>Energia</dt>
+        <dd>{{ statistics.energy_profile || 'n/d' }}</dd>
+      </div>
+      <div class="species-statistics__stat">
+        <dt>Sinergia</dt>
+        <dd>{{ synergy }}</dd>
+      </div>
+    </dl>
+    <slot></slot>
+  </section>
+</template>
+
+<script setup>
+defineProps({
+  statistics: {
+    type: Object,
+    default: () => ({}),
+  },
+  synergy: {
+    type: String,
+    default: 'n/d',
+  },
+});
+</script>
+
+<style scoped>
+.species-statistics {
+  background: rgba(10, 15, 22, 0.6);
+  padding: 1rem;
+  border-radius: 10px;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.species-statistics h3 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.species-statistics__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem 1rem;
+  margin: 0;
+}
+
+.species-statistics__stat dt {
+  font-weight: 600;
+  margin-bottom: 0.1rem;
+  color: rgba(240, 244, 255, 0.75);
+}
+
+.species-statistics__stat dd {
+  margin: 0;
+  font-size: 0.95rem;
+}
+</style>

--- a/webapp/src/components/species/TraitFilterPanel.vue
+++ b/webapp/src/components/species/TraitFilterPanel.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="trait-filter-panel">
+    <div class="trait-filter-panel__group">
+      <h4>Filtra tratti core</h4>
+      <ul>
+        <li v-for="trait in coreOptions" :key="trait">
+          <label>
+            <input type="checkbox" :value="trait" :checked="model.core.includes(trait)" @change="toggleTrait('core', trait, $event)" />
+            {{ trait }}
+          </label>
+        </li>
+      </ul>
+    </div>
+    <div class="trait-filter-panel__group" v-if="derivedOptions.length">
+      <h4>Filtra tratti derivati</h4>
+      <ul>
+        <li v-for="trait in derivedOptions" :key="trait">
+          <label>
+            <input
+              type="checkbox"
+              :value="trait"
+              :checked="model.derived.includes(trait)"
+              @change="toggleTrait('derived', trait, $event)"
+            />
+            {{ trait }}
+          </label>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  coreOptions: {
+    type: Array,
+    default: () => [],
+  },
+  derivedOptions: {
+    type: Array,
+    default: () => [],
+  },
+  modelValue: {
+    type: Object,
+    default: () => ({ core: [], derived: [] }),
+  },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const model = computed({
+  get() {
+    return {
+      core: Array.isArray(props.modelValue.core) ? props.modelValue.core : [],
+      derived: Array.isArray(props.modelValue.derived) ? props.modelValue.derived : [],
+    };
+  },
+  set(value) {
+    emit('update:modelValue', value);
+  },
+});
+
+function toggleTrait(bucket, trait, event) {
+  const checked = event?.target?.checked;
+  const next = {
+    core: [...model.value.core],
+    derived: [...model.value.derived],
+  };
+  const target = next[bucket];
+  const index = target.indexOf(trait);
+  if (checked && index === -1) {
+    target.push(trait);
+  } else if (!checked && index !== -1) {
+    target.splice(index, 1);
+  }
+  model.value = next;
+}
+</script>
+
+<style scoped>
+.trait-filter-panel {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.trait-filter-panel__group h4 {
+  margin: 0 0 0.25rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.trait-filter-panel__group ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.trait-filter-panel__group label {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+}
+</style>

--- a/webapp/src/services/speciesPreviewService.js
+++ b/webapp/src/services/speciesPreviewService.js
@@ -1,0 +1,53 @@
+const DEFAULT_ENDPOINT = '/api/generation/species/batch';
+
+function ensureFetch() {
+  if (typeof fetch === 'function') {
+    return fetch;
+  }
+  if (typeof globalThis !== 'undefined' && typeof globalThis.fetch === 'function') {
+    return globalThis.fetch;
+  }
+  throw new Error('fetch non disponibile nell\'ambiente corrente');
+}
+
+function normaliseEntries(entries) {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  return entries
+    .filter((entry) => entry && Array.isArray(entry.trait_ids) && entry.trait_ids.length)
+    .map((entry) => ({
+      trait_ids: entry.trait_ids,
+      biome_id: entry.biome_id ?? null,
+      seed: entry.seed ?? null,
+      base_name: entry.base_name ?? null,
+      request_id: entry.request_id ?? null,
+      fallback_trait_ids: entry.fallback_trait_ids,
+    }));
+}
+
+export async function requestSpeciesPreviewBatch(entries, options = {}) {
+  const batch = normaliseEntries(entries);
+  if (!batch.length) {
+    return { previews: [], errors: [] };
+  }
+  const endpoint = options.endpoint || DEFAULT_ENDPOINT;
+  const fetchImpl = ensureFetch();
+  const response = await fetchImpl(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ batch }),
+  });
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(errorBody || 'Errore richiesta anteprime specie');
+  }
+  const payload = await response.json();
+  const previews = Array.isArray(payload.results)
+    ? payload.results
+    : Array.isArray(payload.previews)
+      ? payload.previews
+      : [];
+  const errors = Array.isArray(payload.errors) ? payload.errors : [];
+  return { previews, errors };
+}

--- a/webapp/tests/GenerationFlow.spec.ts
+++ b/webapp/tests/GenerationFlow.spec.ts
@@ -31,14 +31,56 @@ function orchestrateSpecies() {
   return JSON.parse(result.stdout);
 }
 
+function orchestrateSpeciesBatch() {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const scriptPath = path.resolve(repoRoot, 'services', 'generation', 'orchestrator.py');
+  const payload = {
+    batch: [
+      {
+        trait_ids: ['artigli_sette_vie', 'coda_frusta_cinetica', 'scheletro_idro_regolante'],
+        seed: 321,
+        base_name: 'Predatore Snapshot',
+        biome_id: 'caverna_risonante',
+      },
+      {
+        trait_ids: ['artigli_sette_vie', 'coda_frusta_cinetica'],
+        seed: 322,
+        base_name: 'Predatore Variant',
+        biome_id: 'caverna_risonante',
+        fallback_trait_ids: ['scheletro_idro_regolante'],
+      },
+    ],
+  };
+  const pythonExecutable = process.env.PYTHON || 'python3';
+  const result = spawnSync(pythonExecutable, [scriptPath, '--action', 'generate-species-batch'], {
+    cwd: repoRoot,
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `orchestrator exited with code ${result.status}`);
+  }
+  return JSON.parse(result.stdout);
+}
+
 describe('Generation flow orchestrato', () => {
   it('renderizza il blueprint orchestrato', () => {
     const response = orchestrateSpecies();
-    const wrapper = mount(SpeciesPanel, { props: { species: response.blueprint } });
+    const batch = orchestrateSpeciesBatch();
+    const wrapper = mount(SpeciesPanel, {
+      props: {
+        species: response.blueprint,
+        validation: response.validation,
+        meta: response.meta,
+        previewBatch: batch.results,
+        autoPreview: false,
+      },
+    });
 
     expect(wrapper.text()).toContain('Predatore Snapshot');
     expect(response.meta.fallback_used).toBe(false);
     expect(Array.isArray(response.validation.messages)).toBe(true);
+    expect(wrapper.text()).toContain('Anteprime sintetiche');
     expect(wrapper.html()).toMatchSnapshot();
   });
 });

--- a/webapp/tests/SpeciesPanel.spec.ts
+++ b/webapp/tests/SpeciesPanel.spec.ts
@@ -1,6 +1,12 @@
-import { mount } from '@vue/test-utils';
-import { describe, expect, it } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import SpeciesPanel from '../src/components/SpeciesPanel.vue';
+
+vi.mock('../src/services/speciesPreviewService', () => ({
+  requestSpeciesPreviewBatch: vi.fn(() => Promise.resolve({ previews: [] })),
+}));
+
+const { requestSpeciesPreviewBatch } = await import('../src/services/speciesPreviewService.js');
 
 const BASE_SPECIES = {
   id: 'synthetic-1d37afd07a',
@@ -26,18 +32,58 @@ const BASE_SPECIES = {
   },
 };
 
+const VALIDATION = {
+  messages: [
+    { level: 'info', code: 'species.schema_version.defaulted', message: 'schema_version mancante' },
+    { level: 'warning', code: 'species.environment_affinity.missing', message: 'environment_affinity non presente' },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe('SpeciesPanel', () => {
-  it('renders species narrative and mechanics', () => {
+  it('renders species narrative and mechanics', async () => {
     const wrapper = mount(SpeciesPanel, {
-      props: { species: BASE_SPECIES },
+      props: { species: BASE_SPECIES, validation: VALIDATION, autoPreview: false },
     });
     expect(wrapper.text()).toContain('Predatore / Coda a Frusta Cinetica');
     expect(wrapper.text()).toContain('Tratti derivati');
+    expect(wrapper.text()).toContain('Revisioni validate');
     expect(wrapper.html()).toMatchSnapshot();
   });
 
   it('renders placeholder when missing species', () => {
     const wrapper = mount(SpeciesPanel);
     expect(wrapper.text()).toContain('Nessuna specie selezionata');
+  });
+
+  it('emits quick action events', async () => {
+    const wrapper = mount(SpeciesPanel, {
+      props: { species: BASE_SPECIES, autoPreview: false },
+    });
+    await wrapper.find('button').trigger('click');
+    await wrapper.findAll('button')[1].trigger('click');
+    expect(wrapper.emitted('export')).toBeTruthy();
+    expect(wrapper.emitted('save')).toBeTruthy();
+  });
+
+  it('requests preview batch when filters change', async () => {
+    const wrapper = mount(SpeciesPanel, {
+      props: { species: BASE_SPECIES },
+    });
+    await flushPromises();
+    await vi.waitFor(() => {
+      expect(requestSpeciesPreviewBatch).toHaveBeenCalled();
+    });
+    const checkbox = wrapper.find('input[type="checkbox"]');
+    expect(checkbox.exists()).toBe(true);
+    const callCount = requestSpeciesPreviewBatch.mock.calls.length;
+    await checkbox.setValue(false);
+    await flushPromises();
+    await vi.waitFor(() => {
+      expect(requestSpeciesPreviewBatch.mock.calls.length).toBeGreaterThan(callCount);
+    });
   });
 });

--- a/webapp/tests/__snapshots__/GenerationFlow.spec.ts.snap
+++ b/webapp/tests/__snapshots__/GenerationFlow.spec.ts.snap
@@ -2,64 +2,174 @@
 
 exports[`Generation flow orchestrato > renderizza il blueprint orchestrato 1`] = `
 "<section data-v-73eb6eb5="" class="species-panel">
-  <header data-v-73eb6eb5="" class="species-panel__header">
-    <h2 data-v-73eb6eb5="" class="species-panel__title">Predatore Snapshot / Scheletro Idro-Regolante</h2>
-    <p data-v-73eb6eb5="" class="species-panel__summary">Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante</p>
+  <header data-v-f805145c="" data-v-73eb6eb5="" class="species-overview">
+    <div data-v-f805145c="" class="species-overview__heading">
+      <h2 data-v-f805145c="" class="species-overview__title">Predatore Snapshot / Scheletro Idro-Regolante</h2>
+      <p data-v-f805145c="" class="species-overview__summary">Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante</p>
+    </div>
+    <p data-v-f805145c="" class="species-overview__description">Sintesi genetica focalizzata su Artigli a Sette Vie e Coda a Frusta Cinetica con impronta morfologica defensive, locomotor, omeostatico, prehensile, structural; comportamento climber. Ottimizzata per biomi: caverna_risonante.</p>
+    <div data-v-78ecd3ce="" data-v-73eb6eb5="" class="species-quick-actions"><button data-v-78ecd3ce="" type="button" class="species-quick-actions__button"> Esporta scheda </button><button data-v-78ecd3ce="" type="button" class="species-quick-actions__button species-quick-actions__button--secondary"> Salva nel pack </button></div>
   </header>
-  <article data-v-73eb6eb5="" class="species-panel__description">
-    <p data-v-73eb6eb5="">Sintesi genetica focalizzata su Artigli a Sette Vie e Coda a Frusta Cinetica con impronta morfologica defensive, locomotor, omeostatico, prehensile, structural; comportamento climber. Ottimizzata per biomi: caverna_risonante.</p>
-  </article>
-  <section data-v-73eb6eb5="" class="species-panel__traits">
-    <h3 data-v-73eb6eb5="">Tratti fondamentali</h3>
-    <ul data-v-73eb6eb5="" class="species-panel__trait-list">
-      <li data-v-73eb6eb5="">artigli_sette_vie</li>
-      <li data-v-73eb6eb5="">coda_frusta_cinetica</li>
-      <li data-v-73eb6eb5="">scheletro_idro_regolante</li>
-    </ul>
-  </section>
-  <section data-v-73eb6eb5="" class="species-panel__traits">
-    <h3 data-v-73eb6eb5="">Tratti derivati</h3>
-    <ul data-v-73eb6eb5="" class="species-panel__trait-list species-panel__trait-list--derived">
-      <li data-v-73eb6eb5="">artigli_sette_vie</li>
-      <li data-v-73eb6eb5="">sacche_galleggianti_ascensoriali</li>
-      <li data-v-73eb6eb5="">struttura_elastica_amorfa</li>
-    </ul>
-  </section>
-  <section data-v-73eb6eb5="" class="species-panel__adaptations">
-    <h3 data-v-73eb6eb5="">Adattamenti</h3>
-    <ul data-v-73eb6eb5="">
-      <li data-v-73eb6eb5="">Dita lunghe e segmentate con punte a uncino multiplo.</li>
-      <li data-v-73eb6eb5="">Precauzione: Angoli di presa limitati se la superficie è perfettamente liscia.</li>
-      <li data-v-73eb6eb5="">Muscolatura della coda densa con tendini e fibre che agiscono come molle.</li>
-      <li data-v-73eb6eb5="">Precauzione: Richiede un periodo di inattività o movimento preparatorio per massimizzare il danno.</li>
-      <li data-v-73eb6eb5="">Struttura ossea porosa capace di scambio rapido di fluidi.</li>
-      <li data-v-73eb6eb5="">Precauzione: Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio.</li>
-    </ul>
-  </section>
-  <section data-v-73eb6eb5="" class="species-panel__behavior">
-    <h3 data-v-73eb6eb5="">Comportamento</h3>
-    <p data-v-73eb6eb5="">climber</p>
-  </section>
-  <section data-v-73eb6eb5="" class="species-panel__statistics">
-    <h3 data-v-73eb6eb5="">Statistiche</h3>
-    <dl data-v-73eb6eb5="">
-      <div data-v-73eb6eb5="" class="species-panel__stat">
-        <dt data-v-73eb6eb5="">Minaccia</dt>
-        <dd data-v-73eb6eb5="">T1</dd>
+  <div data-v-73eb6eb5="" class="species-panel__layout">
+    <section data-v-ae611db0="" data-v-73eb6eb5="" class="species-biology">
+      <div data-v-ae611db0="" class="species-biology__section">
+        <header data-v-ae611db0="" class="species-biology__header">
+          <h3 data-v-ae611db0="">Tratti fondamentali</h3>
+          <div data-v-13adf612="" data-v-73eb6eb5="" class="trait-filter-panel">
+            <div data-v-13adf612="" class="trait-filter-panel__group">
+              <h4 data-v-13adf612="">Filtra tratti core</h4>
+              <ul data-v-13adf612="">
+                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="artigli_sette_vie"> artigli_sette_vie</label></li>
+                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="coda_frusta_cinetica"> coda_frusta_cinetica</label></li>
+                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="scheletro_idro_regolante"> scheletro_idro_regolante</label></li>
+              </ul>
+            </div>
+            <div data-v-13adf612="" class="trait-filter-panel__group">
+              <h4 data-v-13adf612="">Filtra tratti derivati</h4>
+              <ul data-v-13adf612="">
+                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="artigli_sette_vie"> artigli_sette_vie</label></li>
+                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="sacche_galleggianti_ascensoriali"> sacche_galleggianti_ascensoriali</label></li>
+                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="struttura_elastica_amorfa"> struttura_elastica_amorfa</label></li>
+              </ul>
+            </div>
+          </div>
+        </header>
+        <ul data-v-ae611db0="" class="species-biology__trait-list" data-testid="core-traits">
+          <li data-v-ae611db0="">artigli_sette_vie</li>
+          <li data-v-ae611db0="">coda_frusta_cinetica</li>
+          <li data-v-ae611db0="">scheletro_idro_regolante</li>
+        </ul>
       </div>
-      <div data-v-73eb6eb5="" class="species-panel__stat">
-        <dt data-v-73eb6eb5="">Rarità</dt>
-        <dd data-v-73eb6eb5="">R1</dd>
+      <div data-v-ae611db0="" class="species-biology__section">
+        <h3 data-v-ae611db0="">Tratti derivati</h3>
+        <ul data-v-ae611db0="" class="species-biology__trait-list species-biology__trait-list--derived" data-testid="derived-traits">
+          <li data-v-ae611db0="">artigli_sette_vie</li>
+          <li data-v-ae611db0="">sacche_galleggianti_ascensoriali</li>
+          <li data-v-ae611db0="">struttura_elastica_amorfa</li>
+        </ul>
       </div>
-      <div data-v-73eb6eb5="" class="species-panel__stat">
-        <dt data-v-73eb6eb5="">Energia</dt>
-        <dd data-v-73eb6eb5="">medio</dd>
+      <div data-v-ae611db0="" class="species-biology__section">
+        <h3 data-v-ae611db0="">Adattamenti</h3>
+        <ul data-v-ae611db0="" class="species-biology__list">
+          <li data-v-ae611db0="">Dita lunghe e segmentate con punte a uncino multiplo.</li>
+          <li data-v-ae611db0="">Precauzione: Angoli di presa limitati se la superficie è perfettamente liscia.</li>
+          <li data-v-ae611db0="">Muscolatura della coda densa con tendini e fibre che agiscono come molle.</li>
+          <li data-v-ae611db0="">Precauzione: Richiede un periodo di inattività o movimento preparatorio per massimizzare il danno.</li>
+          <li data-v-ae611db0="">Struttura ossea porosa capace di scambio rapido di fluidi.</li>
+          <li data-v-ae611db0="">Precauzione: Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio.</li>
+        </ul>
       </div>
-      <div data-v-73eb6eb5="" class="species-panel__stat">
-        <dt data-v-73eb6eb5="">Sinergia</dt>
-        <dd data-v-73eb6eb5="">17%</dd>
+      <div data-v-ae611db0="" class="species-biology__section">
+        <h3 data-v-ae611db0="">Comportamento</h3>
+        <p data-v-ae611db0="" class="species-biology__behaviour-tags">climber</p>
+        <ul data-v-ae611db0="" class="species-biology__list">
+          <li data-v-ae611db0="">Afferrare superfici irregolari o oggetti multipli.</li>
+          <li data-v-ae611db0="">Arrampicarsi su pareti rocciose o vegetazione densa.</li>
+          <li data-v-ae611db0="">Immagazzinare energia da ogni movimento per un colpo finale potente.</li>
+          <li data-v-ae611db0="">Necessità di un attacco di "sfondamento" dopo movimento preparatorio.</li>
+          <li data-v-ae611db0="">Assorbire o espellere rapidamente acqua dai tessuti ossei per modificare il peso.</li>
+          <li data-v-ae611db0="">Alternare vita terrestre e vita acquatica/aerea.</li>
+        </ul>
       </div>
-    </dl>
+    </section>
+    <aside data-v-73eb6eb5="" class="species-panel__sidebar">
+      <section data-v-e6469edf="" data-v-73eb6eb5="" class="species-statistics">
+        <h3 data-v-e6469edf="">Statistiche</h3>
+        <dl data-v-e6469edf="" class="species-statistics__grid">
+          <div data-v-e6469edf="" class="species-statistics__stat">
+            <dt data-v-e6469edf="">Minaccia</dt>
+            <dd data-v-e6469edf="">T1</dd>
+          </div>
+          <div data-v-e6469edf="" class="species-statistics__stat">
+            <dt data-v-e6469edf="">Rarità</dt>
+            <dd data-v-e6469edf="">R1</dd>
+          </div>
+          <div data-v-e6469edf="" class="species-statistics__stat">
+            <dt data-v-e6469edf="">Energia</dt>
+            <dd data-v-e6469edf="">medio</dd>
+          </div>
+          <div data-v-e6469edf="" class="species-statistics__stat">
+            <dt data-v-e6469edf="">Sinergia</dt>
+            <dd data-v-e6469edf="">17%</dd>
+          </div>
+        </dl>
+        <p data-v-73eb6eb5="" class="species-panel__meta">Tentativi: 1 · Fallback: no</p>
+      </section>
+      <section data-v-5b00ee54="" data-v-73eb6eb5="" class="species-timeline">
+        <h3 data-v-5b00ee54="">Revisioni validate</h3>
+        <ol data-v-5b00ee54="" class="species-timeline__list">
+          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--info">
+            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Info</strong><span data-v-5b00ee54="" class="species-timeline__code">species.schema_version.defaulted</span></header>
+            <p data-v-5b00ee54="">schema_version mancante: impostato a 1.7</p>
+          </li>
+          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--info">
+            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Info</strong><span data-v-5b00ee54="" class="species-timeline__code">species.receipt.defaulted</span></header>
+            <p data-v-5b00ee54="">receipt mancante: impostato a sorgente runtime-generator</p>
+          </li>
+          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--info">
+            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Info</strong><span data-v-5b00ee54="" class="species-timeline__code">species.role.normalized</span></header>
+            <p data-v-5b00ee54="">role_trofico normalizzato a 'evento_ecologico'</p>
+          </li>
+          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--info">
+            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Info</strong><span data-v-5b00ee54="" class="species-timeline__code">species.spawn_rules.density</span></header>
+            <p data-v-5b00ee54="">densita default impostata a moderata</p>
+          </li>
+          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--info">
+            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Info</strong><span data-v-5b00ee54="" class="species-timeline__code">species.balance.encounter_role</span></header>
+            <p data-v-5b00ee54="">encounter_role default impostato a minion</p>
+          </li>
+          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--warning">
+            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Avviso</strong><span data-v-5b00ee54="" class="species-timeline__code">species.environment_affinity.missing</span></header>
+            <p data-v-5b00ee54="">environment_affinity non presente</p>
+          </li>
+          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--warning">
+            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Avviso</strong><span data-v-5b00ee54="" class="species-timeline__code">species.derived_from_environment.missing</span></header>
+            <p data-v-5b00ee54="">derived_from_environment non presente</p>
+          </li>
+        </ol>
+      </section>
+    </aside>
+  </div>
+  <section data-v-38b0498e="" data-v-73eb6eb5="" class="species-preview-grid">
+    <header data-v-38b0498e="" class="species-preview-grid__header">
+      <h3 data-v-38b0498e="">Anteprime sintetiche</h3><button data-v-73eb6eb5="" type="button" class="species-panel__refresh"> Aggiorna batch </button>
+    </header>
+    <div data-v-38b0498e="" class="species-preview-grid__cards">
+      <article data-v-38b0498e="" class="species-preview-card">
+        <header data-v-38b0498e="" class="species-preview-card__header">
+          <h4 data-v-38b0498e="">Predatore Snapshot / Scheletro Idro-Regolante</h4><span data-v-38b0498e="" class="species-preview-card__badge">T1</span>
+        </header>
+        <p data-v-38b0498e="" class="species-preview-card__summary">Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante</p>
+        <dl data-v-38b0498e="" class="species-preview-card__stats">
+          <div data-v-38b0498e="">
+            <dt data-v-38b0498e="">Energia</dt>
+            <dd data-v-38b0498e="">medio</dd>
+          </div>
+          <div data-v-38b0498e="">
+            <dt data-v-38b0498e="">Rarità</dt>
+            <dd data-v-38b0498e="">R1</dd>
+          </div>
+        </dl>
+        <p data-v-38b0498e="" class="species-preview-card__traits">artigli_sette_vie, coda_frusta_cinetica, scheletro_idro_regolante</p>
+      </article>
+      <article data-v-38b0498e="" class="species-preview-card">
+        <header data-v-38b0498e="" class="species-preview-card__header">
+          <h4 data-v-38b0498e="">Predatore Variant / Coda a Frusta Cinetica</h4><span data-v-38b0498e="" class="species-preview-card__badge">T1</span>
+        </header>
+        <p data-v-38b0498e="" class="species-preview-card__summary">Artigli a Sette Vie, Coda a Frusta Cinetica</p>
+        <dl data-v-38b0498e="" class="species-preview-card__stats">
+          <div data-v-38b0498e="">
+            <dt data-v-38b0498e="">Energia</dt>
+            <dd data-v-38b0498e="">medio</dd>
+          </div>
+          <div data-v-38b0498e="">
+            <dt data-v-38b0498e="">Rarità</dt>
+            <dd data-v-38b0498e="">R1</dd>
+          </div>
+        </dl>
+        <p data-v-38b0498e="" class="species-preview-card__traits">artigli_sette_vie, coda_frusta_cinetica</p>
+      </article>
+    </div>
   </section>
 </section>"
 `;

--- a/webapp/tests/__snapshots__/SpeciesPanel.spec.ts.snap
+++ b/webapp/tests/__snapshots__/SpeciesPanel.spec.ts.snap
@@ -2,59 +2,105 @@
 
 exports[`SpeciesPanel > renders species narrative and mechanics 1`] = `
 "<section data-v-73eb6eb5="" class="species-panel">
-  <header data-v-73eb6eb5="" class="species-panel__header">
-    <h2 data-v-73eb6eb5="" class="species-panel__title">Predatore / Coda a Frusta Cinetica</h2>
-    <p data-v-73eb6eb5="" class="species-panel__summary">Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante</p>
+  <header data-v-f805145c="" data-v-73eb6eb5="" class="species-overview">
+    <div data-v-f805145c="" class="species-overview__heading">
+      <h2 data-v-f805145c="" class="species-overview__title">Predatore / Coda a Frusta Cinetica</h2>
+      <p data-v-f805145c="" class="species-overview__summary">Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante</p>
+    </div>
+    <p data-v-f805145c="" class="species-overview__description">Sintesi genetica focalizzata su Artigli a Sette Vie e Coda a Frusta Cinetica con impronta morfologica defensive, locomotor, omeostatico, prehensile, structural; comportamento climber. Ottimizzata per biomi: caverna_risonante.</p>
+    <div data-v-78ecd3ce="" data-v-73eb6eb5="" class="species-quick-actions"><button data-v-78ecd3ce="" type="button" class="species-quick-actions__button"> Esporta scheda </button><button data-v-78ecd3ce="" type="button" class="species-quick-actions__button species-quick-actions__button--secondary"> Salva nel pack </button></div>
   </header>
-  <article data-v-73eb6eb5="" class="species-panel__description">
-    <p data-v-73eb6eb5="">Sintesi genetica focalizzata su Artigli a Sette Vie e Coda a Frusta Cinetica con impronta morfologica defensive, locomotor, omeostatico, prehensile, structural; comportamento climber. Ottimizzata per biomi: caverna_risonante.</p>
-  </article>
-  <section data-v-73eb6eb5="" class="species-panel__traits">
-    <h3 data-v-73eb6eb5="">Tratti fondamentali</h3>
-    <ul data-v-73eb6eb5="" class="species-panel__trait-list">
-      <li data-v-73eb6eb5="">Artigli a Sette Vie</li>
-      <li data-v-73eb6eb5="">Coda a Frusta Cinetica</li>
-      <li data-v-73eb6eb5="">Scheletro Idro-Regolante</li>
-    </ul>
-  </section>
-  <section data-v-73eb6eb5="" class="species-panel__traits">
-    <h3 data-v-73eb6eb5="">Tratti derivati</h3>
-    <ul data-v-73eb6eb5="" class="species-panel__trait-list species-panel__trait-list--derived">
-      <li data-v-73eb6eb5="">struttura_elastica_amorfa</li>
-      <li data-v-73eb6eb5="">sacche_galleggianti_ascensoriali</li>
-    </ul>
-  </section>
-  <section data-v-73eb6eb5="" class="species-panel__adaptations">
-    <h3 data-v-73eb6eb5="">Adattamenti</h3>
-    <ul data-v-73eb6eb5="">
-      <li data-v-73eb6eb5="">Dita lunghe</li>
-      <li data-v-73eb6eb5="">Precauzione: vulnerabile ai veleni</li>
-    </ul>
-  </section>
-  <section data-v-73eb6eb5="" class="species-panel__behavior">
-    <h3 data-v-73eb6eb5="">Comportamento</h3>
-    <p data-v-73eb6eb5="">climber</p>
-  </section>
-  <section data-v-73eb6eb5="" class="species-panel__statistics">
-    <h3 data-v-73eb6eb5="">Statistiche</h3>
-    <dl data-v-73eb6eb5="">
-      <div data-v-73eb6eb5="" class="species-panel__stat">
-        <dt data-v-73eb6eb5="">Minaccia</dt>
-        <dd data-v-73eb6eb5="">T3</dd>
+  <div data-v-73eb6eb5="" class="species-panel__layout">
+    <section data-v-ae611db0="" data-v-73eb6eb5="" class="species-biology">
+      <div data-v-ae611db0="" class="species-biology__section">
+        <header data-v-ae611db0="" class="species-biology__header">
+          <h3 data-v-ae611db0="">Tratti fondamentali</h3>
+          <div data-v-13adf612="" data-v-73eb6eb5="" class="trait-filter-panel">
+            <div data-v-13adf612="" class="trait-filter-panel__group">
+              <h4 data-v-13adf612="">Filtra tratti core</h4>
+              <ul data-v-13adf612="">
+                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="Artigli a Sette Vie"> Artigli a Sette Vie</label></li>
+                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="Coda a Frusta Cinetica"> Coda a Frusta Cinetica</label></li>
+                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="Scheletro Idro-Regolante"> Scheletro Idro-Regolante</label></li>
+              </ul>
+            </div>
+            <div data-v-13adf612="" class="trait-filter-panel__group">
+              <h4 data-v-13adf612="">Filtra tratti derivati</h4>
+              <ul data-v-13adf612="">
+                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="struttura_elastica_amorfa"> struttura_elastica_amorfa</label></li>
+                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="sacche_galleggianti_ascensoriali"> sacche_galleggianti_ascensoriali</label></li>
+              </ul>
+            </div>
+          </div>
+        </header>
+        <ul data-v-ae611db0="" class="species-biology__trait-list" data-testid="core-traits">
+          <li data-v-ae611db0="">Artigli a Sette Vie</li>
+          <li data-v-ae611db0="">Coda a Frusta Cinetica</li>
+          <li data-v-ae611db0="">Scheletro Idro-Regolante</li>
+        </ul>
       </div>
-      <div data-v-73eb6eb5="" class="species-panel__stat">
-        <dt data-v-73eb6eb5="">Rarità</dt>
-        <dd data-v-73eb6eb5="">R2</dd>
+      <div data-v-ae611db0="" class="species-biology__section">
+        <h3 data-v-ae611db0="">Tratti derivati</h3>
+        <ul data-v-ae611db0="" class="species-biology__trait-list species-biology__trait-list--derived" data-testid="derived-traits">
+          <li data-v-ae611db0="">struttura_elastica_amorfa</li>
+          <li data-v-ae611db0="">sacche_galleggianti_ascensoriali</li>
+        </ul>
       </div>
-      <div data-v-73eb6eb5="" class="species-panel__stat">
-        <dt data-v-73eb6eb5="">Energia</dt>
-        <dd data-v-73eb6eb5="">medio</dd>
+      <div data-v-ae611db0="" class="species-biology__section">
+        <h3 data-v-ae611db0="">Adattamenti</h3>
+        <ul data-v-ae611db0="" class="species-biology__list">
+          <li data-v-ae611db0="">Dita lunghe</li>
+          <li data-v-ae611db0="">Precauzione: vulnerabile ai veleni</li>
+        </ul>
       </div>
-      <div data-v-73eb6eb5="" class="species-panel__stat">
-        <dt data-v-73eb6eb5="">Sinergia</dt>
-        <dd data-v-73eb6eb5="">42%</dd>
+      <div data-v-ae611db0="" class="species-biology__section">
+        <h3 data-v-ae611db0="">Comportamento</h3>
+        <p data-v-ae611db0="" class="species-biology__behaviour-tags">climber</p>
+        <!--v-if-->
       </div>
-    </dl>
+    </section>
+    <aside data-v-73eb6eb5="" class="species-panel__sidebar">
+      <section data-v-e6469edf="" data-v-73eb6eb5="" class="species-statistics">
+        <h3 data-v-e6469edf="">Statistiche</h3>
+        <dl data-v-e6469edf="" class="species-statistics__grid">
+          <div data-v-e6469edf="" class="species-statistics__stat">
+            <dt data-v-e6469edf="">Minaccia</dt>
+            <dd data-v-e6469edf="">T3</dd>
+          </div>
+          <div data-v-e6469edf="" class="species-statistics__stat">
+            <dt data-v-e6469edf="">Rarità</dt>
+            <dd data-v-e6469edf="">R2</dd>
+          </div>
+          <div data-v-e6469edf="" class="species-statistics__stat">
+            <dt data-v-e6469edf="">Energia</dt>
+            <dd data-v-e6469edf="">medio</dd>
+          </div>
+          <div data-v-e6469edf="" class="species-statistics__stat">
+            <dt data-v-e6469edf="">Sinergia</dt>
+            <dd data-v-e6469edf="">42%</dd>
+          </div>
+        </dl>
+      </section>
+      <section data-v-5b00ee54="" data-v-73eb6eb5="" class="species-timeline">
+        <h3 data-v-5b00ee54="">Revisioni validate</h3>
+        <ol data-v-5b00ee54="" class="species-timeline__list">
+          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--info">
+            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Info</strong><span data-v-5b00ee54="" class="species-timeline__code">species.schema_version.defaulted</span></header>
+            <p data-v-5b00ee54="">schema_version mancante</p>
+          </li>
+          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--warning">
+            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Avviso</strong><span data-v-5b00ee54="" class="species-timeline__code">species.environment_affinity.missing</span></header>
+            <p data-v-5b00ee54="">environment_affinity non presente</p>
+          </li>
+        </ol>
+      </section>
+    </aside>
+  </div>
+  <section data-v-38b0498e="" data-v-73eb6eb5="" class="species-preview-grid">
+    <header data-v-38b0498e="" class="species-preview-grid__header">
+      <h3 data-v-38b0498e="">Anteprime sintetiche</h3><button data-v-73eb6eb5="" type="button" class="species-panel__refresh"> Aggiorna batch </button>
+    </header>
+    <p data-v-38b0498e="" class="species-preview-grid__empty">Nessuna anteprima disponibile.</p>
   </section>
 </section>"
 `;


### PR DESCRIPTION
## Summary
- refactor SpeciesPanel into modular overview, biology, statistics, quick actions, timeline and preview components
- add trait filter panel with batch preview service wired to the orchestrator batch endpoint
- extend generation orchestrator and bridge to support batch requests and expose new API endpoint with updated tests

## Testing
- npm test -- --update
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690181f439b88332ba25c5cadc7e4422