### PR TITLE
Split CI workflow into dedicated jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  build-and-test:
+  typescript-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -27,13 +27,65 @@ jobs:
         working-directory: tools/ts
         run: npm test
 
+      - name: Validate Species (TS)
+        working-directory: tools/ts
+        run: node dist/validate_species.js ../../data/species.yaml
+
+  cli-checks:
+    runs-on: ubuntu-latest
+    needs: typescript-tests
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: tools/ts/package-lock.json
+
+      - name: Install Node.js dependencies
+        working-directory: tools/ts
+        run: npm ci
+
+      - name: Build TypeScript artifacts
+        working-directory: tools/ts
+        run: npm run build --silent
+
       - name: Run TypeScript CLI
         working-directory: tools/ts
         run: node dist/roll_pack.js ENTP invoker ../../data/packs.yaml
 
-      - name: Validate Species (TS)
-        working-directory: tools/ts
-        run: node dist/validate_species.js ../../data/species.yaml
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        working-directory: tools/py
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --requirement requirements.txt
+
+      - name: Validate base datasets (CLI)
+        working-directory: tools/py
+        run: python3 game_cli.py validate-datasets
+
+      - name: Validate Evo-Tactics ecosystem pack
+        run: python3 tools/py/game_cli.py validate-ecosystem-pack --json-out /tmp/evo_pack_report.json
+
+      - name: Run CLI smoke profiles
+        run: ./scripts/cli_smoke.sh
+
+  python-tests:
+    runs-on: ubuntu-latest
+    needs: cli-checks
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -58,15 +110,24 @@ jobs:
         working-directory: tools/py
         run: python roll_pack.py ENTP invoker ../../data/packs.yaml
 
-      - name: Validate base datasets (CLI)
+  dataset-checks:
+    runs-on: ubuntu-latest
+    needs: python-tests
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
         working-directory: tools/py
-        run: python3 game_cli.py validate-datasets
-
-      - name: Validate Evo-Tactics ecosystem pack
-        run: python3 tools/py/game_cli.py validate-ecosystem-pack --json-out /tmp/evo_pack_report.json
-
-      - name: Run CLI smoke profiles
-        run: ./scripts/cli_smoke.sh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --requirement requirements.txt
 
       - name: Audit trait catalog consistency
         run: python3 scripts/trait_audit.py --check
@@ -96,6 +157,25 @@ jobs:
               print("\n".join(errors))
               sys.exit(1)
           PY
+
+  deployment-checks:
+    runs-on: ubuntu-latest
+    needs: dataset-checks
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        working-directory: tools/py
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --requirement requirements.txt
 
       - name: Run deploy validation checks
         env:


### PR DESCRIPTION
## Summary
- add a build step to the CLI job so the TypeScript bundle exists before invoking the CLI script

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69025faba1448332a2edbace4cf5e255