### PR TITLE
Fix encounter metrics quantity scaling

### DIFF
--- a/webapp/src/services/encounterMetrics.js
+++ b/webapp/src/services/encounterMetrics.js
@@ -40,6 +40,13 @@ function buildAssignments(variant) {
   }));
 }
 
+function resolveAssignmentQuantity(assignment) {
+  const base = Number.isFinite(assignment?.quantity)
+    ? assignment.quantity
+    : assignment?.species?.length || 0;
+  return Math.max(0, Math.floor(base));
+}
+
 function normalizeParameters(variant) {
   const result = {};
   const entries = Object.entries(variant?.parameters || {});
@@ -55,7 +62,13 @@ function computeRarityMix(assignments) {
   const counts = {};
   let total = 0;
   for (const assignment of assignments) {
-    for (const specimen of assignment.species) {
+    const specimens = assignment.species || [];
+    const quantity = resolveAssignmentQuantity(assignment);
+    if (!specimens.length || quantity <= 0) {
+      continue;
+    }
+    for (let i = 0; i < quantity; i += 1) {
+      const specimen = specimens[i % specimens.length];
       const rarity = specimen.statistics?.rarity || 'Sconosciuta';
       counts[rarity] = (counts[rarity] || 0) + 1;
       total += 1;

--- a/webapp/src/state/generator/encounterGenerator.js
+++ b/webapp/src/state/generator/encounterGenerator.js
@@ -142,11 +142,21 @@ export function computeThreat(template, parameters, slotAssignments) {
   const slotWeight = threatConfig.slotWeight || {};
   let score = threatConfig.base ?? 0;
   for (const assignment of slotAssignments) {
+    const specimens = assignment.species || [];
+    const quantityBase = Number.isFinite(assignment.quantity)
+      ? assignment.quantity
+      : specimens.length;
+    const quantity = Math.max(0, Math.floor(quantityBase));
+    if (!specimens.length || quantity <= 0) {
+      continue;
+    }
     const weight = slotWeight[assignment.slot.id] ?? slotWeight.default ?? 1;
-    const slotThreat = assignment.species.reduce((acc, specimen) => {
+    let slotThreat = 0;
+    for (let i = 0; i < quantity; i += 1) {
+      const specimen = specimens[i % specimens.length];
       const tier = parseThreatTier(specimen.statistics?.threat_tier || specimen.balance?.threat_tier);
-      return acc + tier;
-    }, 0);
+      slotThreat += tier;
+    }
     score += slotThreat * weight;
   }
   if (threatConfig.parameterMultipliers) {


### PR DESCRIPTION
## Summary
- scale threat and rarity metrics according to the edited slot quantities
- normalize slot quantities when building assignments to avoid negative or fractional counts
- iterate specimens per quantity unit so live metrics reflect repeated units accurately

## Testing
- npm run test -- --run *(fails: Playwright browser launch error: missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_690203b7f4f8833288b97e3233afb90b