### PR TITLE
Add Pathfinder axis coverage analytics and roadmap

### DIFF
--- a/docs/roadmap_generator.md
+++ b/docs/roadmap_generator.md
@@ -1,0 +1,31 @@
+# Roadmap trimestrale – Generatore Pathfinder ETL (Q1)
+
+## Milestone 1 – Rafforzare l'asse strutturale (Settimane 1-4)
+- **Obiettivo**: coprire il gap prioritario emerso dal report `pathfinder_trait_gap.csv` sull'asse strutturale (`versatility`).
+- **Deliverable**:
+  - 4 nuovi tratti `struttura` bilanciati su blueprint apex/microbici con schede complete (tier, sinergie, requisiti ambientali).
+  - Aggiornamento `PathfinderTraitFormula` per assegnare i nuovi tratti alle creature con `versatility ≥ 0.8`.
+  - Validazione incrociata con `tools/analysis/pathfinder_axis_coverage.py` (nessun `missing_traits` sull'asse strutturale).
+- **Dipendenze**: team Narrative per label/descrizioni, QA sistemi per smoke-test `scripts/trait_audit.py`.
+- **Owner**: Trait Library Strike Team.
+- **Metriche**: `missing_traits` = 0 per `versatility`, incremento ≥20% di specie con bucket `core` aggiornato.
+
+## Milestone 2 – Ampliare le sinergie di mobilità e minaccia (Settimane 5-8)
+- **Obiettivo**: consolidare gli assi `mobility` e `threat`, garantendo copertura per i ruoli tattici ad alta incidenza (predatori apex).
+- **Deliverable**:
+  - Due pass di tuning su tratti `locomozione`/`offensiva` per armonizzare sinergie e conflitti.
+  - Import guidato (CLI) di 50 profili Pathfinder prioritari verificando bucket `core` e `optional`.
+  - Aggiornamento dei dataset `packs/evo_tactics_pack/docs/catalog/env_traits.json` e baseline (`report_trait_coverage.py`).
+- **Dipendenze**: sistemi di generazione (`services/generation/species_builder.py`), bilanciamento VC.
+- **Owner**: Gameplay Systems + Live Ops.
+- **Metriche**: `high_creatures` coperti ≥95% negli assi `mobility` e `threat` (nessun ruolo apex scoperto nel report), audit `trait_gap_report.py` senza nuovi warning.
+
+## Milestone 3 – Integrazione dataset & preparazione release pubblica (Settimane 9-12)
+- **Obiettivo**: consolidare i dataset ETL e predisporre il rilascio pubblico del generatore.
+- **Deliverable**:
+  - Pipeline CI che esegue `pathfinder_axis_coverage.py`, `report_trait_coverage.py` e `trait_gap_report.py` su ogni aggiornamento.
+  - Pacchetto documentazione (`docs/evo-tactics-pack`) con guida d'uso aggiornata e changelog.
+  - Sessione di playtest pubblico con checklist QA (telemetria + feedback) e retroazione su roadmap Q2.
+- **Dipendenze**: DevOps per pipeline, Community Team per playtest.
+- **Owner**: Release Management.
+- **Metriche**: build nightly con report allegati, checklist QA firmata, piano di follow-up approvato entro fine trimestre.

--- a/reports/pathfinder_trait_gap.csv
+++ b/reports/pathfinder_trait_gap.csv
@@ -1,0 +1,10 @@
+axis_key,axis_label,trait_archetype,creatures_total,avg_score,median_score,high_creatures,critical_creatures,top_roles,library_traits,recommended_traits,missing_traits,impact_score,impact_category,effort_estimate
+versatility,Asse Strutturale,struttura,1211,0.804,0.867,944,740,predatore_terziario_apex:515; evento_ecologico:196; minaccia_microbica:121,17,21,4,2424,Critico,Alto (≥4 tratti)
+mobility,Asse Mobilità,locomozione,1211,0.425,0.35,299,159,predatore_terziario_apex:246; evento_ecologico:32; minaccia_microbica:11,21,7,0,617,Stabile,Allineato
+threat,Asse Minaccia,offensiva,1211,0.358,0.3,259,134,predatore_terziario_apex:185; minaccia_microbica:34; evento_ecologico:25,14,6,0,527,Stabile,Allineato
+magic,Asse Strategico,strategia,1211,0.251,0.1,102,33,predatore_terziario_apex:94; minaccia_microbica:8,15,3,0,168,Stabile,Allineato
+defense,Asse Difensivo,difesa,1211,0.389,0.35,49,1,predatore_terziario_apex:49,19,2,0,51,Stabile,Allineato
+environment,Asse Ambientale,metabolismo,1211,0.245,0.167,36,1,evento_ecologico:16; predatore_terziario_apex:15; ingegneri_ecosistema:5,18,1,0,38,Stabile,Allineato
+stealth,Asse Occulto,simbiotico,1211,0.064,0.05,2,2,predatore_terziario_apex:2,19,1,0,6,Stabile,Allineato
+perception,Asse Sensoriale,sensoriale,1211,0.24,0.2,4,0,predatore_terziario_apex:4,22,1,0,4,Stabile,Allineato
+social,Asse Supporto,supporto,1211,0.132,0.1,0,0,,16,0,0,0,Stabile,Allineato

--- a/tools/analysis/pathfinder_axis_coverage.py
+++ b/tools/analysis/pathfinder_axis_coverage.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Generate Pathfinder ETL coverage across functional axes vs trait library."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import statistics
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping
+
+try:  # pragma: no cover - optional dependency for YAML parsing
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover
+    yaml = None
+
+AXIS_CONFIG: tuple[tuple[str, str, str], ...] = (
+    ("threat", "Asse Minaccia", "offensiva"),
+    ("defense", "Asse Difensivo", "difesa"),
+    ("mobility", "Asse Mobilità", "locomozione"),
+    ("perception", "Asse Sensoriale", "sensoriale"),
+    ("magic", "Asse Strategico", "strategia"),
+    ("social", "Asse Supporto", "supporto"),
+    ("stealth", "Asse Occulto", "simbiotico"),
+    ("environment", "Asse Ambientale", "metabolismo"),
+    ("versatility", "Asse Strutturale", "struttura"),
+)
+
+HIGH_THRESHOLD = 0.6
+CRITICAL_THRESHOLD = 0.8
+CREATURES_PER_TRAIT = 45
+
+
+def load_json(path: Path) -> Mapping[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_yaml(path: Path) -> Mapping[str, Any]:
+    if yaml is None:
+        raise RuntimeError(
+            "PyYAML non disponibile: impossibile analizzare la baseline dei tratti"
+        )
+    with path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
+
+
+def role_from_entry(entry: Mapping[str, Any]) -> str:
+    type_field = str(entry.get("type") or "").lower()
+    if type_field in {"dragon", "magical beast", "outsider", "aberration"}:
+        return "predatore_terziario_apex"
+    if type_field in {"plant", "ooze", "vermin"}:
+        return "ingegneri_ecosistema"
+    if type_field in {"construct", "undead"}:
+        return "minaccia_microbica"
+    return "evento_ecologico"
+
+
+def collect_pathfinder_stats(dataset_path: Path) -> dict[str, Any]:
+    payload = load_json(dataset_path)
+    creatures = payload.get("creatures")
+    if not isinstance(creatures, list):
+        return {}
+
+    axis_stats: dict[str, dict[str, Any]] = {}
+    for key, _, _ in AXIS_CONFIG:
+        axis_stats[key] = {
+            "scores": [],
+            "high_count": 0,
+            "critical_count": 0,
+            "roles": Counter(),
+        }
+
+    for entry in creatures:
+        if not isinstance(entry, Mapping):
+            continue
+        axes = entry.get("axes") if isinstance(entry, Mapping) else {}
+        if not isinstance(axes, Mapping):
+            axes = {}
+        role = role_from_entry(entry)
+        for key, _, _ in AXIS_CONFIG:
+            score = axes.get(key, 0)
+            try:
+                numeric = float(score)
+            except (TypeError, ValueError):
+                numeric = 0.0
+            stats = axis_stats[key]
+            stats["scores"].append(numeric)
+            if numeric >= HIGH_THRESHOLD:
+                stats["high_count"] += 1
+                stats["roles"][role] += 1
+            if numeric >= CRITICAL_THRESHOLD:
+                stats["critical_count"] += 1
+
+    return axis_stats
+
+
+def collect_trait_counts(baseline_path: Path) -> Counter[str]:
+    baseline = load_yaml(baseline_path)
+    traits = baseline.get("traits")
+    counts: Counter[str] = Counter()
+    if not isinstance(traits, Mapping):
+        return counts
+    for entry in traits.values():
+        if not isinstance(entry, Mapping):
+            continue
+        if entry.get("missing_metadata"):
+            continue
+        archetype = entry.get("archetype")
+        if isinstance(archetype, str):
+            key = archetype.strip().lower()
+            if key:
+                counts[key] += 1
+    return counts
+
+
+def format_roles(counter: Counter[str]) -> str:
+    if not counter:
+        return ""
+    parts = [f"{role}:{count}" for role, count in counter.most_common(3)]
+    return "; ".join(parts)
+
+
+def impact_category(score: int, missing: int) -> str:
+    if missing <= 0:
+        return "Stabile"
+    if score >= 300:
+        return "Critico"
+    if score >= 150:
+        return "Alto"
+    if score >= 60:
+        return "Medio"
+    return "Basso"
+
+
+def effort_estimate(missing: int) -> str:
+    if missing <= 0:
+        return "Allineato"
+    if missing == 1:
+        return "Basso (1 tratto)"
+    if missing <= 3:
+        return "Medio (2-3 tratti)"
+    return "Alto (≥4 tratti)"
+
+
+def summarise(axis_stats: Mapping[str, Any], trait_counts: Counter[str]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for key, label, archetype in AXIS_CONFIG:
+        stats = axis_stats.get(key, {})
+        scores = stats.get("scores", []) if isinstance(stats, Mapping) else []
+        high_count = int(stats.get("high_count", 0)) if isinstance(stats, Mapping) else 0
+        critical_count = (
+            int(stats.get("critical_count", 0)) if isinstance(stats, Mapping) else 0
+        )
+        total = len(scores)
+        average = round(sum(scores) / total, 3) if total else 0.0
+        median = round(statistics.median(scores), 3) if total else 0.0
+        roles = stats.get("roles") if isinstance(stats, Mapping) else Counter()
+        if not isinstance(roles, Counter):
+            roles = Counter(roles) if isinstance(roles, Mapping) else Counter()
+        library_traits = trait_counts.get(archetype.lower(), 0)
+        recommended = math.ceil(high_count / CREATURES_PER_TRAIT) if high_count else 0
+        missing = max(0, recommended - library_traits)
+        impact_score = high_count + (critical_count * 2)
+        rows.append(
+            {
+                "axis_key": key,
+                "axis_label": label,
+                "trait_archetype": archetype,
+                "creatures_total": total,
+                "avg_score": average,
+                "median_score": median,
+                "high_creatures": high_count,
+                "critical_creatures": critical_count,
+                "top_roles": format_roles(roles),
+                "library_traits": library_traits,
+                "recommended_traits": recommended,
+                "missing_traits": missing,
+                "impact_score": impact_score,
+                "impact_category": impact_category(impact_score, missing),
+                "effort_estimate": effort_estimate(missing),
+            }
+        )
+    rows.sort(key=lambda row: row["impact_score"], reverse=True)
+    return rows
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        with path.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(["axis_key", "axis_label", "trait_archetype", "note"])
+        return
+    fieldnames = list(rows[0].keys())
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dataset",
+        type=Path,
+        default=Path("data/external/pathfinder_bestiary_1e.json"),
+        help="Dataset normalizzato dal bestiario Pathfinder",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=Path("data/analysis/trait_baseline.yaml"),
+        help="Baseline dei tratti Evo Tactics",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("reports/pathfinder_trait_gap.csv"),
+        help="Percorso del report CSV da generare",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    axis_stats = collect_pathfinder_stats(args.dataset)
+    trait_counts = collect_trait_counts(args.baseline)
+    rows = summarise(axis_stats, trait_counts)
+    write_csv(args.out, rows)
+    print(f"Report generato in {args.out}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a CLI utility to compute Pathfinder ETL coverage against the trait library and rank gaps by impact
- generate the initial `reports/pathfinder_trait_gap.csv` output capturing axis, trait availability, and effort estimates
- outline a Q1 roadmap in `docs/roadmap_generator.md` to close high-impact gaps and prepare the public release

## Testing
- python tools/analysis/pathfinder_axis_coverage.py --out reports/pathfinder_trait_gap.csv

------
https://chatgpt.com/codex/tasks/task_e_69027cab9e848332a0ddb5d8edaaa379