### PR TITLE
Switch Mission Console router to hash history for GitHub Pages

### DIFF
--- a/webapp/src/router/index.js
+++ b/webapp/src/router/index.js
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory } from 'vue-router';
+import { createRouter, createWebHashHistory } from 'vue-router';
 import FlowShellView from '../views/FlowShellView.vue';
 import AtlasLayoutView from '../views/atlas/AtlasLayoutView.vue';
 import AtlasPokedexView from '../views/atlas/AtlasPokedexView.vue';
@@ -6,7 +6,7 @@ import AtlasWorldBuilderView from '../views/atlas/AtlasWorldBuilderView.vue';
 import AtlasEncounterLabView from '../views/atlas/AtlasEncounterLabView.vue';
 
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHashHistory(),
   routes: [
     {
       path: '/',


### PR DESCRIPTION
## Summary
- update the Vue Router configuration to use hash-based history so deep links remain under the mission-console bundle on GitHub Pages

## Testing
- npm run build *(fails: Rollup unable to resolve vue-router from src/App.vue)*

------
https://chatgpt.com/codex/tasks/task_e_69026c1423748332a6eee1147b5737d0