### PR TITLE
Switch Mission Console router to hash history for GitHub Pages

### DIFF
--- a/webapp/src/router/index.js
+++ b/webapp/src/router/index.js
@@ -6,7 +6,7 @@ import AtlasWorldBuilderView from '../views/atlas/AtlasWorldBuilderView.vue';
 import AtlasEncounterLabView from '../views/atlas/AtlasEncounterLabView.vue';
 
 const router = createRouter({
-  history: createWebHashHistory(),
+  history: createWebHashHistory(import.meta.env.BASE_URL),
   routes: [
     {
       path: '/',


### PR DESCRIPTION
## Summary
- ensure the hash history respects the configured deployment base path by passing import.meta.env.BASE_URL when creating the router history

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69026d6508188332a770a21db8938a3c