### PR TITLE
Remove base argument from hash history creation

### DIFF
--- a/webapp/src/router/index.js
+++ b/webapp/src/router/index.js
@@ -6,7 +6,7 @@ import AtlasWorldBuilderView from '../views/atlas/AtlasWorldBuilderView.vue';
 import AtlasEncounterLabView from '../views/atlas/AtlasEncounterLabView.vue';
 
 const router = createRouter({
-  history: createWebHashHistory(import.meta.env.BASE_URL),
+  history: createWebHashHistory(),
   routes: [
     {
       path: '/',


### PR DESCRIPTION
## Summary
- stop passing Vite's BASE_URL to `createWebHashHistory` so hash routes keep working for deep links

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902714958148332b79276e1d63e16e9