### PR TITLE
Add psionic biome species coverage

### DIFF
--- a/data/analysis/trait_coverage_matrix.csv
+++ b/data/analysis/trait_coverage_matrix.csv
@@ -11,24 +11,45 @@ eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,mezzanotte_o
 empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,foresta_miceliale,,1,3
 empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,foresta_miceliale,scavenger_corazzato,0,2
 filamenti_digestivi_compattanti,Filamento materiali digeriti,Digestive Compaction Filaments,dorsale_termale_tropicale,scavenger_corazzato,1,2
+filamenti_digestivi_compattanti,Filamento materiali digeriti,Digestive Compaction Filaments,falde_magnetiche_psioniche,,1,1
+filamenti_digestivi_compattanti,Filamento materiali digeriti,Digestive Compaction Filaments,falde_magnetiche_psioniche,scavenger_corazzato,0,1
+filamenti_digestivi_compattanti,Filamento materiali digeriti,Digestive Compaction Filaments,foresta_miceliale,,1,2
 filamenti_digestivi_compattanti,Filamento materiali digeriti,Digestive Compaction Filaments,foresta_miceliale,scavenger_corazzato,0,2
 filamenti_digestivi_compattanti,Filamento materiali digeriti,Digestive Compaction Filaments,mezzanotte_orbitale,scavenger_corazzato,1,1
+focus_frazionato,Focus Frazionato,Fractional Focus,canopia_psionica_leggera,,1,1
+focus_frazionato,Focus Frazionato,Fractional Focus,canopia_psionica_leggera,volatore_planatore,0,1
 focus_frazionato,Focus Frazionato,Fractional Focus,foresta_miceliale,,1,1
+focus_frazionato,Focus Frazionato,Fractional Focus,orbita_psionica_inversa,,1,1
+focus_frazionato,Focus Frazionato,Fractional Focus,orbita_psionica_inversa,volatore_planatore,0,1
 ghiandola_caustica,Ghiandola Caustica,Caustic Gland,foresta_miceliale,,1,1
 lingua_tattile_trama,Lingua Tattile Trama-Sensibile,Texture-Sensing Tongue,foresta_miceliale,,1,1
+mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,canopia_psionica_leggera,,1,1
+mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,canopia_psionica_leggera,volatore_planatore,0,1
 mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,dorsale_termale_tropicale,ingegnere_radicante,1,1
-mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,mezzanotte_orbitale,volatore_planatore,0,2
+mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,mezzanotte_orbitale,volatore_planatore,1,2
 nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,dorsale_termale_tropicale,cursoriale_quadrupede,1,1
+nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,falde_magnetiche_psioniche,,1,1
+nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,falde_magnetiche_psioniche,scavenger_corazzato,0,1
+nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,orbita_psionica_inversa,,1,1
+nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,orbita_psionica_inversa,volatore_planatore,0,1
 occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Infrared Compound Eyes,dorsale_termale_tropicale,volatore_planatore,1,1
-olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,dorsale_termale_tropicale,cursoriale_quadrupede,0,1
+olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,dorsale_termale_tropicale,cursoriale_quadrupede,1,1
+olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,falde_magnetiche_psioniche,,1,1
+olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,falde_magnetiche_psioniche,scavenger_corazzato,0,1
 olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,mezzanotte_orbitale,cursoriale_quadrupede,1,1
+olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,orbita_psionica_inversa,,1,1
+olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,orbita_psionica_inversa,volatore_planatore,0,1
 pathfinder,Pathfinder,Pathfinder,foresta_miceliale,,1,1
 pianificatore,Pianificatore,Strategic Planner,foresta_miceliale,,1,1
 respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,dorsale_termale_tropicale,scavenger_corazzato,1,1
 respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,mezzanotte_orbitale,cursoriale_quadrupede,1,1
 risonanza_di_branco,Risonanza di Branco,Pack Resonance,foresta_miceliale,,1,1
+sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,canopia_psionica_leggera,,1,1
+sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,canopia_psionica_leggera,volatore_planatore,0,1
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,dorsale_termale_tropicale,cursoriale_quadrupede,1,1
-sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,mezzanotte_orbitale,volatore_planatore,0,2
+sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,mezzanotte_orbitale,volatore_planatore,1,2
+sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,orbita_psionica_inversa,,1,1
+sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,orbita_psionica_inversa,volatore_planatore,0,1
 sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,dorsale_termale_tropicale,ingegnere_radicante,1,1
 sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,mezzanotte_orbitale,scavenger_corazzato,1,1
 scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,dorsale_termale_tropicale,cursoriale_quadrupede,1,3
@@ -40,7 +61,12 @@ sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemisph
 spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,dorsale_termale_tropicale,scavenger_corazzato,1,1
 spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,foresta_miceliale,,1,1
 spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,mezzanotte_orbitale,scavenger_corazzato,1,1
+struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,canopia_psionica_leggera,,1,1
+struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,canopia_psionica_leggera,volatore_planatore,0,1
 struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,dorsale_termale_tropicale,cursoriale_quadrupede,1,2
+struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,falde_magnetiche_psioniche,,1,1
+struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,falde_magnetiche_psioniche,scavenger_corazzato,0,1
+struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,foresta_miceliale,,1,2
 struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,foresta_miceliale,scavenger_corazzato,0,2
 tattiche_di_branco,Tattiche di Branco,Pack Tactics,foresta_miceliale,,1,1
 ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,dorsale_termale_tropicale,scavenger_corazzato,1,1

--- a/data/analysis/trait_coverage_report.json
+++ b/data/analysis/trait_coverage_report.json
@@ -1,29 +1,39 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-10-29T00:26:37+00:00",
+  "generated_at": "2025-10-29T12:27:55+00:00",
   "sources": {
     "env_traits": "packs/evo_tactics_pack/docs/catalog/env_traits.json",
     "trait_reference": "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
-    "trait_glossary": "data/traits/glossary.json",
+    "trait_glossary": "/workspace/Game/data/traits/glossary.json",
     "species_root": "packs/evo_tactics_pack/data/species"
   },
   "summary": {
-    "traits_total": 29,
+    "traits_total": 50,
     "traits_with_rules": 27,
     "traits_with_species": 27,
-    "rule_combos_total": 39,
-    "species_combos_total": 46,
+    "rule_combos_total": 56,
+    "species_combos_total": 72,
     "rules_missing_species_total": 0,
     "traits_missing_species": [],
-    "traits_missing_rules": [
-      "filamenti_digestivi_compattanti",
-      "mimetismo_cromatico_passivo",
-      "olfatto_risonanza_magnetica",
-      "sacche_galleggianti_ascensoriali",
-      "struttura_elastica_amorfa"
-    ]
+    "traits_missing_rules": []
   },
   "traits": {
+    "antenne_plasmatiche_tempesta": {
+      "label_it": "Antenne Plasmatiche di Tempesta",
+      "label_en": "Antenne Plasmatiche di Tempesta",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
     "artigli_sette_vie": {
       "label_it": "Artigli a Sette Vie",
       "label_en": "Seven-Way Talons",
@@ -90,6 +100,54 @@
         "missing_in_rules": []
       }
     },
+    "artigli_sghiaccio_glaciale": {
+      "label_it": "Artigli Sghiaccio Glaciale",
+      "label_en": "Artigli Sghiaccio Glaciale",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
+    "branchie_osmotiche_salmastra": {
+      "label_it": "Branchie Osmotiche Salmastre",
+      "label_en": "Branchie Osmotiche Salmastre",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
+    "bulbi_radici_permafrost": {
+      "label_it": "Bulbi Radici del Permafrost",
+      "label_en": "Bulbi Radici del Permafrost",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
     "carapace_fase_variabile": {
       "label_it": "Carapace a Variazione di Fase",
       "label_en": "Phase-Shifting Carapace",
@@ -115,6 +173,86 @@
             ]
           }
         ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
+    "carapace_luminiscente_abissale": {
+      "label_it": "Carapace Luminiscente Abissale",
+      "label_en": "Carapace Luminiscente Abissale",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
+    "cartilagine_flessotermica_venti": {
+      "label_it": "Cartilagine Flessotermica dei Venti",
+      "label_en": "Cartilagine Flessotermica dei Venti",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
+    "cavita_risonanti_tundra": {
+      "label_it": "Cavità Risonanti della Tundra",
+      "label_en": "Cavità Risonanti della Tundra",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
+    "chioma_parassita_canopica": {
+      "label_it": "Chioma Parassita Canopica",
+      "label_en": "Chioma Parassita Canopica",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
+    "circolazione_bifasica_palude": {
+      "label_it": "Circolazione Bifasica di Palude",
+      "label_en": "Circolazione Bifasica di Palude",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
@@ -277,11 +415,21 @@
       "label_it": "Filamento materiali digeriti",
       "label_en": "Digestive Compaction Filaments",
       "rules": {
-        "total": 2,
+        "total": 4,
         "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "scavenger_corazzato",
+            "count": 1
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
             "count": 1
           },
           {
@@ -292,7 +440,7 @@
         ]
       },
       "species": {
-        "total": 5,
+        "total": 9,
         "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
@@ -301,6 +449,31 @@
             "examples": [
               "nano-rust-bloom",
               "rust-scavenger"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "magnet-fathom-surveyor"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "magnet-fathom-surveyor"
+            ]
+          },
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "glowcap-weaver",
+              "myco-spire-warden"
             ]
           },
           {
@@ -324,36 +497,73 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "foresta_miceliale",
-            "morphotype": "scavenger_corazzato"
-          }
-        ]
+        "missing_in_rules": []
       }
     },
     "focus_frazionato": {
       "label_it": "Focus Frazionato",
       "label_en": "Fractional Focus",
       "rules": {
-        "total": 1,
+        "total": 3,
         "coverage": [
           {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 1
+          },
+          {
             "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "orbita_psionica_inversa",
             "morphotype": null,
             "count": 1
           }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 5,
         "coverage": [
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "psionic-canopy-scout"
+            ]
+          },
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "psionic-canopy-scout"
+            ]
+          },
           {
             "biome": "foresta_miceliale",
             "morphotype": null,
             "count": 1,
             "examples": [
               "sentinella-radice"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "orbital-ascendant"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "orbital-ascendant"
             ]
           }
         ]
@@ -394,6 +604,22 @@
         "missing_in_rules": []
       }
     },
+    "lamelle_termoforetiche": {
+      "label_it": "Lamelle Termoforetiche",
+      "label_en": "Thermophoretic Lamellae",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
     "lingua_tattile_trama": {
       "label_it": "Lingua Tattile Trama-Sensibile",
       "label_en": "Texture-Sensing Tongue",
@@ -425,22 +651,64 @@
         "missing_in_rules": []
       }
     },
+    "membrane_eliofiltranti": {
+      "label_it": "Membrane Eliofiltranti",
+      "label_en": "Membrane Eliofiltranti",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
     "mimetismo_cromatico_passivo": {
       "label_it": "Ghiandole di Mimetismo Cromatico Passivo",
       "label_en": "Passive Chromatic Mimicry",
       "rules": {
-        "total": 1,
+        "total": 3,
         "coverage": [
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 1
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "ingegnere_radicante",
+            "count": 1
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore",
             "count": 1
           }
         ]
       },
       "species": {
-        "total": 3,
+        "total": 5,
         "coverage": [
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "psionic-canopy-scout"
+            ]
+          },
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "psionic-canopy-scout"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "ingegnere_radicante",
@@ -462,29 +730,66 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore"
-          }
-        ]
+        "missing_in_rules": []
+      }
+    },
+    "mucillagine_simbionte_mangrovie": {
+      "label_it": "Mucillagine Simbionte delle Mangrovie",
+      "label_en": "Mucillagine Simbionte delle Mangrovie",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
+    "nodi_micorrizici_oracolari": {
+      "label_it": "Nodi Micorrizici Oracolari",
+      "label_en": "Nodi Micorrizici Oracolari",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
       }
     },
     "nucleo_ovomotore_rotante": {
       "label_it": "Uovo rotaia, uovo grande e uova piccole dentro...",
       "label_en": "Rotating Ovomotor Core",
       "rules": {
-        "total": 1,
+        "total": 3,
         "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "cursoriale_quadrupede",
             "count": 1
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null,
+            "count": 1
           }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 5,
         "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
@@ -492,6 +797,38 @@
             "count": 1,
             "examples": [
               "sand-burrower"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "magnet-fathom-surveyor"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "magnet-fathom-surveyor"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "orbital-ascendant"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "orbital-ascendant"
             ]
           }
         ]
@@ -536,17 +873,32 @@
       "label_it": "Olfatto di Risonanza Magnetica",
       "label_en": "Magnetic Resonance Scent",
       "rules": {
-        "total": 1,
+        "total": 4,
         "coverage": [
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 1
+          },
           {
             "biome": "mezzanotte_orbitale",
             "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null,
             "count": 1
           }
         ]
       },
       "species": {
-        "total": 2,
+        "total": 6,
         "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
@@ -557,23 +909,50 @@
             ]
           },
           {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "magnet-fathom-surveyor"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "magnet-fathom-surveyor"
+            ]
+          },
+          {
             "biome": "mezzanotte_orbitale",
             "morphotype": "cursoriale_quadrupede",
             "count": 1,
             "examples": [
               "cryo-lynx"
             ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "orbital-ascendant"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "orbital-ascendant"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede"
-          }
-        ]
+        "missing_in_rules": []
       }
     },
     "pathfinder": {
@@ -632,6 +1011,38 @@
             ]
           }
         ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
+    "piume_solari_fotovoltaiche": {
+      "label_it": "Piume Solari Fotovoltaiche",
+      "label_en": "Piume Solari Fotovoltaiche",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
+    "polmoni_cristallini_alta_quota": {
+      "label_it": "Polmoni Cristallini d'Alta Quota",
+      "label_en": "Polmoni Cristallini d'Alta Quota",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
@@ -733,18 +1144,49 @@
       "label_it": "Sacche galleggianti ascensoriali",
       "label_en": "Elevating Buoyancy Sacs",
       "rules": {
-        "total": 1,
+        "total": 4,
         "coverage": [
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 1
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore",
+            "count": 1
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null,
             "count": 1
           }
         ]
       },
       "species": {
-        "total": 3,
+        "total": 7,
         "coverage": [
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "psionic-canopy-scout"
+            ]
+          },
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "psionic-canopy-scout"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "cursoriale_quadrupede",
@@ -761,17 +1203,44 @@
               "aurora-bridge-runner",
               "zephyr-spore-courier"
             ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "orbital-ascendant"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "orbital-ascendant"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore"
-          }
-        ]
+        "missing_in_rules": []
+      }
+    },
+    "sacche_spore_stratosferiche": {
+      "label_it": "Sacche di Spore Stratosferiche",
+      "label_en": "Sacche di Spore Stratosferiche",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
       }
     },
     "sangue_piroforico": {
@@ -908,6 +1377,38 @@
         "missing_in_rules": []
       }
     },
+    "sensori_geomagnetici": {
+      "label_it": "Sensori a Risonanza Geomagnetica",
+      "label_en": "Geomagnetic Resonance Sensors",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
+    "sinapsi_coraline_polifoniche": {
+      "label_it": "Sinapsi Coraline Polifoniche",
+      "label_en": "Sinapsi Coraline Polifoniche",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
     "sonno_emisferico_alternato": {
       "label_it": "Dormire con solo metà cervello alla volta",
       "label_en": "Unihemispheric Sleep",
@@ -1009,22 +1510,69 @@
         "missing_in_rules": []
       }
     },
+    "squame_rifrangenti_deserto": {
+      "label_it": "Squame Rifrangenti del Deserto",
+      "label_en": "Squame Rifrangenti del Deserto",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
     "struttura_elastica_amorfa": {
       "label_it": "Struttura elastica, allungabile, amorfa, retrattile",
       "label_en": "Elastic Amorphous Frame",
       "rules": {
-        "total": 1,
+        "total": 4,
         "coverage": [
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 1
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
             "count": 1
           }
         ]
       },
       "species": {
-        "total": 4,
+        "total": 10,
         "coverage": [
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "psionic-canopy-scout"
+            ]
+          },
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "psionic-canopy-scout"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "cursoriale_quadrupede",
@@ -1032,6 +1580,31 @@
             "examples": [
               "dune-stalker",
               "slag-veil-ambusher"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "magnet-fathom-surveyor"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "magnet-fathom-surveyor"
+            ]
+          },
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "glowcap-weaver",
+              "myco-spire-warden"
             ]
           },
           {
@@ -1047,12 +1620,7 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "foresta_miceliale",
-            "morphotype": "scavenger_corazzato"
-          }
-        ]
+        "missing_in_rules": []
       }
     },
     "tattiche_di_branco": {
@@ -1080,6 +1648,22 @@
             ]
           }
         ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
+    "vello_condensatore_nebbie": {
+      "label_it": "Vello Condensatore di Nebbie",
+      "label_en": "Vello Condensatore di Nebbie",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
@@ -1133,6 +1717,22 @@
     "zampe_a_molla": {
       "label_it": "Zampe a Molla",
       "label_en": "Spring-Loaded Limbs",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": []
+      }
+    },
+    "zoccoli_risonanti_steppe": {
+      "label_it": "Zoccoli Risonanti delle Steppe",
+      "label_en": "Zoccoli Risonanti delle Steppe",
       "rules": {
         "total": 0,
         "coverage": []
@@ -1318,7 +1918,7 @@
         ]
       },
       "ingegneri_ecosistema": {
-        "total_species": 6,
+        "total_species": 7,
         "biomes": {
           "abisso_vulcanico": {
             "count": 1,
@@ -1330,6 +1930,23 @@
                 "playable_unit": true,
                 "core_traits": [],
                 "source": "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml"
+              }
+            ]
+          },
+          "canopia_psionica_leggera": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "psionic-canopy-scout",
+                "playable_unit": true,
+                "core_traits": [
+                  "focus_frazionato",
+                  "mimetismo_cromatico_passivo",
+                  "sacche_galleggianti_ascensoriali"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/canopia_psionica_leggera/psionic-canopy-scout.yaml"
               }
             ]
           },
@@ -1407,6 +2024,7 @@
         },
         "biomes_missing_threshold": [
           "abisso_vulcanico",
+          "canopia_psionica_leggera",
           "dorsale_termale_tropicale",
           "mezzanotte_orbitale"
         ]
@@ -1487,7 +2105,7 @@
         ]
       },
       "predatore_regolatore_simbionte": {
-        "total_species": 1,
+        "total_species": 2,
         "biomes": {
           "dorsale_termale_tropicale": {
             "count": 1,
@@ -1505,14 +2123,32 @@
                 "source": "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml"
               }
             ]
+          },
+          "falde_magnetiche_psioniche": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "magnet-fathom-surveyor",
+                "playable_unit": false,
+                "core_traits": [
+                  "filamenti_digestivi_compattanti",
+                  "nucleo_ovomotore_rotante",
+                  "olfatto_risonanza_magnetica"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/magnet-fathom-surveyor.yaml"
+              }
+            ]
           }
         },
         "biomes_missing_threshold": [
-          "dorsale_termale_tropicale"
+          "dorsale_termale_tropicale",
+          "falde_magnetiche_psioniche"
         ]
       },
       "predatore_terziario_apex": {
-        "total_species": 7,
+        "total_species": 8,
         "biomes": {
           "abisso_vulcanico": {
             "count": 1,
@@ -1612,13 +2248,31 @@
                 "source": "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml"
               }
             ]
+          },
+          "orbita_psionica_inversa": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "orbital-ascendant",
+                "playable_unit": true,
+                "core_traits": [
+                  "focus_frazionato",
+                  "nucleo_ovomotore_rotante",
+                  "olfatto_risonanza_magnetica"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbital-ascendant.yaml"
+              }
+            ]
           }
         },
         "biomes_missing_threshold": [
           "abisso_vulcanico",
           "caverna_risonante",
           "foresta_miceliale",
-          "mezzanotte_orbitale"
+          "mezzanotte_orbitale",
+          "orbita_psionica_inversa"
         ]
       }
     }

--- a/data/biome_aliases.yaml
+++ b/data/biome_aliases.yaml
@@ -34,3 +34,15 @@ aliases:
   stratosfera:
     canonical: stratosfera_tempestosa
     notes: "Slug abbreviato usato negli snapshot precedenti della stratosfera."
+  canopia_psionica_leggera:
+    canonical: canopia_ionica
+    status: expansion
+    notes: "Nodo T1 per le colture psioniche leggere, collegato alla canopia ionica verticale."
+  falde_magnetiche_psioniche:
+    canonical: dorsale_termale_tropicale
+    status: expansion
+    notes: "Classe T2 che sfrutta le dorsali termali per amplificare i gradienti magnetici psionici."
+  orbita_psionica_inversa:
+    canonical: mezzanotte_orbitale
+    status: expansion
+    notes: "Classe T3 apex ambientata nella Mezzanotte Orbitale e nei suoi loop gravitazionali."

--- a/data/traits/glossary.json
+++ b/data/traits/glossary.json
@@ -5,13 +5,49 @@
     "trait_reference": "packs/evo_tactics_pack/docs/catalog/trait_reference.json"
   },
   "traits": {
+    "antenne_plasmatiche_tempesta": {
+      "label_it": "Antenne Plasmatiche di Tempesta",
+      "label_en": "Antenne Plasmatiche di Tempesta"
+    },
     "artigli_sette_vie": {
       "label_en": "Seven-Way Talons",
       "label_it": "Artigli a Sette Vie"
     },
+    "artigli_sghiaccio_glaciale": {
+      "label_it": "Artigli Sghiaccio Glaciale",
+      "label_en": "Artigli Sghiaccio Glaciale"
+    },
+    "branchie_osmotiche_salmastra": {
+      "label_it": "Branchie Osmotiche Salmastre",
+      "label_en": "Branchie Osmotiche Salmastre"
+    },
+    "bulbi_radici_permafrost": {
+      "label_it": "Bulbi Radici del Permafrost",
+      "label_en": "Bulbi Radici del Permafrost"
+    },
     "carapace_fase_variabile": {
       "label_en": "Phase-Shifting Carapace",
       "label_it": "Carapace a Variazione di Fase"
+    },
+    "carapace_luminiscente_abissale": {
+      "label_it": "Carapace Luminiscente Abissale",
+      "label_en": "Carapace Luminiscente Abissale"
+    },
+    "cartilagine_flessotermica_venti": {
+      "label_it": "Cartilagine Flessotermica dei Venti",
+      "label_en": "Cartilagine Flessotermica dei Venti"
+    },
+    "cavita_risonanti_tundra": {
+      "label_it": "Cavità Risonanti della Tundra",
+      "label_en": "Cavità Risonanti della Tundra"
+    },
+    "chioma_parassita_canopica": {
+      "label_it": "Chioma Parassita Canopica",
+      "label_en": "Chioma Parassita Canopica"
+    },
+    "circolazione_bifasica_palude": {
+      "label_it": "Circolazione Bifasica di Palude",
+      "label_en": "Circolazione Bifasica di Palude"
     },
     "coda_frusta_cinetica": {
       "label_en": "Kinetic Lash Tail",
@@ -41,13 +77,29 @@
       "label_en": "Caustic Gland",
       "label_it": "Ghiandola Caustica"
     },
+    "lamelle_termoforetiche": {
+      "label_en": "Thermophoretic Lamellae",
+      "label_it": "Lamelle Termoforetiche"
+    },
     "lingua_tattile_trama": {
       "label_en": "Texture-Sensing Tongue",
       "label_it": "Lingua Tattile Trama-Sensibile"
     },
+    "membrane_eliofiltranti": {
+      "label_it": "Membrane Eliofiltranti",
+      "label_en": "Membrane Eliofiltranti"
+    },
     "mimetismo_cromatico_passivo": {
       "label_en": "Passive Chromatic Mimicry",
       "label_it": "Ghiandole di Mimetismo Cromatico Passivo"
+    },
+    "mucillagine_simbionte_mangrovie": {
+      "label_it": "Mucillagine Simbionte delle Mangrovie",
+      "label_en": "Mucillagine Simbionte delle Mangrovie"
+    },
+    "nodi_micorrizici_oracolari": {
+      "label_it": "Nodi Micorrizici Oracolari",
+      "label_en": "Nodi Micorrizici Oracolari"
     },
     "nucleo_ovomotore_rotante": {
       "label_en": "Rotating Ovomotor Core",
@@ -69,6 +121,14 @@
       "label_en": "Strategic Planner",
       "label_it": "Pianificatore"
     },
+    "piume_solari_fotovoltaiche": {
+      "label_it": "Piume Solari Fotovoltaiche",
+      "label_en": "Piume Solari Fotovoltaiche"
+    },
+    "polmoni_cristallini_alta_quota": {
+      "label_it": "Polmoni Cristallini d'Alta Quota",
+      "label_en": "Polmoni Cristallini d'Alta Quota"
+    },
     "random": {
       "label_en": "Trait Random",
       "label_it": "Trait Random"
@@ -85,9 +145,9 @@
       "label_en": "Elevating Buoyancy Sacs",
       "label_it": "Sacche galleggianti ascensoriali"
     },
-    "sensori_geomagnetici": {
-      "label_en": "Geomagnetic Resonance Sensors",
-      "label_it": "Sensori a Risonanza Geomagnetica"
+    "sacche_spore_stratosferiche": {
+      "label_it": "Sacche di Spore Stratosferiche",
+      "label_en": "Sacche di Spore Stratosferiche"
     },
     "sangue_piroforico": {
       "label_en": "Pyrophoric Blood",
@@ -101,6 +161,14 @@
       "label_en": "Retarding Palm Secretions",
       "label_it": "Mani secernano liquido rallentante"
     },
+    "sensori_geomagnetici": {
+      "label_en": "Geomagnetic Resonance Sensors",
+      "label_it": "Sensori a Risonanza Geomagnetica"
+    },
+    "sinapsi_coraline_polifoniche": {
+      "label_it": "Sinapsi Coraline Polifoniche",
+      "label_en": "Sinapsi Coraline Polifoniche"
+    },
     "sonno_emisferico_alternato": {
       "label_en": "Unihemispheric Sleep",
       "label_it": "Dormire con solo metà cervello alla volta"
@@ -109,17 +177,21 @@
       "label_en": "Silent Psychic Spores",
       "label_it": "Spora Psichica Silenziosa"
     },
+    "squame_rifrangenti_deserto": {
+      "label_it": "Squame Rifrangenti del Deserto",
+      "label_en": "Squame Rifrangenti del Deserto"
+    },
     "struttura_elastica_amorfa": {
       "label_en": "Elastic Amorphous Frame",
       "label_it": "Struttura elastica, allungabile, amorfa, retrattile"
     },
-    "lamelle_termoforetiche": {
-      "label_en": "Thermophoretic Lamellae",
-      "label_it": "Lamelle Termoforetiche"
-    },
     "tattiche_di_branco": {
       "label_en": "Pack Tactics",
       "label_it": "Tattiche di Branco"
+    },
+    "vello_condensatore_nebbie": {
+      "label_it": "Vello Condensatore di Nebbie",
+      "label_en": "Vello Condensatore di Nebbie"
     },
     "ventriglio_gastroliti": {
       "label_en": "Gastrolith Grinding Gizzard",
@@ -128,6 +200,10 @@
     "zampe_a_molla": {
       "label_en": "Spring-Loaded Limbs",
       "label_it": "Zampe a Molla"
+    },
+    "zoccoli_risonanti_steppe": {
+      "label_it": "Zoccoli Risonanti delle Steppe",
+      "label_en": "Zoccoli Risonanti delle Steppe"
     }
   }
 }

--- a/docs/evo-tactics-pack/trait-reference.json
+++ b/docs/evo-tactics-pack/trait-reference.json
@@ -2,6 +2,40 @@
   "schema_version": "2.0",
   "trait_glossary": "data/traits/glossary.json",
   "traits": {
+    "antenne_plasmatiche_tempesta": {
+      "conflitti": [],
+      "debolezza": "Scariche elettriche massicce possono bruciare i recettori e compromettere la coordinazione.",
+      "famiglia_tipologia": "Sensoriale/Offensivo",
+      "fattore_mantenimento_energetico": "Alto (Canalizzazione costante di plasma atmosferico)",
+      "label": "Antenne Plasmatiche di Tempesta",
+      "mutazione_indotta": "Flagelli coronati da nodi plasma-sensibili che captano e deviano fulmini.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "cicloni_psionici"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Occhi di tempesta permanenti che concentrano elettricità e onde psioniche."
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Comandare fulmini e navigare in cieli turbolenti durante campagne aeree.",
+      "tier": "T3",
+      "uso_funzione": "Canalizza scariche atmosferiche in attacchi direzionati o scudi ionici."
+    },
     "artigli_sette_vie": {
       "conflitti": [],
       "debolezza": "Angoli di presa limitati se la superficie è perfettamente liscia.",
@@ -23,6 +57,7 @@
         }
       ],
       "sinergie": [
+        "coda_frusta_cinetica",
         "struttura_elastica_amorfa"
       ],
       "sinergie_pi": {
@@ -35,6 +70,110 @@
       "spinta_selettiva": "Arrampicarsi su pareti rocciose o vegetazione densa.",
       "tier": "T1",
       "uso_funzione": "Afferrare superfici irregolari o oggetti multipli."
+    },
+    "artigli_sghiaccio_glaciale": {
+      "conflitti": [],
+      "debolezza": "In ambienti temperati i tessuti subiscono microfratture e richiedono continue riparazioni.",
+      "famiglia_tipologia": "Locomotorio/Predatorio",
+      "fattore_mantenimento_energetico": "Medio (Raffreddamento endogeno controllato)",
+      "label": "Artigli Sghiaccio Glaciale",
+      "mutazione_indotta": "Falangi rivestite da ghiaccio strutturale che si espande creando lame traslucide.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "calotte_glaciali"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Calotte di ghiaccio psionico che reagiscono alle vibrazioni e amplificano le lame criogeniche."
+          }
+        }
+      ],
+      "sinergie": [
+        "zampe_a_molla"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Cacciare su superfici gelate e pareti verticali di ghiaccio vivo.",
+      "tier": "T2",
+      "uso_funzione": "Scalza e immobilizza i bersagli congelandoli al contatto."
+    },
+    "branchie_osmotiche_salmastra": {
+      "conflitti": [
+        "polmoni_cristallini_alta_quota"
+      ],
+      "debolezza": "Richiede accesso costante ad acqua salmastra; ambienti d'acqua dolce provocano stress ionico.",
+      "famiglia_tipologia": "Respiratorio/Osmoregolazione",
+      "fattore_mantenimento_energetico": "Medio (Pompe ioniche attive)",
+      "label": "Branchie Osmotiche Salmastre",
+      "mutazione_indotta": "Lamelle branchiali multilivello con valvole che separano sali e tossine.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "delta_salmastri"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Estuari psionici dove l'acqua dolce e marina si mescolano creando gradienti forti."
+          }
+        }
+      ],
+      "sinergie": [
+        "scheletro_idro_regolante"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Colonizzare mangrovie psioniche e barriere di estuario soggette a maree estreme.",
+      "tier": "T2",
+      "uso_funzione": "Bilancia sali e tossine sfruttando microvalvole controllate psionicamente."
+    },
+    "bulbi_radici_permafrost": {
+      "conflitti": [],
+      "debolezza": "Disgeli improvvisi trasformano i bulbi in masse gelatinose che rallentano i movimenti.",
+      "famiglia_tipologia": "Simbiotico/Nutrizione",
+      "fattore_mantenimento_energetico": "Medio (Accumulo e rilascio lento di nutrienti)",
+      "label": "Bulbi Radici del Permafrost",
+      "mutazione_indotta": "Bulbi radicali multipli che immagazzinano energia nelle stagioni fredde per rilasciarla durante le missioni.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "permafrost_psionico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Suoli congelati con vene energetiche che alimentano radici coscienti."
+          }
+        }
+      ],
+      "sinergie": [
+        "vello_condensatore_nebbie"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Sostenere campagne lunghe in climi artici con riserve nutrizionali concentrate.",
+      "tier": "T2",
+      "uso_funzione": "Rilascia energia e calore agli alleati radicati nella stessa rete subglaciale."
     },
     "carapace_fase_variabile": {
       "conflitti": [
@@ -49,12 +188,25 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "canopia_psionica_leggera"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "T1 di acclimatazione nelle canopie conduttrici a bassa intensità.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Percorso T2 che aggiunge gradienti magnetici per pattern cromatici complessi.",
+            "tier": "T2"
           }
         }
       ],
@@ -70,6 +222,182 @@
       "tier": "T1",
       "uso_funzione": "Durezza/densità del guscio modificabile rapidamente."
     },
+    "carapace_luminiscente_abissale": {
+      "conflitti": [
+        "carapace_fase_variabile"
+      ],
+      "debolezza": "Luce intensa di superficie sovraccarica i biofotoni rendendo la corazza fragile.",
+      "famiglia_tipologia": "Strutturale/Sensoriale",
+      "fattore_mantenimento_energetico": "Alto (Bioluminescenza controllata)",
+      "label": "Carapace Luminiscente Abissale",
+      "mutazione_indotta": "Placche chitino-minerali con microrganismi luminescenti che comunicano in pattern.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Gole oceaniche illuminate da coralli psionici e scariche elettrostatiche."
+          }
+        }
+      ],
+      "sinergie": [
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Comunicare e mimetizzarsi nelle profondità prive di luce naturale.",
+      "tier": "T3",
+      "uso_funzione": "Emette segnali di branco e devia attacchi grazie a pattern luminosi cangianti."
+    },
+    "cartilagine_flessotermica_venti": {
+      "conflitti": [
+        "scheletro_idro_regolante"
+      ],
+      "debolezza": "Temperature stabili riducono la reattività della cartilagine rendendo l'organismo lento.",
+      "famiglia_tipologia": "Locomotorio/Adattivo",
+      "fattore_mantenimento_energetico": "Medio (Richiede frequenti riallineamenti fibrosi)",
+      "label": "Cartilagine Flessotermica dei Venti",
+      "mutazione_indotta": "Giunzioni cartilaginee che cambiano rigidità in risposta a gradienti termici e eolici.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "gole_ventose"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Canyon sospesi dove venti caldi e freddi si alternano in pattern ciclici."
+          }
+        }
+      ],
+      "sinergie": [
+        "zoccoli_risonanti_steppe"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Scalare falesie e planare tra correnti ascensionali turbolente.",
+      "tier": "T2",
+      "uso_funzione": "Modula elasticità e rigidità muscolo-scheletrica per manovre evasive rapide."
+    },
+    "cavita_risonanti_tundra": {
+      "conflitti": [],
+      "debolezza": "In ambienti temperati l'eco interna produce rumori udibili che rivelano la posizione.",
+      "famiglia_tipologia": "Sensoriale/Supporto",
+      "fattore_mantenimento_energetico": "Basso (Camere di risonanza statiche)",
+      "label": "Cavità Risonanti della Tundra",
+      "mutazione_indotta": "Camere toraciche espanse che amplificano vibrazioni subsoniche nel permafrost.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "tundra_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Steppe gelate che trasmettono vibrazioni psioniche a chilometri di distanza."
+          }
+        }
+      ],
+      "sinergie": [
+        "eco_interno_riflesso"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Coordinare branchi in lande aperte dove la visibilità è ridotta da bufere di ghiaccio.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica segnali acustici per comunicazioni a lungo raggio nel gelo."
+    },
+    "chioma_parassita_canopica": {
+      "conflitti": [],
+      "debolezza": "Se la pianta ospite muore la chioma psionica collassa causando shock sistemico.",
+      "famiglia_tipologia": "Simbiotico/Utility",
+      "fattore_mantenimento_energetico": "Medio (Nutrimento condiviso con l'ospite arboreo)",
+      "label": "Chioma Parassita Canopica",
+      "mutazione_indotta": "Filamenti vegetali che si intrecciano con la canopia ospite fornendo punti d'ancoraggio e energia.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopie_sospese"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Foreste verticali multilivello con alberi levitanti e liane sensibili."
+          }
+        }
+      ],
+      "sinergie": [
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Stabilizzare piattaforme mobili e reti di trasporto tra gli alberi viventi.",
+      "tier": "T1",
+      "uso_funzione": "Crea passaggi e nodi energetici condivisi nella canopia per movimenti rapidi."
+    },
+    "circolazione_bifasica_palude": {
+      "conflitti": [
+        "sangue_piroforico"
+      ],
+      "debolezza": "Zone asciutte e calde causano stagnazione del circuito linfatico portando a tossicosi.",
+      "famiglia_tipologia": "Metabolico/Resilienza",
+      "fattore_mantenimento_energetico": "Medio (Doppio circuito emolinfa/linfa)",
+      "label": "Circolazione Bifasica di Palude",
+      "mutazione_indotta": "Cuori gemelli che pompano separatamente emolinfa ossigenata e linfa detossificante.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "paludi_gas_luminescenti"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Paludi bioluminescenti piene di gas nervini e batteri simbionti."
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Resistere a tossine e anossia tipiche delle paludi psioniche.",
+      "tier": "T2",
+      "uso_funzione": "Gestisce due circuiti circolatori per filtrare veleni e mantenere prestazioni elevate."
+    },
     "coda_frusta_cinetica": {
       "conflitti": [],
       "debolezza": "Richiede un periodo di inattività o movimento preparatorio per massimizzare il danno.",
@@ -81,12 +409,25 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "falde_magnetiche_psioniche"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Corridore T2 per intercettare campi magnetici psionici sulle dorsali.",
+            "tier": "T2"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante T3 calibrata alle camere di gravità invertita e ai flussi orbitali.",
+            "tier": "T3"
           }
         }
       ],
@@ -118,12 +459,25 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "canopia_psionica_leggera"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Fase T1 controllata: micro-canopie sospese usate per cicli brevi di ibernazione.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante apex T3 in camere orbitali a gravità invertita per stasi prolungate.",
+            "tier": "T3"
           }
         }
       ],
@@ -150,17 +504,32 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "canopia_psionica_leggera"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Start T1 nelle canopie conduttrici per apprendere deformazioni controllate.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Upgrade T2 sulle dorsali magnetiche per mantenere elasticità sotto stress.",
+            "tier": "T2"
           }
         }
       ],
       "sinergie": [
-        "olfatto_risonanza_magnetica"
+        "cavita_risonanti_tundra",
+        "olfatto_risonanza_magnetica",
+        "sensori_geomagnetici"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
@@ -170,7 +539,7 @@
       },
       "slot": [],
       "spinta_selettiva": "Orientamento in ambienti completamente privi di luce.",
-      "tier": "T1",
+      "tier": "T2",
       "uso_funzione": "Utilizzo di onde sonore emesse internamente per mappare l'ambiente."
     },
     "empatia_coordinativa": {
@@ -215,7 +584,20 @@
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante T2 che sfrutta falde magnetiche per compattare residui ad alta densità.",
+            "tier": "T2"
           }
         }
       ],
@@ -230,7 +612,7 @@
       },
       "slot": [],
       "spinta_selettiva": "Necessità di mantenere la pulizia del territorio/nido.",
-      "tier": "T1",
+      "tier": "T2",
       "uso_funzione": "Espulsione compatta e ordinata di scorie."
     },
     "focus_frazionato": {
@@ -241,7 +623,9 @@
       "label": "Focus Frazionato",
       "mutazione_indotta": "Processore di priorità multi-thread per bersagli e obiettivi.",
       "requisiti_ambientali": [],
-      "sinergie": [],
+      "sinergie": [
+        "antenne_plasmatiche_tempesta"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [
           "PE",
@@ -293,6 +677,42 @@
       "tier": "T1",
       "uso_funzione": "Sblocco early di danni da acido per rompere armature leggere."
     },
+    "lamelle_termoforetiche": {
+      "conflitti": [
+        "criostasi_adattiva"
+      ],
+      "debolezza": "Rende instabile la fisiologia in ambienti a gelo improvviso, con rischio di microfratture vascolari.",
+      "famiglia_tipologia": "Respiratorio/Termoregolazione",
+      "fattore_mantenimento_energetico": "Medio (Flusso continuo di fluidi caldi)",
+      "label": "Lamelle Termoforetiche",
+      "mutazione_indotta": "Canali lamellari mineralizzati che convogliano fluidi caldi tra branchie interne.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "sorgenti_geotermiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Habitat idrotermali psionici dove il calore e la pressione variano rapidamente."
+          }
+        }
+      ],
+      "sinergie": [
+        "sangue_piroforico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Sopravvivere a fluidi tossici e temperature estreme nelle fumarole geotermiche.",
+      "tier": "T2",
+      "uso_funzione": "Regola lo scambio gassoso sfruttando gradienti termici controllati."
+    },
     "lingua_tattile_trama": {
       "conflitti": [],
       "debolezza": "Estrema vulnerabilità della lingua a contaminanti chimici o acidi.",
@@ -327,6 +747,41 @@
       "tier": "T1",
       "uso_funzione": "\"Leggere\" la tessitura delle superfici per vibrazioni o micro-fratture."
     },
+    "membrane_eliofiltranti": {
+      "conflitti": [],
+      "debolezza": "Atmosfere acide degradano rapidamente il film eliofiltrante.",
+      "famiglia_tipologia": "Respiratorio/Protezione",
+      "fattore_mantenimento_energetico": "Basso (Auto-riparazione lenta)",
+      "label": "Membrane Eliofiltranti",
+      "mutazione_indotta": "Strati di mucopolisaccaridi trasparenti che filtrano radiazioni e microrganismi sospesi.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laghi_alcalini"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Bacini alcalini sospesi dove la luce viene rifratta da vapori metallici."
+          }
+        }
+      ],
+      "sinergie": [
+        "piume_solari_fotovoltaiche",
+        "polmoni_cristallini_alta_quota"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Proteggersi da radiazioni e agenti patogeni in altopiani ipersalini.",
+      "tier": "T2",
+      "uso_funzione": "Filtra l'aria e i flussi luminosi rendendoli sicuri per tessuti delicati."
+    },
     "mimetismo_cromatico_passivo": {
       "conflitti": [],
       "debolezza": "La colorazione è fissa finché non c'è un nuovo contatto prolungato.",
@@ -338,12 +793,25 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "canopia_psionica_leggera"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "T1 di acclimatazione nelle canopie conduttrici a bassa intensità.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Percorso T2 che aggiunge gradienti magnetici per pattern cromatici complessi.",
+            "tier": "T2"
           }
         }
       ],
@@ -360,6 +828,80 @@
       "spinta_selettiva": "Ambiente con pattern cromatici molto variabili che cambiano lentamente.",
       "tier": "T1",
       "uso_funzione": "Assorbire e replicare il colore dell'ambiente circostante dopo contatto."
+    },
+    "mucillagine_simbionte_mangrovie": {
+      "conflitti": [
+        "ghiandola_caustica"
+      ],
+      "debolezza": "Acque eccessivamente pure diluiscono la mucillagine riducendo la protezione.",
+      "famiglia_tipologia": "Simbiotico/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Coltura simbiotica costante)",
+      "label": "Mucillagine Simbionte delle Mangrovie",
+      "mutazione_indotta": "Strati mucosi che ospitano microfauna detossificante proveniente dalle radici di mangrovia.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovie_risonanti"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Foreste di mangrovie ipersature dove le radici cantano frequenze psioniche."
+          }
+        }
+      ],
+      "sinergie": [
+        "circolazione_bifasica_palude",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Respinge tossine e predatori microbici tipici dei delta paludosi.",
+      "tier": "T1",
+      "uso_funzione": "Forma una barriera viva che neutralizza veleni e sigilla ferite."
+    },
+    "nodi_micorrizici_oracolari": {
+      "conflitti": [
+        "spore_psichiche_silenziate"
+      ],
+      "debolezza": "Se la rete micorrizica viene recisa, l'organismo soffre crisi percettive e perdita di orientamento.",
+      "famiglia_tipologia": "Simbiotico/Nervoso",
+      "fattore_mantenimento_energetico": "Medio (Scambio continuo di segnali con simbionti)",
+      "label": "Nodi Micorrizici Oracolari",
+      "mutazione_indotta": "Radici dermiche che intrecciano funghi psionici capaci di predire variazioni ambientali.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reti_micorriziche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Sottoboschi viventi con reti fungine coscienti che emettono segnali premonitori."
+          }
+        }
+      ],
+      "sinergie": [
+        "chioma_parassita_canopica",
+        "mucillagine_simbionte_mangrovie"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Anticipare frane psioniche e predatori guidati da reti vegetali senzienti.",
+      "tier": "T3",
+      "uso_funzione": "Riceve presagi e segnali tattici dalla rete fungina per coordinare manovre di squadra."
     },
     "nucleo_ovomotore_rotante": {
       "conflitti": [
@@ -440,17 +982,31 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "falde_magnetiche_psioniche"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Corridore T2 per intercettare campi magnetici psionici sulle dorsali.",
+            "tier": "T2"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante T3 calibrata alle camere di gravità invertita e ai flussi orbitali.",
+            "tier": "T3"
           }
         }
       ],
       "sinergie": [
-        "eco_interno_riflesso"
+        "eco_interno_riflesso",
+        "lingua_tattile_trama"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
@@ -460,7 +1016,7 @@
       },
       "slot": [],
       "spinta_selettiva": "Orientamento in ambienti sotterranei senza luce o caccia a prede metallifere.",
-      "tier": "T1",
+      "tier": "T2",
       "uso_funzione": "Percepire la direzione e la composizione di metalli o campi energetici."
     },
     "pathfinder": {
@@ -526,6 +1082,79 @@
       "tier": "T1",
       "uso_funzione": "Coordina finestre di danno e difesa, mantenendo la squadra allineata al piano PI."
     },
+    "piume_solari_fotovoltaiche": {
+      "conflitti": [
+        "criostasi_adattiva"
+      ],
+      "debolezza": "Ombre prolungate o polveri dense riducono drasticamente la produzione energetica.",
+      "famiglia_tipologia": "Tegumentario/Energetico",
+      "fattore_mantenimento_energetico": "Alto (Richiede manutenzione delle lamine fotoreattive)",
+      "label": "Piume Solari Fotovoltaiche",
+      "mutazione_indotta": "Piumaggio stratificato con pigmenti piezo-fotovoltaici che immagazzinano luce.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "altipiani_solari"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Altipiani ad alta insolazione dove le correnti psioniche amplificano la luce."
+          }
+        }
+      ],
+      "sinergie": [
+        "membrane_eliofiltranti",
+        "sacche_spore_stratosferiche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Massimizzare l'autonomia energetica per migrazioni aeree sopra deserti e oceani.",
+      "tier": "T2",
+      "uso_funzione": "Convertire la radiazione solare in riserve energetiche per abilità a lungo raggio."
+    },
+    "polmoni_cristallini_alta_quota": {
+      "conflitti": [
+        "branchie_osmotiche_salmastra"
+      ],
+      "debolezza": "Particolato pesante o sabbia vulcanica graffia i cristalli riducendo l'efficienza respiratoria.",
+      "famiglia_tipologia": "Respiratorio/Aerobico",
+      "fattore_mantenimento_energetico": "Medio (Pulizia periodica dei cristalli)",
+      "label": "Polmoni Cristallini d'Alta Quota",
+      "mutazione_indotta": "Sistemi alveolari irrobustiti da strutture cristalline che catturano ossigeno rarefatto.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "picchi_cristallini"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Catene montuose sospese dove i cristalli amplificano l'aria rarefatta."
+          }
+        }
+      ],
+      "sinergie": [
+        "membrane_eliofiltranti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Operare in missioni d'alta quota senza supporto logistico esterno.",
+      "tier": "T2",
+      "uso_funzione": "Massimizza l'assorbimento di ossigeno rarefatto e filtra agenti nocivi."
+    },
     "random": {
       "conflitti": [],
       "debolezza": "Bassa affidabilità: richiede slot aggiuntivi per mitigare risultati sfavorevoli.",
@@ -576,7 +1205,8 @@
         }
       ],
       "sinergie": [
-        "sacche_galleggianti_ascensoriali"
+        "sacche_galleggianti_ascensoriali",
+        "squame_rifrangenti_deserto"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
@@ -633,16 +1263,31 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "canopia_psionica_leggera"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Fase T1 in canopie sospese per calibrare pompaggio e feedback pressorio.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Apex T3 su piattaforme orbitali a gravità invertita per ascese rapide.",
+            "tier": "T3"
           }
         }
       ],
       "sinergie": [
+        "respiro_a_scoppio",
+        "scheletro_idro_regolante",
         "struttura_elastica_amorfa"
       ],
       "sinergie_pi": {
@@ -655,6 +1300,42 @@
       "spinta_selettiva": "Vivere in un ambiente acquatico con forti correnti verticali.",
       "tier": "T1",
       "uso_funzione": "Controllo preciso della profondità e del movimento verticale."
+    },
+    "sacche_spore_stratosferiche": {
+      "conflitti": [
+        "respiro_a_scoppio"
+      ],
+      "debolezza": "Correnti ionizzate possono incendiare le sacche rendendo l'organismo instabile.",
+      "famiglia_tipologia": "Simbiotico/Supporto",
+      "fattore_mantenimento_energetico": "Alto (Coltura continua di spore portanti)",
+      "label": "Sacche di Spore Stratosferiche",
+      "mutazione_indotta": "Vescicole dermiche che rilasciano spore portatrici capaci di galleggiare per chilometri.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_portante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Correnti ascendenti permanenti che trasportano semi e spore su larga scala."
+          }
+        }
+      ],
+      "sinergie": [
+        "piume_solari_fotovoltaiche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Dispersone genetica rapida tra arcipelaghi aerei e piattaforme galleggianti.",
+      "tier": "T3",
+      "uso_funzione": "Distribuisce simbionti di supporto e crea corridoi di movimento per la squadra."
     },
     "sangue_piroforico": {
       "conflitti": [
@@ -679,7 +1360,9 @@
           }
         }
       ],
-      "sinergie": [],
+      "sinergie": [
+        "lamelle_termoforetiche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -714,7 +1397,9 @@
         }
       ],
       "sinergie": [
-        "sacche_galleggianti_ascensoriali"
+        "branchie_osmotiche_salmastra",
+        "sacche_galleggianti_ascensoriali",
+        "struttura_elastica_amorfa"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
@@ -761,6 +1446,76 @@
       "spinta_selettiva": "Cattura di prede veloci o difesa da aggressori corpo a corpo.",
       "tier": "T1",
       "uso_funzione": "Neutralizzare o immobilizzare prede/nemici."
+    },
+    "sensori_geomagnetici": {
+      "conflitti": [],
+      "debolezza": "Tempeste solari possono saturare il segnale magnetico, causando disorientamento prolungato.",
+      "famiglia_tipologia": "Sensoriale/Navigazione",
+      "fattore_mantenimento_energetico": "Basso (Ricettori passivi)",
+      "label": "Sensori Geomagnetici",
+      "mutazione_indotta": "Cristalli ferromagnetici allineati lungo il cranio che fungono da bussola psionica.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianure_magnetiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Distese pianeggianti con vortici geomagnetici da sfruttare per la navigazione."
+          }
+        }
+      ],
+      "sinergie": [
+        "eco_interno_riflesso"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Orientarsi in steppe polarizzate e tunnel sotterranei privi di riferimenti visivi.",
+      "tier": "T1",
+      "uso_funzione": "Traccia linee di campo e memorizza corridoi magnetici per la migrazione."
+    },
+    "sinapsi_coraline_polifoniche": {
+      "conflitti": [
+        "spore_psichiche_silenziate"
+      ],
+      "debolezza": "Vibrazioni sintonizzate male possono generare feedback dolorosi e perdita di coscienza.",
+      "famiglia_tipologia": "Simbiotico/Comunicazione",
+      "fattore_mantenimento_energetico": "Medio (Scambio continuo di impulsi corallini)",
+      "label": "Sinapsi Coraline Polifoniche",
+      "mutazione_indotta": "Fibre nervose intrecciate con coralli sonori che trasmettono ordini tramite armoniche.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "barriere_coralline_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Scogliere viventi che rispondono a canti psionici e onde sonore."
+          }
+        }
+      ],
+      "sinergie": [
+        "carapace_luminiscente_abissale"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Coordinare banchi e alleati in ambienti tridimensionali complessi.",
+      "tier": "T2",
+      "uso_funzione": "Trasmette comandi e pattern tattici sfruttando armoniche subacquee."
     },
     "sonno_emisferico_alternato": {
       "conflitti": [],
@@ -830,6 +1585,42 @@
       "tier": "T1",
       "uso_funzione": "Indurre uno stato di confusione o letargia negli individui vicini."
     },
+    "squame_rifrangenti_deserto": {
+      "conflitti": [
+        "mimetismo_cromatico_passivo"
+      ],
+      "debolezza": "Soffre danni da feedback termico se colpito da raggi concentrati o laser.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Richiede riallineamento delle placche)",
+      "label": "Squame Rifrangenti del Deserto",
+      "mutazione_indotta": "Placche cristalline sovrapposte che deviano luce e calore lungo superfici multiple.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dune_cristalline"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Deserti di quarzo e vetro dove le tempeste solari vengono amplificate."
+          }
+        }
+      ],
+      "sinergie": [
+        "respiro_a_scoppio"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Sopravvivere a intensi flare termici e accecanti miraggi desertici.",
+      "tier": "T2",
+      "uso_funzione": "Rifrange la luce generando miraggi e dissipando attacchi energetici."
+    },
     "struttura_elastica_amorfa": {
       "conflitti": [],
       "debolezza": "Vulnerabilità a danni da taglio o perforazione (difficile cauterizzazione).",
@@ -841,16 +1632,32 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "canopia_psionica_leggera"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Start T1 nelle canopie conduttrici per apprendere deformazioni controllate.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Upgrade T2 sulle dorsali magnetiche per mantenere elasticità sotto stress.",
+            "tier": "T2"
           }
         }
       ],
       "sinergie": [
+        "artigli_sette_vie",
+        "mimetismo_cromatico_passivo",
+        "sacche_galleggianti_ascensoriali",
         "scheletro_idro_regolante"
       ],
       "sinergie_pi": {
@@ -895,6 +1702,40 @@
       "tier": "T1",
       "uso_funzione": "Coordina prese e focus bersaglio condividendo segnali di priorità."
     },
+    "vello_condensatore_nebbie": {
+      "conflitti": [],
+      "debolezza": "In ambienti aridi accumula detriti che riducono la capacità di condensa.",
+      "famiglia_tipologia": "Tegumentario/Idratazione",
+      "fattore_mantenimento_energetico": "Basso (Strutture passive a microfilo)",
+      "label": "Vello Condensatore di Nebbie",
+      "mutazione_indotta": "Peli cavi microstriati che catturano e canalizzano la bruma atmosferica.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foreste_nubose"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Canopie immerse in nebbia costante con risonanza umida e lampi bioluminescenti."
+          }
+        }
+      ],
+      "sinergie": [
+        "bulbi_radici_permafrost"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Garantire idratazione in climi montani dove l'acqua liquida è scarsa ma la nebbia abbondante.",
+      "tier": "T1",
+      "uso_funzione": "Condensa acqua atmosferica per supportare abilità metaboliche ad alto consumo."
+    },
     "ventriglio_gastroliti": {
       "conflitti": [],
       "debolezza": "Usura e rottura del ventriglio se i gastroliti sono esauriti o troppo lisci.",
@@ -937,7 +1778,9 @@
       "label": "Zampe a Molla",
       "mutazione_indotta": "Arti potenziati con ammortizzatori ad alta compressione.",
       "requisiti_ambientali": [],
-      "sinergie": [],
+      "sinergie": [
+        "artigli_sghiaccio_glaciale"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [
           "cap_pt",
@@ -958,6 +1801,42 @@
       "spinta_selettiva": "Metagame con forte pressione di aggro e necessità di riposizionamento.",
       "tier": "T1",
       "uso_funzione": "Dash esplosivi per mantenere il ritmo di ingaggio o disimpegno."
+    },
+    "zoccoli_risonanti_steppe": {
+      "conflitti": [
+        "zampe_a_molla"
+      ],
+      "debolezza": "Suoli cedevoli come sabbie mobili annullano la vibrazione e riducono la trazione.",
+      "famiglia_tipologia": "Locomotorio/Supporto",
+      "fattore_mantenimento_energetico": "Basso (Vibrazione passiva del suolo)",
+      "label": "Zoccoli Risonanti delle Steppe",
+      "mutazione_indotta": "Placche cornee cave che emettono onde sismiche ritmiche al contatto con il terreno.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_risonanti"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Praterie ventose dove il suolo amplifica vibrazioni utili alla comunicazione di branco."
+          }
+        }
+      ],
+      "sinergie": [
+        "cartilagine_flessotermica_venti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "spinta_selettiva": "Mantenere coesione di branchi su grandi distanze e rilevare predatori sotterranei.",
+      "tier": "T1",
+      "uso_funzione": "Propaga segnali ritmici che sincronizzano movimenti e abilità di squadra."
     }
   }
 }

--- a/packs/evo_tactics_pack/data/species/canopia_psionica_leggera/psionic-canopy-scout.yaml
+++ b/packs/evo_tactics_pack/data/species/canopia_psionica_leggera/psionic-canopy-scout.yaml
@@ -1,0 +1,80 @@
+schema_version: 1.7
+receipt:
+  source: PTPF.v1.0
+  author: designer
+  date: '2025-11-10'
+  trace_hash: to-fill
+id: psionic-canopy-scout
+display_name: Psionic Canopy Scout
+biomes:
+  - canopia_psionica_leggera
+role_trofico: ingegneri_ecosistema
+functional_tags:
+  - supporto_psionico
+  - ricognizione
+morphotype: volatore_planatore
+flags:
+  apex: false
+  keystone: false
+  sentient: false
+  bridge: false
+  threat: false
+  event: false
+playable_unit: true
+vc:
+  aggro: 0.3
+  risk: 0.2
+  cohesion: 0.6
+  setup: 0.7
+  explore: 0.8
+  tilt: 0.2
+spawn_rules:
+  orario:
+    - giorno
+    - crepuscolo
+  meteo:
+    - nebbia_spore
+    - brezza_psionica
+  densita: mid
+balance:
+  rarity: R1
+  threat_tier: T1
+  encounter_role: support
+environment_affinity:
+  biome_class: canopia_psionica_leggera
+  hazards_expected:
+    - vortici_psionici
+    - radiazioni_sottili
+  rationale: "Sentinelle leggere che sfruttano la canopia psionica per mantenere corridoi aerei e supervisionare gli spostamenti del branco."
+derived_from_environment:
+  suggested_traits:
+    - focus_frazionato
+    - mimetismo_cromatico_passivo
+    - sacche_galleggianti_ascensoriali
+    - struttura_elastica_amorfa
+  optional_traits:
+    - olfatto_risonanza_magnetica
+    - spore_psichiche_silenziate
+  synergy_traits:
+    - pathfinder
+    - pianificatore
+  required_capabilities:
+    - lift_control
+jobs_bias:
+  - Support
+  - Invoker
+telemetry:
+  expected_pick_rate: null
+  spawn_weight: 0.08
+services_links: []
+genetic_traits:
+  core:
+    - focus_frazionato
+    - mimetismo_cromatico_passivo
+    - sacche_galleggianti_ascensoriali
+    - struttura_elastica_amorfa
+  optional:
+    - olfatto_risonanza_magnetica
+  synergy: []
+mate_synergy: []
+jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/magnet-fathom-surveyor.yaml
+++ b/packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/magnet-fathom-surveyor.yaml
@@ -1,0 +1,81 @@
+schema_version: 1.7
+receipt:
+  source: PTPF.v1.0
+  author: designer
+  date: '2025-11-10'
+  trace_hash: to-fill
+id: magnet-fathom-surveyor
+display_name: Magnet Fathom Surveyor
+biomes:
+  - falde_magnetiche_psioniche
+role_trofico: predatore_regolatore_simbionte
+functional_tags:
+  - regolazione_prede
+  - stabilizzazione_rete
+morphotype: scavenger_corazzato
+flags:
+  apex: false
+  keystone: true
+  sentient: false
+  bridge: false
+  threat: false
+  event: false
+playable_unit: false
+vc:
+  aggro: 0.5
+  risk: 0.4
+  cohesion: 0.5
+  setup: 0.6
+  explore: 0.4
+  tilt: 0.3
+spawn_rules:
+  orario:
+    - crepuscolo
+    - notte
+  meteo:
+    - tempesta_sabbia_magnetica
+    - pioggia_metallica
+  densita: low
+balance:
+  rarity: R2
+  threat_tier: T2
+  encounter_role: elite
+environment_affinity:
+  biome_class: falde_magnetiche_psioniche
+  hazards_expected:
+    - magnetic_patches
+    - iron_shards
+  rationale: "Predatori corazzati che scandagliano le falde psioniche e compattano i residui magnetici per mantenere i tunnel stabili."
+derived_from_environment:
+  suggested_traits:
+    - filamenti_digestivi_compattanti
+    - nucleo_ovomotore_rotante
+    - olfatto_risonanza_magnetica
+    - struttura_elastica_amorfa
+  optional_traits:
+    - lamelle_termoforetiche
+    - scheletro_idro_regolante
+  synergy_traits:
+    - ventriglio_gastroliti
+  required_capabilities:
+    - dr_impact_cap
+    - seal_vents
+jobs_bias:
+  - Warden
+  - Vanguard
+telemetry:
+  expected_pick_rate: null
+  spawn_weight: 0.06
+services_links: []
+genetic_traits:
+  core:
+    - filamenti_digestivi_compattanti
+    - nucleo_ovomotore_rotante
+    - olfatto_risonanza_magnetica
+    - struttura_elastica_amorfa
+  optional:
+    - lamelle_termoforetiche
+    - scheletro_idro_regolante
+  synergy: []
+mate_synergy: []
+jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbital-ascendant.yaml
+++ b/packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbital-ascendant.yaml
@@ -1,0 +1,80 @@
+schema_version: 1.7
+receipt:
+  source: PTPF.v1.0
+  author: designer
+  date: '2025-11-10'
+  trace_hash: to-fill
+id: orbital-ascendant
+display_name: Orbital Ascendant
+biomes:
+  - orbita_psionica_inversa
+role_trofico: predatore_terziario_apex
+functional_tags:
+  - regolazione_prede
+  - sorveglianza_orbitale
+morphotype: volatore_planatore
+flags:
+  apex: true
+  keystone: true
+  sentient: false
+  bridge: false
+  threat: true
+  event: false
+playable_unit: true
+vc:
+  aggro: 0.8
+  risk: 0.7
+  cohesion: 0.5
+  setup: 0.6
+  explore: 0.7
+  tilt: 0.5
+spawn_rules:
+  orario:
+    - notte
+  meteo:
+    - tempesta_solare
+    - calma_orbitale
+  densita: low
+balance:
+  rarity: R3
+  threat_tier: T3
+  encounter_role: boss
+environment_affinity:
+  biome_class: orbita_psionica_inversa
+  hazards_expected:
+    - tempeste_solari
+    - cadute_orbitali
+  rationale: "Predatori d'élite che padroneggiano i vortici di gravità inversa per controllare le rotte di assalto psioniche."
+derived_from_environment:
+  suggested_traits:
+    - focus_frazionato
+    - nucleo_ovomotore_rotante
+    - olfatto_risonanza_magnetica
+    - sacche_galleggianti_ascensoriali
+  optional_traits:
+    - criostasi_adattiva
+    - eco_interno_riflesso
+  synergy_traits:
+    - carapace_fase_variabile
+  required_capabilities:
+    - lift_control
+    - res_psionic
+jobs_bias:
+  - Vanguard
+  - Invoker
+telemetry:
+  expected_pick_rate: null
+  spawn_weight: 0.04
+services_links: []
+genetic_traits:
+  core:
+    - focus_frazionato
+    - nucleo_ovomotore_rotante
+    - olfatto_risonanza_magnetica
+    - sacche_galleggianti_ascensoriali
+  optional:
+    - criostasi_adattiva
+    - eco_interno_riflesso
+  synergy: []
+mate_synergy: []
+jobs_synergy: []

--- a/packs/evo_tactics_pack/docs/catalog/env_traits.json
+++ b/packs/evo_tactics_pack/docs/catalog/env_traits.json
@@ -694,6 +694,87 @@
     },
     {
       "when": {
+        "biome_class": "canopia_psionica_leggera"
+      },
+      "meta": {
+        "category": "pacchetto_psionico",
+        "description": "Canopie conduttrici sospese che diffondono correnti empatiche a bassa intensità.",
+        "cohort": "spirale_psionica",
+        "tier": "T1"
+      },
+      "suggest": {
+        "traits": [
+          "mimetismo_cromatico_passivo",
+          "struttura_elastica_amorfa",
+          "focus_frazionato",
+          "sacche_galleggianti_ascensoriali"
+        ],
+        "effects": {
+          "res_psionic": "+1",
+          "stealth_bonus": true
+        },
+        "jobs_bias": [
+          "Invoker",
+          "Support"
+        ]
+      }
+    },
+    {
+      "when": {
+        "biome_class": "falde_magnetiche_psioniche"
+      },
+      "meta": {
+        "category": "pacchetto_psionico",
+        "description": "Dorsali e falde magnetiche che amplificano segnali sensoriali e digestivi psionici.",
+        "cohort": "spirale_psionica",
+        "tier": "T2"
+      },
+      "suggest": {
+        "traits": [
+          "filamenti_digestivi_compattanti",
+          "olfatto_risonanza_magnetica",
+          "struttura_elastica_amorfa",
+          "nucleo_ovomotore_rotante"
+        ],
+        "effects": {
+          "res_psionic": "+2",
+          "hazard_sense_magnetico": true
+        },
+        "jobs_bias": [
+          "Warden",
+          "Vanguard"
+        ]
+      }
+    },
+    {
+      "when": {
+        "biome_class": "orbita_psionica_inversa"
+      },
+      "meta": {
+        "category": "pacchetto_psionico",
+        "description": "Corridoi orbitali a gravità invertita che fungono da camere di risonanza mentale.",
+        "cohort": "spirale_psionica",
+        "tier": "T3"
+      },
+      "suggest": {
+        "traits": [
+          "sacche_galleggianti_ascensoriali",
+          "olfatto_risonanza_magnetica",
+          "focus_frazionato",
+          "nucleo_ovomotore_rotante"
+        ],
+        "effects": {
+          "res_psionic": "+2",
+          "lift_control": true
+        },
+        "jobs_bias": [
+          "Invoker",
+          "Skirmisher"
+        ]
+      }
+    },
+    {
+      "when": {
         "biome_class": "dorsale_termale_tropicale",
         "morphotype": "cursoriale_quadrupede"
       },
@@ -706,6 +787,7 @@
         "traits": [
           "artigli_sette_vie",
           "coda_frusta_cinetica",
+          "olfatto_risonanza_magnetica",
           "nucleo_ovomotore_rotante",
           "sacche_galleggianti_ascensoriali",
           "scheletro_idro_regolante",
@@ -804,7 +886,9 @@
           "pianificatore",
           "risonanza_di_branco",
           "spore_psichiche_silenziate",
-          "tattiche_di_branco"
+          "tattiche_di_branco",
+          "filamenti_digestivi_compattanti",
+          "struttura_elastica_amorfa"
         ],
         "jobs_bias": [
           "Warden",
@@ -874,7 +958,9 @@
         "traits": [
           "criostasi_adattiva",
           "eco_interno_riflesso",
-          "sonno_emisferico_alternato"
+          "sonno_emisferico_alternato",
+          "mimetismo_cromatico_passivo",
+          "sacche_galleggianti_ascensoriali"
         ],
         "jobs_bias": [
           "Invoker",

--- a/packs/evo_tactics_pack/docs/catalog/trait_reference.json
+++ b/packs/evo_tactics_pack/docs/catalog/trait_reference.json
@@ -188,12 +188,25 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "canopia_psionica_leggera"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "T1 di acclimatazione nelle canopie conduttrici a bassa intensità.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Percorso T2 che aggiunge gradienti magnetici per pattern cromatici complessi.",
+            "tier": "T2"
           }
         }
       ],
@@ -396,12 +409,25 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "falde_magnetiche_psioniche"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Corridore T2 per intercettare campi magnetici psionici sulle dorsali.",
+            "tier": "T2"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante T3 calibrata alle camere di gravità invertita e ai flussi orbitali.",
+            "tier": "T3"
           }
         }
       ],
@@ -433,12 +459,25 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "canopia_psionica_leggera"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Fase T1 controllata: micro-canopie sospese usate per cicli brevi di ibernazione.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante apex T3 in camere orbitali a gravità invertita per stasi prolungate.",
+            "tier": "T3"
           }
         }
       ],
@@ -465,12 +504,25 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "canopia_psionica_leggera"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Start T1 nelle canopie conduttrici per apprendere deformazioni controllate.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Upgrade T2 sulle dorsali magnetiche per mantenere elasticità sotto stress.",
+            "tier": "T2"
           }
         }
       ],
@@ -487,7 +539,7 @@
       },
       "slot": [],
       "spinta_selettiva": "Orientamento in ambienti completamente privi di luce.",
-      "tier": "T1",
+      "tier": "T2",
       "uso_funzione": "Utilizzo di onde sonore emesse internamente per mappare l'ambiente."
     },
     "empatia_coordinativa": {
@@ -532,7 +584,20 @@
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante T2 che sfrutta falde magnetiche per compattare residui ad alta densità.",
+            "tier": "T2"
           }
         }
       ],
@@ -547,7 +612,7 @@
       },
       "slot": [],
       "spinta_selettiva": "Necessità di mantenere la pulizia del territorio/nido.",
-      "tier": "T1",
+      "tier": "T2",
       "uso_funzione": "Espulsione compatta e ordinata di scorie."
     },
     "focus_frazionato": {
@@ -728,12 +793,25 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "canopia_psionica_leggera"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "T1 di acclimatazione nelle canopie conduttrici a bassa intensità.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Percorso T2 che aggiunge gradienti magnetici per pattern cromatici complessi.",
+            "tier": "T2"
           }
         }
       ],
@@ -904,12 +982,25 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "falde_magnetiche_psioniche"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Corridore T2 per intercettare campi magnetici psionici sulle dorsali.",
+            "tier": "T2"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante T3 calibrata alle camere di gravità invertita e ai flussi orbitali.",
+            "tier": "T3"
           }
         }
       ],
@@ -925,7 +1016,7 @@
       },
       "slot": [],
       "spinta_selettiva": "Orientamento in ambienti sotterranei senza luce o caccia a prede metallifere.",
-      "tier": "T1",
+      "tier": "T2",
       "uso_funzione": "Percepire la direzione e la composizione di metalli o campi energetici."
     },
     "pathfinder": {
@@ -1172,12 +1263,25 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "canopia_psionica_leggera"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Fase T1 in canopie sospese per calibrare pompaggio e feedback pressorio.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Apex T3 su piattaforme orbitali a gravità invertita per ascese rapide.",
+            "tier": "T3"
           }
         }
       ],
@@ -1528,12 +1632,25 @@
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "canopia_psionica_leggera"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Start T1 nelle canopie conduttrici per apprendere deformazioni controllate.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Upgrade T2 sulle dorsali magnetiche per mantenere elasticità sotto stress.",
+            "tier": "T2"
           }
         }
       ],

--- a/packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml
+++ b/packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml
@@ -548,3 +548,57 @@ rules:
     - scheletro_idro_regolante
     - coda_frusta_cinetica
     - eco_interno_riflesso
+- when:
+    biome_class: canopia_psionica_leggera
+  meta:
+    expansion: controllo_psionico
+    notes: Nodo di crescita T1 per canopy conduttive a bassa intensità psionica.
+    tier: T1
+  suggest:
+    traits:
+    - mimetismo_cromatico_passivo
+    - struttura_elastica_amorfa
+    - focus_frazionato
+    - sacche_galleggianti_ascensoriali
+    effects:
+      res_psionic: '+1'
+      stealth_bonus: true
+    jobs_bias:
+    - Invoker
+    - Support
+- when:
+    biome_class: falde_magnetiche_psioniche
+  meta:
+    expansion: controllo_psionico
+    notes: Corridoi T2 su dorsali magnetiche con eco psioniche amplificate.
+    tier: T2
+  suggest:
+    traits:
+    - filamenti_digestivi_compattanti
+    - olfatto_risonanza_magnetica
+    - struttura_elastica_amorfa
+    - nucleo_ovomotore_rotante
+    effects:
+      res_psionic: '+2'
+      hazard_sense_magnetico: true
+    jobs_bias:
+    - Warden
+    - Vanguard
+- when:
+    biome_class: orbita_psionica_inversa
+  meta:
+    expansion: controllo_psionico
+    notes: Spazio T3 apex tra piattaforme orbitali e camere a gravità invertita.
+    tier: T3
+  suggest:
+    traits:
+    - sacche_galleggianti_ascensoriali
+    - olfatto_risonanza_magnetica
+    - focus_frazionato
+    - nucleo_ovomotore_rotante
+    effects:
+      res_psionic: '+2'
+      lift_control: true
+    jobs_bias:
+    - Invoker
+    - Skirmisher


### PR DESCRIPTION
## Summary
- add dedicated psionic canopy, magnetic trench, and orbital species to cover the new biome progression
- sync the env-trait registry and trait glossaries with the expanded psionic trait reference
- regenerate the trait coverage report and matrix with full coverage for the new routes

## Testing
- python tools/py/validate_registry_naming.py
- python3 tools/py/report_trait_coverage.py --species-root packs/evo_tactics_pack/data/species --out-csv data/analysis/trait_coverage_matrix.csv

------
https://chatgpt.com/codex/tasks/task_e_69018ece495c83328f28590119a2eca4