### PR TITLE
Add data health audit tooling and inventory report

### DIFF
--- a/reports/data_inventory.md
+++ b/reports/data_inventory.md
@@ -1,0 +1,142 @@
+# Inventario dataset e sorgenti
+
+I ruoli di responsabilità fanno riferimento alla pipeline agentica documentata nel playbook di triage (`AG-Core`, `AG-Biome`, `AG-Personality`, `AG-Toolsmith`, `AG-Orchestrator`).【F:docs/process/incoming_triage_pipeline.md†L9-L82】 Dimensioni e timestamp sono calcolati dallo stato della working tree al momento dell'audit.
+
+## 1. Mappatura sorgenti strutturate
+
+| Percorso | Formato | Versione | Destinazione/Utilizzo |
+| --- | --- | --- | --- |
+| data/traits/glossary.json | JSON | schema 1.0 | Glossario centrale usato da tool ETL e validatori.【F:docs/DesignDoc-Overview.md†L39-L44】 |
+| packs/evo_tactics_pack/docs/catalog/trait_glossary.json | JSON | schema 1.0 | Glossario distribuito nel pack, sincronizzato dal workflow tratti.【F:docs/DesignDoc-Overview.md†L39-L44】 |
+| packs/evo_tactics_pack/docs/catalog/trait_reference.json | JSON | schema 2.0 | Reference genetico consumato da baseline e validatori.【F:docs/DesignDoc-Overview.md†L40-L44】 |
+| packs/evo_tactics_pack/docs/catalog/env_traits.json | JSON | schema 1.0 | Regole env→trait per generator e ETL coverage.【F:docs/DesignDoc-Overview.md†L40-L44】 |
+| packs/evo_tactics_pack/data/species.yaml | YAML | v0.41 | Catalogo specie consumato da generator e coverage.【F:docs/public/idea-taxonomy.json†L10-L15】 |
+| data/traits/biome_pools.json | JSON | schema 1.0 | Pool tratti per synth biome (biomeSynthesizer).【F:services/generation/biomeSynthesizer.js†L492-L516】 |
+| data/packs.yaml | YAML | N/D | Tabelle pack usate dal CLI roll_pack TS/Python.【F:tools/ts/roll_pack.ts†L106-L158】 |
+| data/analysis/trait_baseline.yaml | YAML | schema 1.0 | Baseline PI generata da `build_trait_baseline.py`.【F:tools/py/build_trait_baseline.py†L15-L55】 |
+| data/analysis/trait_coverage_report.json | JSON | schema 1.0 | Report coverage usato per audit e dashboard.【F:tools/py/report_trait_coverage.py†L15-L53】 |
+| data/analysis/trait_coverage_matrix.csv | CSV | N/D | Matrice flatten per diff e reporting.【F:tools/py/report_trait_coverage.py†L15-L53】 |
+| data/analysis/trait_env_mapping.json | JSON | N/D | Crosswalk PI↔ambienti prodotto dal migrator.【F:tools/py/trait_catalog_migrator.py†L17-L36】 |
+| data/analysis/trait_gap_report.json | JSON | schema 1.0 | Gap ETL vs reference per QA tratti.【F:docs/DesignDoc-Overview.md†L44-L47】 |
+| data/external/pathfinder_bestiary_1e.json | JSON | meta source CSV | Dataset normalizzato per traduzione statblock Pathfinder.【F:tools/importers/pathfinder_bestiary.py†L1-L14】 |
+| incoming/pathfinder/bestiary1e_index.csv | CSV | SRD index | Input grezzo per ETL Pathfinder.【F:tools/importers/pathfinder_bestiary.py†L11-L14】 |
+
+## 2. Registro dataset curati (data/ & packs/)
+
+| Percorso | Dimensione | Ultimo aggiornamento | Responsabile | Dipendenze principali |
+| --- | --- | --- | --- | --- |
+| data/analysis/trait_baseline.yaml | 170.80 KB | 2025-10-29T18:47:06 | AG-Core | Env traits, trait reference e glossario sono dichiarati nel metadata.【F:data/analysis/trait_baseline.yaml†L1-L5】 |
+| data/analysis/trait_coverage_report.json | 258.89 KB | 2025-10-29T18:47:06 | AG-Core | Dipende da env_traits, trait_reference, trait_glossary e species root.【F:data/analysis/trait_coverage_report.json†L1-L9】 |
+| data/analysis/trait_coverage_matrix.csv | 39.29 KB | 2025-10-29T18:47:06 | AG-Core | Generato da `report_trait_coverage.py` con env_traits, trait_reference e species.【F:tools/py/report_trait_coverage.py†L15-L53】 |
+| data/analysis/trait_env_mapping.json | 18.58 KB | 2025-10-29T18:47:06 | AG-Core | Output del migrator che incrocia packs e registri trait.【F:tools/py/trait_catalog_migrator.py†L17-L36】 |
+| data/analysis/trait_gap_report.json | 66.17 KB | 2025-10-29T18:47:06 | AG-Core | Confronta il report ETL con trait_reference e glossario.【F:data/analysis/trait_gap_report.json†L2-L8】 |
+| data/traits/glossary.json | 67.79 KB | 2025-10-29T18:47:07 | AG-Core | Punta al trait_reference del pack come sorgente.【F:data/traits/glossary.json†L1-L12】 |
+| data/traits/biome_pools.json | 13.55 KB | 2025-10-29T18:47:07 | AG-Biome | Caricato insieme al glossario dal biome synthesizer.【F:services/generation/biomeSynthesizer.js†L492-L516】 |
+| data/packs.yaml | 5.60 KB | 2025-10-29T18:47:07 | AG-Core | Consumata dal CLI roll_pack per generare combinazioni.【F:tools/ts/roll_pack.ts†L106-L158】 |
+| data/species.yaml | 1.93 KB | 2025-10-29T18:47:07 | AG-Biome | Ingerita dal taxonomy builder/idea widget.【F:docs/public/idea-taxonomy.json†L10-L15】 |
+| data/biomes.yaml | 18.02 KB | 2025-10-29T18:47:06 | AG-Biome | Fonte primaria per taxonomy e generator.【F:docs/public/idea-taxonomy.json†L2-L16】 |
+| data/biome_aliases.yaml | 1.97 KB | 2025-10-29T18:47:06 | AG-Biome | Alias risolti nel taxonomy JSON pubblico.【F:docs/public/idea-taxonomy.json†L2-L16】 |
+| data/mating.yaml | 16.12 KB | 2025-10-29T18:47:07 | AG-Personality | Descrive compatibilità forme documentata nelle linee guida dataset.【F:docs/data-guidelines.md†L7-L12】 |
+| data/game_functions.yaml | 246.00 B | 2025-10-29T18:47:06 | AG-Orchestrator | Incluso nella tassonomia idea intake e storage server.【F:docs/public/idea-taxonomy.json†L14-L16】【F:server/app.js†L140-L192】 |
+| data/telemetry.yaml | 3.26 KB | 2025-10-29T18:47:07 | AG-Core | Allinea telemetria con pack e PE economy nel design doc.【F:docs/DesignDoc-Overview.md†L33-L45】【F:data/telemetry.yaml†L1-L78】 |
+| data/hud/layout.yaml | 928.00 B | 2025-10-29T18:47:06 | AG-Core | Overlay fa riferimento agli indici telemetrici configurati in `data/telemetry.yaml`.【F:data/hud/layout.yaml†L1-L34】【F:data/telemetry.yaml†L1-L78】 |
+| data/missions/skydock_siege.yaml | 3.62 KB | 2025-10-29T18:47:07 | AG-Core | Tuning missione basato su metriche rischio/tilt annotate nel file.【F:data/missions/skydock_siege.yaml†L1-L34】 |
+| data/external/pathfinder_bestiary_1e.json | 1.56 MB | 2025-10-29T18:47:06 | AG-Core | Deriva dal CSV Pathfinder in incoming secondo lo script ETL.【F:data/external/pathfinder_bestiary_1e.json†L1-L15】【F:tools/importers/pathfinder_bestiary.py†L11-L14】 |
+| data/auto_external_sources.yaml | 847.00 B | 2025-10-29T18:47:06 | AG-Toolsmith | Manifest di sorgenti HTML/JSON da fetchare.【F:data/auto_external_sources.yaml†L1-L18】 |
+| data/chatgpt_sources.yaml | 703.00 B | 2025-10-29T18:47:06 | AG-Toolsmith | Configurazione usata dallo script di sync ChatGPT.【F:data/chatgpt_sources.yaml†L1-L24】【F:README.md†L218-L223】 |
+| data/drive/approved_assets.json | 4.21 KB | 2025-10-29T18:47:06 | AG-Toolsmith | Generato da config `config/drive/approved_asset_sources.json` tramite tool drive.【F:data/drive/approved_assets.json†L1-L39】【F:tools/drive/generate-approved-assets.mjs†L16-L78】 |
+| packs/evo_tactics_pack/data/species.yaml | 4.14 KB | 2025-10-29T18:47:07 | AG-Biome | Metadati pack specie usati in coverage e taxonomy.【F:packs/evo_tactics_pack/data/species.yaml†L1-L11】【F:docs/public/idea-taxonomy.json†L10-L15】 |
+| packs/evo_tactics_pack/docs/catalog/trait_reference.json | 248.13 KB | 2025-10-29T18:47:07 | AG-Core | Reference puntato dal glossario e dagli script baseline.【F:packs/evo_tactics_pack/docs/catalog/trait_reference.json†L1-L13】【F:tools/py/build_trait_baseline.py†L15-L55】 |
+| packs/evo_tactics_pack/docs/catalog/trait_glossary.json | 66.52 KB | 2025-10-29T18:47:07 | AG-Core | Replica pack del glossario legata al reference.【F:packs/evo_tactics_pack/docs/catalog/trait_glossary.json†L1-L8】 |
+| packs/evo_tactics_pack/docs/catalog/env_traits.json | 24.50 KB | 2025-10-29T18:47:07 | AG-Core | Regole ambientali legate al glossario condiviso.【F:packs/evo_tactics_pack/docs/catalog/env_traits.json†L1-L17】 |
+| packs/evo_tactics_pack/docs/catalog/catalog_data.json | 32.41 KB | 2025-10-29T18:47:07 | AG-Core | Indice ecosistemi/specie nel bundle pack.【F:packs/evo_tactics_pack/docs/catalog/catalog_data.json†L1-L17】 |
+| incoming/pathfinder/bestiary1e_index.csv | 141.37 KB | 2025-10-29T18:47:07 | AG-Core | Input CSV per l’ETL Pathfinder.【F:incoming/pathfinder/bestiary1e_index.csv†L1-L4】【F:tools/importers/pathfinder_bestiary.py†L11-L14】 |
+
+## 3. Snapshot incoming/ (2025-10-29)
+
+| File | Dimensione | Ultimo aggiornamento | Responsabile | Note |
+| --- | --- | --- | --- | --- |
+| incoming/Ancestors_Neurons_Attack_Dodge_SelfControl_Ambulation_Partial_v0_6.csv | 6.59 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/EvoTactics_DevKit.zip | 5.34 KB | 2025-10-29T18:47:07 | AG-Toolsmith | N/D (grezzo) |
+| incoming/EvoTactics_FullRepo_v1.0.zip | 1.34 MB | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/FEATURE_MAP_EVO_TACTICS.md | 6.33 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/GAME_COMPAT_README.md | 1.69 KB | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/IDEA-001_ecosistema_template.yaml | 729.00 B | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/Inserisci questi parametri nella tabella e dammi i....docx | 13.09 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/MODELLI_RIF_EVO_TACTICS.md | 4.73 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/README.md | 1.40 KB | 2025-10-29T18:47:07 | AG-Orchestrator | Flag duplicato in incoming |
+| incoming/README_INTEGRAZIONE_MECCANICHE.md | 691.00 B | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/README_SCAN_STAT_EVENTI.md | 938.00 B | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/ancestors_branches_totals_v0.3.csv | 1.33 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/ancestors_evo_pack_v1_3.zip | 7.53 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/ancestors_integration_pack_v0_1.zip | 7.93 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/ancestors_integration_pack_v0_2.zip | 3.50 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/ancestors_integration_pack_v0_3.zip | 3.85 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/ancestors_integration_pack_v0_4.zip | 3.11 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/ancestors_integration_pack_v0_5.zip | 4.21 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/ancestors_neuronal_v0_3.zip | 4.30 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/ancestors_neurons_dump_v0.3__DEXTERITY.csv | 7.38 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/ancestors_neurons_dump_v0_6.zip | 7.33 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/ancestors_neurons_pack_v1_2.zip | 8.09 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/compat_map (1).json | 3.93 KB | 2025-10-29T18:47:07 | AG-Orchestrator | Flag duplicato in incoming |
+| incoming/compat_map.json | 3.60 KB | 2025-10-29T18:47:07 | AG-Orchestrator | Flag duplicato in incoming |
+| incoming/engine_events.schema.json | 416.00 B | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/enneagramma_mechanics_registry.template.json | 6.32 KB | 2025-10-29T18:47:07 | AG-Personality | N/D (grezzo) |
+| incoming/et_alignment_scanner.zip | 3.37 KB | 2025-10-29T18:47:07 | AG-Toolsmith | N/D (grezzo) |
+| incoming/evo-tactics-badlands-addon-v1.7.zip | 43.17 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo-tactics-badlands-ecosystem-it-v1.zip | 9.43 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/evo-tactics-final (1).zip | 75.71 KB | 2025-10-29T18:47:07 | AG-Core | Flag duplicato in incoming |
+| incoming/evo-tactics-final.zip | 75.71 KB | 2025-10-29T18:47:07 | AG-Core | Flag duplicato in incoming |
+| incoming/evo-tactics-interconnect-addon-v1.7.1.zip | 48.72 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo-tactics-merged.zip | 70.39 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo-tactics-normalized.zip | 72.10 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo-tactics-starter.zip | 11.01 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo-tactics-unified-pack-v1.9.zip | 68.39 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo-tactics-unified-plus-validators-v1.9.6.zip | 85.49 KB | 2025-10-29T18:47:07 | AG-Toolsmith | N/D (grezzo) |
+| incoming/evo-tactics-unified-v1.9.7-ecosistema.zip | 90.59 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo-tactics-unified-v1.9.8-ecosistema-catalog.zip | 94.58 KB | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/evo-tactics-unified-v2.0.0-site-tools.zip | 338.40 KB | 2025-10-29T18:47:07 | AG-Toolsmith | N/D (grezzo) |
+| incoming/evo-tactics-unified-v2.0.1-site-tools.zip | 345.99 KB | 2025-10-29T18:47:07 | AG-Toolsmith | N/D (grezzo) |
+| incoming/evo-tactics-validator-pack-v1.5.zip | 15.38 KB | 2025-10-29T18:47:07 | AG-Toolsmith | N/D (grezzo) |
+| incoming/evo-tactics.zip | 22.56 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo_enneagram_addon_v1.zip | 15.38 KB | 2025-10-29T18:47:07 | AG-Personality | N/D (grezzo) |
+| incoming/evo_pacchetto_minimo.zip | 10.64 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo_pacchetto_minimo_v2.zip | 17.78 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo_pacchetto_minimo_v3.zip | 23.89 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo_pacchetto_minimo_v4.zip | 31.47 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo_pacchetto_minimo_v5.zip | 41.64 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo_pacchetto_minimo_v6.zip | 45.51 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo_pacchetto_minimo_v7.zip | 65.24 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo_pacchetto_minimo_v8.zip | 71.60 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo_sentience_branch_layout_v0_1.zip | 3.64 KB | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/evo_sentience_rfc_pack_v0_1.zip | 5.04 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo_tactics_ancestors_repo_pack_v1.0 (1).zip | 12.08 KB | 2025-10-29T18:47:07 | AG-Biome | Flag duplicato in incoming |
+| incoming/evo_tactics_ancestors_repo_pack_v1.0.zip | 11.42 KB | 2025-10-29T18:47:07 | AG-Biome | Flag duplicato in incoming |
+| incoming/evo_tactics_badlands_IT.zip | 11.13 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo_tactics_badlands_PTPF_IT.zip | 14.68 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo_tactics_deduped_v8_1.zip | 166.26 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo_tactics_ecosystem_badlands.zip | 7.50 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/evo_tactics_ecosystems_pack.zip | 3.85 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/evo_tactics_merged_final.zip | 155.01 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo_tactics_param_synergy_v8_3.zip | 166.27 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/evo_tactics_tables_v8_3.xlsx | 21.31 KB | 2025-10-29T18:47:07 | AG-Core | N/D (grezzo) |
+| incoming/game_repo_map.json | 762.00 B | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/generator.html | 5.00 KB | 2025-10-29T18:47:07 | AG-Toolsmith | N/D (grezzo) |
+| incoming/hook_bindings.ts | 1.43 KB | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/idea_catalog.csv | 1.20 KB | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/idea_intake_site_package.zip | 6.96 KB | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/index (1).html | 15.42 KB | 2025-10-29T18:47:07 | AG-Orchestrator | Flag duplicato in incoming |
+| incoming/index.html | 15.08 KB | 2025-10-29T18:47:07 | AG-Orchestrator | Flag duplicato in incoming |
+| incoming/last_report.html | 4.62 KB | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/last_report.json | 7.02 KB | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/logs_48354746845.zip | 9.23 KB | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/pack_biome_jobs_v8_alt.json | 20.48 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/personality_module.v1.json | 24.16 KB | 2025-10-29T18:47:07 | AG-Personality | N/D (grezzo) |
+| incoming/recon_meccaniche.json | 1.82 KB | 2025-10-29T18:47:07 | AG-Orchestrator | N/D (grezzo) |
+| incoming/scan_engine_idents.py | 2.97 KB | 2025-10-29T18:47:07 | AG-Toolsmith | N/D (grezzo) |
+| incoming/sensienti_traits_v0.1.yaml | 3.77 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/species_index.html | 3.52 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+
+### Duplicati segnalati dallo script
+
+Lo script `tools/audit/data_health.py --incoming` evidenzia duplicati da gestire (`compat_map`, `evo-tactics-final`, `evo_tactics_ancestors_repo_pack_v1.0`, `index.html`, `README`).【9688a7†L1-L7】

--- a/tools/audit/data_health.py
+++ b/tools/audit/data_health.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Audit curated datasets and raw incoming assets.
+
+This script verifies that the core data files exist and expose the
+expected schema surface. It also scans the incoming drop-folder for
+probable duplicates (e.g. copies suffixed with ``(1)``) so the team can
+triage them before integration.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+try:
+    import yaml  # type: ignore
+except ModuleNotFoundError as exc:  # pragma: no cover - dependency guard
+    raise SystemExit("PyYAML is required to run this audit") from exc
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class DatasetRule:
+    path: Path
+    fmt: str
+    required_keys: Sequence[str] = ()
+    schema_version: str | None = None
+    version_path: Sequence[str] = ()
+    dependencies: Sequence[Path] = ()
+    description: str = ""
+
+    def absolute_path(self) -> Path:
+        return REPO_ROOT / self.path
+
+    def dependency_paths(self) -> Iterable[Path]:
+        for dependency in self.dependencies:
+            yield REPO_ROOT / dependency
+
+
+EXPECTED_DATASETS: tuple[DatasetRule, ...] = (
+    DatasetRule(
+        path=Path("data/analysis/trait_baseline.yaml"),
+        fmt="yaml",
+        required_keys=("schema_version", "source", "summary", "traits"),
+        schema_version="1.0",
+        dependencies=(
+            Path("packs/evo_tactics_pack/docs/catalog/env_traits.json"),
+            Path("packs/evo_tactics_pack/docs/catalog/trait_reference.json"),
+            Path("data/traits/glossary.json"),
+        ),
+        description="Trait baseline compiled from catalog + glossary references.",
+    ),
+    DatasetRule(
+        path=Path("data/analysis/trait_coverage_report.json"),
+        fmt="json",
+        required_keys=("schema_version", "generated_at", "sources", "summary"),
+        schema_version="1.0",
+        dependencies=(
+            Path("packs/evo_tactics_pack/docs/catalog/env_traits.json"),
+            Path("packs/evo_tactics_pack/docs/catalog/trait_reference.json"),
+            Path("data/traits/glossary.json"),
+            Path("packs/evo_tactics_pack/data/species"),
+        ),
+        description="Coverage metrics computed by ETL pipeline.",
+    ),
+    DatasetRule(
+        path=Path("data/analysis/trait_coverage_matrix.csv"),
+        fmt="csv",
+        required_keys=("trait_id", "label_it", "label_en", "biome"),
+        dependencies=(
+            Path("packs/evo_tactics_pack/docs/catalog/trait_reference.json"),
+            Path("packs/evo_tactics_pack/data/species"),
+        ),
+        description="Flattened matrix backing dashboard exports.",
+    ),
+    DatasetRule(
+        path=Path("data/analysis/trait_env_mapping.json"),
+        fmt="json",
+        required_keys=("environment_only", "pi_traits"),
+        description="Crosswalk between environment-driven and PI traits.",
+    ),
+    DatasetRule(
+        path=Path("data/analysis/trait_gap_report.json"),
+        fmt="json",
+        required_keys=("schema_version", "generated_at", "sources", "summary"),
+        schema_version="1.0",
+        description="Gap analysis comparing ETL and reference registries.",
+    ),
+    DatasetRule(
+        path=Path("data/traits/glossary.json"),
+        fmt="json",
+        required_keys=("schema_version", "updated_at", "sources", "traits"),
+        schema_version="1.0",
+        description="Canonical PI trait glossary consumed by tooling.",
+    ),
+    DatasetRule(
+        path=Path("data/traits/biome_pools.json"),
+        fmt="json",
+        required_keys=("schema_version", "pools"),
+        schema_version="1.0",
+        description="Biome trait pools used for synthetic biomes.",
+    ),
+    DatasetRule(
+        path=Path("data/packs.yaml"),
+        fmt="yaml",
+        required_keys=("pi_shop", "random_general_d20", "forms"),
+        description="Pack tables for MBTI forms and PI shop economy.",
+    ),
+    DatasetRule(
+        path=Path("data/species.yaml"),
+        fmt="yaml",
+        required_keys=("catalog",),
+        description="Slot catalog + synergies for species builder.",
+    ),
+    DatasetRule(
+        path=Path("data/biomes.yaml"),
+        fmt="yaml",
+        required_keys=("biomes",),
+        description="Canonical biome definitions and hazard knobs.",
+    ),
+    DatasetRule(
+        path=Path("data/biome_aliases.yaml"),
+        fmt="yaml",
+        required_keys=("aliases",),
+        description="Legacy biome alias resolution table.",
+    ),
+    DatasetRule(
+        path=Path("data/mating.yaml"),
+        fmt="yaml",
+        required_keys=("compat_forme",),
+        description="Forma compatibility matrix for matchmaking.",
+    ),
+    DatasetRule(
+        path=Path("data/game_functions.yaml"),
+        fmt="yaml",
+        required_keys=("functions",),
+        description="Idea Intake functional taxonomy.",
+    ),
+    DatasetRule(
+        path=Path("data/telemetry.yaml"),
+        fmt="yaml",
+        required_keys=("telemetry", "indices", "telemetry_targets"),
+        description="Telemetry weights and PE economy knobs.",
+    ),
+    DatasetRule(
+        path=Path("data/hud/layout.yaml"),
+        fmt="yaml",
+        required_keys=("version", "overlays"),
+        version_path=("version",),
+        description="HUD overlay layout for smart alerts.",
+    ),
+    DatasetRule(
+        path=Path("data/missions/skydock_siege.yaml"),
+        fmt="yaml",
+        required_keys=("skydock_siege",),
+        version_path=("skydock_siege", "revision"),
+        description="Mission tuning log derived from telemetry.",
+    ),
+    DatasetRule(
+        path=Path("data/external/pathfinder_bestiary_1e.json"),
+        fmt="json",
+        required_keys=("meta", "creatures"),
+        version_path=("meta", "source"),
+        dependencies=(Path("incoming/pathfinder/bestiary1e_index.csv"),),
+        description="Normalized Pathfinder SRD statblocks.",
+    ),
+    DatasetRule(
+        path=Path("data/auto_external_sources.yaml"),
+        fmt="yaml",
+        required_keys=("sources",),
+        description="Manifest of auxiliary fetchable sources.",
+    ),
+    DatasetRule(
+        path=Path("data/chatgpt_sources.yaml"),
+        fmt="yaml",
+        required_keys=("sources",),
+        description="ChatGPT sync configuration.",
+    ),
+    DatasetRule(
+        path=Path("data/drive/approved_assets.json"),
+        fmt="json",
+        required_keys=("version", "generatedAt", "summary", "assets"),
+        schema_version=None,
+        description="Drive sync manifest for approved assets.",
+    ),
+    DatasetRule(
+        path=Path("packs/evo_tactics_pack/data/species.yaml"),
+        fmt="yaml",
+        required_keys=("meta", "global_rules"),
+        version_path=("meta", "version"),
+        description="Pack-level species catalog meta + global rules.",
+    ),
+    DatasetRule(
+        path=Path("packs/evo_tactics_pack/docs/catalog/trait_reference.json"),
+        fmt="json",
+        required_keys=("schema_version", "trait_glossary", "traits"),
+        schema_version="2.0",
+        description="Authoritative trait registry for the pack.",
+    ),
+    DatasetRule(
+        path=Path("packs/evo_tactics_pack/docs/catalog/trait_glossary.json"),
+        fmt="json",
+        required_keys=("schema_version", "updated_at", "traits"),
+        schema_version="1.0",
+        description="Localized trait glossary distributed with the pack.",
+    ),
+    DatasetRule(
+        path=Path("packs/evo_tactics_pack/docs/catalog/env_traits.json"),
+        fmt="json",
+        required_keys=("schema_version", "trait_glossary", "rules"),
+        schema_version="1.0",
+        description="Biome/trait recommendation rules for the pack.",
+    ),
+    DatasetRule(
+        path=Path("packs/evo_tactics_pack/docs/catalog/catalog_data.json"),
+        fmt="json",
+        required_keys=("generated_at", "ecosistema"),
+        description="Bundle summary for Evo Tactics ecosystem pack.",
+    ),
+    DatasetRule(
+        path=Path("incoming/pathfinder/bestiary1e_index.csv"),
+        fmt="csv",
+        required_keys=("name", "type", "environment_tags"),
+        description="Source index for Pathfinder bestiary ETL.",
+    ),
+)
+
+
+def load_structured(path: Path, fmt: str):
+    with path.open("r", encoding="utf-8") as handle:
+        if fmt == "json":
+            return json.load(handle)
+        if fmt == "yaml":
+            return yaml.safe_load(handle)
+        if fmt == "csv":
+            reader = csv.reader(handle)
+            try:
+                header = next(reader)
+            except StopIteration:
+                return []
+            return header
+    raise ValueError(f"Unsupported format: {fmt}")
+
+
+def get_nested(mapping, keys: Sequence[str]):
+    value = mapping
+    for key in keys:
+        if isinstance(value, dict) and key in value:
+            value = value[key]
+        else:
+            return None
+    return value
+
+
+def audit_dataset(rule: DatasetRule) -> list[str]:
+    issues: list[str] = []
+    path = rule.absolute_path()
+    if not path.exists():
+        issues.append(f"Missing file: {rule.path}")
+        return issues
+
+    try:
+        data = load_structured(path, rule.fmt)
+    except Exception as exc:  # pragma: no cover - runtime guard
+        issues.append(f"{rule.path}: failed to parse ({exc})")
+        return issues
+
+    if rule.fmt in {"json", "yaml"}:
+        if not isinstance(data, dict):
+            issues.append(f"{rule.path}: expected mapping, found {type(data).__name__}")
+        else:
+            for key in rule.required_keys:
+                if key not in data:
+                    issues.append(f"{rule.path}: missing key '{key}'")
+            if rule.schema_version is not None:
+                actual = data.get("schema_version")
+                if actual != rule.schema_version:
+                    issues.append(
+                        f"{rule.path}: schema_version={actual!r}, expected {rule.schema_version!r}"
+                    )
+            if rule.version_path:
+                found = get_nested(data, rule.version_path)
+                if found in (None, ""):
+                    pretty = ".".join(rule.version_path)
+                    issues.append(f"{rule.path}: missing version info at '{pretty}'")
+    elif rule.fmt == "csv":
+        header = data
+        expected_columns = set(rule.required_keys)
+        actual_columns = set(header)
+        missing = expected_columns - actual_columns
+        if missing:
+            issues.append(
+                f"{rule.path}: missing CSV columns {', '.join(sorted(missing))}"
+            )
+    else:
+        issues.append(f"{rule.path}: unsupported format '{rule.fmt}'")
+
+    for dependency in rule.dependency_paths():
+        if not dependency.exists():
+            issues.append(
+                f"{rule.path}: dependency missing → {dependency.relative_to(REPO_ROOT)}"
+            )
+
+    return issues
+
+
+DUPLICATE_STRIP_RE = re.compile(r"\s*\(\d+\)$")
+
+
+def canonical_filename(path: Path) -> str:
+    stem = DUPLICATE_STRIP_RE.sub("", path.stem)
+    return f"{stem.lower()}{path.suffix.lower()}"
+
+
+def find_duplicates(folders: Iterable[Path]) -> dict[str, list[Path]]:
+    collisions: dict[str, list[Path]] = {}
+    for folder in folders:
+        if not folder.exists():
+            continue
+        for candidate in folder.rglob("*"):
+            if candidate.is_file():
+                key = canonical_filename(candidate)
+                collisions.setdefault(key, []).append(candidate)
+    return {key: paths for key, paths in collisions.items() if len(paths) > 1}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--incoming", action="store_true", help="Check incoming/ for duplicate payloads"
+    )
+    args = parser.parse_args(argv)
+
+    problems: list[str] = []
+    for rule in EXPECTED_DATASETS:
+        problems.extend(audit_dataset(rule))
+
+    if args.incoming:
+        duplicates = find_duplicates([REPO_ROOT / "incoming"])
+        for key, paths in sorted(duplicates.items()):
+            formatted = ", ".join(str(path.relative_to(REPO_ROOT)) for path in paths)
+            problems.append(f"Duplicate candidate '{key}': {formatted}")
+
+    if problems:
+        print("Data health issues detected:", file=sys.stderr)
+        for issue in problems:
+            print(f" - {issue}", file=sys.stderr)
+        return 1
+
+    print("All dataset checks passed.")
+    if args.incoming:
+        print("No duplicate candidates detected in incoming/.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `tools/audit/data_health.py` to validate expected datasets and flag duplicate payloads in `incoming/`
- document structured sources and the raw `incoming/` snapshot in `reports/data_inventory.md`, including ownership, dependencies, and sizes

## Testing
- `python tools/audit/data_health.py --incoming`


------
https://chatgpt.com/codex/tasks/task_e_69027347aa188332957ac2722f550165