### PR TITLE
Add planar ruins biome with translated Pathfinder species

### DIFF
--- a/config/project_index.json
+++ b/config/project_index.json
@@ -41,7 +41,8 @@
       "foresta_miceliale": "Mycelial Forest",
       "atollo_obsidiana": "Obsidian Atoll",
       "mezzanotte_orbitale": "Orbital Midnight",
-      "caverna_risonante": "Resonant Cavern"
+      "caverna_risonante": "Resonant Cavern",
+      "rovine_planari": "Planar Ruins"
     },
     "hazards": {
       "aerosol_solfurei": "Sulfur Aerosols",
@@ -67,7 +68,8 @@
       "cursoriale_quadrupede": "Cursorial Quadruped",
       "ingegnere_radicante": "Rooting Engineer",
       "scavenger_corazzato": "Armored Scavenger",
-      "volatore_planatore": "Gliding Flier"
+      "volatore_planatore": "Gliding Flier",
+      "anfibio_filtratore": "Filter-Feeding Amphibian"
     },
     "salinity": {
       "dolce": "Freshwater",

--- a/data/biomes.yaml
+++ b/data/biomes.yaml
@@ -1,28 +1,29 @@
 biomes:
   abisso_vulcanico:
-    label: "Abisso Vulcanico"
-    summary: "Camini abissali con lava pressurizzata e fauna bio-termica." 
+    label: Abisso Vulcanico
+    summary: Camini abissali con lava pressurizzata e fauna bio-termica.
     diff_base: 5
     mod_biome: 3
     affixes:
-      - termico
-      - luminescente
-      - spore_diluite
-      - sabbia
+    - termico
+    - luminescente
+    - spore_diluite
+    - sabbia
     aliases:
-      - deserto_caldo
+    - deserto_caldo
     hazard:
-      description: "Sfiati di magma, shock termici e colate improvvise che deformano la topografia."
+      description: Sfiati di magma, shock termici e colate improvvise che deformano
+        la topografia.
       severity: high
       stress_modifiers:
         magma_surge: 0.07
         thermal_shock: 0.06
     npc_archetypes:
       primary:
-        - abyssal_forgers
-        - magma_wardens
+      - abyssal_forgers
+      - magma_wardens
       support:
-        - geode_listeners
+      - geode_listeners
     stresswave:
       baseline: 0.36
       escalation_rate: 0.06
@@ -30,30 +31,30 @@ biomes:
         rescue: 0.58
         overrun: 0.82
     narrative:
-      tone: "Assalti verticali e estrazioni ad alto rischio tra geyser incandescenti."
+      tone: Assalti verticali e estrazioni ad alto rischio tra geyser incandescenti.
       hooks:
-        - "Stabilire condotti di raffreddamento attorno alle fucine naturali." 
-        - "Recuperare artefatti termici prima dell'eruzione cataclismica."
+      - Stabilire condotti di raffreddamento attorno alle fucine naturali.
+      - Recuperare artefatti termici prima dell'eruzione cataclismica.
   atollo_obsidiana:
-    label: "Atollo Obsidiana"
-    summary: "Arcipelago magnetico con maree EMP e piattaforme mobili."
+    label: Atollo Obsidiana
+    summary: Arcipelago magnetico con maree EMP e piattaforme mobili.
     diff_base: 4
     mod_biome: 3
     affixes:
-      - resonance_tide
-      - shard_storm
+    - resonance_tide
+    - shard_storm
     hazard:
-      description: "Maree magnetiche, correnti EMP e schegge taglienti."
+      description: Maree magnetiche, correnti EMP e schegge taglienti.
       severity: high
       stress_modifiers:
         tidal_surge: 0.06
         emp_flash: 0.07
     npc_archetypes:
       primary:
-        - aegis_corsairs
-        - gale_splicers
+      - aegis_corsairs
+      - gale_splicers
       support:
-        - ingegneri_falena
+      - ingegneri_falena
     stresswave:
       baseline: 0.33
       escalation_rate: 0.05
@@ -61,31 +62,31 @@ biomes:
         support: 0.57
         overrun: 0.78
     narrative:
-      tone: "Pirateria magnetica e assedi anfibi high-tech."
+      tone: Pirateria magnetica e assedi anfibi high-tech.
       hooks:
-        - "Proteggere i reattori a risonanza dagli attacchi delle maree."
-        - "Recuperare shard ossidiani prima dell'arrivo della tempesta."
+      - Proteggere i reattori a risonanza dagli attacchi delle maree.
+      - Recuperare shard ossidiani prima dell'arrivo della tempesta.
   badlands:
-    label: "Badlands Ferro-Magnetiche"
-    summary: "Altipiani arrugginiti con tempeste ferrose e rovine sepolte."
+    label: Badlands Ferro-Magnetiche
+    summary: Altipiani arrugginiti con tempeste ferrose e rovine sepolte.
     diff_base: 4
     mod_biome: 2
     affixes:
-      - ferrous_spike
-      - dust_storm
-      - scrap_bloom
+    - ferrous_spike
+    - dust_storm
+    - scrap_bloom
     hazard:
-      description: "Tempeste di limatura magnetica e fulmini che polarizzano equipaggiamenti."
+      description: Tempeste di limatura magnetica e fulmini che polarizzano equipaggiamenti.
       severity: high
       stress_modifiers:
         ferrostorm: 0.05
         debris_field: 0.06
     npc_archetypes:
       primary:
-        - rust_scavengers
-        - ferroclad_brutes
+      - rust_scavengers
+      - ferroclad_brutes
       support:
-        - scrap_oracles
+      - scrap_oracles
     stresswave:
       baseline: 0.31
       escalation_rate: 0.05
@@ -93,31 +94,32 @@ biomes:
         salvage: 0.55
         overrun: 0.77
     narrative:
-      tone: "Scorrerie magnetiche e guerre di logoramento tra clan di recupero."
+      tone: Scorrerie magnetiche e guerre di logoramento tra clan di recupero.
       hooks:
-        - "Recuperare relè Aeon arrugginiti prima che vengano fusi."
-        - "Convincere i clan magnetotattici a cooperare contro le tempeste." 
+      - Recuperare relè Aeon arrugginiti prima che vengano fusi.
+      - Convincere i clan magnetotattici a cooperare contro le tempeste.
   caldera_glaciale:
-    label: "Caldera Glaciale"
-    summary: "Crateri glaciali con geyser criogenici e pareti ricoperte di ghiaccio vivo."
+    label: Caldera Glaciale
+    summary: Crateri glaciali con geyser criogenici e pareti ricoperte di ghiaccio
+      vivo.
     diff_base: 4
     mod_biome: 2
     affixes:
-      - frost_vents
-      - glacial_resonance
-      - ice_slick
+    - frost_vents
+    - glacial_resonance
+    - ice_slick
     hazard:
-      description: "Geyser criogenici e crepacci mascherati da cristalli luminosi."
+      description: Geyser criogenici e crepacci mascherati da cristalli luminosi.
       severity: high
       stress_modifiers:
         frostburst: 0.05
         collapse: 0.07
     npc_archetypes:
       primary:
-        - cryo_wardens
-        - glacial_sentinels
+      - cryo_wardens
+      - glacial_sentinels
       support:
-        - resonance_mappers
+      - resonance_mappers
     stresswave:
       baseline: 0.3
       escalation_rate: 0.05
@@ -125,30 +127,30 @@ biomes:
         rescue: 0.56
         overrun: 0.78
     narrative:
-      tone: "Esplorazioni verticali e gestione di geyser imprevedibili."
+      tone: Esplorazioni verticali e gestione di geyser imprevedibili.
       hooks:
-        - "Stabilire ponti termici per attraversare crepacci dinamici."
-        - "Proteggere gli estrattori di ghiaccio vivo durante le eruzioni." 
+      - Stabilire ponti termici per attraversare crepacci dinamici.
+      - Proteggere gli estrattori di ghiaccio vivo durante le eruzioni.
   canopia_ionica:
-    label: "Canopia Ionica"
-    summary: "Foresta verticale sospesa da campi elettrostatici e rampicanti conduttivi."
+    label: Canopia Ionica
+    summary: Foresta verticale sospesa da campi elettrostatici e rampicanti conduttivi.
     diff_base: 3
     mod_biome: 2
     affixes:
-      - static_vines
-      - ion_lattice
+    - static_vines
+    - ion_lattice
     hazard:
-      description: "Scariche elettrostatiche e cadute da piattaforme sospese."
+      description: Scariche elettrostatiche e cadute da piattaforme sospese.
       severity: medium
       stress_modifiers:
         ion_surge: 0.04
         vertigo: 0.05
     npc_archetypes:
       primary:
-        - canopy_sentinels
-        - lattice_stalkers
+      - canopy_sentinels
+      - lattice_stalkers
       support:
-        - charge_weavers
+      - charge_weavers
     stresswave:
       baseline: 0.28
       escalation_rate: 0.04
@@ -156,30 +158,31 @@ biomes:
         rescue: 0.52
         overrun: 0.72
     narrative:
-      tone: "Missioni acrobatiche tra passerelle elettrostatiche e reti sospese."
+      tone: Missioni acrobatiche tra passerelle elettrostatiche e reti sospese.
       hooks:
-        - "Sincronizzare la rete ionica per aprire corridoi sicuri."
-        - "Recuperare semi conduttivi custoditi dai guardiani della canopia."
+      - Sincronizzare la rete ionica per aprire corridoi sicuri.
+      - Recuperare semi conduttivi custoditi dai guardiani della canopia.
   canyons_risonanti:
-    label: "Canyons Risonanti"
-    summary: "Labirinto ventoso di gole armoniche alimentate da risonanza."
+    label: Canyons Risonanti
+    summary: Labirinto ventoso di gole armoniche alimentate da risonanza.
     diff_base: 4
     mod_biome: 2
     affixes:
-      - echo_surge
-      - shifting_winds
+    - echo_surge
+    - shifting_winds
     hazard:
-      description: "Cadute rovinose e tunnel sonori che amplificano StressWave (+0.05 scoperti)."
+      description: Cadute rovinose e tunnel sonori che amplificano StressWave (+0.05
+        scoperti).
       severity: high
       stress_modifiers:
         open_ground: 0.05
         collapse: 0.07
     npc_archetypes:
       primary:
-        - sibilant_wardens
-        - echo_drifters
+      - sibilant_wardens
+      - echo_drifters
       support:
-        - risonatori_nomadi
+      - risonatori_nomadi
     stresswave:
       baseline: 0.3
       escalation_rate: 0.05
@@ -187,34 +190,34 @@ biomes:
         rescue: 0.6
         overrun: 0.8
     narrative:
-      tone: "Duelli sonori e trattative con tribù eco-sintonizzate."
+      tone: Duelli sonori e trattative con tribù eco-sintonizzate.
       hooks:
-        - "Stabilizzare ponti risonanti prima delle tempeste di vento."
-        - "Seguire tracce sonore per rintracciare nidi dispersivi."
+      - Stabilizzare ponti risonanti prima delle tempeste di vento.
+      - Seguire tracce sonore per rintracciare nidi dispersivi.
   caverna:
-    label: "Caverna Risonante"
-    summary: "Gallerie cristalline dove eco e pressioni invertite modellano la fauna."
+    label: Caverna Risonante
+    summary: Gallerie cristalline dove eco e pressioni invertite modellano la fauna.
     diff_base: 3
     mod_biome: 2
     affixes:
-      - eco
-      - cristallino
-      - fangoso
-      - acque_nere
+    - eco
+    - cristallino
+    - fangoso
+    - acque_nere
     aliases:
-      - caverna_risonante
+    - caverna_risonante
     hazard:
-      description: "Risonanze amplificate, crolli spontanei e pozze acide."
+      description: Risonanze amplificate, crolli spontanei e pozze acide.
       severity: high
       stress_modifiers:
         echo_feedback: 0.05
         collapse: 0.08
     npc_archetypes:
       primary:
-        - guardiani_risonanza
-        - bracconieri_echomantici
+      - guardiani_risonanza
+      - bracconieri_echomantici
       support:
-        - cartografi_subsonici
+      - cartografi_subsonici
     stresswave:
       baseline: 0.32
       escalation_rate: 0.05
@@ -222,262 +225,32 @@ biomes:
         support: 0.55
         overrun: 0.75
     narrative:
-      tone: "Esplorazione claustrofobica guidata da acustica e luce riflessa."
+      tone: Esplorazione claustrofobica guidata da acustica e luce riflessa.
       hooks:
-        - "Disinnescare camere di eco instabile prima del collasso."
-        - "Estrarre cristalli risonanti senza allertare i custodi del nido."
+      - Disinnescare camere di eco instabile prima del collasso.
+      - Estrarre cristalli risonanti senza allertare i custodi del nido.
   palude:
-    label: "Palude Tossica"
-    summary: "Acque stagnanti bio-luminescenti con fauna mutagena."
-    diff_base: 3
-    mod_biome: 2
-    affixes:
-      - termico
-      - mirage_field
-      - silica_bloom
-    hazard:
-      description: "Tempeste di calore radiante, miraggi destabilizzanti e sabbia vetrificata."
-      severity: high
-      stress_modifiers:
-        heat_bloom: 0.06
-        mirage_drift: 0.04
-    npc_archetypes:
-      primary:
-        - dune_raiders
-        - silica_sentinels
-      support:
-        - caravan_medics
-    stresswave:
-      baseline: 0.29
-      escalation_rate: 0.05
-      event_thresholds:
-        support: 0.54
-        overrun: 0.76
-    narrative:
-      tone: "Convogli carovanieri e schermaglie per controllo di oasi risonanti."
-      hooks:
-        - "Guidare i convogli Aeon attraverso corridoi di sabbia viva."
-        - "Recuperare condensatori mirage dalle tempeste in arrivo."
-  dorsale_termale_tropicale:
-    label: "Dorsale Termale Tropicale"
-    summary: "Catena montuosa sommersa con fumarole calde e fauna simbiotica."
-    diff_base: 4
-    mod_biome: 3
-    affixes:
-      - echo_surge
-      - shifting_winds
-    aliases:
-      - badlands
-    hazard:
-      description: "Correnti ascendenti, shock termici e micro-eruzioni sottomarine."
-      severity: high
-      stress_modifiers:
-        thermal_plume: 0.06
-        pressure_wave: 0.05
-    npc_archetypes:
-      primary:
-        - ridge_sentinels
-        - plume_harvesters
-      support:
-        - thermal_diviners
-    stresswave:
-      baseline: 0.32
-      escalation_rate: 0.05
-      event_thresholds:
-        rescue: 0.58
-        overrun: 0.8
-    narrative:
-      tone: "Operazioni anfibie tra fumarole luminescenti e correnti instabili."
-      hooks:
-        - "Sigillare sfiati per proteggere gli avamposti sommersi."
-        - "Scortare i droni estrattori attraverso vortici bioluminescenti."
-  foresta_acida:
-    label: "Foresta Acida"
-    summary: "Bacini tropicali saturi di piogge corrosive e flora predatoria."
-    diff_base: 4
-    mod_biome: 2
-    affixes:
-      - acid_rain
-      - corrosive_bloom
-      - predator_vines
-    hazard:
-      description: "Piogge acide, foschia tossica e spore corrosive che erodono protezioni."
-      severity: high
-      stress_modifiers:
-        acid_fall: 0.05
-        corrosive_mist: 0.06
-    npc_archetypes:
-      primary:
-        - caustic_hunters
-        - ph_balance_enforcers
-      support:
-        - antidote_scribes
-    stresswave:
-      baseline: 0.33
-      escalation_rate: 0.05
-      event_thresholds:
-        rescue: 0.55
-        overrun: 0.79
-    narrative:
-      tone: "Sopravvivenza biochimica e negoziazioni con culti simbiotici acidi."
-      hooks:
-        - "Neutralizzare bacini corrotti prima della tempesta acida." 
-        - "Raccogliere reagenti rari dai guardiani fototropici." 
-  foresta_miceliale:
-    label: "Foresta Miceliale"
-    summary: "Canopia micotica bioluminescente dove la rete fungina coordina la fauna."
-    diff_base: 3
-    mod_biome: 2
-    affixes:
-      - spore_bloom
-      - myco_link
-    aliases:
-      - foresta_temperata
-    hazard:
-      description: "Visibilità ridotta, radici bloccanti e spore neuroreattive."
-      severity: medium
-      stress_modifiers:
-        spores: 0.04
-        entanglement: 0.06
-    npc_archetypes:
-      primary:
-        - verdant_shepherds
-        - fungal_titans
-      support:
-        - myco_empath
-    stresswave:
-      baseline: 0.27
-      escalation_rate: 0.04
-      event_thresholds:
-        hive_alert: 0.58
-        overrun: 0.76
-    narrative:
-      tone: "Fantasia bioluminescente con rischio di simbiosi forzata."
-      hooks:
-        - "Mappare nodi miceliali per isolare la rete neurale."
-        - "Convincere i guardiani a condividere antidoti spora."
-  foresta_temperata:
-    label: "Foresta Temperata Umida"
-    summary: "Boschi piovosi con canopy densa, nebbie calde e radure bioenergetiche."
+    label: Palude Tossica
+    summary: Acque stagnanti bio-luminescenti con fauna mutagena.
     diff_base: 3
     mod_biome: 1
     affixes:
-      - rainshade
-      - canopy_web
-      - floodpulse
+    - fangoso
+    - tossico
+    - luminescente
+    - viti
     hazard:
-      description: "Piogge improvvise, frane saturate d'acqua e muffe reattive."
-      severity: medium
-      stress_modifiers:
-        mudslide: 0.04
-        humidity_shock: 0.05
-    npc_archetypes:
-      primary:
-        - wardens_pluviali
-        - temperate_stalkers
-      support:
-        - druids_pluviometrici
-    stresswave:
-      baseline: 0.26
-      escalation_rate: 0.04
-      event_thresholds:
-        rescue: 0.5
-        overrun: 0.7
-    narrative:
-      tone: "Ricognizioni stealth tra nebbie radiose e comunità arboree."
-      hooks:
-        - "Proteggere i reattori a risonanza dagli attacchi delle maree."
-        - "Recuperare shard ossidiani prima dell'arrivo della tempesta."
-  stratosfera_tempestosa:
-    label: "Stratosfera Tempestosa"
-    summary: "Piattaforme aerostatiche sospese tra bande ioniche e vortici plasmatici."
-    diff_base: 5
-    mod_biome: 4
-    affixes:
-      - ion_shear
-      - storm_current
-      - low_grav
-      - lightning_veils
-    aliases:
-      - stratosfera
-    hazard:
-      description: "Turbolenze fulminanti e tagli di vento che destabilizzano equipaggio e strumenti."
-      severity: high
-      stress_modifiers:
-        turbulence: 0.07
-        ion_surge: 0.08
-    npc_archetypes:
-      primary:
-        - skyward_lancers
-        - ion_tamers
-      support:
-        - aerostat_engineers
-    stresswave:
-      baseline: 0.38
-      escalation_rate: 0.07
-      event_thresholds:
-        support: 0.62
-        overrun: 0.85
-    narrative:
-      tone: "Operazioni a gravità variabile tra correnti ioniche imprevedibili."
-      hooks:
-        - "Stabilizzare i tether dei ponti aerostatici prima del collasso."
-        - "Intercettare navi pirata che sfruttano i canali di tempesta per infiltrarsi."
-  mezzanotte_orbitale:
-    label: "Mezzanotte Orbitale"
-    summary: "Stazione orbitale in decadimento con gravità variabile."
-    diff_base: 4
-    mod_biome: 3
-    affixes:
-      - zero_g_flux
-      - alarm_cascade
-    aliases:
-      - cryosteppe
-    hazard:
-      description: "Zero-G intermittente, allarmi a cascata e compartimenti depressurizzati."
-      severity: high
-      stress_modifiers:
-        zero_g: 0.05
-        lockdown: 0.08
-    npc_archetypes:
-      primary:
-        - skydock_sentinels
-        - aeon_engineers
-      support:
-        - droni_manutentori
-    stresswave:
-      baseline: 0.35
-      escalation_rate: 0.06
-      event_thresholds:
-        rescue: 0.6
-        lockdown: 0.82
-    narrative:
-      tone: "Thriller techno con evacuazioni di emergenza e sabotaggi."
-      hooks:
-        - "Ripristinare i reattori Aeon prima del blackout totale."
-        - "Neutralizzare l'allarme a cascata per evitare l'arrivo dei rinforzi."
-  palude:
-    label: "Palude Tossica"
-    summary: "Acque stagnanti bio-luminescenti con fauna mutagena."
-    diff_base: 3
-    mod_biome: 1
-    affixes:
-      - fangoso
-      - tossico
-      - luminescente
-      - viti
-    hazard:
-      description: "Miasmi corrosivi e radici che intrappolano i movimenti."
+      description: Miasmi corrosivi e radici che intrappolano i movimenti.
       severity: medium
       stress_modifiers:
         miasma: 0.04
         entanglement: 0.06
     npc_archetypes:
       primary:
-        - custodi_miasmatici
-        - druidi_sporeguard
+      - custodi_miasmatici
+      - druidi_sporeguard
       support:
-        - raccoglitori_di_fluoro
+      - raccoglitori_di_fluoro
     stresswave:
       baseline: 0.3
       escalation_rate: 0.04
@@ -485,159 +258,161 @@ biomes:
         support: 0.52
         overrun: 0.72
     narrative:
-      tone: "Survival horror organico e diplomazia con culti simbiotici."
+      tone: Survival horror organico e diplomazia con culti simbiotici.
       hooks:
-        - "Recuperare reagenti bio-luminescenti per le squadre mediche."
-        - "Placare le colonie simbiotiche prima che scatenino la nube tossica."
-  pianura_salina_iperarida:
-    label: "Pianura Salina Iperarida"
-    summary: "Distese saline ciclotroniche che riflettono radiazione e drenano umidità."
+      - Recuperare reagenti bio-luminescenti per le squadre mediche.
+      - Placare le colonie simbiotiche prima che scatenino la nube tossica.
+  dorsale_termale_tropicale:
+    label: Dorsale Termale Tropicale
+    summary: Catena montuosa sommersa con fumarole calde e fauna simbiotica.
+    diff_base: 4
+    mod_biome: 3
+    affixes:
+    - echo_surge
+    - shifting_winds
+    aliases:
+    - badlands
+    hazard:
+      description: Correnti ascendenti, shock termici e micro-eruzioni sottomarine.
+      severity: high
+      stress_modifiers:
+        thermal_plume: 0.06
+        pressure_wave: 0.05
+    npc_archetypes:
+      primary:
+      - ridge_sentinels
+      - plume_harvesters
+      support:
+      - thermal_diviners
+    stresswave:
+      baseline: 0.32
+      escalation_rate: 0.05
+      event_thresholds:
+        rescue: 0.58
+        overrun: 0.8
+    narrative:
+      tone: Operazioni anfibie tra fumarole luminescenti e correnti instabili.
+      hooks:
+      - Sigillare sfiati per proteggere gli avamposti sommersi.
+      - Scortare i droni estrattori attraverso vortici bioluminescenti.
+  foresta_acida:
+    label: Foresta Acida
+    summary: Bacini tropicali saturi di piogge corrosive e flora predatoria.
     diff_base: 4
     mod_biome: 2
     affixes:
-      - salt_mirage
-      - resonance_pan
+    - acid_rain
+    - corrosive_bloom
+    - predator_vines
     hazard:
-      description: "Radiazione riflessa, sinkhole cristallini e tempeste di sale tagliente."
+      description: Piogge acide, foschia tossica e spore corrosive che erodono protezioni.
       severity: high
       stress_modifiers:
-        saltstorm: 0.06
-        dehydration: 0.05
+        acid_fall: 0.05
+        corrosive_mist: 0.06
     npc_archetypes:
       primary:
-        - salt_nomads
-        - prismatic_riders
+      - caustic_hunters
+      - ph_balance_enforcers
       support:
-        - aquifer_surveyors
+      - antidote_scribes
     stresswave:
-      baseline: 0.3
+      baseline: 0.33
       escalation_rate: 0.05
       event_thresholds:
         rescue: 0.55
-        overrun: 0.77
+        overrun: 0.79
     narrative:
-      tone: "Convogli di sopravvivenza e cacce a miraggi con specchi risonanti."
+      tone: Sopravvivenza biochimica e negoziazioni con culti simbiotici acidi.
       hooks:
-        - "Stabilire torri condensatrici per sostenere gli avamposti."
-        - "Recuperare cristalli prismatici senza attirare predatori desertici."
-  reef_luminescente:
-    label: "Reef Luminescente"
-    summary: "Barriere coralline sintetiche con correnti luminescenti e fauna sensibile alla risonanza."
+      - Neutralizzare bacini corrotti prima della tempesta acida.
+      - Raccogliere reagenti rari dai guardiani fototropici.
+  foresta_miceliale:
+    label: Foresta Miceliale
+    summary: Canopia micotica bioluminescente dove la rete fungina coordina la fauna.
     diff_base: 3
     mod_biome: 2
     affixes:
-      - light_current
-      - coral_spire
+    - spore_bloom
+    - myco_link
+    aliases:
+    - foresta_temperata
     hazard:
-      description: "Correnti imprevedibili e creature simbiotiche sensibili ai disturbi."
+      description: Visibilità ridotta, radici bloccanti e spore neuroreattive.
       severity: medium
       stress_modifiers:
-        current_pull: 0.05
-        glare: 0.04
+        spores: 0.04
+        entanglement: 0.06
     npc_archetypes:
       primary:
-        - reef_wardens
-        - luminescent_harriers
+      - verdant_shepherds
+      - fungal_titans
       support:
-        - tide_callers
+      - myco_empath
     stresswave:
-      baseline: 0.28
+      baseline: 0.27
+      escalation_rate: 0.04
+      event_thresholds:
+        hive_alert: 0.58
+        overrun: 0.76
+    narrative:
+      tone: Fantasia bioluminescente con rischio di simbiosi forzata.
+      hooks:
+      - Mappare nodi miceliali per isolare la rete neurale.
+      - Convincere i guardiani a condividere antidoti spora.
+  foresta_temperata:
+    label: Foresta Temperata Umida
+    summary: Boschi piovosi con canopy densa, nebbie calde e radure bioenergetiche.
+    diff_base: 3
+    mod_biome: 1
+    affixes:
+    - rainshade
+    - canopy_web
+    - floodpulse
+    hazard:
+      description: Piogge improvvise, frane saturate d'acqua e muffe reattive.
+      severity: medium
+      stress_modifiers:
+        mudslide: 0.04
+        humidity_shock: 0.05
+    npc_archetypes:
+      primary:
+      - wardens_pluviali
+      - temperate_stalkers
+      support:
+      - druids_pluviometrici
+    stresswave:
+      baseline: 0.26
       escalation_rate: 0.04
       event_thresholds:
         rescue: 0.5
-        overrun: 0.71
-    narrative:
-      tone: "Operazioni stealth subacquee tra colonne fotoniche e alveari acquatici."
-      hooks:
-        - "Proteggere le colonie coralline da razzie di risonanza."
-        - "Convincere i custodi del reef a condividere i filtri luminescenti."
-  savana:
-    label: "Savana Ionizzata"
-    summary: "Dune fotoniche con branchi adattivi e rovine sepolte."
-    diff_base: 2
-    mod_biome: 1
-    affixes:
-      - termico
-      - luminescente
-      - spore_diluite
-      - sabbia
-    hazard:
-      description: "Tempeste ioniche e sabbia vetrificata che erodono equipaggiamento."
-      severity: medium
-      stress_modifiers:
-        exposure: 0.03
-        sandstorm: 0.06
-    npc_archetypes:
-      primary:
-        - predoni_nomadi
-        - guardiani_delle_dune
-      support:
-        - cartografi_erranti
-    stresswave:
-      baseline: 0.28
-      escalation_rate: 0.04
-      event_thresholds:
-        support: 0.5
         overrun: 0.7
     narrative:
-      tone: "Western sci-fi e sopravvivenza carovaniera."
+      tone: Ricognizioni stealth tra nebbie radiose e comunità arboree.
       hooks:
-        - "Recuperare convogli cristallizzati e nodi di risonanza sepolti."
-        - "Mediare tregue tra clan itineranti e guardiani della tempesta."
-    aliases:
-      - savanna
-  steppe_algoritmiche:
-    label: "Steppe Algoritmiche"
-    summary: "Pianure modulari controllate da IA agricole con pattern mutevoli."
-    diff_base: 3
-    mod_biome: 2
-    affixes:
-      - sync_fields
-      - drone_grazers
-    hazard:
-      description: "Picchi di controllo IA, blackout locali e sciami di droni pastori."
-      severity: medium
-      stress_modifiers:
-        sync_spike: 0.05
-        drone_stampede: 0.04
-    npc_archetypes:
-      primary:
-        - protocol_shepherds
-        - logic_riders
-      support:
-        - calibration_mediators
-    stresswave:
-      baseline: 0.29
-      escalation_rate: 0.04
-      event_thresholds:
-        rescue: 0.52
-        overrun: 0.73
-    narrative:
-      tone: "Conflitti tra IA agricole e tribù adattate alla rete."
-      hooks:
-        - "Ripristinare i nodi sincroni per evitare la tempesta algoritmica."
-        - "Tracciare branchi dronici deviati prima della fusione." 
+      - Proteggere i reattori a risonanza dagli attacchi delle maree.
+      - Recuperare shard ossidiani prima dell'arrivo della tempesta.
   stratosfera_tempestosa:
-    label: "Stratosfera Tempestosa"
-    summary: "Piattaforme aerostatiche tra nubi di tempesta, fulmini e venti supersonici."
+    label: Stratosfera Tempestosa
+    summary: Piattaforme aerostatiche tra nubi di tempesta, fulmini e venti supersonici.
     diff_base: 5
     mod_biome: 3
     affixes:
-      - stormfront
-      - jetstream
-      - thunder_bloom
+    - stormfront
+    - jetstream
+    - thunder_bloom
     hazard:
-      description: "Fulmini continui, shear supersonico e cadute verso pozze di plasma."
+      description: Fulmini continui, shear supersonico e cadute verso pozze di plasma.
       severity: high
       stress_modifiers:
         lightning_chain: 0.07
         shear_winds: 0.06
     npc_archetypes:
       primary:
-        - storm_paladins
-        - jetstream_outriders
+      - storm_paladins
+      - jetstream_outriders
       support:
-        - sky_anchor_techs
+      - sky_anchor_techs
     stresswave:
       baseline: 0.37
       escalation_rate: 0.06
@@ -645,40 +420,283 @@ biomes:
         rescue: 0.6
         overrun: 0.84
     narrative:
-      tone: "Assalti aerei tra piattaforme volanti e tempeste iper-ionizzate."
+      tone: Assalti aerei tra piattaforme volanti e tempeste iper-ionizzate.
       hooks:
-        - "Stabilizzare gli ancoraggi stratosferici prima del collasso." 
-        - "Recuperare celle di energia trasportate da fulmini guidati."
+      - Stabilizzare gli ancoraggi stratosferici prima del collasso.
+      - Recuperare celle di energia trasportate da fulmini guidati.
+  mezzanotte_orbitale:
+    label: Mezzanotte Orbitale
+    summary: Stazione orbitale in decadimento con gravità variabile.
+    diff_base: 4
+    mod_biome: 3
+    affixes:
+    - zero_g_flux
+    - alarm_cascade
+    aliases:
+    - cryosteppe
+    hazard:
+      description: Zero-G intermittente, allarmi a cascata e compartimenti depressurizzati.
+      severity: high
+      stress_modifiers:
+        zero_g: 0.05
+        lockdown: 0.08
+    npc_archetypes:
+      primary:
+      - skydock_sentinels
+      - aeon_engineers
+      support:
+      - droni_manutentori
+    stresswave:
+      baseline: 0.35
+      escalation_rate: 0.06
+      event_thresholds:
+        rescue: 0.6
+        lockdown: 0.82
+    narrative:
+      tone: Thriller techno con evacuazioni di emergenza e sabotaggi.
+      hooks:
+      - Ripristinare i reattori Aeon prima del blackout totale.
+      - Neutralizzare l'allarme a cascata per evitare l'arrivo dei rinforzi.
+  pianura_salina_iperarida:
+    label: Pianura Salina Iperarida
+    summary: Distese saline ciclotroniche che riflettono radiazione e drenano umidità.
+    diff_base: 4
+    mod_biome: 2
+    affixes:
+    - salt_mirage
+    - resonance_pan
+    hazard:
+      description: Radiazione riflessa, sinkhole cristallini e tempeste di sale tagliente.
+      severity: high
+      stress_modifiers:
+        saltstorm: 0.06
+        dehydration: 0.05
+    npc_archetypes:
+      primary:
+      - salt_nomads
+      - prismatic_riders
+      support:
+      - aquifer_surveyors
+    stresswave:
+      baseline: 0.3
+      escalation_rate: 0.05
+      event_thresholds:
+        rescue: 0.55
+        overrun: 0.77
+    narrative:
+      tone: Convogli di sopravvivenza e cacce a miraggi con specchi risonanti.
+      hooks:
+      - Stabilire torri condensatrici per sostenere gli avamposti.
+      - Recuperare cristalli prismatici senza attirare predatori desertici.
+  reef_luminescente:
+    label: Reef Luminescente
+    summary: Barriere coralline sintetiche con correnti luminescenti e fauna sensibile
+      alla risonanza.
+    diff_base: 3
+    mod_biome: 2
+    affixes:
+    - light_current
+    - coral_spire
+    hazard:
+      description: Correnti imprevedibili e creature simbiotiche sensibili ai disturbi.
+      severity: medium
+      stress_modifiers:
+        current_pull: 0.05
+        glare: 0.04
+    npc_archetypes:
+      primary:
+      - reef_wardens
+      - luminescent_harriers
+      support:
+      - tide_callers
+    stresswave:
+      baseline: 0.28
+      escalation_rate: 0.04
+      event_thresholds:
+        rescue: 0.5
+        overrun: 0.71
+    narrative:
+      tone: Operazioni stealth subacquee tra colonne fotoniche e alveari acquatici.
+      hooks:
+      - Proteggere le colonie coralline da razzie di risonanza.
+      - Convincere i custodi del reef a condividere i filtri luminescenti.
+  savana:
+    label: Savana Ionizzata
+    summary: Dune fotoniche con branchi adattivi e rovine sepolte.
+    diff_base: 2
+    mod_biome: 1
+    affixes:
+    - termico
+    - luminescente
+    - spore_diluite
+    - sabbia
+    hazard:
+      description: Tempeste ioniche e sabbia vetrificata che erodono equipaggiamento.
+      severity: medium
+      stress_modifiers:
+        exposure: 0.03
+        sandstorm: 0.06
+    npc_archetypes:
+      primary:
+      - predoni_nomadi
+      - guardiani_delle_dune
+      support:
+      - cartografi_erranti
+    stresswave:
+      baseline: 0.28
+      escalation_rate: 0.04
+      event_thresholds:
+        support: 0.5
+        overrun: 0.7
+    narrative:
+      tone: Western sci-fi e sopravvivenza carovaniera.
+      hooks:
+      - Recuperare convogli cristallizzati e nodi di risonanza sepolti.
+      - Mediare tregue tra clan itineranti e guardiani della tempesta.
+    aliases:
+    - savanna
+  steppe_algoritmiche:
+    label: Steppe Algoritmiche
+    summary: Pianure modulari controllate da IA agricole con pattern mutevoli.
+    diff_base: 3
+    mod_biome: 2
+    affixes:
+    - sync_fields
+    - drone_grazers
+    hazard:
+      description: Picchi di controllo IA, blackout locali e sciami di droni pastori.
+      severity: medium
+      stress_modifiers:
+        sync_spike: 0.05
+        drone_stampede: 0.04
+    npc_archetypes:
+      primary:
+      - protocol_shepherds
+      - logic_riders
+      support:
+      - calibration_mediators
+    stresswave:
+      baseline: 0.29
+      escalation_rate: 0.04
+      event_thresholds:
+        rescue: 0.52
+        overrun: 0.73
+    narrative:
+      tone: Conflitti tra IA agricole e tribù adattate alla rete.
+      hooks:
+      - Ripristinare i nodi sincroni per evitare la tempesta algoritmica.
+      - Tracciare branchi dronici deviati prima della fusione.
+  rovine_planari:
+    label: Rovine Planari Fratturate
+    summary: Metropoli extraplanare in rovina con portali instabili e correnti di
+      energia astrale.
+    diff_base: 4
+    mod_biome: 3
+    affixes:
+    - planar_rift
+    - psionic_echo
+    - cenere_memetica
+    hazard:
+      description: Fenditure di teletrasporto, eco psionici e detriti gravitazionali
+        erranti.
+      severity: high
+      stress_modifiers:
+        planar_rend: 0.06
+        echo_overload: 0.05
+    npc_archetypes:
+      primary:
+      - wardens_planari
+      - mercanti_iconoclasti
+      support:
+      - oracoli_aurorali
+    stresswave:
+      baseline: 0.34
+      escalation_rate: 0.05
+      event_thresholds:
+        rescue: 0.57
+        overrun: 0.8
+    narrative:
+      tone: Esplorazioni tra archi spezzati e conflitti con entità traslocanti.
+      hooks:
+      - Sigillare i portali corrotti prima del collasso dimensionale.
+      - Recuperare reliquie pathfinder riadattate ai protocolli Evo Tactics.
 vc_adapt:
-  aggro_high: {add_control: 1, add_guardia: 1}
-  cohesion_high: {add_knockback: 1}
-  setup_high: {add_disarmers: 1}
-  explore_high: {add_ambushers: 1}
-  risk_high: {add_burst: 1, reduce_armor: 1}
+  aggro_high:
+    add_control: 1
+    add_guardia: 1
+  cohesion_high:
+    add_knockback: 1
+  setup_high:
+    add_disarmers: 1
+  explore_high:
+    add_ambushers: 1
+  risk_high:
+    add_burst: 1
+    reduce_armor: 1
 mutations:
   SG_max: 3
   t0_table_d12:
-    - Adrenalina
-    - Fasici
-    - Spine
-    - Cromatofori
-    - Tendini
-    - EcoFlash
-    - SangueGelido
-    - Chelazione
-    - MicroDroni
-    - RisonanzaMentale
-    - ZanneSottili
-    - Immunoscossa
+  - Adrenalina
+  - Fasici
+  - Spine
+  - Cromatofori
+  - Tendini
+  - EcoFlash
+  - SangueGelido
+  - Chelazione
+  - MicroDroni
+  - RisonanzaMentale
+  - ZanneSottili
+  - Immunoscossa
   t1_table_d8:
-    - LamelleAcide
-    - Cartilagine
-    - SensiTermici
-    - FibreCorte
-    - GhiandolaFeroce
-    - OmbraRadente
-    - PlaccaCristallina
-    - EcoBranco
+  - LamelleAcide
+  - Cartilagine
+  - SensiTermici
+  - FibreCorte
+  - GhiandolaFeroce
+  - OmbraRadente
+  - PlaccaCristallina
+  - EcoBranco
 frequencies:
-  trap_trigger: {t0: 0.6, t1: 0.2, none: 0.2}
-  crit_event: {t0: 0.4, t1: 0.1, none: 0.5}
+  trap_trigger:
+    t0: 0.6
+    t1: 0.2
+    none: 0.2
+  crit_event:
+    t0: 0.4
+    t1: 0.1
+    none: 0.5
+  rovine_planari:
+    label: Rovine Planari Fratturate
+    summary: Metropoli extraplanare in rovina con portali instabili e correnti di
+      energia astrale.
+    diff_base: 4
+    mod_biome: 3
+    affixes:
+    - planar_rift
+    - psionic_echo
+    - cenere_memetica
+    hazard:
+      description: Fenditure di teletrasporto, eco psionici e detriti gravitazionali
+        erranti.
+      severity: high
+      stress_modifiers:
+        planar_rend: 0.06
+        echo_overload: 0.05
+    npc_archetypes:
+      primary:
+      - wardens_planari
+      - mercanti_iconoclasti
+      support:
+      - oracoli_aurorali
+    stresswave:
+      baseline: 0.34
+      escalation_rate: 0.05
+      event_thresholds:
+        rescue: 0.57
+        overrun: 0.8
+    narrative:
+      tone: Esplorazioni tra archi spezzati e conflitti con entità traslocanti.
+      hooks:
+      - Sigillare i portali corrotti prima del collasso dimensionale.
+      - Recuperare reliquie pathfinder riadattate ai protocolli Evo Tactics.

--- a/data/biomes.yaml
+++ b/data/biomes.yaml
@@ -667,36 +667,6 @@ frequencies:
     t1: 0.1
     none: 0.5
   rovine_planari:
-    label: Rovine Planari Fratturate
-    summary: Metropoli extraplanare in rovina con portali instabili e correnti di
-      energia astrale.
-    diff_base: 4
-    mod_biome: 3
-    affixes:
-    - planar_rift
-    - psionic_echo
-    - cenere_memetica
-    hazard:
-      description: Fenditure di teletrasporto, eco psionici e detriti gravitazionali
-        erranti.
-      severity: high
-      stress_modifiers:
-        planar_rend: 0.06
-        echo_overload: 0.05
-    npc_archetypes:
-      primary:
-      - wardens_planari
-      - mercanti_iconoclasti
-      support:
-      - oracoli_aurorali
-    stresswave:
-      baseline: 0.34
-      escalation_rate: 0.05
-      event_thresholds:
-        rescue: 0.57
-        overrun: 0.8
-    narrative:
-      tone: Esplorazioni tra archi spezzati e conflitti con entità traslocanti.
-      hooks:
-      - Sigillare i portali corrotti prima del collasso dimensionale.
-      - Recuperare reliquie pathfinder riadattate ai protocolli Evo Tactics.
+    t0: 0.25
+    t1: 0.55
+    none: 0.2

--- a/data/traits/glossary.json
+++ b/data/traits/glossary.json
@@ -1024,6 +1024,30 @@
       "label_en": "Mucose Barofile",
       "description_it": "Mucose Barofile permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di abisso vulcanico.",
       "description_en": "Mucose Barofile allow squads to disperse energy and attenuate corrosive or thermal impacts within abisso vulcanico."
+    },
+    "aura_scudo_radianza": {
+      "label_it": "Aura Scudo di Radianza",
+      "label_en": "Radiant Shield Aura",
+      "description_it": "Campo fotoplasmatico che devia danni planari e sincronizza i battiti della squadra.",
+      "description_en": "Photoplasmic field that deflects planar damage while syncing squad vitals."
+    },
+    "frusta_fiammeggiante": {
+      "label_it": "Frusta Fiammeggiante",
+      "label_en": "Flame Lash",
+      "description_it": "Appendice di plasma vincolato capace di arpionare e incendiare bersagli.",
+      "description_en": "Bound plasma appendage that can hook and ignite targets."
+    },
+    "mantello_meteoritico": {
+      "label_it": "Mantello Meteoritico",
+      "label_en": "Meteoric Mantle",
+      "description_it": "Strati ablativi rigeneranti che vaporizzano l'impatto convertendolo in impulso termico.",
+      "description_en": "Regenerating ablative layers that vaporize impacts into thermal pulses."
+    },
+    "armatura_pietra_planare": {
+      "label_it": "Armatura di Pietra Planare",
+      "label_en": "Planar Stone Plating",
+      "description_it": "Corazza risonante scolpita da roccia extradimensionale che smorza onde d'urto.",
+      "description_en": "Resonant plating carved from extradimensional stone that dampens shockwaves."
     }
   }
 }

--- a/docs/catalog/catalog_data.json
+++ b/docs/catalog/catalog_data.json
@@ -129,7 +129,10 @@
       "label": "Carapace a Variazione di Fase",
       "mutation": "Strutture minerali a legame reversibile o micro-strutture a rigidità controllata.",
       "selective_drive": "Alternanza tra ambienti con attacchi cinetici pesanti e ambienti che richiedono velocità.",
-      "synergies": [],
+      "synergies": [
+        "armatura_pietra_planare",
+        "mantello_meteoritico"
+      ],
       "tier": "T1",
       "usage": "Durezza/densità del guscio modificabile rapidamente.",
       "usage_map": {
@@ -397,7 +400,9 @@
       "label": "Empatia Coordinativa",
       "mutation": "Circuiti sensorio-emotivi collegati al feed HUD PI.",
       "selective_drive": "Turni lunghi con rischio alto in cui serve mitigare tilt e HP critici.",
-      "synergies": [],
+      "synergies": [
+        "aura_scudo_radianza"
+      ],
       "tier": "T1",
       "usage": "Collega cooldown difensivi e cura quando la squadra entra in finestra rischio.",
       "usage_map": {
@@ -532,7 +537,9 @@
       "label": "Focus Frazionato",
       "mutation": "Processore di priorità multi-thread per bersagli e obiettivi.",
       "selective_drive": "Comunicazioni piatte dove occorre coprire minacce su più fronti.",
-      "synergies": [],
+      "synergies": [
+        "frusta_fiammeggiante"
+      ],
       "tier": "T1",
       "usage": "Permette di gestire due ingaggi paralleli senza perdere efficienza.",
       "usage_map": {
@@ -1259,7 +1266,9 @@
       "label": "Risonanza di Branco",
       "mutation": "Reticolo empatico che collega i canali PI cooperativi.",
       "selective_drive": "Forme che eccellono in difesa coordinata e scudi sovrapposti.",
-      "synergies": [],
+      "synergies": [
+        "aura_scudo_radianza"
+      ],
       "tier": "T1",
       "usage": "Amplifica buff condivisi sincronizzando i timer di squadra.",
       "usage_map": {

--- a/docs/catalog/catalog_data.json
+++ b/docs/catalog/catalog_data.json
@@ -1955,6 +1955,161 @@
         "synergy": []
       },
       "weakness": "Perdita di valore su mappe con spazi stretti o controllo setup elevato."
+    },
+    "aura_scudo_radianza": {
+      "id": "aura_scudo_radianza",
+      "label": "Aura Scudo di Radianza",
+      "tier": "T3",
+      "families": [
+        "Supporto",
+        "Difesa"
+      ],
+      "energy_profile": "Alto (Canalizzazione fotonica continua)",
+      "usage": "Canalizza scudi fotoplasmatici condivisi.",
+      "selective_drive": "Proteggere i punti di ancoraggio durante tempeste planari.",
+      "mutation": "Integra cristalli luminescenti connessi al sistema nervoso.",
+      "synergies": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflicts": [
+        "mantello_meteoritico"
+      ],
+      "environments": [
+        "rovine_planari"
+      ],
+      "weakness": "Sovraccarica in presenza di ombre gravitazionali.",
+      "dataset_sources": [
+        "data/traits/glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/data/species/rovine_planari/archon-solare.yaml"
+      ],
+      "usage_map": {
+        "core": [
+          "archon-solare"
+        ],
+        "optional": [],
+        "synergy": [
+          "balor-fission",
+          "couatl-aurora"
+        ]
+      }
+    },
+    "frusta_fiammeggiante": {
+      "id": "frusta_fiammeggiante",
+      "label": "Frusta Fiammeggiante",
+      "tier": "T2",
+      "families": [
+        "Offensivo",
+        "Controllo"
+      ],
+      "energy_profile": "Medio (Filamenti di plasma vincolato)",
+      "usage": "Cattura e trascina bersagli mentre infonde danni termici.",
+      "selective_drive": "Gestire predatori élite nelle fratture planari.",
+      "mutation": "Forma tentacoli plasmatici con nocciolo runico stabilizzante.",
+      "synergies": [
+        "focus_frazionato",
+        "mantello_meteoritico"
+      ],
+      "conflicts": [
+        "armatura_pietra_planare"
+      ],
+      "environments": [
+        "rovine_planari"
+      ],
+      "weakness": "Richiede dissipazione termica continua.",
+      "dataset_sources": [
+        "data/traits/glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml",
+        "packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml"
+      ],
+      "usage_map": {
+        "core": [
+          "balor-fission",
+          "marilith-vault"
+        ],
+        "optional": [],
+        "synergy": []
+      }
+    },
+    "mantello_meteoritico": {
+      "id": "mantello_meteoritico",
+      "label": "Mantello Meteoritico",
+      "tier": "T3",
+      "families": [
+        "Difesa",
+        "Termico"
+      ],
+      "energy_profile": "Alto (Rivestimento ablativo rigenerante)",
+      "usage": "Dissipa impatti estremi e converte l'energia in contropressioni.",
+      "selective_drive": "Sopravvivere a bombardamenti planari prolungati.",
+      "mutation": "Deposita strati di minerali meteoritici autorigeneranti.",
+      "synergies": [
+        "frusta_fiammeggiante",
+        "carapace_fase_variabile"
+      ],
+      "conflicts": [
+        "aura_scudo_radianza"
+      ],
+      "environments": [
+        "rovine_planari"
+      ],
+      "weakness": "Perde efficacia con raffreddamento gravitazionale improvviso.",
+      "dataset_sources": [
+        "data/traits/glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml",
+        "packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml"
+      ],
+      "usage_map": {
+        "core": [
+          "balor-fission",
+          "marilith-vault"
+        ],
+        "optional": [],
+        "synergy": []
+      }
+    },
+    "armatura_pietra_planare": {
+      "id": "armatura_pietra_planare",
+      "label": "Armatura di Pietra Planare",
+      "tier": "T2",
+      "families": [
+        "Difesa",
+        "Strutturale"
+      ],
+      "energy_profile": "Basso (Risonanza geodetica stabile)",
+      "usage": "Stabilizza il corpo contro onde d'urto e torsioni dimensionali.",
+      "selective_drive": "Ancorare unità difensive durante aperture di portali.",
+      "mutation": "Cristallizza il dermascheletro con nodi runici.",
+      "synergies": [
+        "carapace_fase_variabile"
+      ],
+      "conflicts": [
+        "frusta_fiammeggiante"
+      ],
+      "environments": [
+        "rovine_planari"
+      ],
+      "weakness": "Peso elevato in atmosfera standard.",
+      "dataset_sources": [
+        "data/traits/glossary.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+        "packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml",
+        "packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml",
+        "packs/evo_tactics_pack/data/species/rovine_planari/treant-portale.yaml"
+      ],
+      "usage_map": {
+        "core": [
+          "golem-runico"
+        ],
+        "optional": [
+          "bulette-fase",
+          "treant-portale"
+        ],
+        "synergy": []
+      }
     }
   }
 }

--- a/docs/evo-tactics-pack/trait-glossary.json
+++ b/docs/evo-tactics-pack/trait-glossary.json
@@ -1024,6 +1024,30 @@
       "label_en": "Mucose Barofile",
       "description_it": "Mucose Barofile permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di abisso vulcanico.",
       "description_en": "Mucose Barofile allow squads to disperse energy and attenuate corrosive or thermal impacts within abisso vulcanico."
+    },
+    "aura_scudo_radianza": {
+      "label_it": "Aura Scudo di Radianza",
+      "label_en": "Radiant Shield Aura",
+      "description_it": "Campo fotoplasmatico che protegge i compagni nelle rovine planari.",
+      "description_en": "Photoplasmic field shielding allies across planar ruins."
+    },
+    "frusta_fiammeggiante": {
+      "label_it": "Frusta Fiammeggiante",
+      "label_en": "Flame Lash",
+      "description_it": "Filamento di plasma controllato usato per arpionare bersagli extraplanari.",
+      "description_en": "Controlled plasma filament used to hook extraplanar targets."
+    },
+    "mantello_meteoritico": {
+      "label_it": "Mantello Meteoritico",
+      "label_en": "Meteoric Mantle",
+      "description_it": "Strato ablativo rigenerante che converte gli impatti in impulsi termici.",
+      "description_en": "Regenerating ablative mantle converting impacts into thermal pulses."
+    },
+    "armatura_pietra_planare": {
+      "label_it": "Armatura di Pietra Planare",
+      "label_en": "Planar Stone Plating",
+      "description_it": "Corazza litica extradimensionale che assorbe shock gravitazionali.",
+      "description_en": "Extradimensional stone plating absorbing gravitational shocks."
     }
   }
 }

--- a/docs/evo-tactics-pack/trait-reference.json
+++ b/docs/evo-tactics-pack/trait-reference.json
@@ -7156,6 +7156,181 @@
         "core": "locomotorio",
         "complementare": "supporto"
       }
+    },
+    "aura_scudo_radianza": {
+      "label": "Aura Scudo di Radianza",
+      "famiglia_tipologia": "Supporto/Difesa",
+      "fattore_mantenimento_energetico": "Alto (Canalizzazione fotonica continua)",
+      "tier": "T3",
+      "slot": [],
+      "slot_profile": {
+        "core": "supporto",
+        "complementare": "difesa"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [
+        "mantello_meteoritico"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [
+            "flight"
+          ],
+          "condizioni": {
+            "biome_class": "rovine_planari"
+          },
+          "fonte": "pathfinder_import",
+          "meta": {
+            "expansion": "pathfinder_dataset",
+            "tier": "T3",
+            "notes": "Richiede catalizzatori luminosi stabili nelle rovine planari."
+          }
+        }
+      ],
+      "mutazione_indotta": "Innesta organi fotoplasmatici che diffondono uno scudo radiante.",
+      "uso_funzione": "Proietta schermature luminose a copertura della squadra.",
+      "spinta_selettiva": "Proteggere corridoi di evacuazione planare.",
+      "debolezza": "Sensibile a zone di antimagia e ombre gravitazionali.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "frusta_fiammeggiante": {
+      "label": "Frusta Fiammeggiante",
+      "famiglia_tipologia": "Offensivo/Controllo",
+      "fattore_mantenimento_energetico": "Medio (Filamenti di plasma vincolato)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "controllo"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "mantello_meteoritico"
+      ],
+      "conflitti": [
+        "armatura_pietra_planare"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [
+            "void_stride"
+          ],
+          "condizioni": {
+            "biome_class": "rovine_planari"
+          },
+          "fonte": "pathfinder_import",
+          "meta": {
+            "expansion": "pathfinder_dataset",
+            "tier": "T2",
+            "notes": "Necessita condotti di dissipazione infernale."
+          }
+        }
+      ],
+      "mutazione_indotta": "Genera appendici di plasma controllato con nocciolo runico.",
+      "uso_funzione": "Aggancia bersagli e sigilla varchi con colpi incendiarî.",
+      "spinta_selettiva": "Contenere demoni e predatori extraplanari.",
+      "debolezza": "Richiede dissipazione continua per evitare corti plasmatici.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "mantello_meteoritico": {
+      "label": "Mantello Meteoritico",
+      "famiglia_tipologia": "Difesa/Termoregolazione",
+      "fattore_mantenimento_energetico": "Alto (Rivestimento ablativo rigenerante)",
+      "tier": "T3",
+      "slot": [],
+      "slot_profile": {
+        "core": "difesa",
+        "complementare": "termico"
+      },
+      "sinergie": [
+        "frusta_fiammeggiante",
+        "carapace_fase_variabile"
+      ],
+      "conflitti": [
+        "aura_scudo_radianza"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [
+            "fire_resist"
+          ],
+          "condizioni": {
+            "biome_class": "rovine_planari"
+          },
+          "fonte": "pathfinder_import",
+          "meta": {
+            "expansion": "pathfinder_dataset",
+            "tier": "T3",
+            "notes": "Richiede bagni di plasma per restare attivo."
+          }
+        }
+      ],
+      "mutazione_indotta": "Depone strati ablativi che vaporizzano gli impatti.",
+      "uso_funzione": "Assorbe bombardamenti energetici estremi.",
+      "spinta_selettiva": "Sopravvivere a piogge di meteore dimensionali.",
+      "debolezza": "Rigidezza in ambienti criogenici.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "armatura_pietra_planare": {
+      "label": "Armatura di Pietra Planare",
+      "famiglia_tipologia": "Difesa/Strutturale",
+      "fattore_mantenimento_energetico": "Basso (Risonanza geodetica stabile)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "core": "difesa",
+        "complementare": "strutturale"
+      },
+      "sinergie": [
+        "carapace_fase_variabile"
+      ],
+      "conflitti": [
+        "frusta_fiammeggiante"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [
+            "deploy_barrier"
+          ],
+          "condizioni": {
+            "biome_class": "rovine_planari"
+          },
+          "fonte": "pathfinder_import",
+          "meta": {
+            "expansion": "pathfinder_dataset",
+            "tier": "T2",
+            "notes": "Si consolida attraverso risonanza litica planare."
+          }
+        }
+      ],
+      "mutazione_indotta": "Cristallizza dermascheletro con nodi rune deflettenti.",
+      "uso_funzione": "Stabilizza varchi e assorbe shock dimensionali.",
+      "spinta_selettiva": "Proteggere infrastrutture nelle rovine planari.",
+      "debolezza": "Gravosa in ambienti a bassa gravità.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
     }
   }
 }

--- a/docs/evo-tactics-pack/trait-reference.json
+++ b/docs/evo-tactics-pack/trait-reference.json
@@ -1859,7 +1859,9 @@
         "giunti_antitorsione",
         "lingua_cristallina",
         "mucose_barofile",
-        "sensori_geomagnetici"
+        "sensori_geomagnetici",
+        "armatura_pietra_planare",
+        "mantello_meteoritico"
       ],
       "sinergie_pi": {
         "co_occorrenze": [
@@ -3670,7 +3672,8 @@
         "foliage_fotocatodico",
         "ghiandole_inchiostro_luce",
         "gusci_criovetro",
-        "luminescenza_hydrotermica"
+        "luminescenza_hydrotermica",
+        "aura_scudo_radianza"
       ],
       "sinergie_pi": {
         "co_occorrenze": [
@@ -4247,7 +4250,8 @@
         "ghiandole_eco_mappanti",
         "ghiandole_resina_conduttiva",
         "lamine_scudo_silice",
-        "midollo_antivibrazione"
+        "midollo_antivibrazione",
+        "frusta_fiammeggiante"
       ],
       "sinergie_pi": {
         "co_occorrenze": [
@@ -6378,7 +6382,8 @@
         "foliage_fotocatodico",
         "ghiandole_inchiostro_luce",
         "gusci_criovetro",
-        "luminescenza_hydrotermica"
+        "luminescenza_hydrotermica",
+        "aura_scudo_radianza"
       ],
       "sinergie_pi": {
         "co_occorrenze": [

--- a/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
@@ -6,96 +6,130 @@ receipt:
   trace_hash: to-fill
 links:
   ecosystems:
-    - packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
-    - packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
-    - packs/evo_tactics_pack/data/ecosystems/deserto_caldo.ecosystem.yaml
-    - packs/evo_tactics_pack/data/ecosystems/cryosteppe.ecosystem.yaml
+  - packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
+  - packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
+  - packs/evo_tactics_pack/data/ecosystems/deserto_caldo.ecosystem.yaml
+  - packs/evo_tactics_pack/data/ecosystems/cryosteppe.ecosystem.yaml
+  - packs/evo_tactics_pack/data/ecosystems/rovine_planari.ecosystem.yaml
 network:
   id: ET_NET_ALPHA
   label: Evo-Tactics Meta‑Ecosystem Alpha
   nodes:
-    - id: BADLANDS
-      biome_id: canyons_risonanti
-      path: packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
-      weight: 0.45
-    - id: FORESTA_TEMPERATA
-      biome_id: foresta_miceliale
-      path: 
-        packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
-      weight: 0.55
-    - id: DESERTO_CALDO
-      biome_id: savana
-      path: packs/evo_tactics_pack/data/ecosystems/deserto_caldo.ecosystem.yaml
-      weight: 0.4
-    - id: CRYOSTEPPE
-      biome_id: mezzanotte_orbitale
-      path: packs/evo_tactics_pack/data/ecosystems/cryosteppe.ecosystem.yaml
-      weight: 0.4
+  - id: BADLANDS
+    biome_id: canyons_risonanti
+    path: packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
+    weight: 0.45
+  - id: FORESTA_TEMPERATA
+    biome_id: foresta_miceliale
+    path: packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
+    weight: 0.55
+  - id: DESERTO_CALDO
+    biome_id: savana
+    path: packs/evo_tactics_pack/data/ecosystems/deserto_caldo.ecosystem.yaml
+    weight: 0.4
+  - id: CRYOSTEPPE
+    biome_id: mezzanotte_orbitale
+    path: packs/evo_tactics_pack/data/ecosystems/cryosteppe.ecosystem.yaml
+    weight: 0.4
+  - id: ROVINE_PLANARI
+    biome_id: rovine_planari
+    path: packs/evo_tactics_pack/data/ecosystems/rovine_planari.ecosystem.yaml
+    weight: 0.5
   edges:
-    - from: BADLANDS
-      to: FORESTA_TEMPERATA
-      type: corridor
-      resistance: 0.6
-      seasonality: primavera/autunno
-      notes: gole ombreggiate e canyon → valichi boscosi
-    - from: FORESTA_TEMPERATA
-      to: BADLANDS
-      type: trophic_spillover
-      resistance: 0.4
-      seasonality: episodico
-      notes: boom detrito → pulse detritivoro in badlands
-    - from: BADLANDS
-      to: DESERTO_CALDO
-      type: corridor
-      resistance: 0.5
-      seasonality: estate
-      notes: canali wadi → dune mobili
-    - from: DESERTO_CALDO
-      to: BADLANDS
-      type: corridor
-      resistance: 0.55
-      seasonality: estate/notte
-      notes: carovane notturne sfruttano i canali raffreddati
-    - from: FORESTA_TEMPERATA
-      to: CRYOSTEPPE
-      type: seasonal_bridge
-      resistance: 0.6
-      seasonality: inverno
-      notes: valichi nevosi con copertura forestale rada
-    - from: CRYOSTEPPE
-      to: FORESTA_TEMPERATA
-      type: seasonal_bridge
-      resistance: 0.65
-      seasonality: inverno profondo
-      notes: coltri di ghiaccio creano corridoi di transito sotto chioma
-    - from: CRYOSTEPPE
-      to: BADLANDS
-      type: trophic_spillover
-      resistance: 0.5
-      seasonality: episodico
-      notes: pulse detrito post disgelo
-    - from: CRYOSTEPPE
-      to: BADLANDS
-      type: corridor
-      resistance: 0.7
-      seasonality: tarda_inverno
-      notes: gole ghiacciate convogliano tempeste di brina verso le gole ferrose
+  - from: BADLANDS
+    to: FORESTA_TEMPERATA
+    type: corridor
+    resistance: 0.6
+    seasonality: primavera/autunno
+    notes: gole ombreggiate e canyon → valichi boscosi
+  - from: FORESTA_TEMPERATA
+    to: BADLANDS
+    type: trophic_spillover
+    resistance: 0.4
+    seasonality: episodico
+    notes: boom detrito → pulse detritivoro in badlands
+  - from: BADLANDS
+    to: DESERTO_CALDO
+    type: corridor
+    resistance: 0.5
+    seasonality: estate
+    notes: canali wadi → dune mobili
+  - from: DESERTO_CALDO
+    to: BADLANDS
+    type: corridor
+    resistance: 0.55
+    seasonality: estate/notte
+    notes: carovane notturne sfruttano i canali raffreddati
+  - from: FORESTA_TEMPERATA
+    to: CRYOSTEPPE
+    type: seasonal_bridge
+    resistance: 0.6
+    seasonality: inverno
+    notes: valichi nevosi con copertura forestale rada
+  - from: CRYOSTEPPE
+    to: FORESTA_TEMPERATA
+    type: seasonal_bridge
+    resistance: 0.65
+    seasonality: inverno profondo
+    notes: coltri di ghiaccio creano corridoi di transito sotto chioma
+  - from: CRYOSTEPPE
+    to: BADLANDS
+    type: trophic_spillover
+    resistance: 0.5
+    seasonality: episodico
+    notes: pulse detrito post disgelo
+  - from: CRYOSTEPPE
+    to: BADLANDS
+    type: corridor
+    resistance: 0.7
+    seasonality: tarda_inverno
+    notes: gole ghiacciate convogliano tempeste di brina verso le gole ferrose
+  - from: ROVINE_PLANARI
+    to: FORESTA_TEMPERATA
+    type: corridor
+    resistance: 0.55
+    seasonality: primavera
+    notes: Portali stabilizzati collegano le radure miceliali alle rovine planari.
+  - from: FORESTA_TEMPERATA
+    to: ROVINE_PLANARI
+    type: trophic_spillover
+    resistance: 0.5
+    seasonality: primavera
+    notes: Impollinatori planari riforniscono i giardini sospesi delle rovine.
+  - from: ROVINE_PLANARI
+    to: DESERTO_CALDO
+    type: corridor
+    resistance: 0.6
+    seasonality: estate
+    notes: Spaccature dimensionali aprono varchi sulle dune termiche.
+  - from: DESERTO_CALDO
+    to: ROVINE_PLANARI
+    type: seasonal_bridge
+    resistance: 0.65
+    seasonality: notte
+    notes: Carovane planari sfruttano la quiete notturna per trasferire risorse.
   bridge_species_map:
-    - species_id: echo-wing
-      roles:
-        - dispersore_ponte
-        - impollinatore
-      present_in_nodes:
-        - BADLANDS
-        - FORESTA_TEMPERATA
-        - DESERTO_CALDO
-        - CRYOSTEPPE
-    - species_id: ferrocolonia-magnetotattica
-      roles:
-        - sentinella
-        - ingegnere_ecosistema
-      present_in_nodes:
-        - BADLANDS
+  - species_id: echo-wing
+    roles:
+    - dispersore_ponte
+    - impollinatore
+    present_in_nodes:
+    - BADLANDS
+    - FORESTA_TEMPERATA
+    - DESERTO_CALDO
+    - CRYOSTEPPE
+  - species_id: ferrocolonia-magnetotattica
+    roles:
+    - sentinella
+    - ingegnere_ecosistema
+    present_in_nodes:
+    - BADLANDS
+  - species_id: archon-solare
+    roles:
+    - dispersore_ponte
+    - impollinatore
+    present_in_nodes:
+    - ROVINE_PLANARI
   rules:
     at_least:
       sentient: 1

--- a/packs/evo_tactics_pack/data/ecosystems/rovine_planari.biome.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/rovine_planari.biome.yaml
@@ -1,0 +1,186 @@
+schema_version: 1.1
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: to-fill
+ecosistema:
+  metadati:
+    nome: rovine_planari (Pathfinder bridge)
+    localizzazione:
+      lat: null
+      lon: null
+      quota_m: null
+      area_km2: null
+    periodo_riferimento: 1991–2020
+    fonti: []
+  bioma:
+    classe_bioma: rovine_planari
+    ecoregione: ''
+    koppen_zone:
+      - Cfa
+      - Cfb
+    npp_gC_m2_anno: null
+    note: ''
+  morfologia:
+    rilievo:
+      quota_min_max_m:
+        - null
+        - null
+      pendenza_media_gradi: null
+      rugosita_indice: null
+    forme_terreno: []
+    geologia_substrato: []
+    suolo_superficiale:
+      tessitura: ''
+      pH: null
+      sostanza_organica_%: null
+    idrografia:
+      corsi_acqua: []
+      zone_umide: []
+      falda: superficiale
+    frammentazione_connettivita:
+      indice_frattura: null
+      corridoi_ecologici: []
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 20.95
+      Ar: 0.93
+      CO2: 0.04
+    tracce_ppm:
+      CH4: null
+      N2O: null
+      O3_troposferico: null
+    aerosol_inquinanti:
+      PM10: null
+      PM2_5: null
+      sali_marini: basso
+      polveri_sahariane: assenti
+    variazioni_stagionali_nota: ''
+    forzanti_locali: []
+  clima:
+    classificazione_koppen: Cfa
+    temperatura_C:
+      media_annua: 24.0
+      min_mese_piu_freddo: 12.0
+      max_mese_piu_caldo: 34.0
+      giorni_gelo_annui: 4
+      giorni_ondata_calore_annui: 18
+    precipitazioni_mm:
+      totale_annuo: 620
+      indice_stagionalita: bimodale
+      mesi_secchi: []
+      mesi_umidi: []
+    vento:
+      regime: vortici_planari
+      velocita_media_m_s: 6.2
+    bilancio_idrico:
+      et0_mm: 540
+      indice_aridita_P_su_ET0: 0.9
+    estremi_e_rischi:
+      eventi:
+        - collasso_portale
+        - pioggia_cenere_memetica
+    teleconnessioni:
+      - nexus_astral
+  abiotico:
+    luce:
+      radiazione_media_MJ_m2_giorno: 18.4
+      fotoperiodo: variabile
+    nutrienti:
+      N: medio
+      P: medio
+      K: medio
+    salinita: dolce
+  trofico:
+    produttori: []
+    consumatori:
+      primari: []
+      secondari: []
+      terziari: []
+    decompositori: []
+    reti_note: []
+  gruppi_funzionali:
+    predatori: []
+    prede_erbivori: []
+    impollinatori: []
+    dispersori_semi: []
+    simbionti_mutualistici: []
+    parassiti_parasitoidi: []
+    detritivori: []
+    filtratori: []
+    ingegneri_ecosistema: []
+    specie_chiave_di_volta: []
+  suolo:
+    orizzonti:
+      - O
+      - A
+      - B
+      - C
+    processi:
+      - fissazione_N
+      - nitrificazione
+      - mineralizzazione
+      - formazione_microportali
+    microbioma: []
+    fauna_edafica: []
+  acque:
+    comparti: []
+    processi: []
+    qualita:
+      DO_mgL: null
+      BOD_mgL: null
+      conducibilita_uScm: null
+  servizi_ecosistemici:
+    supporto: []
+    regolazione: []
+    approvvigionamento: []
+    culturali: []
+  pressioni_stato_risposte:
+    pressioni: []
+    indicatori_stato: []
+    risposte_gestione: []
+links:
+  biome_id: rovine_planari
+  species_dir: packs/evo_tactics_pack/data/species/rovine_planari
+  foodweb: packs/evo_tactics_pack/data/foodwebs/rovine_planari_foodweb.yaml
+registries:
+  functional_groups: packs/evo_tactics_pack/tools/config/registries/functional_groups.yaml
+  trophic_roles: packs/evo_tactics_pack/tools/config/registries/trophic_roles.yaml
+  biome_classes: packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml
+  climate_profiles: packs/evo_tactics_pack/tools/config/registries/climate_profiles.yaml
+  morphotypes: packs/evo_tactics_pack/tools/config/registries/morphotypes.yaml
+  hazards: packs/evo_tactics_pack/tools/config/registries/hazards.yaml
+  env_to_traits: packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml
+rules:
+  at_least:
+    sentient: 1
+    apex: 1
+    keystone: 1
+    bridge: 1
+    threat: 1
+    event: 1
+manifest:
+  species_counts:
+    apex: 1
+    keystone: 2
+    bridge: 2
+    threat: 3
+    event: 1
+  functional_groups_present:
+    - predatore
+    - prede
+    - impollinatore
+    - dispersore
+    - simbionte
+    - parassita
+    - detritivoro
+    - filtratore
+    - ingegneri_ecosistema
+    - specie_chiave
+    - pulse_climatico
+    - minaccia
+  foodweb_links:
+    path: packs/evo_tactics_pack/data/foodwebs/rovine_planari_foodweb.yaml
+    sink_detrito: true

--- a/packs/evo_tactics_pack/data/ecosystems/rovine_planari.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/rovine_planari.ecosystem.yaml
@@ -1,0 +1,57 @@
+schema_version: 1.0
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: to-fill
+ecosistema:
+  id: ROVINE_PLANARI
+  label: Rovine Planari Fratturate
+  biome_id: rovine_planari
+  clima:
+    temperatura_C:
+      media_annua: 24.0
+      min_mese_piu_freddo: 12.0
+      max_mese_piu_caldo: 34.0
+    precipitazioni_mm:
+      totale_annuo: 620
+      indice_stagionalita: bimodale
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 20.95
+      Ar: 0.93
+      CO2: 0.04
+  abiotico:
+    salinita: dolce
+    nutrienti:
+      N: medio
+      P: medio
+      K: medio
+  trofico:
+    produttori:
+      - treant-portale
+    consumatori:
+      primari:
+        - bulette-fase
+      secondari:
+        - otyugh-sentinella
+        - couatl-aurora
+      terziari:
+        - balor-fission
+        - marilith-vault
+        - rakshasa-corte
+    decompositori:
+      - otyugh-sentinella
+      - banshee-risonante
+  note: Rete planare ricostruita da creature Pathfinder tradotte in blueprint Evo Tactics.
+links:
+  species_dir: packs/evo_tactics_pack/data/species/rovine_planari
+  foodweb: packs/evo_tactics_pack/data/foodwebs/rovine_planari_foodweb.yaml
+rules:
+  at_least:
+    apex: 1
+    keystone: 1
+    bridge: 1
+    threat: 1
+    event: 1

--- a/packs/evo_tactics_pack/data/ecosystems/rovine_planari.manifest.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/rovine_planari.manifest.yaml
@@ -1,0 +1,23 @@
+schema_version: 1.0
+biome: rovine_planari
+requirements:
+  groups:
+    - predatori
+    - prede_erbivori
+    - impollinatori
+    - dispersori_semi
+    - simbionti_mutualistici
+    - parassiti_parasitoidi
+    - detritivori
+    - filtratori
+    - ingegneri_ecosistema
+    - specie_chiave_di_volta
+  at_least:
+    sentient: 1
+    apex: 1
+    keystone: 1
+    bridge: 1
+    threat: 1
+    event: 1
+species_dir: packs/evo_tactics_pack/data/species/rovine_planari
+foodweb: packs/evo_tactics_pack/data/foodwebs/rovine_planari_foodweb.yaml

--- a/packs/evo_tactics_pack/data/foodwebs/rovine_planari_foodweb.yaml
+++ b/packs/evo_tactics_pack/data/foodwebs/rovine_planari_foodweb.yaml
@@ -1,0 +1,108 @@
+nodes:
+  - id: reliquie_planari
+  - id: spore_memetiche
+  - id: flussi_radianza
+  - id: archon-solare
+  - id: balor-fission
+  - id: marilith-vault
+  - id: treant-portale
+  - id: couatl-aurora
+  - id: golem-runico
+  - id: banshee-risonante
+  - id: rakshasa-corte
+  - id: bulette-fase
+  - id: otyugh-sentinella
+  - id: detrito
+edges:
+  - from: reliquie_planari
+    to: treant-portale
+    type: mutualism
+    weight: 0.5
+  - from: treant-portale
+    to: archon-solare
+    type: support
+    weight: 0.4
+  - from: treant-portale
+    to: couatl-aurora
+    type: support
+    weight: 0.4
+  - from: flussi_radianza
+    to: archon-solare
+    type: energy
+    weight: 0.6
+  - from: flussi_radianza
+    to: couatl-aurora
+    type: energy
+    weight: 0.5
+  - from: spore_memetiche
+    to: otyugh-sentinella
+    type: detritus
+    weight: 0.6
+  - from: detrito
+    to: otyugh-sentinella
+    type: detritus
+    weight: 0.5
+  - from: otyugh-sentinella
+    to: treant-portale
+    type: nutrient_cycle
+    weight: 0.4
+  - from: bulette-fase
+    to: otyugh-sentinella
+    type: waste
+    weight: 0.3
+  - from: treant-portale
+    to: bulette-fase
+    type: herbivory
+    weight: 0.5
+  - from: couatl-aurora
+    to: treant-portale
+    type: pollination
+    weight: 0.5
+  - from: archon-solare
+    to: couatl-aurora
+    type: coordination
+    weight: 0.4
+  - from: balor-fission
+    to: bulette-fase
+    type: predation
+    weight: 0.5
+  - from: balor-fission
+    to: archon-solare
+    type: predation
+    weight: 0.3
+  - from: marilith-vault
+    to: balor-fission
+    type: contest
+    weight: 0.4
+  - from: marilith-vault
+    to: rakshasa-corte
+    type: suppression
+    weight: 0.4
+  - from: rakshasa-corte
+    to: archon-solare
+    type: parasitism
+    weight: 0.3
+  - from: rakshasa-corte
+    to: treant-portale
+    type: parasitism
+    weight: 0.3
+  - from: banshee-risonante
+    to: balor-fission
+    type: disruption
+    weight: 0.5
+  - from: banshee-risonante
+    to: rakshasa-corte
+    type: disruption
+    weight: 0.4
+  - from: golem-runico
+    to: archon-solare
+    type: fortification
+    weight: 0.4
+  - from: golem-runico
+    to: couatl-aurora
+    type: fortification
+    weight: 0.3
+  - from: golem-runico
+    to: treant-portale
+    type: support
+    weight: 0.5

--- a/packs/evo_tactics_pack/data/species.yaml
+++ b/packs/evo_tactics_pack/data/species.yaml
@@ -134,4 +134,24 @@ species:
   file: species/cryosteppe/thaw-rot.yaml
 - id: evento-brinastorm
   file: species/cryosteppe/evento-brinastorm.yaml
+- id: archon-solare
+  file: species/rovine_planari/archon-solare.yaml
+- id: balor-fission
+  file: species/rovine_planari/balor-fission.yaml
+- id: marilith-vault
+  file: species/rovine_planari/marilith-vault.yaml
+- id: treant-portale
+  file: species/rovine_planari/treant-portale.yaml
+- id: couatl-aurora
+  file: species/rovine_planari/couatl-aurora.yaml
+- id: golem-runico
+  file: species/rovine_planari/golem-runico.yaml
+- id: banshee-risonante
+  file: species/rovine_planari/banshee-risonante.yaml
+- id: rakshasa-corte
+  file: species/rovine_planari/rakshasa-corte.yaml
+- id: bulette-fase
+  file: species/rovine_planari/bulette-fase.yaml
+- id: otyugh-sentinella
+  file: species/rovine_planari/otyugh-sentinella.yaml
 schema_reference: {}

--- a/packs/evo_tactics_pack/data/species/rovine_planari/archon-solare.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/archon-solare.yaml
@@ -87,12 +87,15 @@ derived_from_environment:
     - Skirmisher
 genetic_traits:
   core:
+    - ciclo_vitale_completo
+    - metabolismo_attivo
+    - respirazione_biologica
+    - adattamento_volo
     - aura_scudo_radianza
-    - empatia_coordinativa
   optional:
-    - focus_frazionato
-    - lamelle_termoforetiche
+    - empatia_coordinativa
   synergy:
+    - focus_frazionato
     - risonanza_di_branco
 mate_synergy:
   - empatia_coordinativa

--- a/packs/evo_tactics_pack/data/species/rovine_planari/archon-solare.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/archon-solare.yaml
@@ -1,0 +1,99 @@
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: to-fill
+id: archon-solare
+display_name: Archon Solare Custode
+biomes:
+  - rovine_planari
+role_trofico: dispersore_ponte
+functional_tags:
+  - impollinatore
+  - dispersore
+  - specie_chiave
+  - sentinella
+morphotype: volatore_planatore
+flags:
+  apex: false
+  keystone: true
+  sentient: true
+  bridge: true
+  threat: false
+  event: false
+playable_unit: true
+pi_loadout:
+  weight_budget: 13
+  default_parts:
+    locomotion: glide_wings
+    senses:
+      - echolocate
+    offense:
+      - claw_finesse
+    defense:
+      - elastomer_skin
+vc:
+  aggro: 0.5
+  risk: 0.4
+  cohesion: 0.8
+  setup: 0.6
+  explore: 0.7
+  tilt: 0.2
+services_links:
+  - supporto:luci_sacre
+  - regolazione:scudi_radiani
+spawn_rules:
+  orario:
+    - crepuscolo
+    - notte
+  meteo:
+    - nebbia_risonante
+    - quiete_planare
+  densita: low
+balance:
+  rarity: R3
+  threat_tier: T2
+  encounter_role: support
+telemetry:
+  expected_pick_rate: 0.24
+  spawn_weight: 0.18
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+    - Cfb
+  hazards_expected:
+    - tempesta_radianza
+    - fratture_planari
+derived_from_environment:
+  suggested_traits:
+    - ali_solari_fotoni
+    - empatia_coordinativa
+    - risonanza_di_branco
+    - aura_scudo_radianza
+    - visione_spettrale
+  optional_traits:
+    - focus_frazionato
+    - lamelle_termoforetiche
+  required_capabilities:
+    - flight
+    - radiant_resist
+  services_links:
+    - supporto:rinforzo_barriere
+    - culturale:guida_spirituale
+  jobs_bias:
+    - Invoker
+    - Skirmisher
+genetic_traits:
+  core:
+    - aura_scudo_radianza
+    - empatia_coordinativa
+  optional:
+    - focus_frazionato
+    - lamelle_termoforetiche
+  synergy:
+    - risonanza_di_branco
+mate_synergy:
+  - empatia_coordinativa
+jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml
@@ -70,12 +70,16 @@ derived_from_environment:
     - Warden
 genetic_traits:
   core:
-    - artigli_sette_vie
+    - ciclo_vitale_completo
+    - metabolismo_attivo
+    - respirazione_biologica
+    - adattamento_volo
+    - mantello_meteoritico
     - frusta_fiammeggiante
   optional:
-    - armatura_pietra_planare
+    - empatia_coordinativa
     - carapace_fase_variabile
   synergy:
-    - mantello_meteoritico
+    - focus_frazionato
 mate_synergy: []
 jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml
@@ -1,0 +1,81 @@
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: to-fill
+id: balor-fission
+display_name: Balor a Fissione
+biomes:
+  - rovine_planari
+role_trofico: predatore_terziario_apex
+functional_tags:
+  - predatore
+  - minaccia
+morphotype: cursoriale_quadrupede
+flags:
+  apex: true
+  keystone: false
+  sentient: false
+  bridge: false
+  threat: true
+  event: false
+playable_unit: false
+vc:
+  aggro: 0.9
+  risk: 0.8
+  cohesion: 0.3
+  setup: 0.5
+  explore: 0.4
+  tilt: 0.6
+spawn_rules:
+  orario:
+    - notte
+  meteo:
+    - tempesta_radianza
+    - pioggia_cenere
+  densita: very_low
+balance:
+  rarity: R4
+  threat_tier: T4
+  encounter_role: boss
+services_links:
+  - minaccia:collasso_portali
+telemetry:
+  expected_pick_rate: 0.08
+  spawn_weight: 0.05
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+    - Cfb
+  hazards_expected:
+    - vortici_abiurazione
+    - piogge_cenere_planare
+derived_from_environment:
+  suggested_traits:
+    - artigli_sette_vie
+    - frusta_fiammeggiante
+    - armatura_pietra_planare
+    - carapace_fase_variabile
+    - mantello_meteoritico
+  optional_traits:
+    - criostasi_adattiva
+    - tattiche_di_branco
+  required_capabilities:
+    - fire_resist
+    - void_stride
+  jobs_bias:
+    - Vanguard
+    - Warden
+genetic_traits:
+  core:
+    - artigli_sette_vie
+    - frusta_fiammeggiante
+  optional:
+    - armatura_pietra_planare
+    - carapace_fase_variabile
+  synergy:
+    - mantello_meteoritico
+mate_synergy: []
+jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/banshee-risonante.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/banshee-risonante.yaml
@@ -1,0 +1,74 @@
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: to-fill
+id: banshee-risonante
+display_name: Banshee Risonante
+biomes:
+  - rovine_planari
+role_trofico: evento_ecologico
+functional_tags:
+  - pulse_climatico
+  - minaccia
+morphotype: volatore_planatore
+flags:
+  apex: false
+  keystone: false
+  sentient: true
+  bridge: false
+  threat: true
+  event: true
+playable_unit: false
+vc:
+  aggro: 0.6
+  risk: 0.7
+  cohesion: 0.2
+  setup: 0.6
+  explore: 0.5
+  tilt: 0.8
+services_links:
+  - culturale:avvisi_spettrali
+spawn_rules:
+  orario:
+    - notte
+  meteo:
+    - nebbia_risonante
+    - pioggia_cenere
+  densita: event
+balance:
+  rarity: R5
+  threat_tier: T4
+  encounter_role: event
+telemetry:
+  expected_pick_rate: null
+  spawn_weight: null
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfb
+  hazards_expected:
+    - tempesta_radianza
+    - eco_mnemonico
+derived_from_environment:
+  suggested_traits:
+    - eco_sismico
+    - voce_spettrale
+    - intangibilita_parziale
+    - lamenti_diradanti
+  optional_traits:
+    - focus_frazionato
+    - risonanza_di_branco
+  required_capabilities:
+    - phase_shift
+    - sonic_control
+  services_links:
+    - culturale:memorie_orali
+    - regolazione:scarico_emozionale
+  jobs_bias:
+    - Invoker
+    - Support
+genetic_traits: []
+mate_synergy: []
+jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/banshee-risonante.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/banshee-risonante.yaml
@@ -69,6 +69,16 @@ derived_from_environment:
   jobs_bias:
     - Invoker
     - Support
-genetic_traits: []
+genetic_traits:
+  core:
+    - ciclo_vitale_anomalo
+    - metabolismo_sostentato
+    - assenza_respirazione
+    - origine_artificiale
+    - adattamento_volo
+    - risonanza_di_branco
+  optional: []
+  synergy:
+    - focus_frazionato
 mate_synergy: []
 jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml
@@ -1,0 +1,73 @@
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: to-fill
+id: bulette-fase
+display_name: Bulette di Fase
+biomes:
+  - rovine_planari
+role_trofico: erbivoro_primario
+functional_tags:
+  - prede
+  - detritivoro
+morphotype: cursoriale_quadrupede
+flags:
+  apex: false
+  keystone: false
+  sentient: false
+  bridge: false
+  threat: false
+  event: false
+playable_unit: false
+vc:
+  aggro: 0.35
+  risk: 0.5
+  cohesion: 0.6
+  setup: 0.4
+  explore: 0.7
+  tilt: 0.3
+services_links:
+  - approvvigionamento:minerali_planari
+spawn_rules:
+  orario:
+    - diurno
+  meteo:
+    - pioggia_cenere
+    - quiete_planare
+  densita: high
+balance:
+  rarity: R1
+  threat_tier: T2
+  encounter_role: minion
+telemetry:
+  expected_pick_rate: 0.28
+  spawn_weight: 0.32
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+  hazards_expected:
+    - cedimenti_portale
+    - tempesta_radianza
+derived_from_environment:
+  suggested_traits:
+    - scheletro_idro_regolante
+    - sensori_geomagnetici
+    - coda_frusta_cinetica
+    - lamelle_termoforetiche
+  optional_traits:
+    - carapace_fase_variabile
+    - sacche_galleggianti_ascensoriali
+  required_capabilities:
+    - burrow
+    - planar_tremor_sense
+  services_links:
+    - approvvigionamento:estrazione_fragili
+  jobs_bias:
+    - Vanguard
+    - Warden
+genetic_traits: []
+mate_synergy: []
+jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml
@@ -68,6 +68,15 @@ derived_from_environment:
   jobs_bias:
     - Vanguard
     - Warden
-genetic_traits: []
+genetic_traits:
+  core:
+    - ciclo_vitale_completo
+    - metabolismo_attivo
+    - respirazione_biologica
+    - fisiologia_predatoria
+  optional:
+    - carapace_fase_variabile
+    - armatura_pietra_planare
+  synergy: []
 mate_synergy: []
 jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/couatl-aurora.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/couatl-aurora.yaml
@@ -1,0 +1,86 @@
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: to-fill
+id: couatl-aurora
+display_name: Couatl Aurora Custode
+biomes:
+  - rovine_planari
+role_trofico: dispersore_ponte
+functional_tags:
+  - impollinatore
+  - dispersore
+  - simbionte
+morphotype: volatore_planatore
+flags:
+  apex: false
+  keystone: false
+  sentient: true
+  bridge: true
+  threat: false
+  event: false
+playable_unit: true
+pi_loadout:
+  weight_budget: 11
+  default_parts:
+    locomotion: glide_wings
+    senses:
+      - echolocate
+    offense:
+      - acid_gland
+vc:
+  aggro: 0.4
+  risk: 0.3
+  cohesion: 0.7
+  setup: 0.6
+  explore: 0.8
+  tilt: 0.3
+services_links:
+  - supporto:cartografia_planare
+  - culturale:oracolo_di_corrente
+spawn_rules:
+  orario:
+    - diurno
+    - crepuscolo
+  meteo:
+    - quiete_planare
+    - vento_memetico
+  densita: mid
+balance:
+  rarity: R2
+  threat_tier: T1
+  encounter_role: support
+telemetry:
+  expected_pick_rate: 0.26
+  spawn_weight: 0.25
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+    - Cfb
+  hazards_expected:
+    - tempesta_radianza
+    - pioggia_cenere
+derived_from_environment:
+  suggested_traits:
+    - empatia_coordinativa
+    - sensori_geomagnetici
+    - ali_solari_fotoni
+    - ghiandole_nettare_memetico
+  optional_traits:
+    - occhi_infrarosso_composti
+    - focus_frazionato
+  required_capabilities:
+    - flight
+    - planar_map
+  services_links:
+    - supporto:rituale_migrazione
+    - culturale:memoria_delle_porte
+  jobs_bias:
+    - Invoker
+    - Skirmisher
+genetic_traits: []
+mate_synergy: []
+jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/couatl-aurora.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/couatl-aurora.yaml
@@ -81,6 +81,18 @@ derived_from_environment:
   jobs_bias:
     - Invoker
     - Skirmisher
-genetic_traits: []
+genetic_traits:
+  core:
+    - ciclo_vitale_completo
+    - metabolismo_attivo
+    - respirazione_biologica
+    - adattamento_volo
+  optional:
+    - empatia_coordinativa
+    - lamelle_termoforetiche
+    - artigli_sette_vie
+  synergy:
+    - focus_frazionato
+    - risonanza_di_branco
 mate_synergy: []
 jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml
@@ -70,6 +70,14 @@ derived_from_environment:
   jobs_bias:
     - Warden
     - Artificer
-genetic_traits: []
+genetic_traits:
+  core:
+    - ciclo_vitale_anomalo
+    - metabolismo_sostentato
+    - assenza_respirazione
+    - origine_artificiale
+    - armatura_pietra_planare
+  optional: []
+  synergy: []
 mate_synergy: []
 jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml
@@ -1,0 +1,75 @@
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: to-fill
+id: golem-runico
+display_name: Golem Runico Custodiale
+biomes:
+  - rovine_planari
+role_trofico: ingegneri_ecosistema
+functional_tags:
+  - ingegneri_ecosistema
+  - sentinella
+morphotype: scavenger_corazzato
+flags:
+  apex: false
+  keystone: false
+  sentient: false
+  bridge: false
+  threat: false
+  event: false
+playable_unit: false
+vc:
+  aggro: 0.4
+  risk: 0.3
+  cohesion: 0.6
+  setup: 0.7
+  explore: 0.3
+  tilt: 0.2
+services_links:
+  - supporto:mantenimento_sigilli
+  - regolazione:scarico_energia
+spawn_rules:
+  orario:
+    - diurno
+  meteo:
+    - quiete_planare
+  densita: mid
+balance:
+  rarity: R2
+  threat_tier: T2
+  encounter_role: support
+telemetry:
+  expected_pick_rate: 0.18
+  spawn_weight: 0.2
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+    - Cfb
+  hazards_expected:
+    - scariche_arcane
+    - cedimenti_portale
+derived_from_environment:
+  suggested_traits:
+    - carapace_fase_variabile
+    - armatura_pietra_planare
+    - nuclei_di_controllo
+    - matrice_antimagia
+  optional_traits:
+    - campo_di_fase
+    - rinforzi_modulari
+  required_capabilities:
+    - deploy_barrier
+    - purge_magic
+  services_links:
+    - supporto:manutenzione_sigilli
+    - regolazione:smaltimento_residui
+  jobs_bias:
+    - Warden
+    - Artificer
+genetic_traits: []
+mate_synergy: []
+jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml
@@ -1,0 +1,75 @@
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: to-fill
+id: marilith-vault
+display_name: Marilith delle Volte
+biomes:
+  - rovine_planari
+role_trofico: predatore_terziario_apex
+functional_tags:
+  - predatore
+  - sentinella
+morphotype: cursoriale_quadrupede
+flags:
+  apex: false
+  keystone: false
+  sentient: true
+  bridge: false
+  threat: false
+  event: false
+playable_unit: false
+vc:
+  aggro: 0.85
+  risk: 0.7
+  cohesion: 0.4
+  setup: 0.6
+  explore: 0.5
+  tilt: 0.5
+services_links:
+  - sicurezza:duello_portale
+spawn_rules:
+  orario:
+    - notte
+    - crepuscolo
+  meteo:
+    - quiete_planare
+    - vento_memetico
+  densita: low
+balance:
+  rarity: R3
+  threat_tier: T3
+  encounter_role: elite
+telemetry:
+  expected_pick_rate: 0.14
+  spawn_weight: 0.12
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfb
+    - Cfc
+  hazards_expected:
+    - vortici_abiurazione
+    - lame_risonanti
+derived_from_environment:
+  suggested_traits:
+    - artigli_sette_vie
+    - coda_frusta_cinetica
+    - visione_spettrale
+    - sensori_geomagnetici
+  optional_traits:
+    - riflessi_preternaturali
+    - tessuti_adattivi
+  required_capabilities:
+    - multi_attack
+    - planar_anchor
+  services_links:
+    - sicurezza:controllo_passaggi
+  jobs_bias:
+    - Vanguard
+    - Skirmisher
+genetic_traits: []
+mate_synergy: []
+jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml
@@ -70,6 +70,17 @@ derived_from_environment:
   jobs_bias:
     - Vanguard
     - Skirmisher
-genetic_traits: []
+genetic_traits:
+  core:
+    - ciclo_vitale_completo
+    - metabolismo_attivo
+    - respirazione_biologica
+    - mantello_meteoritico
+    - frusta_fiammeggiante
+    - focus_frazionato
+  optional:
+    - empatia_coordinativa
+    - artigli_sette_vie
+  synergy: []
 mate_synergy: []
 jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/otyugh-sentinella.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/otyugh-sentinella.yaml
@@ -1,0 +1,77 @@
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: to-fill
+id: otyugh-sentinella
+display_name: Otyugh Sentinella delle Fogne Astrali
+biomes:
+  - rovine_planari
+role_trofico: ingegneri_ecosistema
+functional_tags:
+  - filtratore
+  - detritivoro
+  - ingegneri_ecosistema
+morphotype: anfibio_filtratore
+flags:
+  apex: false
+  keystone: false
+  sentient: false
+  bridge: false
+  threat: false
+  event: false
+playable_unit: false
+vc:
+  aggro: 0.3
+  risk: 0.4
+  cohesion: 0.5
+  setup: 0.6
+  explore: 0.5
+  tilt: 0.2
+services_links:
+  - regolazione:depurazione_residui
+  - supporto:riciclo_nutrienti
+spawn_rules:
+  orario:
+    - diurno
+    - notte
+  meteo:
+    - pioggia_cenere
+    - nebbia_risonante
+  densita: mid
+balance:
+  rarity: R2
+  threat_tier: T2
+  encounter_role: ambient
+telemetry:
+  expected_pick_rate: 0.22
+  spawn_weight: 0.24
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+    - Cfb
+  hazards_expected:
+    - invasione_vite_dimensionali
+    - eco_mnemonico
+derived_from_environment:
+  suggested_traits:
+    - filtri_bioattivi
+    - proboscide_polifaga
+    - sensori_chimici
+    - membrane_osmotiche
+  optional_traits:
+    - secrezioni_antisepsi
+    - nodi_micotici
+  required_capabilities:
+    - purge_toxins
+    - anchor_waste
+  services_links:
+    - regolazione:purificazione_canali
+  jobs_bias:
+    - Artificer
+    - Warden
+genetic_traits: []
+mate_synergy: []
+jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/otyugh-sentinella.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/otyugh-sentinella.yaml
@@ -72,6 +72,15 @@ derived_from_environment:
   jobs_bias:
     - Artificer
     - Warden
-genetic_traits: []
+genetic_traits:
+  core:
+    - ciclo_vitale_completo
+    - metabolismo_attivo
+    - respirazione_biologica
+  optional:
+    - carapace_fase_variabile
+    - lamelle_termoforetiche
+    - artigli_sette_vie
+  synergy: []
 mate_synergy: []
 jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/rakshasa-corte.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/rakshasa-corte.yaml
@@ -1,0 +1,74 @@
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: to-fill
+id: rakshasa-corte
+display_name: Rakshasa della Corte Spezzata
+biomes:
+  - rovine_planari
+role_trofico: minaccia_microbica
+functional_tags:
+  - parassita
+  - predatore
+morphotype: cursoriale_quadrupede
+flags:
+  apex: false
+  keystone: false
+  sentient: true
+  bridge: false
+  threat: true
+  event: false
+playable_unit: false
+vc:
+  aggro: 0.55
+  risk: 0.6
+  cohesion: 0.4
+  setup: 0.7
+  explore: 0.6
+  tilt: 0.5
+services_links:
+  - minaccia:corruzione_iconica
+spawn_rules:
+  orario:
+    - notte
+    - crepuscolo
+  meteo:
+    - nebbia_risonante
+    - vento_memetico
+  densita: low
+balance:
+  rarity: R3
+  threat_tier: T3
+  encounter_role: elite
+telemetry:
+  expected_pick_rate: 0.16
+  spawn_weight: 0.14
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+  hazards_expected:
+    - eco_mnemonico
+    - invasioni_iconiche
+derived_from_environment:
+  suggested_traits:
+    - maschera_illusoria
+    - empatia_coordinativa
+    - artigli_psionici
+    - tessuti_adattivi
+  optional_traits:
+    - focus_frazionato
+    - sinapsi_riflettenti
+  required_capabilities:
+    - infiltrate
+    - disrupt_psionics
+  services_links:
+    - minaccia:propagazione_iconica
+  jobs_bias:
+    - Invoker
+    - Skirmisher
+genetic_traits: []
+mate_synergy: []
+jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/rakshasa-corte.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/rakshasa-corte.yaml
@@ -69,6 +69,14 @@ derived_from_environment:
   jobs_bias:
     - Invoker
     - Skirmisher
-genetic_traits: []
+genetic_traits:
+  core:
+    - ciclo_vitale_completo
+    - metabolismo_attivo
+    - respirazione_biologica
+  optional:
+    - empatia_coordinativa
+  synergy:
+    - risonanza_di_branco
 mate_synergy: []
 jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/treant-portale.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/treant-portale.yaml
@@ -1,0 +1,77 @@
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: to-fill
+id: treant-portale
+display_name: Treant dei Portali Antichi
+biomes:
+  - rovine_planari
+role_trofico: ingegneri_ecosistema
+functional_tags:
+  - ingegneri_ecosistema
+  - specie_chiave
+  - simbionte
+morphotype: ingegnere_radicante
+flags:
+  apex: false
+  keystone: true
+  sentient: true
+  bridge: false
+  threat: false
+  event: false
+playable_unit: false
+vc:
+  aggro: 0.3
+  risk: 0.2
+  cohesion: 0.9
+  setup: 0.7
+  explore: 0.5
+  tilt: 0.2
+services_links:
+  - supporto:stabilizzazione_portali
+  - regolazione:assorbimento_energia
+spawn_rules:
+  orario:
+    - diurno
+  meteo:
+    - pioggia_cenere
+    - quiete_planare
+  densita: mid
+balance:
+  rarity: R2
+  threat_tier: T2
+  encounter_role: ambient
+telemetry:
+  expected_pick_rate: 0.2
+  spawn_weight: 0.22
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+    - Cfb
+  hazards_expected:
+    - fratture_planari
+    - invasione_vite_dimensionali
+derived_from_environment:
+  suggested_traits:
+    - radici_ancora_planare
+    - reti_capillari_radici
+    - pigmenti_aurorali
+    - corteccia_memetica
+  optional_traits:
+    - nodi_micotici
+    - fotosintesi_bifase
+  required_capabilities:
+    - stabilize_gate
+    - cleanse_corruption
+  services_links:
+    - supporto:rinforzo_strutturale
+    - regolazione:depurazione_flussi
+  jobs_bias:
+    - Artificer
+    - Warden
+genetic_traits: []
+mate_synergy: []
+jobs_synergy: []

--- a/packs/evo_tactics_pack/data/species/rovine_planari/treant-portale.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/treant-portale.yaml
@@ -72,6 +72,14 @@ derived_from_environment:
   jobs_bias:
     - Artificer
     - Warden
-genetic_traits: []
+genetic_traits:
+  core:
+    - ciclo_vitale_completo
+    - metabolismo_attivo
+    - respirazione_biologica
+  optional:
+    - armatura_pietra_planare
+  synergy:
+    - risonanza_di_branco
 mate_synergy: []
 jobs_synergy: []

--- a/packs/evo_tactics_pack/docs/catalog/trait_reference.json
+++ b/packs/evo_tactics_pack/docs/catalog/trait_reference.json
@@ -7156,6 +7156,181 @@
         "core": "locomotorio",
         "complementare": "supporto"
       }
+    },
+    "aura_scudo_radianza": {
+      "label": "Aura Scudo di Radianza",
+      "famiglia_tipologia": "Supporto/Difesa",
+      "fattore_mantenimento_energetico": "Alto (Canalizzazione fotonica continua)",
+      "tier": "T3",
+      "slot": [],
+      "slot_profile": {
+        "core": "supporto",
+        "complementare": "difesa"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [
+        "mantello_meteoritico"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [
+            "flight"
+          ],
+          "condizioni": {
+            "biome_class": "rovine_planari"
+          },
+          "fonte": "pathfinder_import",
+          "meta": {
+            "expansion": "pathfinder_dataset",
+            "tier": "T3",
+            "notes": "Richiede catalizzatori di luce stabili nelle rovine planari."
+          }
+        }
+      ],
+      "mutazione_indotta": "Innesta organi fotoplasmatici che diffondono uno scudo radiante sugli alleati vicini.",
+      "uso_funzione": "Proietta schermature luminose sincronizzate con i segnali tattici della squadra.",
+      "spinta_selettiva": "Proteggere gli hub di evacuazione durante tempeste di energia planare.",
+      "debolezza": "Soffre saturazione se esposta a ombre gravitazionali o zone di antimagia.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "frusta_fiammeggiante": {
+      "label": "Frusta Fiammeggiante",
+      "famiglia_tipologia": "Offensivo/Controllo",
+      "fattore_mantenimento_energetico": "Medio (Filamenti di plasma vincolato)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "controllo"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "mantello_meteoritico"
+      ],
+      "conflitti": [
+        "armatura_pietra_planare"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [
+            "void_stride"
+          ],
+          "condizioni": {
+            "biome_class": "rovine_planari"
+          },
+          "fonte": "pathfinder_import",
+          "meta": {
+            "expansion": "pathfinder_dataset",
+            "tier": "T2",
+            "notes": "Necessita condotti di stabilizzazione infernale nelle rovine planari."
+          }
+        }
+      ],
+      "mutazione_indotta": "Genera appendici tentacolari avvolte da plasma infernale controllato.",
+      "uso_funzione": "Afferra e disarma avversari o sigilla varchi planari con tagli di energia.",
+      "spinta_selettiva": "Creare distanza di sicurezza contro predatori d'élite nelle zone instabili.",
+      "debolezza": "Consumante: richiede costante dissipazione termica per non bruciare la matrice portante.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "mantello_meteoritico": {
+      "label": "Mantello Meteoritico",
+      "famiglia_tipologia": "Difesa/Termoregolazione",
+      "fattore_mantenimento_energetico": "Alto (Rivestimento ablativo rigenerante)",
+      "tier": "T3",
+      "slot": [],
+      "slot_profile": {
+        "core": "difesa",
+        "complementare": "termico"
+      },
+      "sinergie": [
+        "frusta_fiammeggiante",
+        "carapace_fase_variabile"
+      ],
+      "conflitti": [
+        "aura_scudo_radianza"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [
+            "fire_resist"
+          ],
+          "condizioni": {
+            "biome_class": "rovine_planari"
+          },
+          "fonte": "pathfinder_import",
+          "meta": {
+            "expansion": "pathfinder_dataset",
+            "tier": "T3",
+            "notes": "Richiede continue docce di plasma per mantenere la matrice ablativa."
+          }
+        }
+      ],
+      "mutazione_indotta": "Deposita strati sovrapposti di materiale meteorico che vaporizzano l'impatto e rilasciano radianza.",
+      "uso_funzione": "Assorbe colpi energetici estremi e converte il surplus in impulsi offensivi.",
+      "spinta_selettiva": "Sopravvivere a bombardamenti planari e piogge di meteore dimensionali.",
+      "debolezza": "Vulnerabile a scariche di freddo gravitazionale che irrigidiscono il mantello.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "armatura_pietra_planare": {
+      "label": "Armatura di Pietra Planare",
+      "famiglia_tipologia": "Difesa/Strutturale",
+      "fattore_mantenimento_energetico": "Basso (Risonanza geodetica stabile)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "core": "difesa",
+        "complementare": "strutturale"
+      },
+      "sinergie": [
+        "carapace_fase_variabile"
+      ],
+      "conflitti": [
+        "frusta_fiammeggiante"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [
+            "deploy_barrier"
+          ],
+          "condizioni": {
+            "biome_class": "rovine_planari"
+          },
+          "fonte": "pathfinder_import",
+          "meta": {
+            "expansion": "pathfinder_dataset",
+            "tier": "T2",
+            "notes": "Plasmazione del substrato lapideo proveniente da fratture planari."
+          }
+        }
+      ],
+      "mutazione_indotta": "Cristallizza il dermascheletro con nodi rune che deviano energia.",
+      "uso_funzione": "Offre schermatura massiva e ancoraggio durante le aperture dimensionali.",
+      "spinta_selettiva": "Stabilizzare varchi e proteggere infrastrutture dalle onde d'urto.",
+      "debolezza": "Pesante: riduce mobilità in ambienti non supportati o a bassa gravità.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
     }
   }
 }

--- a/packs/evo_tactics_pack/docs/catalog/trait_reference.json
+++ b/packs/evo_tactics_pack/docs/catalog/trait_reference.json
@@ -1859,7 +1859,9 @@
         "giunti_antitorsione",
         "lingua_cristallina",
         "mucose_barofile",
-        "sensori_geomagnetici"
+        "sensori_geomagnetici",
+        "armatura_pietra_planare",
+        "mantello_meteoritico"
       ],
       "sinergie_pi": {
         "co_occorrenze": [
@@ -3670,7 +3672,8 @@
         "foliage_fotocatodico",
         "ghiandole_inchiostro_luce",
         "gusci_criovetro",
-        "luminescenza_hydrotermica"
+        "luminescenza_hydrotermica",
+        "aura_scudo_radianza"
       ],
       "sinergie_pi": {
         "co_occorrenze": [
@@ -4247,7 +4250,8 @@
         "ghiandole_eco_mappanti",
         "ghiandole_resina_conduttiva",
         "lamine_scudo_silice",
-        "midollo_antivibrazione"
+        "midollo_antivibrazione",
+        "frusta_fiammeggiante"
       ],
       "sinergie_pi": {
         "co_occorrenze": [
@@ -6378,7 +6382,8 @@
         "foliage_fotocatodico",
         "ghiandole_inchiostro_luce",
         "gusci_criovetro",
-        "luminescenza_hydrotermica"
+        "luminescenza_hydrotermica",
+        "aura_scudo_radianza"
       ],
       "sinergie_pi": {
         "co_occorrenze": [

--- a/packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml
+++ b/packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml
@@ -27,6 +27,7 @@ classes:
 - canopia_ionica
 - steppe_algoritmiche
 - caverna_risonante
+- rovine_planari
 koppen_examples:
   foresta_temperata:
   - Cfb
@@ -66,3 +67,6 @@ koppen_examples:
   - BSk
   caverna_risonante:
   - n/a
+  rovine_planari:
+  - Cfa
+  - Cfb

--- a/services/generation/biomeSynthesizer.js
+++ b/services/generation/biomeSynthesizer.js
@@ -1,7 +1,7 @@
 const fs = require('node:fs/promises');
 const path = require('node:path');
 
-const { createSpeciesBuilder } = require('./speciesBuilder');
+const { createSpeciesBuilder, buildPathfinderProfile } = require('./speciesBuilder');
 const { createRuntimeValidator } = require('./runtimeValidator');
 
 const ROLE_FLAG_SET = new Set(['apex', 'keystone', 'bridge', 'threat', 'event']);
@@ -92,6 +92,14 @@ function ensureArray(value) {
   if (!value) return [];
   if (Array.isArray(value)) return value;
   return [value];
+}
+
+function translatePathfinderStatblock(statblock, context = {}) {
+  const fallbackTraits = ensureArray(context.fallbackTraits);
+  return buildPathfinderProfile(statblock, {
+    biomeId: context.biomeId || null,
+    fallbackTraits,
+  });
 }
 
 function pickMany(array, count, rng) {
@@ -584,4 +592,5 @@ function createBiomeSynthesizer(options = {}) {
 
 module.exports = {
   createBiomeSynthesizer,
+  translatePathfinderStatblock,
 };

--- a/services/generation/orchestratorBridge.js
+++ b/services/generation/orchestratorBridge.js
@@ -57,6 +57,8 @@ function normaliseRequestPayload(input) {
     base_name: input.base_name || input.baseName || null,
     request_id: input.request_id || input.requestId || null,
     fallback_trait_ids: fallback,
+    dataset_id: input.dataset_id || input.datasetId || null,
+    profile_id: input.profile_id || input.profileId || null,
   };
 }
 

--- a/services/generation/species_builder.py
+++ b/services/generation/species_builder.py
@@ -25,6 +25,7 @@ DEFAULT_TRAIT_REFERENCE_PATH = (
 )
 DEFAULT_TRAIT_GLOSSARY_PATH = REPO_ROOT / "data" / "traits" / "glossary.json"
 DEFAULT_INVENTORY_PATH = REPO_ROOT / "docs" / "catalog" / "traits_inventory.json"
+DEFAULT_PATHFINDER_DATASET_PATH = REPO_ROOT / "data" / "external" / "pathfinder_bestiary_1e.json"
 
 
 @dataclass(slots=True)
@@ -395,6 +396,183 @@ def _synergy_score(traits: Sequence[TraitProfile]) -> float:
     return round(total / (len(traits) * max(len(traits) - 1, 1)), 3)
 
 
+def _clamp_score(value: float | int | None) -> float:
+    try:
+        numeric = float(value) if value is not None else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(round(numeric, 3), 1.0))
+
+
+class PathfinderProfileTranslator:
+    """Translate Pathfinder statblocks into runtime-ready blueprints."""
+
+    def __init__(self, dataset_path: Path = DEFAULT_PATHFINDER_DATASET_PATH) -> None:
+        self.dataset_path = dataset_path
+        self._index: Dict[str, Mapping[str, Any]] | None = None
+
+    def _load_dataset(self) -> Dict[str, Mapping[str, Any]]:
+        if self._index is None:
+            payload = _load_json(self.dataset_path)
+            creatures = payload.get("creatures") if isinstance(payload, Mapping) else []
+            index: Dict[str, Mapping[str, Any]] = {}
+            if isinstance(creatures, list):
+                for entry in creatures:
+                    if isinstance(entry, Mapping) and entry.get("id"):
+                        index[str(entry["id"])] = dict(entry)
+            self._index = index
+        return self._index
+
+    def get_profile(self, profile_id: str) -> Mapping[str, Any]:
+        dataset = self._load_dataset()
+        try:
+            return dataset[str(profile_id)]
+        except KeyError as exc:  # pragma: no cover - defensive guard
+            raise KeyError(f"Profilo Pathfinder '{profile_id}' non trovato") from exc
+
+    @staticmethod
+    def _threat_tier_from_score(score: float | int | None) -> str:
+        numeric = _clamp_score(score)
+        tier = max(1, min(5, int(round(numeric * 4)) + 1))
+        return f"T{tier}"
+
+    @staticmethod
+    def _rarity_from_score(score: float | int | None) -> str:
+        numeric = _clamp_score(score)
+        if numeric >= 0.85:
+            return "R4"
+        if numeric >= 0.65:
+            return "R3"
+        if numeric >= 0.4:
+            return "R2"
+        return "R1"
+
+    @staticmethod
+    def _role_from_entry(entry: Mapping[str, Any]) -> str:
+        type_field = str(entry.get("type") or "").lower()
+        if type_field in {"dragon", "magical beast", "outsider", "aberration"}:
+            return "predatore_terziario_apex"
+        if type_field in {"plant", "ooze", "vermin"}:
+            return "ingegneri_ecosistema"
+        if type_field in {"construct", "undead"}:
+            return "minaccia_microbica"
+        return "evento_ecologico"
+
+    @staticmethod
+    def _vc_from_axes(axes: Mapping[str, Any]) -> Dict[str, float]:
+        threat = _clamp_score(axes.get("threat"))
+        defense = _clamp_score(axes.get("defense"))
+        mobility = _clamp_score(axes.get("mobility"))
+        perception = _clamp_score(axes.get("perception"))
+        magic = _clamp_score(axes.get("magic"))
+        social = _clamp_score(axes.get("social"))
+        stealth = _clamp_score(axes.get("stealth"))
+        environment = _clamp_score(axes.get("environment"))
+        versatility = _clamp_score(axes.get("versatility"))
+        return {
+            "aggro": threat,
+            "risk": _clamp_score(1.0 - defense),
+            "cohesion": social,
+            "setup": max(magic, versatility),
+            "explore": max(mobility, environment),
+            "tilt": max(perception, stealth),
+        }
+
+    @staticmethod
+    def _summary_from_entry(entry: Mapping[str, Any]) -> str:
+        abilities = entry.get("special_abilities")
+        if isinstance(abilities, list) and abilities:
+            head = ", ".join(str(item) for item in abilities[:3])
+            return f"Capacità chiave: {head}"
+        return str(entry.get("visual_description") or "Profilo importato dal bestiario Pathfinder")
+
+    def build_blueprint(
+        self,
+        profile_id: str,
+        *,
+        biome_id: str | None = None,
+        fallback_traits: Sequence[str] = (),
+    ) -> tuple[Dict[str, Any], Dict[str, Any]]:
+        entry = self.get_profile(profile_id)
+        axes = entry.get("axes") if isinstance(entry, Mapping) else {}
+        vc = self._vc_from_axes(axes if isinstance(axes, Mapping) else {})
+        threat_tier = self._threat_tier_from_score(axes.get("threat") if isinstance(axes, Mapping) else None)
+        rarity = self._rarity_from_score(axes.get("versatility") if isinstance(axes, Mapping) else None)
+        traits = list(
+            dict.fromkeys(
+                ["pathfinder", *(entry.get("genetic_traits") or []), *fallback_traits]
+            )
+        )
+        abilities = [ability for ability in entry.get("special_abilities", []) if ability]
+        environment_tags = [tag for tag in entry.get("environment_tags", []) if tag]
+        functional_tags = [
+            tag
+            for tag in (
+                "pathfinder",
+                str(entry.get("type") or "").lower(),
+                str(entry.get("subtype") or "").lower(),
+            )
+            if tag
+        ]
+
+        blueprint: Dict[str, Any] = {
+            "id": f"pathfinder-{entry.get('id')}",
+            "display_name": str(entry.get("name") or entry.get("id") or "Creatura Pathfinder"),
+            "summary": self._summary_from_entry(entry),
+            "description": str(entry.get("visual_description") or ""),
+            "role_trofico": self._role_from_entry(entry),
+            "functional_tags": functional_tags,
+            "biomes": [biome_id] if biome_id else [],
+            "vc": vc,
+            "playable_unit": False,
+            "spawn_rules": {"densita": "moderata"},
+            "balance": {
+                "threat_tier": threat_tier,
+                "rarity": rarity,
+                "encounter_role": "ambient",
+            },
+            "statistics": {
+                "threat_tier": threat_tier,
+                "rarity": rarity,
+                "energy_profile": None,
+                "synergy_score": _clamp_score(axes.get("versatility") if isinstance(axes, Mapping) else None),
+            },
+            "traits": {"core": traits, "derived": [], "conflicts": []},
+            "morphology": {
+                "families": [str(entry.get("type") or "").lower()],
+                "adaptations": entry.get("genetic_traits") or [],
+                "environments": environment_tags,
+            },
+            "behavior": {"tags": ["pathfinder"], "drives": abilities[:2]},
+            "special_abilities": abilities,
+            "environment_affinity": {
+                "biome_class": biome_id or "pathfinder_unknown",
+                "source_tags": environment_tags,
+            },
+            "derived_from_environment": {
+                "suggested_traits": entry.get("genetic_traits") or [],
+                "optional_traits": [],
+                "synergy_traits": ["pathfinder"],
+            },
+            "source_dataset": {
+                "id": "pathfinder",
+                "profile_id": profile_id,
+                "cr": entry.get("cr"),
+                "axes": axes,
+            },
+        }
+
+        meta = {
+            "dataset_id": "pathfinder",
+            "profile_id": profile_id,
+            "source_cr": entry.get("cr"),
+            "source_axes": axes,
+        }
+
+        return blueprint, meta
+
+
+
 class SpeciesBuilder:
     """Generate species blueprints from trait identifiers."""
 
@@ -539,4 +717,5 @@ __all__ = [
     "TraitUsage",
     "build_trait_catalog_map",
     "load_builder",
+    "PathfinderProfileTranslator",
 ]

--- a/tests/test_pathfinder_generation.py
+++ b/tests/test_pathfinder_generation.py
@@ -1,0 +1,64 @@
+import pytest
+
+from services.generation.orchestrator import (
+    GenerationError,
+    GenerationOrchestrator,
+    SpeciesGenerationRequest,
+)
+from services.generation.species_builder import PathfinderProfileTranslator
+
+
+@pytest.fixture(scope="module")
+def pathfinder_translator() -> PathfinderProfileTranslator:
+    return PathfinderProfileTranslator()
+
+
+@pytest.fixture
+def orchestrator(pathfinder_translator: PathfinderProfileTranslator) -> GenerationOrchestrator:
+    return GenerationOrchestrator(
+        fallback_traits=[],
+        dataset_translators={"pathfinder": pathfinder_translator},
+    )
+
+
+def test_pathfinder_generation_matches_statblock(
+    orchestrator: GenerationOrchestrator, pathfinder_translator: PathfinderProfileTranslator
+) -> None:
+    profile_id = "aboleth"
+    request = SpeciesGenerationRequest(
+        trait_ids=[],
+        dataset_id="pathfinder",
+        profile_id=profile_id,
+        biome_id="mare_profondo",
+    )
+
+    result = orchestrator.generate_species(request)
+    entry = pathfinder_translator.get_profile(profile_id)
+    expected_blueprint, _ = pathfinder_translator.build_blueprint(profile_id, biome_id="mare_profondo")
+
+    assert result.meta["dataset_id"] == "pathfinder"
+    assert result.meta["profile_id"] == profile_id
+    assert result.meta["source_cr"] == entry.get("cr")
+
+    assert result.blueprint["statistics"]["threat_tier"] == expected_blueprint["statistics"]["threat_tier"]
+    assert result.blueprint["balance"]["rarity"] == expected_blueprint["balance"]["rarity"]
+    assert set(result.blueprint["special_abilities"]) >= set(entry.get("special_abilities", [])[:3])
+    assert result.blueprint["environment_affinity"]["source_tags"] == [
+        tag for tag in entry.get("environment_tags", []) if tag
+    ]
+
+
+def test_missing_profile_raises(orchestrator: GenerationOrchestrator) -> None:
+    request = SpeciesGenerationRequest(trait_ids=[], dataset_id="pathfinder", biome_id="foresta_miceliale")
+    with pytest.raises(GenerationError):
+        orchestrator.generate_species(request)
+
+
+def test_unknown_dataset_raises(pathfinder_translator: PathfinderProfileTranslator) -> None:
+    orchestrator = GenerationOrchestrator(
+        fallback_traits=[],
+        dataset_translators={"pathfinder": pathfinder_translator},
+    )
+    request = SpeciesGenerationRequest(trait_ids=[], dataset_id="sconosciuto", profile_id="aboleth")
+    with pytest.raises(GenerationError):
+        orchestrator.generate_species(request)

--- a/tests/test_pathfinder_generation.py
+++ b/tests/test_pathfinder_generation.py
@@ -5,7 +5,10 @@ from services.generation.orchestrator import (
     GenerationOrchestrator,
     SpeciesGenerationRequest,
 )
-from services.generation.species_builder import PathfinderProfileTranslator
+from services.generation.species_builder import (
+    PathfinderProfileTranslator,
+    PathfinderTraitFormula,
+)
 
 
 @pytest.fixture(scope="module")
@@ -46,6 +49,24 @@ def test_pathfinder_generation_matches_statblock(
     assert result.blueprint["environment_affinity"]["source_tags"] == [
         tag for tag in entry.get("environment_tags", []) if tag
     ]
+
+
+def test_pathfinder_trait_formula_extracts_signature_traits(
+    pathfinder_translator: PathfinderProfileTranslator,
+) -> None:
+    formula: PathfinderTraitFormula = pathfinder_translator.trait_formula
+
+    balor_profile = pathfinder_translator.get_profile("balor")
+    balor_traits = formula.extract(balor_profile)
+    assert "mantello_meteoritico" in balor_traits["core"]
+    assert "frusta_fiammeggiante" in balor_traits["core"]
+    assert "carapace_fase_variabile" in balor_traits["optional"]
+
+    solar_profile = pathfinder_translator.get_profile("solar")
+    solar_traits = formula.extract(solar_profile)
+    assert "aura_scudo_radianza" in solar_traits["core"]
+    assert "empatia_coordinativa" in solar_traits["core"]
+    assert "risonanza_di_branco" in solar_traits["synergy"]
 
 
 def test_missing_profile_raises(orchestrator: GenerationOrchestrator) -> None:


### PR DESCRIPTION
## Summary
- add the rovine_planari biome metadata, ecosystem sheets, and foodweb connecting the new planar ruins environment
- translate ten Pathfinder statblocks into Evo Tactics species placed in the rovine_planari biome with coverage for apex, bridge, keystone, threat, and event roles
- register the new biome class, species catalog entries, and network connections so the Pathfinder profile is available to the orchestrator pipeline

## Testing
- PYTHONPATH=. pytest tests/test_generation_orchestrator.py tests/test_pathfinder_generation.py

------
https://chatgpt.com/codex/tasks/task_e_69022e174f488332b54df62179e8a339