### PR TITLE
Add canonical data schemas and extend audit validation

### DIFF
--- a/config/schemas/biome.schema.yaml
+++ b/config/schemas/biome.schema.yaml
@@ -1,0 +1,177 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://game.schemas.local/biome.schema.yaml
+title: Catalogo Biomi
+description: Struttura canonica per il catalogo dei biomi.
+type: object
+additionalProperties: false
+required:
+  - biomes
+properties:
+  biomes:
+    type: object
+    minProperties: 1
+    patternProperties:
+      "^[a-z0-9_]+$":
+        $ref: "#/$defs/biomeEntry"
+    additionalProperties: false
+  vc_adapt:
+    type: object
+    patternProperties:
+      "^[a-z0-9_]+$":
+        type: object
+        patternProperties:
+          "^[a-z0-9_]+$":
+            type: number
+        additionalProperties: false
+    additionalProperties: false
+  mutations:
+    type: object
+    additionalProperties: false
+    required:
+      - SG_max
+      - t0_table_d12
+      - t1_table_d8
+    properties:
+      SG_max:
+        type: integer
+        minimum: 0
+      t0_table_d12:
+        type: array
+        minItems: 1
+        items:
+          type: string
+          minLength: 1
+      t1_table_d8:
+        type: array
+        minItems: 1
+        items:
+          type: string
+          minLength: 1
+  frequencies:
+    type: object
+    patternProperties:
+      "^[a-z0-9_]+$":
+        type: object
+        minProperties: 1
+        patternProperties:
+          "^[a-z0-9_]+$":
+            type: number
+        additionalProperties: false
+    additionalProperties: false
+$defs:
+  biomeEntry:
+    type: object
+    additionalProperties: false
+    required:
+      - label
+      - summary
+      - diff_base
+      - mod_biome
+      - affixes
+      - hazard
+      - npc_archetypes
+      - stresswave
+      - narrative
+    properties:
+      label:
+        type: string
+        minLength: 1
+      summary:
+        type: string
+        minLength: 1
+      diff_base:
+        type: integer
+        minimum: 0
+      mod_biome:
+        type: integer
+        minimum: 0
+      affixes:
+        type: array
+        minItems: 1
+        items:
+          type: string
+          pattern: "^[a-z0-9_]+$"
+      aliases:
+        type: array
+        items:
+          type: string
+          pattern: "^[a-z0-9_]+$"
+      hazard:
+        type: object
+        additionalProperties: false
+        required:
+          - description
+          - severity
+          - stress_modifiers
+        properties:
+          description:
+            type: string
+            minLength: 1
+          severity:
+            type: string
+            enum:
+              - low
+              - medium
+              - high
+              - critical
+          stress_modifiers:
+            type: object
+            minProperties: 1
+            patternProperties:
+              "^[a-z0-9_]+$":
+                type: number
+      npc_archetypes:
+        type: object
+        additionalProperties: false
+        required:
+          - primary
+          - support
+        properties:
+          primary:
+            type: array
+            minItems: 1
+            items:
+              type: string
+              minLength: 1
+          support:
+            type: array
+            minItems: 1
+            items:
+              type: string
+              minLength: 1
+      stresswave:
+        type: object
+        additionalProperties: false
+        required:
+          - baseline
+          - escalation_rate
+          - event_thresholds
+        properties:
+          baseline:
+            type: number
+            minimum: 0
+          escalation_rate:
+            type: number
+            minimum: 0
+          event_thresholds:
+            type: object
+            minProperties: 1
+            patternProperties:
+              "^[a-z0-9_]+$":
+                type: number
+      narrative:
+        type: object
+        additionalProperties: false
+        required:
+          - tone
+          - hooks
+        properties:
+          tone:
+            type: string
+            minLength: 1
+          hooks:
+            type: array
+            minItems: 1
+            items:
+              type: string
+              minLength: 1

--- a/config/schemas/catalog.schema.json
+++ b/config/schemas/catalog.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://game.schemas.local/catalog.schema.json",
+  "title": "Catalogo Tratti",
+  "description": "Schema canonico per i cataloghi di tratti del pacchetto Evo Tactics.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "trait_glossary",
+    "traits"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+$"
+    },
+    "trait_glossary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "traits": {
+      "type": "object",
+      "minProperties": 1,
+      "patternProperties": {
+        "^[a-z0-9_]+$": {
+          "$ref": "https://game.schemas.local/trait.schema.json"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/config/schemas/species.schema.yaml
+++ b/config/schemas/species.schema.yaml
@@ -1,0 +1,212 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://game.schemas.local/species.schema.yaml
+title: Catalogo Specie
+description: Struttura canonica per il catalogo delle specie giocabili.
+type: object
+additionalProperties: false
+required:
+  - catalog
+  - global_rules
+  - species
+properties:
+  catalog:
+    type: object
+    additionalProperties: false
+    required:
+      - slots
+      - synergies
+    properties:
+      slots:
+        type: object
+        minProperties: 1
+        patternProperties:
+          "^[a-z0-9_]+$":
+            type: object
+            minProperties: 1
+            patternProperties:
+              "^[a-z0-9_]+$":
+                $ref: "#/$defs/partDefinition"
+            additionalProperties: false
+        additionalProperties: false
+      synergies:
+        type: array
+        items:
+          type: object
+          additionalProperties: false
+          required:
+            - id
+            - name
+            - when_all
+          properties:
+            id:
+              type: string
+              pattern: "^[a-z0-9_]+$"
+            name:
+              type: string
+              minLength: 1
+            when_all:
+              type: array
+              minItems: 1
+              items:
+                type: string
+                pattern: '^[a-z0-9_]+(\.[a-z0-9_]+)?$'
+  global_rules:
+    type: object
+    additionalProperties: false
+    required:
+      - morph_budget
+      - stacking_caps
+      - counters_reference
+    properties:
+      morph_budget:
+        type: object
+        additionalProperties: false
+        required:
+          - default_weight_budget
+        properties:
+          default_weight_budget:
+            type: integer
+            minimum: 0
+      stacking_caps:
+        type: object
+        additionalProperties: false
+        required:
+          - res_cap_per_type
+          - dr_cap_per_type
+        properties:
+          res_cap_per_type:
+            type: integer
+            minimum: 0
+          dr_cap_per_type:
+            type: integer
+            minimum: 0
+      counters_reference:
+        type: array
+        items:
+          type: object
+          additionalProperties: false
+          required:
+            - counter
+            - counters
+          properties:
+            counter:
+              type: string
+              minLength: 1
+            counters:
+              type: array
+              minItems: 1
+              items:
+                type: string
+                minLength: 1
+  species:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - display_name
+        - estimated_weight
+        - weight_budget
+        - biome_affinity
+        - default_parts
+        - synergy_hints
+        - trait_plan
+      properties:
+        id:
+          type: string
+          pattern: "^[a-z0-9_]+$"
+        display_name:
+          type: string
+          minLength: 1
+        estimated_weight:
+          type: number
+          minimum: 0
+        weight_budget:
+          type: number
+          minimum: 0
+        biome_affinity:
+          type: string
+          pattern: "^[a-z0-9_]+$"
+        default_parts:
+          type: object
+          minProperties: 1
+          patternProperties:
+            "^[a-z0-9_]+$":
+              oneOf:
+                - type: string
+                  pattern: "^[a-z0-9_]+$"
+                - type: array
+                  minItems: 1
+                  items:
+                    type: string
+                    pattern: "^[a-z0-9_]+$"
+          additionalProperties: false
+        synergy_hints:
+          type: array
+          items:
+            type: string
+            pattern: "^[a-z0-9_]+$"
+        trait_plan:
+          type: object
+          additionalProperties: false
+          required:
+            - core
+          properties:
+            core:
+              type: array
+              minItems: 1
+              items:
+                type: string
+                pattern: "^[a-z0-9_]+$"
+            optional:
+              type: array
+              items:
+                type: string
+                pattern: "^[a-z0-9_]+$"
+            synergies:
+              type: array
+              items:
+                type: string
+                pattern: "^[a-z0-9_]+$"
+            environment_focus:
+              type: object
+              additionalProperties: false
+              required:
+                - biome_class
+                - rationale
+              properties:
+                biome_class:
+                  type: string
+                  pattern: "^[a-z0-9_]+$"
+                rationale:
+                  type: string
+                  minLength: 1
+$defs:
+  partDefinition:
+    type: object
+    additionalProperties: false
+    required:
+      - name
+      - effects
+    properties:
+      name:
+        type: string
+        minLength: 1
+      description:
+        type: string
+      effects:
+        type: object
+        default: {}
+        properties:
+          resistances:
+            type: object
+            additionalProperties: false
+            properties:
+              res:
+                type: object
+                patternProperties:
+                  "^[a-z0-9_]+$":
+                    type: number
+        additionalProperties: true

--- a/config/schemas/trait.schema.json
+++ b/config/schemas/trait.schema.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://game.schemas.local/trait.schema.json",
+  "title": "Trait",
+  "description": "Definizione canonica di un tratto biologico per i cataloghi di gioco.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "label",
+    "famiglia_tipologia",
+    "fattore_mantenimento_energetico",
+    "tier",
+    "slot",
+    "sinergie",
+    "conflitti",
+    "mutazione_indotta",
+    "uso_funzione",
+    "spinta_selettiva",
+    "sinergie_pi"
+  ],
+  "properties": {
+    "label": {
+      "type": "string",
+      "minLength": 1
+    },
+    "famiglia_tipologia": {
+      "type": "string",
+      "minLength": 1
+    },
+    "fattore_mantenimento_energetico": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tier": {
+      "type": "string",
+      "pattern": "^T[1-5]$"
+    },
+    "slot": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Z]$"
+      }
+    },
+    "slot_profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "core",
+        "complementare"
+      ],
+      "properties": {
+        "core": {
+          "type": "string",
+          "minLength": 1
+        },
+        "complementare": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "sinergie": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "conflitti": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "requisiti_ambientali": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "condizioni",
+          "fonte"
+        ],
+        "properties": {
+          "capacita_richieste": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "condizioni": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "biome_class"
+            ],
+            "properties": {
+              "biome_class": {
+                "type": "string",
+                "pattern": "^[a-z0-9_]+$"
+              }
+            }
+          },
+          "fonte": {
+            "type": "string",
+            "minLength": 1
+          },
+          "meta": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "expansion": {
+                "type": "string",
+                "minLength": 1
+              },
+              "tier": {
+                "type": "string",
+                "pattern": "^T[1-5]$"
+              },
+              "notes": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "mutazione_indotta": {
+      "type": "string",
+      "minLength": 1
+    },
+    "uso_funzione": {
+      "type": "string",
+      "minLength": 1
+    },
+    "spinta_selettiva": {
+      "type": "string",
+      "minLength": 1
+    },
+    "debolezza": {
+      "type": "string"
+    },
+    "sinergie_pi": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "co_occorrenze",
+        "combo_totale",
+        "forme",
+        "tabelle_random"
+      ],
+      "properties": {
+        "co_occorrenze": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "combo_totale": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "forme": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "tabelle_random": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/reports/schema_validation.json
+++ b/reports/schema_validation.json
@@ -1,0 +1,26 @@
+{
+  "generated_at": "2025-10-29T20:29:03Z",
+  "files": [
+    {
+      "path": "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+      "schema": "https://game.schemas.local/catalog.schema.json",
+      "errors": [],
+      "warnings": [],
+      "status": "ok"
+    },
+    {
+      "path": "data/biomes.yaml",
+      "schema": "https://game.schemas.local/biome.schema.yaml",
+      "errors": [],
+      "warnings": [],
+      "status": "ok"
+    },
+    {
+      "path": "data/species.yaml",
+      "schema": "https://game.schemas.local/species.schema.yaml",
+      "errors": [],
+      "warnings": [],
+      "status": "ok"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add canonical JSON and YAML schemas for trait catalogs, biomes, and species data
- extend `scripts/trait_audit.py` to validate datasets against the schemas and write `reports/schema_validation.json`
- document slug, naming, and slot conventions in `docs/data-guidelines.md`

## Testing
- python scripts/trait_audit.py
- python scripts/trait_audit.py --check

------
https://chatgpt.com/codex/tasks/task_e_6902775eedc48332b65380c22d0307d3