### PR TITLE
Add Quality & Release validations and publishing workflow UI

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -34,6 +34,7 @@ import {
   globalTimeline,
   biomeSynthesisConfig,
   demoBiomeGraph,
+  qualityReleaseContext,
 } from './state/demoOrchestration.js';
 import OverviewView from './views/OverviewView.vue';
 import SpeciesView from './views/SpeciesView.vue';
@@ -41,6 +42,7 @@ import BiomeSetupView from './views/BiomeSetupView.vue';
 import BiomesView from './views/BiomesView.vue';
 import EncounterView from './views/EncounterView.vue';
 import PublishingView from './views/PublishingView.vue';
+import QualityReleaseView from './views/QualityReleaseView.vue';
 
 const flow = useGeneratorFlow();
 
@@ -74,6 +76,22 @@ flow.updateMetrics('encounter', {
   label: 'Varianti',
 });
 
+const qualityChecks = orchestratorSnapshot.qualityRelease.checks || {};
+const totalQualityChecks = Object.values(qualityChecks).reduce(
+  (acc, item) => acc + (item.total || 0),
+  0,
+);
+const completedQualityChecks = Object.values(qualityChecks).reduce(
+  (acc, item) => acc + (item.passed || 0),
+  0,
+);
+
+flow.updateMetrics('qualityRelease', {
+  completed: completedQualityChecks,
+  total: totalQualityChecks,
+  label: 'Check QA',
+});
+
 flow.updateMetrics('publishing', {
   completed: orchestratorSnapshot.publishing.artifactsReady,
   total: orchestratorSnapshot.publishing.totalArtifacts,
@@ -91,6 +109,7 @@ const viewMap = {
   biomeSetup: BiomeSetupView,
   biomes: BiomesView,
   encounter: EncounterView,
+  qualityRelease: QualityReleaseView,
   publishing: PublishingView,
 };
 
@@ -116,6 +135,12 @@ const activeProps = computed(() => {
   }
   if (id === 'encounter') {
     return { encounter: demoEncounter, summary: orchestratorSnapshot.encounter };
+  }
+  if (id === 'qualityRelease') {
+    return {
+      snapshot: orchestratorSnapshot.qualityRelease,
+      context: qualityReleaseContext,
+    };
   }
   if (id === 'publishing') {
     return { publishing: orchestratorSnapshot.publishing };

--- a/webapp/src/services/runtimeValidationService.js
+++ b/webapp/src/services/runtimeValidationService.js
@@ -1,0 +1,51 @@
+const DEFAULT_ENDPOINT = '/api/validators/runtime';
+
+function ensureFetch() {
+  if (typeof fetch === 'function') {
+    return fetch;
+  }
+  if (typeof globalThis !== 'undefined' && typeof globalThis.fetch === 'function') {
+    return globalThis.fetch;
+  }
+  throw new Error("fetch non disponibile nell'ambiente corrente");
+}
+
+async function postRuntime(kind, payload, options = {}) {
+  if (!kind) {
+    throw new Error("Parametro 'kind' richiesto per la validazione runtime");
+  }
+  const endpoint = options.endpoint || DEFAULT_ENDPOINT;
+  const fetchImpl = ensureFetch();
+  const response = await fetchImpl(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ kind, payload }),
+  });
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(errorBody || 'Errore validazione runtime');
+  }
+  const body = await response.json();
+  return body && body.result ? body.result : body;
+}
+
+export async function validateSpeciesBatch(entries, context = {}, options = {}) {
+  const payload = {
+    entries: Array.isArray(entries) ? entries : [],
+    biomeId: context.biomeId || null,
+  };
+  return postRuntime('species', payload, options);
+}
+
+export async function validateBiome(biome, context = {}, options = {}) {
+  const payload = {
+    biome: biome || null,
+    defaultHazard: context.defaultHazard || null,
+  };
+  return postRuntime('biome', payload, options);
+}
+
+export async function validateFoodweb(foodweb, options = {}) {
+  const payload = { foodweb: foodweb || null };
+  return postRuntime('foodweb', payload, options);
+}

--- a/webapp/src/state/demoOrchestration.js
+++ b/webapp/src/state/demoOrchestration.js
@@ -201,10 +201,71 @@ export const orchestratorSnapshot = reactive({
     variants: 4,
     warnings: 1,
   },
+  qualityRelease: {
+    checks: {
+      species: { passed: 2, total: 3 },
+      biomes: { passed: 1, total: 2 },
+      foodweb: { passed: 1, total: 1 },
+    },
+    lastRun: '2024-05-18T09:20:00Z',
+    owners: ['QA Core', 'Narrative QA'],
+  },
   publishing: {
     artifactsReady: 2,
     totalArtifacts: 5,
     channels: ['Compendio digitale', 'Brief video'],
+    workflow: {
+      preview: {
+        status: 'ready',
+        owner: 'QA Core',
+        eta: 'Oggi · 15:00',
+        notes: 'Build promossa in staging con fixture aggiornate.',
+      },
+      approval: {
+        status: 'pending',
+        owner: 'Creative Lead',
+        eta: 'Domani · 10:30',
+        notes: 'In attesa di sign-off narrativo e marketing.',
+      },
+      deploy: {
+        status: 'scheduled',
+        owner: 'Web Ops',
+        eta: 'Domani · 18:00',
+        notes: 'Deploy su CDN con finestra di rollback di 30 minuti.',
+      },
+    },
+    history: [
+      {
+        id: 'preview-generated',
+        label: 'Preview generata',
+        author: 'QA Core',
+        timestamp: '2024-05-18 09:10',
+        details: 'Snapshot giocabile caricata sul portale interno.',
+      },
+      {
+        id: 'qa-sync',
+        label: 'Sync QA & Narrative',
+        author: 'Narrative QA',
+        timestamp: '2024-05-18 11:45',
+        details: 'Definite correzioni di localizzazione per il briefing video.',
+      },
+    ],
+    notifications: [
+      {
+        id: 'notif-slack',
+        channel: 'Slack #release-alerts',
+        message: 'Richiesta approvazione finale pubblicazione patch 1.2.',
+        recipients: ['Creative Lead', 'Web Ops'],
+        time: '2024-05-18 11:50',
+      },
+      {
+        id: 'notif-email',
+        channel: 'Email Team Marketing',
+        message: 'Disponibile anteprima aggiornata per campagna social.',
+        recipients: ['Marketing'],
+        time: '2024-05-18 12:05',
+      },
+    ],
   },
   biomeSetup: {
     prepared: 1,
@@ -220,4 +281,115 @@ export const globalTimeline = computed(() => {
     label: `Sincronizzazione ${percent}%`,
     percent,
   };
+});
+
+export const qualityReleaseContext = reactive({
+  orchestrator: {
+    stage: 'QA Freeze',
+    releaseWindow: 'Patch 1.2 · 48h',
+    coordinator: 'QA Core',
+    focusAreas: ['Specie prioritarie', 'Bilanciamento biomi', 'Foodweb narrativo'],
+  },
+  speciesBatch: {
+    entries: [
+      {
+        trait_ids: ['shadow_pack', 'luminous_feral'],
+        biome_id: 'twilight-marsh',
+        seed: 'QA-NEB-01',
+        base_name: 'Lupi Nebbiosi',
+        request_id: 'spec-check-01',
+      },
+      {
+        trait_ids: ['echo_stalker', 'prism_lurker'],
+        biome_id: 'obsidian-ridge',
+        seed: 'QA-OBS-05',
+        base_name: 'Predatori di Risonanza',
+        request_id: 'spec-check-02',
+      },
+      {
+        trait_ids: ['mist_rider', 'thermal_climber'],
+        biome_id: 'twilight-marsh',
+        seed: 'QA-NEB-07',
+        base_name: 'Assaltatori Nebulari',
+        request_id: 'spec-check-03',
+      },
+    ],
+    biomeId: 'twilight-marsh',
+  },
+  biomeCheck: {
+    biome: {
+      id: 'twilight-marsh',
+      hazard: { id: null, label: null },
+      stability: { erosion: 'medio', vents: 'variabile' },
+      fauna: { apex: ['lupus-nebulis'], support: ['support-1'] },
+      brief: 'Bioma di riferimento per il branch orchestrato in fase di QA.',
+    },
+    defaultHazard: 'Nebbia fotonica instabile',
+  },
+  foodwebCheck: {
+    foodweb: {
+      anchors: [
+        { id: 'alpha-pack', role: 'predatore_apice' },
+        { id: 'lure-flora', role: 'flora_reagente' },
+      ],
+      links: [
+        { from: 'alpha-pack', to: 'lure-flora', weight: 0.7 },
+        { from: 'lure-flora', to: 'alpha-pack', weight: 0.4 },
+      ],
+      focus: 'Sincronizzazione tra branchi e flora prismatica.',
+    },
+  },
+  suggestions: [
+    {
+      id: 'species-duplicates',
+      scope: 'species',
+      title: 'Allineare trait duplicati',
+      description: 'Rimuovere il tratto ripetuto per il branch QA-NEB-07 e riallineare il seed.',
+      action: 'fix',
+    },
+    {
+      id: 'biome-hazard',
+      scope: 'biome',
+      title: 'Impostare hazard predefinito',
+      description: 'Forzare l\'hazard Nebbia fotonica instabile per evitare fallback in produzione.',
+      action: 'fix',
+    },
+    {
+      id: 'foodweb-refresh',
+      scope: 'foodweb',
+      title: 'Rigenerare anelli secondari',
+      description: 'Eseguire una rigenerazione mirata dei link con peso < 0.5 per ampliare le sinergie.',
+      action: 'regenerate',
+    },
+  ],
+  notifications: [
+    {
+      id: 'notify-qa',
+      channel: 'Slack #qa-ops',
+      message: 'Runtime validator completato per i branch Nebbia/Obsydian.',
+      time: '09:45',
+    },
+    {
+      id: 'notify-release',
+      channel: 'Email Release Team',
+      message: 'In attesa approvazione finale per deploy patch 1.2.',
+      time: '10:05',
+    },
+  ],
+  logs: [
+    {
+      id: 'log-species',
+      scope: 'species',
+      level: 'info',
+      message: 'Batch QA-NEB completato con 2 fix automatici.',
+      timestamp: '2024-05-18T09:12:00Z',
+    },
+    {
+      id: 'log-biome',
+      scope: 'biome',
+      level: 'warning',
+      message: 'Hazard non impostato, applicare default QA.',
+      timestamp: '2024-05-18T09:18:00Z',
+    },
+  ],
 });

--- a/webapp/src/state/flowMachine.js
+++ b/webapp/src/state/flowMachine.js
@@ -32,6 +32,12 @@ const BASE_STEPS = [
     description: 'Seed, varianti e parametri del combattimento.',
   },
   {
+    id: 'qualityRelease',
+    title: 'Quality & Release',
+    caption: 'Validazione runtime',
+    description: 'Controlli QA automatizzati e readiness per la release.',
+  },
+  {
     id: 'publishing',
     title: 'Publishing',
     caption: 'Preparazione artefatti',

--- a/webapp/src/views/PublishingView.vue
+++ b/webapp/src/views/PublishingView.vue
@@ -22,11 +22,74 @@
         <p class="flow-card__body">Coordinare il QA narrativo e validare la sincronizzazione media.</p>
       </article>
     </div>
+
+    <section class="publishing-workflow">
+      <header>
+        <h3>Workflow di pubblicazione</h3>
+        <p>Anteprima, approvazione e deploy con stato aggiornato e referenti di riferimento.</p>
+      </header>
+      <div class="publishing-workflow__steps">
+        <article
+          v-for="step in workflowSteps"
+          :key="step.id"
+          :class="['publishing-step', `publishing-step--${step.status}`]"
+        >
+          <header>
+            <h4>{{ step.title }}</h4>
+            <span class="publishing-step__status">{{ statusLabel(step.status) }}</span>
+          </header>
+          <p>{{ step.notes }}</p>
+          <footer>
+            <span class="publishing-step__meta">Owner · {{ step.owner }}</span>
+            <span class="publishing-step__meta">ETA · {{ step.eta }}</span>
+          </footer>
+        </article>
+      </div>
+    </section>
+
+    <div class="publishing-updates">
+      <section class="publishing-timeline">
+        <header>
+          <h3>Cronologia release</h3>
+          <p>Eventi recenti e milestone approvate per il pacchetto corrente.</p>
+        </header>
+        <ul>
+          <li v-for="entry in historyEntries" :key="entry.id">
+            <div>
+              <strong>{{ entry.label }}</strong>
+              <p>{{ entry.details }}</p>
+            </div>
+            <footer>
+              <span>{{ entry.author }}</span>
+              <time>{{ entry.timestamp }}</time>
+            </footer>
+          </li>
+        </ul>
+      </section>
+      <section class="publishing-notifications">
+        <header>
+          <h3>Notifiche team</h3>
+          <p>Avvisi inviati a stakeholder e canali di comunicazione.</p>
+        </header>
+        <ul>
+          <li v-for="notification in notificationEntries" :key="notification.id">
+            <div>
+              <strong>{{ notification.channel }}</strong>
+              <p>{{ notification.message }}</p>
+            </div>
+            <footer>
+              <span v-if="notification.recipients?.length">{{ notification.recipients.join(', ') }}</span>
+              <time>{{ notification.time }}</time>
+            </footer>
+          </li>
+        </ul>
+      </section>
+    </div>
   </section>
 </template>
 
 <script setup>
-import { toRefs } from 'vue';
+import { computed, toRefs } from 'vue';
 
 const props = defineProps({
   publishing: {
@@ -36,6 +99,58 @@ const props = defineProps({
 });
 
 const { publishing } = toRefs(props);
+
+const workflowSteps = computed(() => {
+  const workflow = publishing.value.workflow || {};
+  return [
+    {
+      id: 'preview',
+      title: 'Anteprima',
+      status: workflow.preview?.status || 'pending',
+      owner: workflow.preview?.owner || '—',
+      eta: workflow.preview?.eta || '—',
+      notes: workflow.preview?.notes || '—',
+    },
+    {
+      id: 'approval',
+      title: 'Approvazione',
+      status: workflow.approval?.status || 'pending',
+      owner: workflow.approval?.owner || '—',
+      eta: workflow.approval?.eta || '—',
+      notes: workflow.approval?.notes || '—',
+    },
+    {
+      id: 'deploy',
+      title: 'Deploy sul sito',
+      status: workflow.deploy?.status || 'pending',
+      owner: workflow.deploy?.owner || '—',
+      eta: workflow.deploy?.eta || '—',
+      notes: workflow.deploy?.notes || '—',
+    },
+  ];
+});
+
+const historyEntries = computed(() => (Array.isArray(publishing.value.history) ? publishing.value.history : []));
+
+const notificationEntries = computed(() =>
+  Array.isArray(publishing.value.notifications) ? publishing.value.notifications : []
+);
+
+function statusLabel(status) {
+  if (status === 'ready') {
+    return 'Pronto';
+  }
+  if (status === 'scheduled') {
+    return 'Programmato';
+  }
+  if (status === 'in-progress') {
+    return 'In corso';
+  }
+  if (status === 'done') {
+    return 'Completato';
+  }
+  return 'In attesa';
+}
 </script>
 
 <style scoped>
@@ -93,5 +208,151 @@ const { publishing } = toRefs(props);
   color: rgba(240, 244, 255, 0.85);
   display: grid;
   gap: 0.25rem;
+}
+
+.publishing-workflow {
+  display: grid;
+  gap: 0.75rem;
+  background: rgba(9, 14, 20, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1.1rem;
+}
+
+.publishing-workflow header h3,
+.publishing-timeline header h3,
+.publishing-notifications header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.publishing-workflow header p,
+.publishing-timeline header p,
+.publishing-notifications header p {
+  margin: 0.35rem 0 0;
+  color: rgba(240, 244, 255, 0.65);
+}
+
+.publishing-workflow__steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.publishing-step {
+  background: rgba(12, 18, 26, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 0.9rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.publishing-step header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.publishing-step h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.publishing-step__status {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  border: 1px solid rgba(96, 213, 255, 0.45);
+  color: rgba(96, 213, 255, 0.85);
+}
+
+.publishing-step p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(240, 244, 255, 0.75);
+}
+
+.publishing-step__meta {
+  font-size: 0.8rem;
+  color: rgba(240, 244, 255, 0.6);
+}
+
+.publishing-step--ready {
+  border-color: rgba(129, 255, 199, 0.55);
+}
+
+.publishing-step--scheduled {
+  border-color: rgba(96, 213, 255, 0.45);
+}
+
+.publishing-updates {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.publishing-timeline,
+.publishing-notifications {
+  background: rgba(9, 14, 20, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1.1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.publishing-timeline ul,
+.publishing-notifications ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.publishing-timeline li,
+.publishing-notifications li {
+  background: rgba(12, 18, 26, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.publishing-timeline strong,
+.publishing-notifications strong {
+  font-size: 0.95rem;
+  color: rgba(240, 244, 255, 0.85);
+}
+
+.publishing-timeline p,
+.publishing-notifications p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(240, 244, 255, 0.7);
+}
+
+.publishing-timeline footer,
+.publishing-notifications footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.75rem;
+  color: rgba(240, 244, 255, 0.6);
+}
+
+@media (max-width: 720px) {
+  .publishing-workflow__steps {
+    grid-template-columns: 1fr;
+  }
+
+  .publishing-updates {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/webapp/src/views/QualityReleaseView.vue
+++ b/webapp/src/views/QualityReleaseView.vue
@@ -1,0 +1,711 @@
+<template>
+  <section class="flow-view quality-release">
+    <header class="flow-view__header">
+      <h2>Quality &amp; Release</h2>
+      <p>
+        Coordinamento tra orchestrator e runtime validator per assicurare che i branch siano pronti alla
+        pubblicazione.
+      </p>
+    </header>
+
+    <div class="quality-release__status">
+      <article class="quality-release__card">
+        <h3>Finestra di release</h3>
+        <p class="quality-release__primary">{{ orchestrator.releaseWindow }}</p>
+        <p class="quality-release__meta">Stato orchestrator: {{ orchestrator.stage }}</p>
+        <p class="quality-release__meta">Coordinatore: {{ orchestrator.coordinator }}</p>
+        <ul>
+          <li v-for="focus in orchestrator.focusAreas" :key="focus">{{ focus }}</li>
+        </ul>
+      </article>
+      <article class="quality-release__card">
+        <h3>Referenti QA</h3>
+        <p class="quality-release__primary">{{ owners.join(', ') }}</p>
+        <p class="quality-release__meta">Ultimo batch: {{ formatTimestamp(snapshot.lastRun) }}</p>
+        <ul class="quality-release__notifications">
+          <li v-for="notification in context.notifications" :key="notification.id">
+            <strong>{{ notification.channel }}</strong>
+            <span>{{ notification.message }}</span>
+            <small>{{ notification.time }}</small>
+          </li>
+        </ul>
+      </article>
+    </div>
+
+    <section class="quality-release__validators">
+      <header class="quality-release__section-header">
+        <h3>Runtime checks</h3>
+        <p>Avvia validazioni mirate utilizzando il runtime validator collegato all'orchestrator.</p>
+      </header>
+      <div class="quality-release__checks">
+        <article class="quality-check">
+          <header>
+            <h4>Specie</h4>
+            <span class="quality-check__badge">{{ qualityCount('species') }}</span>
+          </header>
+          <p class="quality-check__summary">
+            {{ checkSummaryText(speciesCheck.result, snapshot.checks?.species) }}
+          </p>
+          <p v-if="speciesCheck.error" class="quality-check__error">{{ speciesCheck.error }}</p>
+          <footer>
+            <button type="button" class="quality-check__action" :disabled="speciesCheck.running" @click="runSpeciesCheck">
+              {{ speciesCheck.running ? 'In corso…' : 'Esegui batch specie' }}
+            </button>
+          </footer>
+        </article>
+        <article class="quality-check">
+          <header>
+            <h4>Biomi</h4>
+            <span class="quality-check__badge">{{ qualityCount('biomes') }}</span>
+          </header>
+          <p class="quality-check__summary">
+            {{ checkSummaryText(biomeCheck.result, snapshot.checks?.biomes) }}
+          </p>
+          <p v-if="biomeCheck.error" class="quality-check__error">{{ biomeCheck.error }}</p>
+          <footer>
+            <button type="button" class="quality-check__action" :disabled="biomeCheck.running" @click="runBiomeCheck">
+              {{ biomeCheck.running ? 'In corso…' : 'Sanitizza bioma' }}
+            </button>
+          </footer>
+        </article>
+        <article class="quality-check">
+          <header>
+            <h4>Foodweb</h4>
+            <span class="quality-check__badge">{{ qualityCount('foodweb') }}</span>
+          </header>
+          <p class="quality-check__summary">
+            {{ checkSummaryText(foodwebCheck.result, snapshot.checks?.foodweb) }}
+          </p>
+          <p v-if="foodwebCheck.error" class="quality-check__error">{{ foodwebCheck.error }}</p>
+          <footer>
+            <button type="button" class="quality-check__action" :disabled="foodwebCheck.running" @click="runFoodwebCheck">
+              {{ foodwebCheck.running ? 'In corso…' : 'Valida foodweb' }}
+            </button>
+          </footer>
+        </article>
+      </div>
+    </section>
+
+    <section class="quality-release__suggestions" v-if="suggestions.length">
+      <header class="quality-release__section-header">
+        <h3>Suggerimenti di correzione</h3>
+        <p>Applica fix automatici o rigenera selezioni specifiche sulla base dei risultati runtime.</p>
+      </header>
+      <ul class="quality-suggestions">
+        <li v-for="suggestion in suggestions" :key="suggestion.id" :class="['quality-suggestion', `quality-suggestion--${suggestion.scope}`]">
+          <div>
+            <h4>{{ suggestion.title }}</h4>
+            <p>{{ suggestion.description }}</p>
+          </div>
+          <button
+            type="button"
+            class="quality-suggestion__action"
+            :disabled="suggestion.applied"
+            @click="applySuggestion(suggestion)"
+          >
+            {{ suggestionLabel(suggestion) }}
+          </button>
+        </li>
+      </ul>
+    </section>
+
+    <section class="quality-release__logs">
+      <header class="quality-release__section-header">
+        <h3>Log runtime</h3>
+        <p>Traccia degli eventi emessi dal runtime validator e dalle azioni correttive.</p>
+      </header>
+      <div class="quality-logs__toolbar">
+        <button
+          v-for="option in scopeOptions"
+          :key="option.value"
+          type="button"
+          :class="['quality-logs__filter', { 'quality-logs__filter--active': option.value === scopeFilter }]"
+          @click="scopeFilter = option.value"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+      <ul class="quality-logs">
+        <li v-for="log in filteredLogs" :key="log.id" :class="['quality-log', `quality-log--${log.level}`]">
+          <div class="quality-log__meta">
+            <span class="quality-log__scope">{{ displayScope(log.scope) }}</span>
+            <time class="quality-log__time">{{ formatTimestamp(log.timestamp) }}</time>
+          </div>
+          <p class="quality-log__message">{{ log.message }}</p>
+        </li>
+        <li v-if="!filteredLogs.length" class="quality-log quality-log--empty">
+          Nessun log per il filtro selezionato.
+        </li>
+      </ul>
+    </section>
+  </section>
+</template>
+
+<script setup>
+import { computed, reactive, ref, toRefs } from 'vue';
+import { validateBiome, validateFoodweb, validateSpeciesBatch } from '../services/runtimeValidationService.js';
+
+const props = defineProps({
+  snapshot: {
+    type: Object,
+    required: true,
+  },
+  context: {
+    type: Object,
+    required: true,
+  },
+});
+
+const { snapshot, context } = toRefs(props);
+
+const speciesCheck = reactive({ running: false, result: null, error: null, lastRun: null });
+const biomeCheck = reactive({ running: false, result: null, error: null, lastRun: null });
+const foodwebCheck = reactive({ running: false, result: null, error: null, lastRun: null });
+
+const runtimeLogs = ref([]);
+const appliedSuggestionIds = ref([]);
+let logCounter = 0;
+
+const orchestrator = computed(() => {
+  const info = context.value.orchestrator || {};
+  return {
+    stage: info.stage || '—',
+    releaseWindow: info.releaseWindow || '—',
+    coordinator: info.coordinator || '—',
+    focusAreas: Array.isArray(info.focusAreas) ? info.focusAreas : [],
+  };
+});
+
+const owners = computed(() => {
+  const value = snapshot.value && snapshot.value.owners;
+  return Array.isArray(value) ? value : [];
+});
+
+const suggestions = computed(() => {
+  const items = Array.isArray(context.value.suggestions) ? context.value.suggestions : [];
+  return items.map((item) => ({
+    ...item,
+    applied: appliedSuggestionIds.value.includes(item.id),
+  }));
+});
+
+const baseLogs = computed(() => {
+  const logs = Array.isArray(context.value.logs) ? context.value.logs : [];
+  return logs.map((item) => ({
+    id: item.id,
+    scope: item.scope || 'general',
+    level: item.level || 'info',
+    message: item.message,
+    timestamp: item.timestamp,
+  }));
+});
+
+const allLogs = computed(() => [...baseLogs.value, ...runtimeLogs.value]);
+
+const scopeOptions = computed(() => [
+  { value: 'all', label: 'Tutti' },
+  { value: 'species', label: 'Specie' },
+  { value: 'biome', label: 'Biomi' },
+  { value: 'foodweb', label: 'Foodweb' },
+]);
+
+const scopeFilter = ref('all');
+
+const filteredLogs = computed(() => {
+  const logs = allLogs.value;
+  if (scopeFilter.value === 'all') {
+    return logs;
+  }
+  return logs.filter((log) => log.scope === scopeFilter.value);
+});
+
+function appendLogs(kind, entries = []) {
+  if (!entries.length) {
+    return;
+  }
+  const payload = entries.map((entry) => {
+    const message = typeof entry === 'string' ? entry : entry.message || entry.text || '';
+    const level = entry.level || entry.severity || (entry.type === 'error' ? 'error' : 'info');
+    const timestamp = entry.timestamp || new Date().toISOString();
+    return {
+      id: `${kind}-${Date.now()}-${logCounter++}`,
+      scope: entry.scope || kind,
+      level,
+      message,
+      timestamp,
+    };
+  });
+  runtimeLogs.value = [...runtimeLogs.value, ...payload];
+}
+
+function normaliseMessages(kind, result) {
+  const messages = [];
+  if (Array.isArray(result?.messages)) {
+    for (const item of result.messages) {
+      if (item) {
+        messages.push(item);
+      }
+    }
+  }
+  if (Array.isArray(result?.discarded) && result.discarded.length) {
+    messages.push({
+      level: 'warning',
+      message: `Elementi scartati: ${result.discarded.length}`,
+    });
+  }
+  if (Array.isArray(result?.corrected) && result.corrected.length) {
+    messages.push({
+      level: 'success',
+      message: `Correzioni applicate: ${result.corrected.length}`,
+    });
+  }
+  return messages.map((message) => ({ ...message, scope: kind }));
+}
+
+function checkSummaryText(result, check) {
+  const passed = check?.passed ?? 0;
+  const total = check?.total ?? 0;
+  if (!result) {
+    return `${passed} di ${total} check già superati.`;
+  }
+  const corrected = Array.isArray(result.corrected) ? result.corrected.length : 0;
+  const discarded = Array.isArray(result.discarded) ? result.discarded.length : 0;
+  return `Correzioni ${corrected} · Scartati ${discarded}`;
+}
+
+function qualityCount(kind) {
+  const check = snapshot.value?.checks?.[kind];
+  if (!check) {
+    return '0 / 0';
+  }
+  return `${check.passed || 0} / ${check.total || 0}`;
+}
+
+function suggestionLabel(suggestion) {
+  if (suggestion.applied) {
+    return 'Completato';
+  }
+  if (suggestion.action === 'regenerate') {
+    return 'Rigenera mirato';
+  }
+  return 'Applica fix';
+}
+
+function displayScope(scope) {
+  if (scope === 'species') {
+    return 'Specie';
+  }
+  if (scope === 'biome' || scope === 'biomes') {
+    return 'Biomi';
+  }
+  if (scope === 'foodweb') {
+    return 'Foodweb';
+  }
+  return 'Generale';
+}
+
+function formatTimestamp(value) {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat('it-IT', {
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+async function runSpeciesCheck() {
+  speciesCheck.running = true;
+  speciesCheck.error = null;
+  try {
+    const result = await validateSpeciesBatch(context.value.speciesBatch.entries, {
+      biomeId: context.value.speciesBatch.biomeId,
+    });
+    speciesCheck.result = result;
+    speciesCheck.lastRun = new Date().toISOString();
+    appendLogs('species', normaliseMessages('species', result));
+  } catch (error) {
+    speciesCheck.error = error?.message || 'Errore validazione specie';
+    appendLogs('species', [
+      {
+        level: 'error',
+        message: speciesCheck.error,
+      },
+    ]);
+  } finally {
+    speciesCheck.running = false;
+  }
+}
+
+async function runBiomeCheck() {
+  biomeCheck.running = true;
+  biomeCheck.error = null;
+  try {
+    const result = await validateBiome(context.value.biomeCheck.biome, {
+      defaultHazard: context.value.biomeCheck.defaultHazard,
+    });
+    biomeCheck.result = result;
+    biomeCheck.lastRun = new Date().toISOString();
+    appendLogs('biome', normaliseMessages('biome', result));
+  } catch (error) {
+    biomeCheck.error = error?.message || 'Errore sanitizzazione bioma';
+    appendLogs('biome', [
+      {
+        level: 'error',
+        message: biomeCheck.error,
+      },
+    ]);
+  } finally {
+    biomeCheck.running = false;
+  }
+}
+
+async function runFoodwebCheck() {
+  foodwebCheck.running = true;
+  foodwebCheck.error = null;
+  try {
+    const result = await validateFoodweb(context.value.foodwebCheck.foodweb);
+    foodwebCheck.result = result;
+    foodwebCheck.lastRun = new Date().toISOString();
+    appendLogs('foodweb', normaliseMessages('foodweb', result));
+  } catch (error) {
+    foodwebCheck.error = error?.message || 'Errore validazione foodweb';
+    appendLogs('foodweb', [
+      {
+        level: 'error',
+        message: foodwebCheck.error,
+      },
+    ]);
+  } finally {
+    foodwebCheck.running = false;
+  }
+}
+
+function applySuggestion(suggestion) {
+  if (!appliedSuggestionIds.value.includes(suggestion.id)) {
+    appliedSuggestionIds.value = [...appliedSuggestionIds.value, suggestion.id];
+    const level = suggestion.action === 'regenerate' ? 'info' : 'success';
+    const message = suggestion.action === 'regenerate'
+      ? `Rigenerazione avviata: ${suggestion.title}`
+      : `Fix applicato: ${suggestion.title}`;
+    appendLogs(suggestion.scope, [
+      {
+        level,
+        message,
+      },
+    ]);
+  }
+}
+</script>
+
+<style scoped>
+.quality-release {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.quality-release__status {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.quality-release__card {
+  background: rgba(9, 14, 20, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.quality-release__card h3 {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(240, 244, 255, 0.6);
+}
+
+.quality-release__primary {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #f0f4ff;
+}
+
+.quality-release__meta {
+  margin: 0;
+  color: rgba(240, 244, 255, 0.65);
+  font-size: 0.85rem;
+}
+
+.quality-release__card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: rgba(240, 244, 255, 0.75);
+  display: grid;
+  gap: 0.25rem;
+}
+
+.quality-release__notifications {
+  list-style: none;
+  padding: 0;
+}
+
+.quality-release__notifications li {
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.35rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.quality-release__notifications li:last-child {
+  border-bottom: none;
+}
+
+.quality-release__notifications strong {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: rgba(129, 255, 199, 0.8);
+}
+
+.quality-release__notifications span {
+  font-size: 0.85rem;
+  color: rgba(240, 244, 255, 0.8);
+}
+
+.quality-release__notifications small {
+  font-size: 0.75rem;
+  color: rgba(240, 244, 255, 0.55);
+}
+
+.quality-release__validators,
+.quality-release__suggestions,
+.quality-release__logs {
+  background: rgba(9, 14, 20, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: 1.2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.quality-release__section-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.quality-release__section-header p {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(240, 244, 255, 0.65);
+}
+
+.quality-release__checks {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.quality-check {
+  background: rgba(12, 18, 26, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.quality-check header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.quality-check h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.quality-check__badge {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid rgba(96, 213, 255, 0.45);
+  color: rgba(96, 213, 255, 0.85);
+}
+
+.quality-check__summary {
+  margin: 0;
+  min-height: 2.2rem;
+  color: rgba(240, 244, 255, 0.75);
+}
+
+.quality-check__error {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 133, 133, 0.85);
+}
+
+.quality-check footer {
+  display: flex;
+}
+
+.quality-check__action {
+  border: none;
+  background: linear-gradient(90deg, #57ca8a 0%, #61d5ff 100%);
+  color: #05080d;
+  font-weight: 600;
+  padding: 0.45rem 0.75rem;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.quality-check__action:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.quality-suggestions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.quality-suggestion {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 18, 26, 0.85);
+}
+
+.quality-suggestion h4 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+.quality-suggestion p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(240, 244, 255, 0.7);
+}
+
+.quality-suggestion__action {
+  border: none;
+  background: rgba(96, 213, 255, 0.12);
+  color: #61d5ff;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-weight: 600;
+}
+
+.quality-suggestion__action:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background: rgba(129, 255, 199, 0.15);
+  color: rgba(129, 255, 199, 0.85);
+}
+
+.quality-logs__toolbar {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.quality-logs__filter {
+  background: rgba(96, 213, 255, 0.12);
+  border: 1px solid transparent;
+  color: rgba(240, 244, 255, 0.8);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 0.2s ease;
+}
+
+.quality-logs__filter--active {
+  border-color: rgba(96, 213, 255, 0.55);
+  color: #61d5ff;
+}
+
+.quality-logs {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.quality-log {
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  background: rgba(12, 18, 26, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.quality-log__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: rgba(240, 244, 255, 0.6);
+}
+
+.quality-log__scope {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.quality-log__message {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(240, 244, 255, 0.8);
+}
+
+.quality-log--warning {
+  border-color: rgba(255, 210, 113, 0.55);
+}
+
+.quality-log--error {
+  border-color: rgba(255, 133, 133, 0.65);
+}
+
+.quality-log--success {
+  border-color: rgba(129, 255, 199, 0.55);
+}
+
+.quality-log--empty {
+  text-align: center;
+  color: rgba(240, 244, 255, 0.55);
+  font-style: italic;
+}
+
+@media (max-width: 720px) {
+  .quality-suggestion {
+    flex-direction: column;
+  }
+
+  .quality-release__checks {
+    grid-template-columns: 1fr;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- add a Quality & Release step that orchestrates runtime validation batches with a dedicated view
- expose a client-side runtime validation service and demo orchestration data to drive QA interactions
- extend the publishing view with workflow stages, release history, and team notifications

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_69018dedbd008332890b96e8efdcd27e