### PR TITLE
Add biome synthesis setup workflow and runtime validation UI

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -32,9 +32,12 @@ import {
   demoEncounter,
   orchestratorSnapshot,
   globalTimeline,
+  biomeSynthesisConfig,
+  demoBiomeGraph,
 } from './state/demoOrchestration.js';
 import OverviewView from './views/OverviewView.vue';
 import SpeciesView from './views/SpeciesView.vue';
+import BiomeSetupView from './views/BiomeSetupView.vue';
 import BiomesView from './views/BiomesView.vue';
 import EncounterView from './views/EncounterView.vue';
 import PublishingView from './views/PublishingView.vue';
@@ -51,6 +54,12 @@ flow.updateMetrics('species', {
   completed: orchestratorSnapshot.species.curated,
   total: orchestratorSnapshot.species.total,
   label: 'Specie',
+});
+
+flow.updateMetrics('biomeSetup', {
+  completed: orchestratorSnapshot.biomeSetup.prepared,
+  total: orchestratorSnapshot.biomeSetup.total,
+  label: 'Preset',
 });
 
 flow.updateMetrics('biomes', {
@@ -79,6 +88,7 @@ const summary = flow.summary;
 const viewMap = {
   overview: OverviewView,
   species: SpeciesView,
+  biomeSetup: BiomeSetupView,
   biomes: BiomesView,
   encounter: EncounterView,
   publishing: PublishingView,
@@ -93,6 +103,13 @@ const activeProps = computed(() => {
   }
   if (id === 'species') {
     return { species: demoSpecies, status: orchestratorSnapshot.species };
+  }
+  if (id === 'biomeSetup') {
+    return {
+      config: biomeSynthesisConfig,
+      graph: demoBiomeGraph,
+      validators: demoBiomes,
+    };
   }
   if (id === 'biomes') {
     return { biomes: demoBiomes };

--- a/webapp/src/components/biomes/BiomeSynthesisMap.vue
+++ b/webapp/src/components/biomes/BiomeSynthesisMap.vue
@@ -1,0 +1,294 @@
+<template>
+  <section class="synthesis-map">
+    <header class="synthesis-map__header">
+      <div>
+        <h3>Schema modulare</h3>
+        <p>Visualizza i nodi generati e le connessioni tattiche previste.</p>
+      </div>
+      <button type="button" class="synthesis-map__action" @click="$emit('regenerate:layout')">
+        Rigenera layout
+      </button>
+    </header>
+
+    <div class="synthesis-map__canvas-wrapper">
+      <svg class="synthesis-map__canvas" viewBox="0 0 360 240" role="img">
+        <defs>
+          <pattern id="tile-grid" width="24" height="24" patternUnits="userSpaceOnUse">
+            <path d="M24 0 H0 V24" fill="none" stroke="rgba(255,255,255,0.05)" stroke-width="1" />
+          </pattern>
+        </defs>
+        <rect x="0" y="0" width="360" height="240" fill="url(#tile-grid)" />
+        <g class="synthesis-map__connections">
+          <line
+            v-for="connection in connections"
+            :key="connection.id"
+            :x1="positionFor(connection.from).x"
+            :y1="positionFor(connection.from).y"
+            :x2="positionFor(connection.to).x"
+            :y2="positionFor(connection.to).y"
+            :stroke-width="1.5 + connection.weight * 0.6"
+            :class="['synthesis-map__connection', `synthesis-map__connection--w${connection.weight}`]"
+          />
+        </g>
+        <g class="synthesis-map__nodes">
+          <g
+            v-for="node in nodes"
+            :key="node.id"
+            class="synthesis-map__node"
+            :transform="`translate(${positionFor(node.id).x} ${positionFor(node.id).y})`"
+          >
+            <circle :r="18" :class="[`synthesis-map__node-circle`, `synthesis-map__node-circle--${node.type}`]" />
+            <text class="synthesis-map__node-label" y="32">{{ node.label }}</text>
+            <text class="synthesis-map__node-metric" y="-26">{{ formatIntensity(node.intensity) }}</text>
+          </g>
+        </g>
+      </svg>
+    </div>
+
+    <div class="synthesis-map__legend">
+      <section>
+        <h4>Nodi</h4>
+        <ul>
+          <li v-for="node in nodes" :key="node.id">
+            <div>
+              <strong>{{ node.label }}</strong>
+              <span>{{ describeNode(node.type) }}</span>
+            </div>
+            <button type="button" @click="$emit('regenerate:node', node.id)">Rigenera</button>
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h4>Connessioni</h4>
+        <ul>
+          <li v-for="connection in connections" :key="connection.id">
+            <div>
+              <strong>{{ prettyConnection(connection) }}</strong>
+              <span>Intensità {{ connection.weight }}</span>
+            </div>
+            <button type="button" @click="$emit('regenerate:connection', connection.id)">Rigenera</button>
+          </li>
+        </ul>
+      </section>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  nodes: {
+    type: Array,
+    default: () => [],
+  },
+  connections: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const nodeLookup = computed(() => {
+  const map = new Map();
+  props.nodes.forEach((node) => {
+    map.set(node.id, node);
+  });
+  return map;
+});
+
+const formatIntensity = (value) => `${Math.round(value * 100)}%`;
+
+const positionFor = (nodeId) => {
+  const node = nodeLookup.value.get(nodeId);
+  if (!node) {
+    return { x: 0, y: 0 };
+  }
+  return node.position || { x: 0, y: 0 };
+};
+
+const describeNode = (type) => {
+  const descriptions = {
+    staging: 'Smistamento squadre',
+    ambush: 'Punto di agguato',
+    lure: 'Innesco diversivo',
+    safe: 'Nodo di recupero',
+  };
+  return descriptions[type] || 'Nodo operativo';
+};
+
+const prettyConnection = (connection) => {
+  const from = nodeLookup.value.get(connection.from)?.label || connection.from;
+  const to = nodeLookup.value.get(connection.to)?.label || connection.to;
+  return `${from} → ${to}`;
+};
+</script>
+
+<style scoped>
+.synthesis-map {
+  background: rgba(9, 14, 20, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: 1.25rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.synthesis-map__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.synthesis-map__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.synthesis-map__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(240, 244, 255, 0.6);
+}
+
+.synthesis-map__action {
+  background: rgba(16, 24, 34, 0.92);
+  border: 1px solid rgba(96, 213, 255, 0.35);
+  border-radius: 10px;
+  padding: 0.55rem 0.95rem;
+  color: #f0f4ff;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.synthesis-map__action:hover {
+  transform: translateY(-1px);
+  border-color: rgba(96, 213, 255, 0.65);
+}
+
+.synthesis-map__canvas-wrapper {
+  position: relative;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.synthesis-map__canvas {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: rgba(11, 17, 25, 0.9);
+  border-radius: 16px;
+}
+
+.synthesis-map__connection {
+  stroke: rgba(96, 213, 255, 0.55);
+  stroke-linecap: round;
+}
+
+.synthesis-map__connection--w1 {
+  stroke: rgba(96, 213, 255, 0.4);
+}
+
+.synthesis-map__connection--w2 {
+  stroke: rgba(142, 227, 255, 0.65);
+}
+
+.synthesis-map__connection--w3,
+.synthesis-map__connection--w4 {
+  stroke: rgba(161, 255, 212, 0.85);
+}
+
+.synthesis-map__node-circle {
+  fill: rgba(15, 23, 34, 0.95);
+  stroke-width: 2;
+}
+
+.synthesis-map__node-circle--staging {
+  stroke: rgba(96, 213, 255, 0.7);
+}
+
+.synthesis-map__node-circle--ambush {
+  stroke: rgba(255, 169, 105, 0.8);
+}
+
+.synthesis-map__node-circle--lure {
+  stroke: rgba(207, 145, 255, 0.75);
+}
+
+.synthesis-map__node-circle--safe {
+  stroke: rgba(129, 255, 199, 0.8);
+}
+
+.synthesis-map__node-label {
+  fill: rgba(240, 244, 255, 0.9);
+  font-size: 0.7rem;
+  text-anchor: middle;
+}
+
+.synthesis-map__node-metric {
+  fill: rgba(240, 244, 255, 0.55);
+  font-size: 0.65rem;
+  text-anchor: middle;
+}
+
+.synthesis-map__legend {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.synthesis-map__legend section {
+  background: rgba(11, 17, 25, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.synthesis-map__legend h4 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.synthesis-map__legend ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.synthesis-map__legend li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.synthesis-map__legend strong {
+  display: block;
+  font-size: 0.85rem;
+}
+
+.synthesis-map__legend span {
+  display: block;
+  font-size: 0.75rem;
+  color: rgba(240, 244, 255, 0.6);
+}
+
+.synthesis-map__legend button {
+  background: rgba(16, 24, 34, 0.92);
+  border: 1px solid rgba(207, 145, 255, 0.35);
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  color: #f0f4ff;
+  cursor: pointer;
+  font-size: 0.75rem;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.synthesis-map__legend button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(207, 145, 255, 0.6);
+}
+</style>

--- a/webapp/src/state/demoOrchestration.js
+++ b/webapp/src/state/demoOrchestration.js
@@ -29,23 +29,82 @@ export const demoBiomes = reactive([
     id: 'twilight-marsh',
     name: 'Paludi del Crepuscolo',
     climate: 'Umido temperato',
+    hazard: 'Nebbia fotonica instabile',
     risk: 'Moderato',
     focus: 'Nebbia fotonica pulsante',
     opportunities: ['Creare corridoi acustici', 'Reindirizzare i riflettori naturali'],
     readiness: 3,
     total: 5,
+    validators: [
+      {
+        id: 'fog-density',
+        label: 'Densità della nebbia',
+        status: 'passed',
+        message: 'Gradienti fotonici entro la banda consentita per i branchi nebulosi.',
+      },
+      {
+        id: 'thermal-vents',
+        label: 'Sfiati termici',
+        status: 'warning',
+        message: 'Rilevate pulsazioni sporadiche: consigliare modulazione dei filtri respiratori.',
+      },
+    ],
   },
   {
     id: 'obsidian-ridge',
     name: 'Cresta di Ossidiana',
     climate: 'Freddo secco',
+    hazard: 'Venti taglienti cristallizzati',
     risk: 'Elevato',
     focus: 'Canaloni lavici cristallizzati',
     opportunities: ['Proiezioni sonore a lunga distanza', 'Nascondigli naturali multilivello'],
     readiness: 2,
     total: 4,
+    validators: [
+      {
+        id: 'stability',
+        label: 'Stabilità dei camminamenti',
+        status: 'failed',
+        message: 'Cedimenti ripetuti nelle passerelle basalte: richiede rinforzo prima del deploy.',
+      },
+      {
+        id: 'visibility',
+        label: 'Visibilità notturna',
+        status: 'passed',
+        message: 'Rifrazioni luminose controllate: i marker tattici sono visibili ai branchi.',
+      },
+    ],
   },
 ]);
+
+export const biomeSynthesisConfig = reactive({
+  hazard: 'Nebbia fotonica instabile',
+  hazardOptions: [
+    'Nebbia fotonica instabile',
+    'Radiazione prismatica impulsiva',
+    'Correnti elettrostatiche latenti',
+  ],
+  climate: 'Umido temperato',
+  climateOptions: ['Umido temperato', 'Freddo secco', 'Subtropicale ventilato'],
+  requiredRoles: ['Scout fotonico', 'Controller ambientale'],
+  roleCatalog: ['Scout fotonico', 'Controller ambientale', 'Supporto tattico', 'Biologo da campo'],
+  graphicSeed: 'NEBULA-42A',
+});
+
+export const demoBiomeGraph = reactive({
+  nodes: [
+    { id: 'hub', label: 'Nodo di staging', type: 'staging', intensity: 0.82 },
+    { id: 'ambush', label: 'Set ambush', type: 'ambush', intensity: 0.67 },
+    { id: 'lure', label: 'Piazzola esca', type: 'lure', intensity: 0.54 },
+    { id: 'retreat', label: 'Ritro retrattile', type: 'safe', intensity: 0.73 },
+  ],
+  connections: [
+    { id: 'edge-1', from: 'hub', to: 'ambush', weight: 3 },
+    { id: 'edge-2', from: 'ambush', to: 'lure', weight: 2 },
+    { id: 'edge-3', from: 'lure', to: 'retreat', weight: 1 },
+    { id: 'edge-4', from: 'hub', to: 'retreat', weight: 2 },
+  ],
+});
 
 export const demoEncounter = reactive({
   templateName: 'Assalto Nella Nebbia',
@@ -146,6 +205,10 @@ export const orchestratorSnapshot = reactive({
     artifactsReady: 2,
     totalArtifacts: 5,
     channels: ['Compendio digitale', 'Brief video'],
+  },
+  biomeSetup: {
+    prepared: 1,
+    total: 3,
   },
 });
 

--- a/webapp/src/state/flowMachine.js
+++ b/webapp/src/state/flowMachine.js
@@ -14,6 +14,12 @@ const BASE_STEPS = [
     description: 'Selezione e revisione delle specie protagoniste.',
   },
   {
+    id: 'biomeSetup',
+    title: 'Setup Biomi',
+    caption: 'Parametri di sintesi',
+    description: 'Definizione dei vincoli ambientali prima della generazione.',
+  },
+  {
     id: 'biomes',
     title: 'Biomi',
     caption: 'Scenari ecologici',

--- a/webapp/src/views/BiomeSetupView.vue
+++ b/webapp/src/views/BiomeSetupView.vue
@@ -1,0 +1,426 @@
+<template>
+  <section class="flow-view biome-setup">
+    <header class="flow-view__header">
+      <h2>Pre-sintesi biomi</h2>
+      <p>Definisci vincoli critici e ruoli necessari prima di invocare il biomeSynthesizer.</p>
+    </header>
+
+    <div class="biome-setup__grid">
+      <form class="biome-setup__panel" @submit.prevent="queueSynthesis">
+        <fieldset>
+          <legend>Perimetro ambientale</legend>
+          <label>
+            <span>Hazard dominante</span>
+            <select v-model="state.hazard">
+              <option v-for="option in hazardOptions" :key="option" :value="option">{{ option }}</option>
+            </select>
+          </label>
+          <label>
+            <span>Clima operativo</span>
+            <select v-model="state.climate">
+              <option v-for="option in climateOptions" :key="option" :value="option">{{ option }}</option>
+            </select>
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend>Ruoli richiesti</legend>
+          <div class="role-grid">
+            <label v-for="role in roleCatalog" :key="role">
+              <input type="checkbox" :value="role" v-model="state.requiredRoles" />
+              <span>{{ role }}</span>
+            </label>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend>Seed grafico</legend>
+          <div class="seed-row">
+            <input v-model="state.graphicSeed" type="text" placeholder="Inserisci seed procedurale" />
+            <button type="button" @click="randomizeSeed">Random</button>
+          </div>
+        </fieldset>
+
+        <footer class="biome-setup__actions">
+          <button type="submit" :disabled="!canSynthesize">Invoca biomeSynthesizer</button>
+          <p class="biome-setup__hint">
+            Il seed e i ruoli selezionati verranno passati come contesto obbligatorio per i nodi rigenerati.
+          </p>
+        </footer>
+      </form>
+
+      <BiomeSynthesisMap
+        :nodes="graphState.nodes"
+        :connections="graphState.connections"
+        @regenerate:layout="regenerateLayout"
+        @regenerate:node="regenerateNode"
+        @regenerate:connection="regenerateConnection"
+      />
+    </div>
+
+    <section class="biome-setup__validators">
+      <header>
+        <h3>Feedback dai validator runtime</h3>
+        <p>Monitoraggio in tempo reale delle anomalie per bioma.</p>
+      </header>
+      <ul>
+        <li v-for="item in validationDigest" :key="item.id" :class="`status-${item.status}`">
+          <div class="biome-setup__validator-title">
+            <strong>{{ item.biome }}</strong>
+            <span>{{ item.label }}</span>
+          </div>
+          <p>{{ item.message }}</p>
+        </li>
+      </ul>
+    </section>
+  </section>
+</template>
+
+<script setup>
+import { computed, reactive, watch } from 'vue';
+import BiomeSynthesisMap from '../components/biomes/BiomeSynthesisMap.vue';
+
+const props = defineProps({
+  config: {
+    type: Object,
+    default: () => ({}),
+  },
+  graph: {
+    type: Object,
+    default: () => ({ nodes: [], connections: [] }),
+  },
+  validators: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const emit = defineEmits(['synthesize']);
+
+const state = reactive({
+  hazard: '',
+  climate: '',
+  requiredRoles: [],
+  graphicSeed: '',
+});
+
+const graphState = reactive({
+  nodes: [],
+  connections: [],
+});
+
+const hazardOptions = computed(() => props.config?.hazardOptions || []);
+const climateOptions = computed(() => props.config?.climateOptions || []);
+const roleCatalog = computed(() => props.config?.roleCatalog || []);
+
+const canSynthesize = computed(
+  () => state.hazard && state.climate && state.requiredRoles.length > 0 && state.graphicSeed
+);
+
+const validationDigest = computed(() => {
+  return props.validators.flatMap((biome) => {
+    return (biome.validators || []).map((validator) => ({
+      id: `${biome.id}-${validator.id}`,
+      biome: biome.name,
+      status: validator.status,
+      label: validator.label,
+      message: validator.message,
+    }));
+  });
+});
+
+const syncConfig = () => {
+  state.hazard = props.config?.hazard || '';
+  state.climate = props.config?.climate || '';
+  state.graphicSeed = props.config?.graphicSeed || '';
+  state.requiredRoles = [...(props.config?.requiredRoles || [])];
+};
+
+const randomPosition = () => ({
+  x: 60 + Math.random() * 240,
+  y: 60 + Math.random() * 140,
+});
+
+const createNodeState = (node) => ({
+  ...node,
+  position: node.position || randomPosition(),
+});
+
+const createConnectionState = (connection) => ({
+  ...connection,
+});
+
+const syncGraph = () => {
+  graphState.nodes = (props.graph?.nodes || []).map((node) => createNodeState(node));
+  graphState.connections = (props.graph?.connections || []).map((connection) =>
+    createConnectionState(connection)
+  );
+};
+
+const bumpIntensity = (node) => {
+  const baseline = Number.isFinite(node.intensity) ? node.intensity : 0.55;
+  const next = Math.max(0.35, Math.min(0.95, baseline + (Math.random() * 0.4 - 0.2)));
+  node.intensity = Number(next.toFixed(2));
+};
+
+const regenerateNode = (nodeId) => {
+  const node = graphState.nodes.find((item) => item.id === nodeId);
+  if (!node) {
+    return;
+  }
+  node.position = randomPosition();
+  bumpIntensity(node);
+};
+
+const regenerateConnection = (connectionId) => {
+  const connection = graphState.connections.find((item) => item.id === connectionId);
+  if (!connection) {
+    return;
+  }
+  const delta = Math.round(Math.random() * 2 - 1);
+  connection.weight = Math.max(1, connection.weight + delta);
+};
+
+const regenerateLayout = () => {
+  graphState.nodes.forEach((node) => {
+    node.position = randomPosition();
+    bumpIntensity(node);
+  });
+};
+
+const randomizeSeed = () => {
+  const stamp = Math.random().toString(16).slice(2, 8).toUpperCase();
+  state.graphicSeed = `${state.hazard?.split(' ')[0] || 'BIOME'}-${stamp}`;
+};
+
+const queueSynthesis = () => {
+  if (!canSynthesize.value) {
+    return;
+  }
+  emit('synthesize', {
+    hazard: state.hazard,
+    climate: state.climate,
+    requiredRoles: [...state.requiredRoles],
+    graphicSeed: state.graphicSeed,
+    graph: {
+      nodes: graphState.nodes.map((node) => ({
+        id: node.id,
+        position: node.position,
+        intensity: node.intensity,
+      })),
+      connections: graphState.connections.map((connection) => ({
+        id: connection.id,
+        weight: connection.weight,
+      })),
+    },
+  });
+};
+
+watch(
+  () => [props.config?.hazard, props.config?.climate, props.config?.graphicSeed],
+  syncConfig,
+  { immediate: true }
+);
+
+watch(
+  () => props.config?.requiredRoles && [...props.config.requiredRoles],
+  () => {
+    state.requiredRoles = [...(props.config?.requiredRoles || [])];
+  },
+  { immediate: true }
+);
+
+watch(
+  () => [props.graph?.nodes?.length, props.graph?.connections?.length],
+  syncGraph,
+  { immediate: true }
+);
+</script>
+
+<style scoped>
+.biome-setup {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.biome-setup__grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+
+.biome-setup__panel {
+  background: rgba(9, 14, 20, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: 1.2rem;
+  display: grid;
+  gap: 1.1rem;
+}
+
+.biome-setup__panel fieldset {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 0.95rem;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.biome-setup__panel legend {
+  padding: 0 0.4rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(240, 244, 255, 0.6);
+}
+
+.biome-setup__panel label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.biome-setup__panel select,
+.biome-setup__panel input[type='text'] {
+  background: rgba(16, 24, 34, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  padding: 0.55rem 0.7rem;
+  color: #f0f4ff;
+}
+
+.role-grid {
+  display: grid;
+  gap: 0.45rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.role-grid label {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.35rem 0.45rem;
+  border-radius: 10px;
+  background: rgba(16, 24, 34, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.role-grid input {
+  accent-color: #61d5ff;
+}
+
+.seed-row {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.seed-row button {
+  background: rgba(16, 24, 34, 0.92);
+  border: 1px solid rgba(207, 145, 255, 0.35);
+  border-radius: 10px;
+  padding: 0.5rem 0.9rem;
+  color: #f0f4ff;
+  cursor: pointer;
+}
+
+.biome-setup__actions {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.biome-setup__actions button {
+  background: linear-gradient(90deg, rgba(96, 213, 255, 0.8), rgba(161, 255, 212, 0.8));
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.2rem;
+  color: #06101a;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.biome-setup__actions button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.biome-setup__actions button:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+.biome-setup__hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: rgba(240, 244, 255, 0.6);
+}
+
+.biome-setup__validators {
+  background: rgba(9, 14, 20, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: 1.2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.biome-setup__validators header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.biome-setup__validators header p {
+  margin: 0.35rem 0 0;
+  color: rgba(240, 244, 255, 0.6);
+}
+
+.biome-setup__validators ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.biome-setup__validators li {
+  border-radius: 12px;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(16, 24, 34, 0.8);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.biome-setup__validator-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.biome-setup__validator-title strong {
+  font-size: 0.9rem;
+}
+
+.biome-setup__validator-title span {
+  font-size: 0.75rem;
+  color: rgba(240, 244, 255, 0.65);
+}
+
+.biome-setup__validators li p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(240, 244, 255, 0.75);
+}
+
+.status-passed {
+  border-color: rgba(129, 255, 199, 0.6);
+}
+
+.status-warning {
+  border-color: rgba(255, 210, 130, 0.6);
+}
+
+.status-failed {
+  border-color: rgba(255, 135, 135, 0.6);
+}
+</style>

--- a/webapp/src/views/BiomesView.vue
+++ b/webapp/src/views/BiomesView.vue
@@ -11,8 +11,22 @@
           <span class="biome-card__badge">{{ biome.climate }}</span>
         </header>
         <p class="biome-card__focus">{{ biome.focus }}</p>
+        <p class="biome-card__hazard"><strong>Hazard:</strong> {{ biome.hazard }}</p>
         <ul>
           <li v-for="item in biome.opportunities" :key="item">{{ item }}</li>
+        </ul>
+        <ul class="biome-card__validators">
+          <li
+            v-for="validator in biome.validators || []"
+            :key="validator.id"
+            :class="`validator validator--${validator.status}`"
+          >
+            <span class="validator__marker"></span>
+            <div>
+              <strong>{{ validator.label }}</strong>
+              <p>{{ validator.message }}</p>
+            </div>
+          </li>
         </ul>
         <footer>
           <div class="biome-card__meter">
@@ -104,6 +118,16 @@ const readinessPercent = (biome) => {
   color: rgba(240, 244, 255, 0.75);
 }
 
+.biome-card__hazard {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(240, 244, 255, 0.65);
+}
+
+.biome-card__hazard strong {
+  color: rgba(240, 244, 255, 0.85);
+}
+
 .biome-card ul {
   margin: 0;
   padding-left: 1.25rem;
@@ -126,5 +150,66 @@ const readinessPercent = (biome) => {
 
 small {
   color: rgba(240, 244, 255, 0.6);
+}
+
+.biome-card__validators {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.validator {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.55rem;
+  padding: 0.5rem 0.6rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 18, 26, 0.75);
+}
+
+.validator strong {
+  font-size: 0.8rem;
+  color: rgba(240, 244, 255, 0.9);
+}
+
+.validator p {
+  margin: 0.15rem 0 0;
+  font-size: 0.75rem;
+  color: rgba(240, 244, 255, 0.7);
+}
+
+.validator__marker {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  margin-top: 0.2rem;
+  background: rgba(240, 244, 255, 0.35);
+}
+
+.validator--passed {
+  border-color: rgba(129, 255, 199, 0.55);
+}
+
+.validator--passed .validator__marker {
+  background: rgba(129, 255, 199, 0.85);
+}
+
+.validator--warning {
+  border-color: rgba(255, 210, 130, 0.6);
+}
+
+.validator--warning .validator__marker {
+  background: rgba(255, 210, 130, 0.85);
+}
+
+.validator--failed {
+  border-color: rgba(255, 135, 135, 0.6);
+}
+
+.validator--failed .validator__marker {
+  background: rgba(255, 135, 135, 0.85);
 }
 </style>


### PR DESCRIPTION
## Summary
- insert a dedicated biome setup step with form controls and modular graph map to prepare biome synthesis
- provide reusable BiomeSynthesisMap component with regeneration controls for nodes and connections
- surface runtime validator feedback both within the setup view and inline on biome cards using enriched demo data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690185533dac833297687fba45878eba