### PR TITLE
Ensure evo tactics synergies stay reciprocal

### DIFF
--- a/packs/evo_tactics_pack/docs/catalog/trait_reference.json
+++ b/packs/evo_tactics_pack/docs/catalog/trait_reference.json
@@ -70,8 +70,8 @@
       ],
       "sinergie": [
         "coda_frusta_cinetica",
-        "struttura_elastica_amorfa",
         "mimetismo_cromatico_passivo",
+        "struttura_elastica_amorfa",
         "tattiche_di_branco"
       ],
       "sinergie_pi": {
@@ -842,8 +842,8 @@
         }
       ],
       "sinergie": [
-        "struttura_elastica_amorfa",
-        "artigli_sette_vie"
+        "artigli_sette_vie",
+        "struttura_elastica_amorfa"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
@@ -1513,8 +1513,8 @@
         }
       ],
       "sinergie": [
-        "carapace_luminiscente_abissale",
-        "antenne_plasmatiche_tempesta"
+        "antenne_plasmatiche_tempesta",
+        "carapace_luminiscente_abissale"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],

--- a/tests/validators/test_trait_synergies_reciprocal.py
+++ b/tests/validators/test_trait_synergies_reciprocal.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TRAIT_REFERENCE = PROJECT_ROOT / "packs" / "evo_tactics_pack" / "docs" / "catalog" / "trait_reference.json"
+
+
+def test_trait_synergies_are_mutual():
+    with TRAIT_REFERENCE.open(encoding="utf-8") as fh:
+        traits = json.load(fh)["traits"]
+
+    missing_traits = []
+    asymmetric_pairs = []
+
+    for trait_key, payload in traits.items():
+        for partner in payload.get("sinergie", []):
+            if partner not in traits:
+                missing_traits.append((trait_key, partner))
+                continue
+
+            partner_synergies = traits[partner].get("sinergie", [])
+            if trait_key not in partner_synergies:
+                asymmetric_pairs.append((trait_key, partner))
+
+    assert not missing_traits, f"sinergie refer to unknown traits: {missing_traits}"
+    assert not asymmetric_pairs, f"sinergie not reciprocal: {asymmetric_pairs}"


### PR DESCRIPTION
## Summary
- normalize the evo tactics trait entries touched by the new psionic synergies so their partner lists clearly include the reciprocal links
- add a validator test that loads the trait catalog and fails when a sinergie points to an unknown or non-reciprocated trait

## Testing
- pytest tests/validators/test_trait_synergies_reciprocal.py

------
https://chatgpt.com/codex/tasks/task_e_690203bd9dc08332b0d36b4284e11c92