### PR TITLE
Automatizza refresh giornaliero dei tracker e dello stato README

### DIFF
--- a/.github/workflows/daily-tracker-refresh.yml
+++ b/.github/workflows/daily-tracker-refresh.yml
@@ -1,0 +1,29 @@
+name: Daily tracker refresh
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip && pip install PyYAML
+      - name: Aggiorna tracker e README
+        run: python scripts/daily_tracker_refresh.py --export-json reports/daily_tracker_summary.json
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: refresh tracker index'
+          commit_author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          branch: main

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ evo-tactics/
 
 Consulta la sezione [Indice Tracker & Stato](#indice-tracker--stato) per percentuali e stato sintetico dei principali blocchi di lavoro.
 
+_Sezione mantenuta automaticamente dallo script [`scripts/daily_tracker_refresh.py`](scripts/daily_tracker_refresh.py), eseguito ogni giorno a mezzogiorno tramite il workflow [`daily-tracker-refresh`](.github/workflows/daily-tracker-refresh.yml)._ 
+
 ## Quick Start — Node/TypeScript
 ```bash
 cd tools/ts
@@ -199,17 +201,19 @@ git push -u origin main
 
 ### Indice Tracker & Stato
 
+<!-- tracker-status:start -->
 #### Operativo
-- **████████░░ 80% · Telemetria VC** — Le milestone operative hanno completato playtest, normalizzazione e documentazione; restano l'overlay HUD telemetrico, il ribilanciamento XP Cipher e il contrasto EVT-03. Vedi [`docs/checklist/milestones.md#in-corso`](docs/checklist/milestones.md#in-corso).【F:docs/checklist/milestones.md†L8-L17】
+- **███████░░░ 74% · Telemetria VC** — Le milestone operative hanno completato playtest, normalizzazione e documentazione; restano overlay HUD, ribilanciamento XP Cipher e contrasto EVT-03. Vedi [docs/checklist/milestones.md#in-corso](docs/checklist/milestones.md#in-corso).
 
 #### Processo
-- **██████░░░░ 60% · Pipeline deploy web** — Il processo di rilascio è definito ma i riesami settimanali riportano ancora il blocco Playwright 403 e test manuali da pianificare prima di considerarlo stabile. Vedi [`docs/process/web_pipeline.md`](docs/process/web_pipeline.md) e il registro [`logs/web_status.md`](logs/web_status.md).【F:docs/process/web_pipeline.md†L1-L64】【F:logs/web_status.md†L15-L50】
+- **░░░░░░░░░░ 0% · Pipeline deploy web** — Il processo di rilascio è definito ma i riesami settimanali riportano ancora blocchi Playwright e smoke test manuali aperti. Vedi [docs/process/web_pipeline.md](docs/process/web_pipeline.md) e [logs/web_status.md](logs/web_status.md).
 
 #### Log & metriche
-- **███████░░░ 70% · Inventario trait** — La copertura tratti/specie è stata riallineata (`traits_with_species = 27/29`), ma restano da integrare i trait delle appendici e ulteriori dataset mock. Consulta [`logs/traits_tracking.md`](logs/traits_tracking.md).【F:logs/traits_tracking.md†L1-L37】
+- **██████░░░░ 55% · Inventario trait** — La copertura tratti/specie è riallineata ma restano da integrare appendici e dataset mock aggiuntivi. Vedi [logs/traits_tracking.md](logs/traits_tracking.md).
 
 #### Appendici
-- **█████░░░░░ 50% · Canvas e integrazioni** — Gli appendici A/C/D restano l'ultima revisione ufficiale mentre il Canvas segnala follow-up aperti su overlay HUD, patch PROG-04 ed effetti EVT-03 prima del prossimo aggiornamento. Riferimento: [`docs/00-INDEX.md#appendici-di-stato`](docs/00-INDEX.md#appendici-di-stato) e [`docs/Canvas/feature-updates.md`](docs/Canvas/feature-updates.md).【F:docs/00-INDEX.md†L23-L29】【F:docs/Canvas/feature-updates.md†L23-L27】
+- **█████░░░░░ 50% · Canvas e integrazioni** — Gli appendici A/C/D riportano l'ultima revisione mentre canvas e feature updates conservano follow-up aperti. Vedi [docs/00-INDEX.md#appendici-di-stato](docs/00-INDEX.md#appendici-di-stato) e [docs/Canvas/feature-updates.md](docs/Canvas/feature-updates.md).
+<!-- tracker-status:end -->
 
 ## Sincronizzazione contenuti ChatGPT
 - Configura le fonti da monitorare in `data/chatgpt_sources.yaml` (URL del progetto, canvas esportati, ecc.).

--- a/config/tracker_registry.yaml
+++ b/config/tracker_registry.yaml
@@ -1,0 +1,180 @@
+# Configurazione per il refresh giornaliero dei tracker e dello stato README.
+# La sezione "tables" alimenta `docs/00-INDEX.md`, mentre "progress_sections"
+# descrive le barre di avanzamento in `README.md`.
+tables:
+  - slug: operativo
+    title: "Operativo (checklist)"
+    entries:
+      - path: docs/checklist/action-items.md
+        title: "Action Items — Sintesi operativa"
+        purpose: "Sintesi quotidiana attività cross-team e follow-up PR giornalieri."
+        owner: "UI Systems · Progression Design · VFX/Lighting · QA Support"
+      - path: docs/checklist/bug-intake.md
+        title: "Bug Intake Checklist"
+        purpose: "Verifica dati obbligatori prima del triage ticket."
+        owner: "N/D"
+      - path: docs/checklist/clone-setup.md
+        title: "Procedura di clone e setup iniziale"
+        purpose: "Istruzioni ambiente standard container /workspace/Game."
+        owner: "Ops/ChatGPT"
+      - path: docs/checklist/demo-release.md
+        title: "Checklist release demo pubblica"
+        purpose: "Passi di coordinamento per bundle demo Evo Tactics Pack."
+        owner: "N/D"
+      - path: docs/checklist/milestones.md
+        title: "Checklist Milestone"
+        purpose: "Stato avanzamento milestone telemetria/dataset/playtest."
+        owner: "N/D"
+      - path: docs/checklist/project-setup-todo.md
+        title: "TODO Operativo — Avvio completo del progetto"
+        purpose: "Sequenza end-to-end per rendere operativo il progetto con note storiche."
+        owner: "Ops/ChatGPT · Release Ops · Marketing Ops · Lead Dev Tools"
+      - path: docs/checklist/telemetry.md
+        title: "Checklist — Telemetry Export & QA Filters"
+        purpose: "Controlli giornalieri/settimanali su export telemetria e filtri QA."
+        owner: "N/D"
+      - path: docs/checklist/vc_playtest_plan.md
+        title: "Playtest VC Mirati alla Telemetria"
+        purpose: "Piano sessioni mirate agli indici VC e setup strumentazione."
+        owner: "N/D"
+  - slug: processo
+    title: "Processo"
+    entries:
+      - path: docs/process/incident_reporting_table.md
+        title: "Registro Segnalazioni Cross-Team — Implementazione Operativa"
+        purpose: "Configurazione tabella Airtable e permessi per segnalazioni condivise."
+        owner: "N/D"
+      - path: docs/process/qa_hud.md
+        title: "QA — HUD Smart Alerts"
+        purpose: "Metriche e pipeline QA per monitorare ack/filter ratio degli alert HUD."
+        owner: "QA lead"
+      - path: docs/process/qa_reporting_schema.md
+        title: "QA Telemetry & Segnalazioni — Schema condiviso"
+        purpose: "Panorama fonti dati QA, campi disponibili e gap di reporting."
+        owner: "N/D"
+      - path: docs/process/telemetry_ingestion_pipeline.md
+        title: "Pipeline Dati Telemetria → Tabella QA/Design"
+        purpose: "Flusso di ingestione telemetria, snapshot visuali e modulo QA manuale."
+        owner: "N/D"
+      - path: docs/process/traits_checklist.md
+        title: "Checklist iterativa tratti"
+        purpose: "Step incrementali per aggiungere/revisionare tratti con controlli dati."
+        owner: "N/D"
+      - path: docs/process/web_handoff.md
+        title: "Web Handoff · Foodweb Archetypes 2025-11-05"
+        purpose: "Nota di consegna verso team web/UI con archetipi ruolo×bioma aggiornati."
+        owner: "N/D"
+      - path: docs/process/web_pipeline.md
+        title: "Pipeline web · Procedura di rilascio"
+        purpose: "Processo end-to-end per promuovere la web experience su GitHub Pages."
+        owner: "N/D"
+  - slug: log_metriche
+    title: "Log & metriche"
+    entries:
+      - path: logs/chatgpt_sync.log
+        title: "Log sincronizzazione ChatGPT"
+        purpose: "Cronologia esecuzioni scripts/chatgpt_sync.py e diff generati."
+        owner: "N/D"
+      - path: logs/chatgpt_sync_last.json
+        title: "Snapshot ultima sincronizzazione ChatGPT"
+        purpose: "Esito strutturato dell'ultima run con percorsi export/diff."
+        owner: "N/D"
+      - path: logs/drive/2025-11-XX-dryrun.json
+        title: "Drive sync dry-run"
+        purpose: "Stato dry-run convertYamlToSheetsDryRun() e azioni suggerite."
+        owner: "N/D"
+      - path: logs/exports/2025-11-08-filter-selections.md
+        title: "Telemetry Export — Log interazioni filtri"
+        purpose: "Audit settimanale applicazione filtri export (Analytics/Support)."
+        owner: "Analytics · Support"
+      - path: logs/traits_tracking.md
+        title: "Monitoraggio inventario trait"
+        purpose: "Aggiornamenti periodici copertura trait/specie e risultati validator."
+        owner: "N/D"
+      - path: logs/trait_audit.md
+        title: "Trait Data Audit"
+        purpose: "Stato errori/warning dataset trait."
+        owner: "N/D"
+      - path: logs/web_status.md
+        title: "Programmazione riesami sito web"
+        purpose: "Agenda e checklist riesami settimanali sito con azioni QA."
+        owner: "N/D"
+      - path: logs/qa/latest-dashboard-metrics.json
+        title: "Dashboard & generator metrics snapshot"
+        purpose: "Metriche più recenti per dashboard/generator con audit accessibilità."
+        owner: "N/D"
+      - path: logs/qa/dashboard_metrics.jsonl
+        title: "Storico metriche dashboard"
+        purpose: "Append log JSONL con run successive e confronti visual regression."
+        owner: "N/D"
+      - path: logs/tooling/2025-10-24-tooling.md
+        title: "2025-10-24 — Verifica ambiente & toolchain"
+        purpose: "Verifica versioni e operazioni tooling (npm, pip, CLI)."
+        owner: "N/D"
+  - slug: pianificazione
+    title: "Pianificazione"
+    entries:
+      - path: docs/piani/roadmap.md
+        title: "Roadmap Operativa"
+        purpose: "Procedura settimanale post-ottobre 2025 con milestone e follow-up."
+        owner: "N/D"
+  - slug: appendici
+    title: "Appendici di stato"
+    entries:
+      - path: appendici/A-CANVAS_ORIGINALE.txt
+        title: "Canvas A — Originale"
+        purpose: "Visione principale con note telemetria/Resonance Shards."
+        owner: "N/D"
+      - path: appendici/C-CANVAS_NPG_BIOMI.txt
+        title: "Canvas C — NPG & Biomi"
+        purpose: "Canvas NPG reattivi, biomi e protocolli soccorso."
+        owner: "N/D"
+      - path: appendici/D-CANVAS_ACCOPPIAMENTO.txt
+        title: "Canvas D — Mating, Reclutamento & Nido"
+        purpose: "Canvas sistemi attrazione, nido e ereditarietà parti."
+        owner: "N/D"
+progress_sections:
+  - category: "Operativo"
+    items:
+      - name: "Telemetria VC"
+        description: "Le milestone operative hanno completato playtest, normalizzazione e documentazione; restano overlay HUD, ribilanciamento XP Cipher e contrasto EVT-03."
+        compute:
+          type: checkbox
+          path: docs/checklist/milestones.md
+        references:
+          - label: "docs/checklist/milestones.md#in-corso"
+            target: "docs/checklist/milestones.md#in-corso"
+  - category: "Processo"
+    items:
+      - name: "Pipeline deploy web"
+        description: "Il processo di rilascio è definito ma i riesami settimanali riportano ancora blocchi Playwright e smoke test manuali aperti."
+        compute:
+          type: checkbox
+          path: docs/process/web_pipeline.md
+        references:
+          - label: "docs/process/web_pipeline.md"
+            target: "docs/process/web_pipeline.md"
+          - label: "logs/web_status.md"
+            target: "logs/web_status.md"
+  - category: "Log & metriche"
+    items:
+      - name: "Inventario trait"
+        description: "La copertura tratti/specie è riallineata ma restano da integrare appendici e dataset mock aggiuntivi."
+        compute:
+          type: checkbox
+          path: logs/traits_tracking.md
+        references:
+          - label: "logs/traits_tracking.md"
+            target: "logs/traits_tracking.md"
+  - category: "Appendici"
+    items:
+      - name: "Canvas e integrazioni"
+        description: "Gli appendici A/C/D riportano l'ultima revisione mentre canvas e feature updates conservano follow-up aperti."
+        compute:
+          type: manual
+          value: 0.5
+        references:
+          - label: "docs/00-INDEX.md#appendici-di-stato"
+            target: "docs/00-INDEX.md#appendici-di-stato"
+          - label: "docs/Canvas/feature-updates.md"
+            target: "docs/Canvas/feature-updates.md"

--- a/docs/00-INDEX.md
+++ b/docs/00-INDEX.md
@@ -30,56 +30,58 @@
 
 ## Tracker operativi e log
 
+<!-- tracker-registry:start -->
 ### Operativo (checklist)
 
 | File | Titolo | Scopo | Owner attuale | Ultimo aggiornamento | Percorso |
 | --- | --- | --- | --- | --- | --- |
-| action-items.md | Action Items — Sintesi operativa | Sintesi quotidiana attività cross-team e follow-up PR giornalieri. | UI Systems · Progression Design · VFX/Lighting · QA Support | 2025-11-07 | `docs/checklist/action-items.md` |
-| bug-intake.md | Bug Intake Checklist | Verifica dati obbligatori prima del triage ticket. | N/D | N/D | `docs/checklist/bug-intake.md` |
-| clone-setup.md | Procedura di clone e setup iniziale | Istruzioni ambiente standard container /workspace/Game. | Ops/ChatGPT | 2025-11-12 | `docs/checklist/clone-setup.md` |
-| demo-release.md | Checklist release demo pubblica | Passi di coordinamento per bundle demo Evo Tactics Pack. | N/D | N/D | `docs/checklist/demo-release.md` |
-| milestones.md | Checklist Milestone | Stato avanzamento milestone telemetria/dataset/playtest. | N/D | N/D | `docs/checklist/milestones.md` |
-| project-setup-todo.md | TODO Operativo — Avvio completo del progetto | Sequenza end-to-end per rendere operativo il progetto con note storiche. | Ops/ChatGPT · Release Ops · Marketing Ops · Lead Dev Tools | 2025-11-20 | `docs/checklist/project-setup-todo.md` |
-| telemetry.md | Checklist — Telemetry Export & QA Filters | Controlli giornalieri/settimanali su export telemetria e filtri QA. | N/D | N/D | `docs/checklist/telemetry.md` |
-| vc_playtest_plan.md | Playtest VC Mirati alla Telemetria | Piano sessioni mirate agli indici VC e setup strumentazione. | N/D | N/D | `docs/checklist/vc_playtest_plan.md` |
+| [action-items.md](docs/checklist/action-items.md) | Action Items — Sintesi operativa | Sintesi quotidiana attività cross-team e follow-up PR giornalieri. | UI Systems · Progression Design · VFX/Lighting · QA Support | 2025-10-28 | `docs/checklist/action-items.md` |
+| [bug-intake.md](docs/checklist/bug-intake.md) | Bug Intake Checklist | Verifica dati obbligatori prima del triage ticket. | N/D | 2025-10-27 | `docs/checklist/bug-intake.md` |
+| [clone-setup.md](docs/checklist/clone-setup.md) | Procedura di clone e setup iniziale | Istruzioni ambiente standard container /workspace/Game. | Ops/ChatGPT | 2025-10-26 | `docs/checklist/clone-setup.md` |
+| [demo-release.md](docs/checklist/demo-release.md) | Checklist release demo pubblica | Passi di coordinamento per bundle demo Evo Tactics Pack. | N/D | 2025-10-27 | `docs/checklist/demo-release.md` |
+| [milestones.md](docs/checklist/milestones.md) | Checklist Milestone | Stato avanzamento milestone telemetria/dataset/playtest. | N/D | 2025-10-28 | `docs/checklist/milestones.md` |
+| [project-setup-todo.md](docs/checklist/project-setup-todo.md) | TODO Operativo — Avvio completo del progetto | Sequenza end-to-end per rendere operativo il progetto con note storiche. | Ops/ChatGPT · Release Ops · Marketing Ops · Lead Dev Tools | 2025-10-28 | `docs/checklist/project-setup-todo.md` |
+| [telemetry.md](docs/checklist/telemetry.md) | Checklist — Telemetry Export & QA Filters | Controlli giornalieri/settimanali su export telemetria e filtri QA. | N/D | 2025-10-28 | `docs/checklist/telemetry.md` |
+| [vc_playtest_plan.md](docs/checklist/vc_playtest_plan.md) | Playtest VC Mirati alla Telemetria | Piano sessioni mirate agli indici VC e setup strumentazione. | N/D | 2025-10-24 | `docs/checklist/vc_playtest_plan.md` |
 
 ### Processo
 
 | File | Titolo | Scopo | Owner attuale | Ultimo aggiornamento | Percorso |
 | --- | --- | --- | --- | --- | --- |
-| incident_reporting_table.md | Registro Segnalazioni Cross-Team — Implementazione Operativa | Configurazione tabella Airtable e permessi per segnalazioni condivise. | N/D | N/D | `docs/process/incident_reporting_table.md` |
-| qa_hud.md | QA — HUD Smart Alerts | Metriche e pipeline QA per monitorare ack/filter ratio degli alert HUD. | QA lead | N/D | `docs/process/qa_hud.md` |
-| qa_reporting_schema.md | QA Telemetry & Segnalazioni — Schema condiviso | Panorama fonti dati QA, campi disponibili e gap di reporting. | N/D | N/D | `docs/process/qa_reporting_schema.md` |
-| telemetry_ingestion_pipeline.md | Pipeline Dati Telemetria → Tabella QA/Design | Flusso di ingestione telemetria, snapshot visuali e modulo QA manuale. | N/D | N/D | `docs/process/telemetry_ingestion_pipeline.md` |
-| traits_checklist.md | Checklist iterativa tratti | Step incrementali per aggiungere/revisionare tratti con controlli dati. | N/D | N/D | `docs/process/traits_checklist.md` |
-| web_handoff.md | Web Handoff · Foodweb Archetypes 2025-11-05 | Nota di consegna verso team web/UI con archetipi ruolo×bioma aggiornati. | N/D | 2025-11-05 | `docs/process/web_handoff.md` |
-| web_pipeline.md | Pipeline web · Procedura di rilascio | Processo end-to-end per promuovere la web experience su GitHub Pages. | N/D | N/D | `docs/process/web_pipeline.md` |
+| [incident_reporting_table.md](docs/process/incident_reporting_table.md) | Registro Segnalazioni Cross-Team — Implementazione Operativa | Configurazione tabella Airtable e permessi per segnalazioni condivise. | N/D | 2025-10-27 | `docs/process/incident_reporting_table.md` |
+| [qa_hud.md](docs/process/qa_hud.md) | QA — HUD Smart Alerts | Metriche e pipeline QA per monitorare ack/filter ratio degli alert HUD. | QA lead | 2025-10-27 | `docs/process/qa_hud.md` |
+| [qa_reporting_schema.md](docs/process/qa_reporting_schema.md) | QA Telemetry & Segnalazioni — Schema condiviso | Panorama fonti dati QA, campi disponibili e gap di reporting. | N/D | 2025-10-27 | `docs/process/qa_reporting_schema.md` |
+| [telemetry_ingestion_pipeline.md](docs/process/telemetry_ingestion_pipeline.md) | Pipeline Dati Telemetria → Tabella QA/Design | Flusso di ingestione telemetria, snapshot visuali e modulo QA manuale. | N/D | 2025-10-27 | `docs/process/telemetry_ingestion_pipeline.md` |
+| [traits_checklist.md](docs/process/traits_checklist.md) | Checklist iterativa tratti | Step incrementali per aggiungere/revisionare tratti con controlli dati. | N/D | 2025-10-28 | `docs/process/traits_checklist.md` |
+| [web_handoff.md](docs/process/web_handoff.md) | Web Handoff · Foodweb Archetypes 2025-11-05 | Nota di consegna verso team web/UI con archetipi ruolo×bioma aggiornati. | N/D | 2025-10-29 | `docs/process/web_handoff.md` |
+| [web_pipeline.md](docs/process/web_pipeline.md) | Pipeline web · Procedura di rilascio | Processo end-to-end per promuovere la web experience su GitHub Pages. | N/D | 2025-10-28 | `docs/process/web_pipeline.md` |
 
 ### Log & metriche
 
 | File | Titolo | Scopo | Owner attuale | Ultimo aggiornamento | Percorso |
 | --- | --- | --- | --- | --- | --- |
-| chatgpt_sync.log | Log sincronizzazione ChatGPT | Cronologia esecuzioni `scripts/chatgpt_sync.py` e diff generati. | N/D | 2025-10-24 | `logs/chatgpt_sync.log` |
-| chatgpt_sync_last.json | Snapshot ultima sincronizzazione ChatGPT | Esito strutturato dell'ultima run con percorsi export/diff. | N/D | 2025-10-24 | `logs/chatgpt_sync_last.json` |
-| drive/2025-11-XX-dryrun.json | Drive sync dry-run | Stato dry-run `convertYamlToSheetsDryRun()` e azioni suggerite. | N/D | 2025-11-XX | `logs/drive/2025-11-XX-dryrun.json` |
-| exports/2025-11-08-filter-selections.md | Telemetry Export — Log interazioni filtri | Audit settimanale applicazione filtri export (Analytics/Support). | Analytics · Support | 2025-11-08 | `logs/exports/2025-11-08-filter-selections.md` |
-| traits_tracking.md | Monitoraggio inventario trait | Aggiornamenti periodici copertura trait/specie e risultati validator. | N/D | 2025-11-16 | `logs/traits_tracking.md` |
-| trait_audit.md | Trait Data Audit | Stato errori/warning dataset trait. | N/D | N/D | `logs/trait_audit.md` |
-| web_status.md | Programmazione riesami sito web | Agenda e checklist riesami settimanali sito con azioni QA. | N/D | N/D | `logs/web_status.md` |
-| qa/latest-dashboard-metrics.json | Dashboard & generator metrics snapshot | Metriche più recenti per dashboard/generator con audit accessibilità. | N/D | 2025-10-27 | `logs/qa/latest-dashboard-metrics.json` |
-| qa/dashboard_metrics.jsonl | Storico metriche dashboard | Append log JSONL con run successive e confronti visual regression. | N/D | 2025-10-27 | `logs/qa/dashboard_metrics.jsonl` |
-| tooling/2025-10-24-tooling.md | 2025-10-24 — Verifica ambiente & toolchain | Verifica versioni e operazioni tooling (npm, pip, CLI). | N/D | 2025-10-24 | `logs/tooling/2025-10-24-tooling.md` |
+| [chatgpt_sync.log](logs/chatgpt_sync.log) | Log sincronizzazione ChatGPT | Cronologia esecuzioni scripts/chatgpt_sync.py e diff generati. | N/D | 2025-10-24 | `logs/chatgpt_sync.log` |
+| [chatgpt_sync_last.json](logs/chatgpt_sync_last.json) | Snapshot ultima sincronizzazione ChatGPT | Esito strutturato dell'ultima run con percorsi export/diff. | N/D | 2025-10-24 | `logs/chatgpt_sync_last.json` |
+| [2025-11-XX-dryrun.json](logs/drive/2025-11-XX-dryrun.json) | Drive sync dry-run | Stato dry-run convertYamlToSheetsDryRun() e azioni suggerite. | N/D | 2025-10-28 | `logs/drive/2025-11-XX-dryrun.json` |
+| [2025-11-08-filter-selections.md](logs/exports/2025-11-08-filter-selections.md) | Telemetry Export — Log interazioni filtri | Audit settimanale applicazione filtri export (Analytics/Support). | Analytics · Support | 2025-10-28 | `logs/exports/2025-11-08-filter-selections.md` |
+| [traits_tracking.md](logs/traits_tracking.md) | Monitoraggio inventario trait | Aggiornamenti periodici copertura trait/specie e risultati validator. | N/D | 2025-10-29 | `logs/traits_tracking.md` |
+| [trait_audit.md](logs/trait_audit.md) | Trait Data Audit | Stato errori/warning dataset trait. | N/D | 2025-10-29 | `logs/trait_audit.md` |
+| [web_status.md](logs/web_status.md) | Programmazione riesami sito web | Agenda e checklist riesami settimanali sito con azioni QA. | N/D | 2025-10-29 | `logs/web_status.md` |
+| [latest-dashboard-metrics.json](logs/qa/latest-dashboard-metrics.json) | Dashboard & generator metrics snapshot | Metriche più recenti per dashboard/generator con audit accessibilità. | N/D | 2025-10-27 | `logs/qa/latest-dashboard-metrics.json` |
+| [dashboard_metrics.jsonl](logs/qa/dashboard_metrics.jsonl) | Storico metriche dashboard | Append log JSONL con run successive e confronti visual regression. | N/D | 2025-10-27 | `logs/qa/dashboard_metrics.jsonl` |
+| [2025-10-24-tooling.md](logs/tooling/2025-10-24-tooling.md) | 2025-10-24 — Verifica ambiente & toolchain | Verifica versioni e operazioni tooling (npm, pip, CLI). | N/D | 2025-10-24 | `logs/tooling/2025-10-24-tooling.md` |
 
 ### Pianificazione
 
 | File | Titolo | Scopo | Owner attuale | Ultimo aggiornamento | Percorso |
 | --- | --- | --- | --- | --- | --- |
-| roadmap.md | Roadmap Operativa | Procedura settimanale post-ottobre 2025 con milestone e follow-up. | N/D | N/D | `docs/piani/roadmap.md` |
+| [roadmap.md](docs/piani/roadmap.md) | Roadmap Operativa | Procedura settimanale post-ottobre 2025 con milestone e follow-up. | N/D | 2025-10-28 | `docs/piani/roadmap.md` |
 
 ### Appendici di stato
 
 | File | Titolo | Scopo | Owner attuale | Ultimo aggiornamento | Percorso |
 | --- | --- | --- | --- | --- | --- |
-| A-CANVAS_ORIGINALE.txt | Canvas A — Originale | Visione principale con note telemetria/Resonance Shards. | N/D | 2025-10-23 | `appendici/A-CANVAS_ORIGINALE.txt` |
-| C-CANVAS_NPG_BIOMI.txt | Canvas C — NPG & Biomi | Canvas NPG reattivi, biomi e protocolli soccorso. | N/D | 2025-10-23 | `appendici/C-CANVAS_NPG_BIOMI.txt` |
-| D-CANVAS_ACCOPPIAMENTO.txt | Canvas D — Mating, Reclutamento & Nido | Canvas sistemi attrazione, nido e ereditarietà parti. | N/D | 2025-10-23 | `appendici/D-CANVAS_ACCOPPIAMENTO.txt` |
+| [A-CANVAS_ORIGINALE.txt](appendici/A-CANVAS_ORIGINALE.txt) | Canvas A — Originale | Visione principale con note telemetria/Resonance Shards. | N/D | 2025-10-27 | `appendici/A-CANVAS_ORIGINALE.txt` |
+| [C-CANVAS_NPG_BIOMI.txt](appendici/C-CANVAS_NPG_BIOMI.txt) | Canvas C — NPG & Biomi | Canvas NPG reattivi, biomi e protocolli soccorso. | N/D | 2025-10-26 | `appendici/C-CANVAS_NPG_BIOMI.txt` |
+| [D-CANVAS_ACCOPPIAMENTO.txt](appendici/D-CANVAS_ACCOPPIAMENTO.txt) | Canvas D — Mating, Reclutamento & Nido | Canvas sistemi attrazione, nido e ereditarietà parti. | N/D | 2025-10-26 | `appendici/D-CANVAS_ACCOPPIAMENTO.txt` |
+<!-- tracker-registry:end -->

--- a/reports/daily_tracker_summary.json
+++ b/reports/daily_tracker_summary.json
@@ -1,0 +1,262 @@
+{
+  "generated_at": "2025-10-29T13:49:51.031862Z",
+  "tables": {
+    "Operativo (checklist)": [
+      {
+        "path": "docs/checklist/action-items.md",
+        "title": "Action Items — Sintesi operativa",
+        "purpose": "Sintesi quotidiana attività cross-team e follow-up PR giornalieri.",
+        "owner": "UI Systems · Progression Design · VFX/Lighting · QA Support",
+        "last_update": "2025-10-28"
+      },
+      {
+        "path": "docs/checklist/bug-intake.md",
+        "title": "Bug Intake Checklist",
+        "purpose": "Verifica dati obbligatori prima del triage ticket.",
+        "owner": "N/D",
+        "last_update": "2025-10-27"
+      },
+      {
+        "path": "docs/checklist/clone-setup.md",
+        "title": "Procedura di clone e setup iniziale",
+        "purpose": "Istruzioni ambiente standard container /workspace/Game.",
+        "owner": "Ops/ChatGPT",
+        "last_update": "2025-10-26"
+      },
+      {
+        "path": "docs/checklist/demo-release.md",
+        "title": "Checklist release demo pubblica",
+        "purpose": "Passi di coordinamento per bundle demo Evo Tactics Pack.",
+        "owner": "N/D",
+        "last_update": "2025-10-27"
+      },
+      {
+        "path": "docs/checklist/milestones.md",
+        "title": "Checklist Milestone",
+        "purpose": "Stato avanzamento milestone telemetria/dataset/playtest.",
+        "owner": "N/D",
+        "last_update": "2025-10-28"
+      },
+      {
+        "path": "docs/checklist/project-setup-todo.md",
+        "title": "TODO Operativo — Avvio completo del progetto",
+        "purpose": "Sequenza end-to-end per rendere operativo il progetto con note storiche.",
+        "owner": "Ops/ChatGPT · Release Ops · Marketing Ops · Lead Dev Tools",
+        "last_update": "2025-10-28"
+      },
+      {
+        "path": "docs/checklist/telemetry.md",
+        "title": "Checklist — Telemetry Export & QA Filters",
+        "purpose": "Controlli giornalieri/settimanali su export telemetria e filtri QA.",
+        "owner": "N/D",
+        "last_update": "2025-10-28"
+      },
+      {
+        "path": "docs/checklist/vc_playtest_plan.md",
+        "title": "Playtest VC Mirati alla Telemetria",
+        "purpose": "Piano sessioni mirate agli indici VC e setup strumentazione.",
+        "owner": "N/D",
+        "last_update": "2025-10-24"
+      }
+    ],
+    "Processo": [
+      {
+        "path": "docs/process/incident_reporting_table.md",
+        "title": "Registro Segnalazioni Cross-Team — Implementazione Operativa",
+        "purpose": "Configurazione tabella Airtable e permessi per segnalazioni condivise.",
+        "owner": "N/D",
+        "last_update": "2025-10-27"
+      },
+      {
+        "path": "docs/process/qa_hud.md",
+        "title": "QA — HUD Smart Alerts",
+        "purpose": "Metriche e pipeline QA per monitorare ack/filter ratio degli alert HUD.",
+        "owner": "QA lead",
+        "last_update": "2025-10-27"
+      },
+      {
+        "path": "docs/process/qa_reporting_schema.md",
+        "title": "QA Telemetry & Segnalazioni — Schema condiviso",
+        "purpose": "Panorama fonti dati QA, campi disponibili e gap di reporting.",
+        "owner": "N/D",
+        "last_update": "2025-10-27"
+      },
+      {
+        "path": "docs/process/telemetry_ingestion_pipeline.md",
+        "title": "Pipeline Dati Telemetria → Tabella QA/Design",
+        "purpose": "Flusso di ingestione telemetria, snapshot visuali e modulo QA manuale.",
+        "owner": "N/D",
+        "last_update": "2025-10-27"
+      },
+      {
+        "path": "docs/process/traits_checklist.md",
+        "title": "Checklist iterativa tratti",
+        "purpose": "Step incrementali per aggiungere/revisionare tratti con controlli dati.",
+        "owner": "N/D",
+        "last_update": "2025-10-28"
+      },
+      {
+        "path": "docs/process/web_handoff.md",
+        "title": "Web Handoff · Foodweb Archetypes 2025-11-05",
+        "purpose": "Nota di consegna verso team web/UI con archetipi ruolo×bioma aggiornati.",
+        "owner": "N/D",
+        "last_update": "2025-10-29"
+      },
+      {
+        "path": "docs/process/web_pipeline.md",
+        "title": "Pipeline web · Procedura di rilascio",
+        "purpose": "Processo end-to-end per promuovere la web experience su GitHub Pages.",
+        "owner": "N/D",
+        "last_update": "2025-10-28"
+      }
+    ],
+    "Log & metriche": [
+      {
+        "path": "logs/chatgpt_sync.log",
+        "title": "Log sincronizzazione ChatGPT",
+        "purpose": "Cronologia esecuzioni scripts/chatgpt_sync.py e diff generati.",
+        "owner": "N/D",
+        "last_update": "2025-10-24"
+      },
+      {
+        "path": "logs/chatgpt_sync_last.json",
+        "title": "Snapshot ultima sincronizzazione ChatGPT",
+        "purpose": "Esito strutturato dell'ultima run con percorsi export/diff.",
+        "owner": "N/D",
+        "last_update": "2025-10-24"
+      },
+      {
+        "path": "logs/drive/2025-11-XX-dryrun.json",
+        "title": "Drive sync dry-run",
+        "purpose": "Stato dry-run convertYamlToSheetsDryRun() e azioni suggerite.",
+        "owner": "N/D",
+        "last_update": "2025-10-28"
+      },
+      {
+        "path": "logs/exports/2025-11-08-filter-selections.md",
+        "title": "Telemetry Export — Log interazioni filtri",
+        "purpose": "Audit settimanale applicazione filtri export (Analytics/Support).",
+        "owner": "Analytics · Support",
+        "last_update": "2025-10-28"
+      },
+      {
+        "path": "logs/traits_tracking.md",
+        "title": "Monitoraggio inventario trait",
+        "purpose": "Aggiornamenti periodici copertura trait/specie e risultati validator.",
+        "owner": "N/D",
+        "last_update": "2025-10-29"
+      },
+      {
+        "path": "logs/trait_audit.md",
+        "title": "Trait Data Audit",
+        "purpose": "Stato errori/warning dataset trait.",
+        "owner": "N/D",
+        "last_update": "2025-10-29"
+      },
+      {
+        "path": "logs/web_status.md",
+        "title": "Programmazione riesami sito web",
+        "purpose": "Agenda e checklist riesami settimanali sito con azioni QA.",
+        "owner": "N/D",
+        "last_update": "2025-10-29"
+      },
+      {
+        "path": "logs/qa/latest-dashboard-metrics.json",
+        "title": "Dashboard & generator metrics snapshot",
+        "purpose": "Metriche più recenti per dashboard/generator con audit accessibilità.",
+        "owner": "N/D",
+        "last_update": "2025-10-27"
+      },
+      {
+        "path": "logs/qa/dashboard_metrics.jsonl",
+        "title": "Storico metriche dashboard",
+        "purpose": "Append log JSONL con run successive e confronti visual regression.",
+        "owner": "N/D",
+        "last_update": "2025-10-27"
+      },
+      {
+        "path": "logs/tooling/2025-10-24-tooling.md",
+        "title": "2025-10-24 — Verifica ambiente & toolchain",
+        "purpose": "Verifica versioni e operazioni tooling (npm, pip, CLI).",
+        "owner": "N/D",
+        "last_update": "2025-10-24"
+      }
+    ],
+    "Pianificazione": [
+      {
+        "path": "docs/piani/roadmap.md",
+        "title": "Roadmap Operativa",
+        "purpose": "Procedura settimanale post-ottobre 2025 con milestone e follow-up.",
+        "owner": "N/D",
+        "last_update": "2025-10-28"
+      }
+    ],
+    "Appendici di stato": [
+      {
+        "path": "appendici/A-CANVAS_ORIGINALE.txt",
+        "title": "Canvas A — Originale",
+        "purpose": "Visione principale con note telemetria/Resonance Shards.",
+        "owner": "N/D",
+        "last_update": "2025-10-27"
+      },
+      {
+        "path": "appendici/C-CANVAS_NPG_BIOMI.txt",
+        "title": "Canvas C — NPG & Biomi",
+        "purpose": "Canvas NPG reattivi, biomi e protocolli soccorso.",
+        "owner": "N/D",
+        "last_update": "2025-10-26"
+      },
+      {
+        "path": "appendici/D-CANVAS_ACCOPPIAMENTO.txt",
+        "title": "Canvas D — Mating, Reclutamento & Nido",
+        "purpose": "Canvas sistemi attrazione, nido e ereditarietà parti.",
+        "owner": "N/D",
+        "last_update": "2025-10-26"
+      }
+    ]
+  },
+  "progress": {
+    "Operativo": [
+      {
+        "name": "Telemetria VC",
+        "description": "Le milestone operative hanno completato playtest, normalizzazione e documentazione; restano overlay HUD, ribilanciamento XP Cipher e contrasto EVT-03.",
+        "ratio": 0.7368421052631579,
+        "references": [
+          "docs/checklist/milestones.md#in-corso"
+        ]
+      }
+    ],
+    "Processo": [
+      {
+        "name": "Pipeline deploy web",
+        "description": "Il processo di rilascio è definito ma i riesami settimanali riportano ancora blocchi Playwright e smoke test manuali aperti.",
+        "ratio": 0.0,
+        "references": [
+          "docs/process/web_pipeline.md",
+          "logs/web_status.md"
+        ]
+      }
+    ],
+    "Log & metriche": [
+      {
+        "name": "Inventario trait",
+        "description": "La copertura tratti/specie è riallineata ma restano da integrare appendici e dataset mock aggiuntivi.",
+        "ratio": 0.5454545454545454,
+        "references": [
+          "logs/traits_tracking.md"
+        ]
+      }
+    ],
+    "Appendici": [
+      {
+        "name": "Canvas e integrazioni",
+        "description": "Gli appendici A/C/D riportano l'ultima revisione mentre canvas e feature updates conservano follow-up aperti.",
+        "ratio": 0.5,
+        "references": [
+          "docs/00-INDEX.md#appendici-di-stato",
+          "docs/Canvas/feature-updates.md"
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/daily_tracker_refresh.py
+++ b/scripts/daily_tracker_refresh.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Genera l'indice tracker e aggiorna lo stato di avanzamento nel README.
+
+Il contenuto è guidato da `config/tracker_registry.yaml` e viene inserito tra
+marcatori dedicati in `docs/00-INDEX.md` e `README.md`.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_PATH = REPO_ROOT / "config" / "tracker_registry.yaml"
+INDEX_MARKER_START = "<!-- tracker-registry:start -->"
+INDEX_MARKER_END = "<!-- tracker-registry:end -->"
+STATUS_MARKER_START = "<!-- tracker-status:start -->"
+STATUS_MARKER_END = "<!-- tracker-status:end -->"
+CHECKBOX_PATTERN = re.compile(r"- \[(?P<state>[ xX])\]")
+
+
+@dataclass
+class TrackerEntry:
+    path: Path
+    title: str
+    purpose: str
+    owner: str
+
+    def last_update(self) -> str:
+        return git_last_modified(self.path)
+
+    def file_name(self) -> str:
+        return self.path.name
+
+
+@dataclass
+class ProgressCompute:
+    kind: str
+    path: Optional[Path] = None
+    value: Optional[float] = None
+
+
+@dataclass
+class ProgressReference:
+    label: str
+    target: str
+
+    def to_markdown(self) -> str:
+        return f"[{self.label}]({self.target})"
+
+
+@dataclass
+class ProgressItem:
+    name: str
+    description: str
+    compute: ProgressCompute
+    references: List[ProgressReference]
+
+    def ratio(self) -> float:
+        if self.compute.kind == "checkbox":
+            if self.compute.path is None:
+                raise ValueError("Il percorso per il metodo checkbox non può essere nullo")
+            checked, total = count_checkboxes(self.compute.path)
+            if total == 0:
+                return 0.0
+            return checked / total
+        if self.compute.kind == "manual":
+            if self.compute.value is None:
+                raise ValueError("Il metodo manual richiede un valore esplicito")
+            return max(0.0, min(1.0, self.compute.value))
+        raise ValueError(f"Metodo di calcolo sconosciuto: {self.compute.kind}")
+
+    def progress_bar(self) -> str:
+        ratio = self.ratio()
+        percent = round(ratio * 100)
+        filled = int(round(percent / 10))
+        filled = max(0, min(10, filled))
+        bar = "█" * filled + "░" * (10 - filled)
+        references_md = " e ".join(ref.to_markdown() for ref in self.references)
+        reference_tail = f" Vedi {references_md}." if references_md else ""
+        return (
+            f"- **{bar} {percent}% · {self.name}** — {self.description}{reference_tail}"
+        )
+
+
+@dataclass
+class ProgressSection:
+    category: str
+    items: List[ProgressItem]
+
+    def to_markdown(self) -> str:
+        lines = [f"#### {self.category}"]
+        lines.extend(item.progress_bar() for item in self.items)
+        return "\n".join(lines)
+
+
+def load_config(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def build_tracker_entries(config: Dict[str, Any]) -> Dict[str, List[TrackerEntry]]:
+    result: Dict[str, List[TrackerEntry]] = {}
+    for table in config.get("tables", []):
+        entries: List[TrackerEntry] = []
+        for raw_entry in table.get("entries", []):
+            entry = TrackerEntry(
+                path=(REPO_ROOT / raw_entry["path"]).resolve().relative_to(REPO_ROOT),
+                title=raw_entry["title"],
+                purpose=raw_entry["purpose"],
+                owner=raw_entry.get("owner", "N/D"),
+            )
+            entries.append(entry)
+        result[table["title"]] = entries
+    return result
+
+
+def build_progress_sections(config: Dict[str, Any]) -> List[ProgressSection]:
+    sections: List[ProgressSection] = []
+    for raw_section in config.get("progress_sections", []):
+        items: List[ProgressItem] = []
+        for raw_item in raw_section.get("items", []):
+            compute_cfg = raw_item.get("compute", {})
+            compute = ProgressCompute(
+                kind=compute_cfg.get("type", "manual"),
+                path=(REPO_ROOT / compute_cfg["path"]).resolve().relative_to(REPO_ROOT)
+                if compute_cfg.get("path")
+                else None,
+                value=compute_cfg.get("value"),
+            )
+            references = [
+                ProgressReference(label=ref.get("label", ref["target"]), target=ref["target"])
+                for ref in raw_item.get("references", [])
+            ]
+            items.append(
+                ProgressItem(
+                    name=raw_item["name"],
+                    description=raw_item["description"],
+                    compute=compute,
+                    references=references,
+                )
+            )
+        sections.append(ProgressSection(category=raw_section["category"], items=items))
+    return sections
+
+
+def count_checkboxes(path: Path) -> tuple[int, int]:
+    file_path = REPO_ROOT / path
+    text = file_path.read_text(encoding="utf-8")
+    matches = CHECKBOX_PATTERN.findall(text)
+    total = len(matches)
+    checked = sum(1 for state in matches if state.lower() == "x")
+    return checked, total
+
+
+def git_last_modified(path: Path) -> str:
+    rel_path = str(path)
+    try:
+        output = subprocess.check_output(
+            ["git", "log", "-1", "--format=%cs", rel_path],
+            cwd=REPO_ROOT,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        return "N/D"
+    value = output.decode().strip()
+    return value or "N/D"
+
+
+def generate_table_markdown(entries_by_category: Dict[str, List[TrackerEntry]]) -> str:
+    sections: List[str] = []
+    for category, entries in entries_by_category.items():
+        lines = [f"### {category}", "", "| File | Titolo | Scopo | Owner attuale | Ultimo aggiornamento | Percorso |", "| --- | --- | --- | --- | --- | --- |"]
+        for entry in entries:
+            file_link = f"[{entry.file_name()}]({entry.path.as_posix()})"
+            last_update = entry.last_update()
+            percorso = f"`{entry.path.as_posix()}`"
+            lines.append(
+                f"| {file_link} | {entry.title} | {entry.purpose} | {entry.owner} | {last_update} | {percorso} |"
+            )
+        sections.append("\n".join(lines))
+    return "\n\n".join(sections)
+
+
+def generate_status_markdown(progress_sections: Iterable[ProgressSection]) -> str:
+    return "\n\n".join(section.to_markdown() for section in progress_sections)
+
+
+def replace_section(content: str, marker_start: str, marker_end: str, new_section: str) -> str:
+    if marker_start not in content or marker_end not in content:
+        raise ValueError("Marcatori non trovati nel file di destinazione")
+    before, _, rest = content.partition(marker_start)
+    _, _, after = rest.partition(marker_end)
+    return f"{before}{marker_start}\n{new_section}\n{marker_end}{after}"
+
+
+def write_if_changed(path: Path, new_content: str) -> bool:
+    path = path if path.is_absolute() else REPO_ROOT / path
+    existing = path.read_text(encoding="utf-8")
+    if existing == new_content:
+        return False
+    path.write_text(new_content, encoding="utf-8")
+    return True
+
+
+def update_index(entries_by_category: Dict[str, List[TrackerEntry]], index_path: Path) -> bool:
+    full_path = REPO_ROOT / index_path
+    content = full_path.read_text(encoding="utf-8")
+    table_md = generate_table_markdown(entries_by_category)
+    new_content = replace_section(content, INDEX_MARKER_START, INDEX_MARKER_END, table_md)
+    return write_if_changed(full_path, new_content)
+
+
+def update_readme(progress_sections: List[ProgressSection], readme_path: Path) -> bool:
+    full_path = REPO_ROOT / readme_path
+    content = full_path.read_text(encoding="utf-8")
+    status_md = generate_status_markdown(progress_sections)
+    new_content = replace_section(content, STATUS_MARKER_START, STATUS_MARKER_END, status_md)
+    return write_if_changed(full_path, new_content)
+
+
+def export_summary(
+    path: Optional[Path],
+    entries: Dict[str, List[TrackerEntry]],
+    sections: List[ProgressSection],
+) -> None:
+    if path is None:
+        return
+    summary = {
+        "generated_at": dt.datetime.utcnow().isoformat() + "Z",
+        "tables": {
+            category: [
+                {
+                    "path": entry.path.as_posix(),
+                    "title": entry.title,
+                    "purpose": entry.purpose,
+                    "owner": entry.owner,
+                    "last_update": entry.last_update(),
+                }
+                for entry in entries_list
+            ]
+            for category, entries_list in entries.items()
+        },
+        "progress": {
+            section.category: [
+                {
+                    "name": item.name,
+                    "description": item.description,
+                    "ratio": item.ratio(),
+                    "references": [ref.target for ref in item.references],
+                }
+                for item in section.items
+            ]
+            for section in sections
+        },
+    }
+    export_path = path if path.is_absolute() else REPO_ROOT / path
+    export_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Aggiorna tracker e stato README")
+    parser.add_argument("--config", default=str(CONFIG_PATH), help="File di configurazione YAML")
+    parser.add_argument("--index", default="docs/00-INDEX.md", help="Percorso dell'indice da aggiornare")
+    parser.add_argument("--readme", default="README.md", help="Percorso del README da aggiornare")
+    parser.add_argument("--export-json", dest="export_json", default=None, help="Percorso opzionale per esportare un riepilogo JSON")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_config(Path(args.config))
+    entries_by_category = build_tracker_entries(config)
+    progress_sections = build_progress_sections(config)
+
+    index_changed = update_index(entries_by_category, Path(args.index))
+    readme_changed = update_readme(progress_sections, Path(args.readme))
+    if args.export_json:
+        export_summary(Path(args.export_json), entries_by_category, progress_sections)
+
+    changed = []
+    if index_changed:
+        changed.append(args.index)
+    if readme_changed:
+        changed.append(args.readme)
+    if changed:
+        print("Aggiornati:", ", ".join(changed))
+    else:
+        print("Nessun aggiornamento necessario")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce il file di configurazione `config/tracker_registry.yaml` e lo script `scripts/daily_tracker_refresh.py` che generano automaticamente l'indice tracker e le progress bar del README
- aggiorna `README.md` e `docs/00-INDEX.md` inserendo marcatori gestiti dallo script e aggiunge l'export `reports/daily_tracker_summary.json`
- aggiunge il workflow pianificato `daily-tracker-refresh.yml` per eseguire lo script ogni giorno a mezzogiorno e committare gli aggiornamenti

## Testing
- python3 scripts/daily_tracker_refresh.py
- python3 scripts/daily_tracker_refresh.py --export-json reports/daily_tracker_summary.json

------
https://chatgpt.com/codex/tasks/task_e_6901212e81cc8332851794967f5bb10e