### PR TITLE
Adjust macro dashboard counts for nested checkboxes

### DIFF
--- a/reports/progress-dashboard.md
+++ b/reports/progress-dashboard.md
@@ -11,10 +11,10 @@ oppure `Bloccato = 0%`.
 
 | Macro-area | Tracker | Completati | Totale | Avanzamento |
 | --- | --- | ---: | ---: | --- |
-| Ecosistemi | `docs/checklist/milestones.md` (setup + encounter) | 4 | 4 | 100%【F:docs/checklist/milestones.md†L3-L14】 |
+| Ecosistemi | `docs/checklist/milestones.md` (setup + encounter) | 9 | 9 | 100%【F:docs/checklist/milestones.md†L3-L14】 |
 | Ecosistemi | `logs/traits_tracking.md` | 6 | 11 | 55%【F:logs/traits_tracking.md†L24-L44】 |
 | Ecosistemi | `docs/process/traits_checklist.md` | 0 | 25 | 0%【F:docs/process/traits_checklist.md†L6-L95】 |
-| Telemetria | `docs/checklist/milestones.md` (telemetria) | 6 | 7 | 86%【F:docs/checklist/milestones.md†L9-L23】 |
+| Telemetria | `docs/checklist/milestones.md` (telemetria) | 9 | 12 | 75%【F:docs/checklist/milestones.md†L9-L23】 |
 | Telemetria | `docs/checklist/telemetry.md` | 0 | 9 | 0%【F:docs/checklist/telemetry.md†L3-L16】 |
 | Telemetria | `logs/exports/2025-11-08-filter-selections.md` (surrogato stato: On track) | 1 | 1 | 100%【F:logs/exports/2025-11-08-filter-selections.md†L3-L11】 |
 | Web | `docs/checklist/milestones.md` (milestone web) | 3 | 5 | 60%【F:docs/checklist/milestones.md†L25-L32】 |
@@ -25,23 +25,23 @@ oppure `Bloccato = 0%`.
 | QA | `docs/checklist/action-items.md` | 16 | 17 | 94%【F:docs/checklist/action-items.md†L19-L37】 |
 | QA | `docs/checklist/bug-intake.md` | 0 | 17 | 0%【F:docs/checklist/bug-intake.md†L5-L28】 |
 | QA | `docs/playtest/SESSION-2025-11-12.md` (checklist feedback) | 6 | 6 | 100%【F:docs/playtest/SESSION-2025-11-12.md†L34-L40】 |
-| QA | `docs/checklist/milestones.md` (follow-up QA) | 0 | 2 | 0%【F:docs/checklist/milestones.md†L15-L17】 |
+| QA | `docs/checklist/milestones.md` (follow-up QA) | 0 | 3 | 0%【F:docs/checklist/milestones.md†L15-L17】 |
 | Operazioni | `docs/checklist/project-setup-todo.md` | 45 | 47 | 96%【F:docs/checklist/project-setup-todo.md†L7-L87】 |
 | Operazioni | `docs/support/token-rotation.md` | 2 | 3 | 67%【F:docs/support/token-rotation.md†L29-L33】 |
 | Operazioni | `docs/adr/ADR-2025-11-18-cli-rollout.md` | 0 | 3 | 0%【F:docs/adr/ADR-2025-11-18-cli-rollout.md†L22-L25】 |
 | Operazioni | `docs/adr/ADR-2025-12-07-generation-orchestrator.md` | 0 | 3 | 0%【F:docs/adr/ADR-2025-12-07-generation-orchestrator.md†L56-L61】 |
 | Operazioni | `docs/adr/ADR-XXX-refactor-cli.md` | 1 | 4 | 25%【F:docs/adr/ADR-XXX-refactor-cli.md†L34-L38】 |
-| Operazioni | `docs/checklist/milestones.md` (Canvas & comunicazione) | 1 | 1 | 100%【F:docs/checklist/milestones.md†L19-L23】 |
+| Operazioni | `docs/checklist/milestones.md` (Canvas & comunicazione) | 2 | 2 | 100%【F:docs/checklist/milestones.md†L19-L23】 |
 
 ## Riepilogo per macro-area
 
 | Macro-area | Completati | Totale | Percentuale (≈) | Stato |
 | --- | ---: | ---: | --- | --- |
-| Ecosistemi | 10 | 40 | **25%** | Carico elevato sui passi operativi e QA da completare. |
-| Telemetria | 7 | 17 | **40%** | Checklist dedicate ferme, ma milestone telemetriche già validate. |
+| Ecosistemi | 15 | 45 | **35%** | Carico elevato sui passi operativi e QA da completare. |
+| Telemetria | 10 | 22 | **45%** | Checklist dedicate ferme, ma milestone telemetriche già validate. |
 | Web | 3.5 | 41 | **10%** | Pipeline web quasi tutta da rilanciare; log stato ancora parziali. |
-| QA | 22 | 42 | **50%** | Action item quasi chiusi, intake e follow-up QA ancora aperti. |
-| Operazioni | 49 | 61 | **80%** | Setup e manutenzione quasi completati; restano ADR e tag release. |
+| QA | 22 | 43 | **50%** | Action item quasi chiusi, intake e follow-up QA ancora aperti. |
+| Operazioni | 50 | 62 | **80%** | Setup e manutenzione quasi completati; restano ADR e tag release. |
 
 _Nota:_ le percentuali sono arrotondate alla soglia di comunicazione più vicina (5%).
 
@@ -50,8 +50,8 @@ _Nota:_ le percentuali sono arrotondate alla soglia di comunicazione più vicina
 ```markdown
 | Macro-area | Avanzamento |
 | --- | --- |
-| Ecosistemi | ![Ecosistemi 25%](https://progress-bar.dev/25/?title=Ecosistemi&width=180&suffix=%25) |
-| Telemetria | ![Telemetria 40%](https://progress-bar.dev/40/?title=Telemetria&width=180&suffix=%25) |
+| Ecosistemi | ![Ecosistemi 35%](https://progress-bar.dev/35/?title=Ecosistemi&width=180&suffix=%25) |
+| Telemetria | ![Telemetria 45%](https://progress-bar.dev/45/?title=Telemetria&width=180&suffix=%25) |
 | Web | ![Web 10%](https://progress-bar.dev/10/?title=Web&width=180&suffix=%25) |
 | QA | ![QA 50%](https://progress-bar.dev/50/?title=QA&width=180&suffix=%25) |
 | Operazioni | ![Operazioni 80%](https://progress-bar.dev/80/?title=Operazioni&width=180&suffix=%25) |
@@ -60,8 +60,8 @@ _Nota:_ le percentuali sono arrotondate alla soglia di comunicazione più vicina
 In alternativa, è possibile usare il tag HTML `<progress>`:
 
 ```html
-<p><strong>Ecosistemi</strong>: <progress value="25" max="100"></progress> 25%</p>
-<p><strong>Telemetria</strong>: <progress value="40" max="100"></progress> 40%</p>
+<p><strong>Ecosistemi</strong>: <progress value="35" max="100"></progress> 35%</p>
+<p><strong>Telemetria</strong>: <progress value="45" max="100"></progress> 45%</p>
 <p><strong>Web</strong>: <progress value="10" max="100"></progress> 10%</p>
 <p><strong>QA</strong>: <progress value="50" max="100"></progress> 50%</p>
 <p><strong>Operazioni</strong>: <progress value="80" max="100"></progress> 80%</p>


### PR DESCRIPTION
## Summary
- add a consolidated progress dashboard with macro-area percentages and README-ready snippets
- document tracker-level counts and surrogate metrics for logs without checkboxes
- recalculate milestone checkbox totals (including nested items) and refresh the macro-area summaries and snippets

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_6902183eb7d88332904f298d087d5fcf