### PR TITLE
Document incoming triage workflow and create supporting templates

### DIFF
--- a/docs/checklist/incoming_triage.md
+++ b/docs/checklist/incoming_triage.md
@@ -1,0 +1,27 @@
+# Checklist Triage Cartella `incoming/`
+
+## Pre-meeting (T-1 giorno)
+- [ ] Eseguire `./scripts/report_incoming.sh --destination sessione-AAAA-MM-GG`.
+- [ ] Caricare report HTML/JSON nella calendar invite o nel canale `#incoming-triage`.
+- [ ] Ping dei caretaker con elenco asset da revisionare.
+- [ ] Verificare spazio libero per decompressioni temporanee (`/tmp`).
+- [ ] Aggiornare board Kanban: nuove card in `Da analizzare` per asset arrivati durante la settimana.
+
+## Durante il meeting
+- [ ] Aprire il report HTML (ordine per esito validazione).
+- [ ] Annotare decisioni su template meeting (`docs/templates/incoming_triage_meeting.md`).
+- [ ] Assegnare owner/caretaker per ogni asset.
+- [ ] Identificare dipendenze (es. compatibilità Enneagramma, hook telemetria).
+- [ ] Decidere etichetta: `Da integrare`, `Archivio storico`, `Scarto`.
+
+## Post-meeting (entro 24h)
+- [ ] Spostare fisicamente i file nelle cartelle definite (§3 del playbook).
+- [ ] Aprire issue/PR per asset `Da integrare` con link al report.
+- [ ] Aggiornare `incoming/archive/INDEX.md` per ogni elemento archiviato.
+- [ ] Aggiornare board Kanban (colonna, owner, due date).
+- [ ] Aggiornare knowledge base con summary e follow-up.
+
+## Controlli periodici
+- [ ] Ogni sprint: rivedere backlog `In integrazione` per pianificare sprint tematici.
+- [ ] Ogni mese: verificare stato manutenzione tool (log in `docs/process/tooling_maintenance_log.md`).
+- [ ] Ogni quarter: retrospettiva asset in `Archivio` per recuperare idee.

--- a/docs/process/incoming_review_log.md
+++ b/docs/process/incoming_review_log.md
@@ -1,0 +1,15 @@
+# Incoming Review — Registro sessioni
+
+Annotare ogni meeting seguendo il [template](../templates/incoming_triage_meeting.md). Aggiungere le nuove sessioni in cima al file.
+
+---
+
+## YYYY-MM-DD — Facilitator: Nome
+- Report: `reports/incoming/sessione-YYYY-MM-DD/index.html`
+- Partecipanti: ...
+- Decisioni chiave:
+  - ...
+- Follow-up:
+  - ...
+
+*(Aggiungere nuove sezioni sopra questa riga di placeholder.)*

--- a/docs/process/incoming_triage_pipeline.md
+++ b/docs/process/incoming_triage_pipeline.md
@@ -1,0 +1,113 @@
+# Pipeline operativo per il triage della cartella `incoming/`
+
+## Obiettivi
+- Trasformare `incoming/` da deposito grezzo a flusso controllato e versionato.
+- Garantire che ogni asset passi per analisi automatica (`scripts/report_incoming.sh`) e valutazione umana coordinata.
+- Preservare idee scartate ma interessanti tramite archiviazione motivata.
+
+## 1. Ciclo settimanale "Incoming Review"
+1. **Pianificazione**
+   - Calendarizzare un recurring meeting di 30 minuti ogni lunedì.
+   - Owner: Lead Game Designer. Partecipanti fissi: Narrative, Systems, Tooling.
+2. **Pre-work (T-1 giorno)**
+   - L'owner esegue:
+     ```bash
+     ./scripts/report_incoming.sh --destination sessione-$(date +%Y-%m-%d)
+     ```
+   - Lo script genera: log di validazione (`reports/incoming/validation/`), report HTML/JSON (`reports/incoming/sessione-AAAA-MM-GG/`).
+   - Condividere il link al report nella calendar invite.
+3. **Durante il meeting**
+   - Scorrere l'output ordinato per "risultato validazione" e "novità".
+   - Per ogni asset segnare etichetta provvisoria: **Da integrare**, **Archivio storico**, **Scarto** (vedi §3).
+   - Registrare decisioni in `docs/process/incoming_review_log.md` (nuovo file per meeting) oppure nello strumento knowledge base.
+4. **Post-meeting (entro 24h)**
+   - Spostare i file secondo etichetta (§3).
+   - Aggiornare board Kanban (§2) e knowledge base (§6).
+
+## 2. Board Kanban dedicato
+- **Struttura colonne**: `Da analizzare` → `In validazione` → `In integrazione` → `In playtest` → `Archivio`.
+- **Card**: una card per ogni asset o gruppo logico (es. `evo_tactics_unified_pack-v1.9.zip`).
+- **Automazioni suggerite**:
+  - Creazione card automatica tramite import CSV dal report JSON.
+  - Notifica Slack quando una card entra in `In playtest`.
+- **Definition of Done per colonna**:
+  - `Da analizzare`: asset estratto e metadati compilati.
+  - `In validazione`: `report_incoming.sh` eseguito, log allegati.
+  - `In integrazione`: task implementativo aperto nel repo (issue/PR) e owner assegnato.
+  - `In playtest`: build o scenario disponibile per QA/telemetria.
+  - `Archivio`: indice aggiornato (vedi §3.3) con motivazioni.
+
+## 3. Gestione asset dopo il triage
+### 3.1 Da integrare
+- Spostare asset nella directory target (`packs/`, `docs/`, `tools/`, ...).
+- Aprire issue con checklist di integrazione e link al report di validazione.
+- Pianificare eventuale sprint tematico (§7).
+
+### 3.2 Archivio storico
+- Spostare in `incoming/archive/YYYY/MM/` (creare cartella se assente).
+- Aggiornare `incoming/archive/INDEX.md` con tabella motivazioni.
+- Aggiungere tag `archivio` nella board Kanban.
+
+### 3.3 Scarto controllato
+- Se il materiale è duplicato o obsoleto ma contiene intuizioni, salvarne estratti in `incoming/archive/` e documentarli.
+- In caso di file non più utili, eliminarli solo dopo aver verificato che esista copia versionata su repository o drive.
+
+## 4. Ruoli "Caretaker"
+| Area | Owner primario | Back-up | Responsabilità |
+| --- | --- | --- | --- |
+| Core Rules & Stats | Lead Systems Designer | Senior Analyst | Revisione numeri, compatibilità dadi, bilanciamento pack core |
+| Specie/Morph & Biomi | Narrative Biome Lead | Worldbuilding | Sincronizzare pacchetti specie/biomi, verificare hook ambienti |
+| Personality Modules | Narrative Psych Lead | UX Research | Aggiornare moduli MBTI/Enneagram, definire limiti provvisori |
+| Tools & Validation | Toolsmith | QA Automation | Manutenzione script, pipeline CI, documentazione tecnica |
+
+- Ogni caretaker prepara note pre-meeting: highlights dei propri asset, regressioni, richieste.
+- Rotazione trimestrale delle responsabilità per evitare single point of failure.
+
+## 5. Documentazione di compatibilità
+- Applicare immediatamente le istruzioni di `incoming/GAME_COMPAT_README.md` per l'addon Enneagramma:
+  - Aggiornare `compat_map.json` e `personality_module.v1.json` quando l'asset passa in `In integrazione`.
+  - Registrare i test rapidi (108 profili) in `reports/incoming/tests/`.
+- Replicare la stessa disciplina per altri README guida (`README_INTEGRAZIONE_MECCANICHE.md`, ecc.).
+- Allegare i link in ogni card della board Kanban.
+
+## 6. Knowledge base condivisa
+- Dopo il meeting, aggiornare pagina Notion/Confluence con sezioni:
+  - **Integrati**: elenco + link PR/report.
+  - **Backlog**: asset rimasti in `Da analizzare` o `In validazione`.
+  - **Archivio**: highlight spunti creativi con riferimento a `incoming/archive/INDEX.md`.
+  - **Decisioni**: motivazioni e follow-up.
+- In assenza di strumento esterno, usare `docs/process/incoming_review_log.md` con formato meeting template (§8).
+
+## 7. Sprint tematici
+- Pianificare sprint di 1-2 settimane focalizzati su cluster (es. "MBTI ↔ Job affinities").
+- Input: card `In integrazione` correlate.
+- Output: pacchetto aggiornato, test passati, note di tuning.
+- Registra risultato sprint in `docs/piani/` con summary e telemetria.
+
+## 8. Template meeting e checklist
+- Meeting template: `docs/templates/incoming_triage_meeting.md` (agenda standard, spazio note).
+- Checklist operativa: `docs/checklist/incoming_triage.md` (pre/durante/post meeting).
+- Salvare meeting note generate in `docs/process/incoming_review_log.md` oppure export su knowledge base.
+
+## 9. Loop feedback playtest & telemetria
+- Quando una card entra in `In playtest`:
+  - Collegare i file YAML di telemetria (`telemetry/vc.yaml`, `telemetry/pf_session.yaml`).
+  - Aprire task QA per comparare ipotesi vs. dati raccolti.
+  - Aggiornare card con conclusioni e azioni di tuning.
+
+## 10. Manutenzione strumenti
+- Micro-sprint mensile (mezza giornata) per:
+  - Aggiornare `scripts/report_incoming.sh` (supporto nuovi formati, log più chiari).
+  - Validare schemi JSON utilizzati dagli asset.
+  - Sincronizzare script Python/TypeScript per addon (es. Enneagramma) con feedback dell'ultimo triage.
+- Registrare azioni in `docs/process/tooling_maintenance_log.md`.
+
+## Metriche di salute
+- % asset triagiati entro 7 giorni dall'arrivo.
+- Numero di regressioni rilevate dagli script di validazione vs. manuali.
+- Tempo medio per passaggio `Da analizzare` → `In integrazione`.
+
+## Allegati
+- [Checklist triage](../checklist/incoming_triage.md)
+- [Template meeting](../templates/incoming_triage_meeting.md)
+- [Indice archivio incoming](../../incoming/archive/INDEX.md)

--- a/docs/process/tooling_maintenance_log.md
+++ b/docs/process/tooling_maintenance_log.md
@@ -1,0 +1,13 @@
+# Tooling Maintenance Log — Incoming Pipeline
+
+Registrare attività di manutenzione mensili relative a script, validatori e pipeline collegate all'onboarding degli asset in `incoming/`.
+
+| Data | Task | Owner | Stato | Note |
+| --- | --- | --- | --- | --- |
+| YYYY-MM-DD | Aggiornare `scripts/report_incoming.sh` per supportare nuovo formato | Toolsmith | Pianificato | | 
+| | | | | |
+
+## Linee guida
+- Inserire link a PR o commit nella colonna **Note**.
+- Se un'attività riguarda più sprint, duplicare la riga con date diverse e stato aggiornato.
+- Chiudere ogni voce con conferma QA/Automation (test eseguiti).

--- a/docs/templates/incoming_triage_meeting.md
+++ b/docs/templates/incoming_triage_meeting.md
@@ -1,0 +1,31 @@
+# Template Meeting — Incoming Review
+
+- **Data**: YYYY-MM-DD
+- **Partecipanti**: Lead GD, Narrative, Systems, Toolsmith, ospiti
+- **Facilitatore**: _Nome_
+- **Report HTML**: `reports/incoming/sessione-YYYY-MM-DD/index.html`
+- **Recording / Link call**: 
+
+## 1. Radar rapido (5')
+- Novità arrivi settimana
+- Avvisi caretaker (regressioni, dipendenze)
+
+## 2. Revisione asset (15')
+| Asset | Esito validazione | Decisione | Owner | Follow-up |
+| --- | --- | --- | --- | --- |
+| | | | | |
+| | | | | |
+
+## 3. Focus tematici (5')
+- Sprint / Playtest imminenti
+- Aggiornamenti compatibilità (es. Enneagramma)
+
+## 4. Azioni & comunicazioni (5')
+- Task aperti
+- Aggiornamenti knowledge base
+- Comunicazioni verso altri team
+
+## Allegati
+- Log validazione: `reports/incoming/validation/<asset>/<timestamp>/summary.txt`
+- Board Kanban: URL
+- Archivio: `incoming/archive/INDEX.md`

--- a/incoming/archive/INDEX.md
+++ b/incoming/archive/INDEX.md
@@ -1,0 +1,13 @@
+# Archivio Incoming — Registro decisioni
+
+Utilizzare questa tabella per registrare gli asset spostati in archivio o scartati con potenziale futuro. Aggiornare durante il post-meeting della "Incoming Review".
+
+| Data | Percorso origine | Cartella archivio | Motivazione | Spunti/Follow-up | Owner |
+| --- | --- | --- | --- | --- | --- |
+| YYYY-MM-DD | incoming/evo_tactics_unified_pack-v1.9.zip | incoming/archive/2024/05/ | Sostituito da v1.9.8 ma contiene hook interessanti | Riprendere parametri stamina per DLC survival | Narrative |
+| | | | | | |
+
+## Note operative
+- Organizzare l'archivio per anno/mese (`incoming/archive/YYYY/MM/`).
+- Inserire eventuali asset derivati (documenti estratti) nella stessa cartella con README locale.
+- Quando un asset viene recuperato dall'archivio, segnare la riga come **Ripreso** e linkare a issue/PR.


### PR DESCRIPTION
## Summary
- add an operational playbook for the weekly Incoming Review and downstream workflows
- provide supporting artifacts: meeting template, actionable checklist, caretaker log, and archive index stub

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_690227fd06f48332b3bfc5a92ee2c50f