### PR TITLE
Refine CI workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     outputs:
       ts: ${{ steps.filter.outputs.ts }}
       cli: ${{ steps.filter.outputs.cli }}
+      python: ${{ steps.filter.outputs.python }}
       data: ${{ steps.filter.outputs.data }}
       deploy: ${{ steps.filter.outputs.deploy }}
 
@@ -23,14 +24,31 @@ jobs:
         with:
           filters: |
             ts:
+              - 'package.json'
+              - 'package-lock.json'
               - 'tools/ts/**'
+              - 'webapp/package.json'
+              - 'webapp/package-lock.json'
+              - 'webapp/src/**'
             cli:
               - 'scripts/cli_smoke.sh'
+              - 'tools/py/game_cli.py'
+              - 'tools/py/game_cli/**'
+            python:
+              - 'scripts/**/*.py'
+              - 'server/**/*.py'
+              - 'services/**/*.py'
+              - 'tests/**/*.py'
+              - 'tools/py/**'
             data:
               - 'data/**'
               - 'packs/**'
+              - 'reports/**'
             deploy:
               - 'scripts/trait_audit.py'
+              - 'scripts/run_deploy_checks.sh'
+              - 'tools/py/report_trait_coverage.py'
+              - 'config/deploy/**'
 
   typescript-tests:
     runs-on: ubuntu-latest
@@ -64,8 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - paths-filter
-      - typescript-tests
-    if: needs.paths-filter.outputs.cli == 'true'
+    if: needs.paths-filter.outputs.cli == 'true' || needs.paths-filter.outputs.data == 'true'
 
     steps:
       - name: Checkout repository
@@ -115,8 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - paths-filter
-      - cli-checks
-    if: needs.paths-filter.outputs.data == 'true'
+    if: needs.paths-filter.outputs.python == 'true' || needs.paths-filter.outputs.data == 'true'
 
     steps:
       - name: Checkout repository
@@ -149,7 +165,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - paths-filter
-      - python-tests
     if: needs.paths-filter.outputs.data == 'true' || needs.paths-filter.outputs.deploy == 'true'
 
     steps:
@@ -198,7 +213,9 @@ jobs:
 
   deployment-checks:
     runs-on: ubuntu-latest
-    needs: dataset-checks
+    needs:
+      - paths-filter
+    if: needs.paths-filter.outputs.deploy == 'true'
 
     steps:
       - name: Checkout repository

--- a/docs/ci-pipeline.md
+++ b/docs/ci-pipeline.md
@@ -1,28 +1,35 @@
 # Pipeline CI completa
 
-Il workflow GitHub Actions mantiene in salute la toolchain TS/Python e i dataset di gioco.
+Il workflow GitHub Actions mantiene in salute la toolchain TS/Python e i dataset di gioco. Per evitare esecuzioni superflue, la pipeline principale è stata suddivisa in più job specializzati che si attivano solo quando i file interessati vengono toccati nella PR.
 
 ## Workflow `CI`
 
 Il file di configurazione è `.github/workflows/ci.yml` e viene attivato su `push` e `pull_request`.
 
-Passaggi principali del job `build-and-test`:
+### Sequenza dei job
 
-1. Checkout del repository.
-2. Setup di Node.js 20 con cache su `tools/ts/package-lock.json`.
-3. Installazione delle dipendenze TypeScript (`npm ci`).
-4. Esecuzione delle suite TypeScript (build + unit + Playwright) tramite `npm test`.
-5. Esecuzione della CLI compilata per generare un pack di esempio (`node dist/roll_pack.js ENTP invoker ../../data/packs.yaml`).
-6. Validazione dataset specie lato TypeScript (`node dist/validate_species.js ../../data/species.yaml`).
-7. Setup di Python 3.11.
-8. Installazione delle dipendenze Python da `tools/py/requirements.txt`.
-9. Esecuzione della suite `pytest` dalla radice del progetto.
-10. Validazione specie lato Python (`python3 validate_species.py ../../data/species.yaml`).
-11. Verifica CLI Python (`python roll_pack.py ENTP invoker ../../data/packs.yaml`).
-12. Validazione dataset base via CLI (`python3 game_cli.py validate-datasets`).
-13. Validazione pack ecosistema Evo-Tactics (`python3 tools/py/game_cli.py validate-ecosystem-pack --json-out /tmp/evo_pack_report.json`).
-14. Smoke test profili CLI (`./scripts/cli_smoke.sh`).
-15. Preparazione del bundle statico per la dashboard tramite `scripts/run_deploy_checks.sh` (riusa gli artefatti già prodotti e, in CI, salta lo smoke test HTTP).
+1. **`paths-filter`** – usa `dorny/paths-filter@v3` per popolare le variabili booleane `ts`, `cli`, `python`, `data`, `deploy` in base ai percorsi modificati. Esempi:
+   - `ts`: `tools/ts/**`, `package.json`, `webapp/src/**`, ecc.
+   - `cli`: `scripts/cli_smoke.sh`, `tools/py/game_cli.py`, `tools/py/game_cli/**`.
+   - `python`: `tools/py/**`, `scripts/**/*.py`, `server/**`, `services/**`, `tests/**/*.py`.
+   - `data`: `data/**`, `packs/**`, `reports/**`.
+   - `deploy`: `scripts/trait_audit.py`, `scripts/run_deploy_checks.sh`, `tools/py/report_trait_coverage.py`, `config/deploy/**`.
+
+2. **`typescript-tests`** – esegue il setup Node.js 20, installa le dipendenze (`npm ci` in `tools/ts`), lancia `npm test` e `node dist/validate_species.js`. Viene eseguito solo se `ts == 'true'`.
+
+3. **`cli-checks`** – builda gli artefatti TypeScript (`npm run build --silent`) e verifica i comandi CLI:
+   - `node dist/roll_pack.js …`
+   - `python3 tools/py/game_cli.py validate-datasets`
+   - `./scripts/cli_smoke.sh`
+   Si attiva quando `cli == 'true'` o `data == 'true'` per intercettare variazioni sia alla shell che ai dataset.
+
+4. **`python-tests`** – predispone Python 3.11, installa i requisiti e lancia `pytest`, `validate_species.py` e `roll_pack.py`. Parte quando `python == 'true'` oppure `data == 'true'`.
+
+5. **`dataset-checks`** – controlla la coerenza dei trait (`scripts/trait_audit.py`) e la copertura minima (`tools/py/report_trait_coverage.py`). Si attiva se `data == 'true'` o `deploy == 'true'`.
+
+6. **`deployment-checks`** – esegue `scripts/run_deploy_checks.sh` in modalità CI per verificare che il pacchetto statico sia generabile. Parte solo quando `deploy == 'true'`.
+
+Nei casi in cui nessun filtro si attiva (es. PR di sola documentazione), i job specialistici vengono saltati mantenendo il workflow in stato `success`.
 
 ### `scripts/run_deploy_checks.sh`
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -13,6 +13,15 @@ Questa pagina estende le note in [docs/ci-pipeline.md](ci-pipeline.md) descriven
 
 ## Dettagli workflow
 
+### CI
+- **Trigger**: `push` e `pull_request`. Un job preliminare (`paths-filter`) usa `dorny/paths-filter@v3` per valutare i percorsi toccati e abilita i job specializzati:
+  - `typescript-tests` quando cambia la toolchain TS (`tools/ts/**`, `package.json`, `webapp/src/**`, …).
+  - `cli-checks` quando vengono toccati la CLI o i dataset (`scripts/cli_smoke.sh`, `tools/py/game_cli.py`, `data/**`, `packs/**`).
+  - `python-tests` se sono modificati gli script/server Python o i dataset (`tools/py/**`, `scripts/**/*.py`, `data/**`).
+  - `dataset-checks` per variazioni ai dataset o agli script di audit (`data/**`, `reports/**`, `scripts/trait_audit.py`, `tools/py/report_trait_coverage.py`).
+  - `deployment-checks` solo per modifiche ai file di deploy (`scripts/run_deploy_checks.sh`, `config/deploy/**`).
+- **Note operative**: le PR puramente documentali non abilitano alcun job, il workflow termina in stato `success` senza eseguire test.
+
 ### Validate registry naming
 - **Trigger**: push e pull request che toccano i file elencati nel blocco `paths` (registri, reference trait, script validator e workflow stesso).
 - **Job**: `naming` esegue Python 3.11, installa `tools/py/requirements.txt` e lancia `python tools/py/validate_registry_naming.py` per assicurare che i registri condivisi rispettino le convenzioni.


### PR DESCRIPTION
## Summary
- expand the `paths-filter` job to detect TS, CLI, Python, data, and deploy changes and expose the scopes to downstream jobs
- relax job dependencies so each CI segment runs only when its scope requires it
- document the new conditional workflow layout and activation rules in the CI guides

## Testing
- not run (configuration-only changes)


------
https://chatgpt.com/codex/tasks/task_e_69025d4927808332af8990995a4433b1