### PR TITLE
Fix biome synthesis payload to include connection endpoints

### DIFF
--- a/webapp/src/views/BiomeSetupView.vue
+++ b/webapp/src/views/BiomeSetupView.vue
@@ -210,6 +210,8 @@ const queueSynthesis = () => {
       })),
       connections: graphState.connections.map((connection) => ({
         id: connection.id,
+        from: connection.from,
+        to: connection.to,
         weight: connection.weight,
       })),
     },


### PR DESCRIPTION
## Summary
- ensure biome synthesis emits connection endpoint metadata when forwarding graph state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901881752088332a60674c1e31033d0