### PR TITLE
Restore tracker status markers and refresh tracker data

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,14 +187,19 @@ node dist/roll_pack.js ENTP invoker --seed demo
 - **Indice tracker & stato**: usa `docs/00-INDEX.md` per checklist quotidiane, log e roadmap; la sezione viene aggiornata automaticamente da [`scripts/daily_tracker_refresh.py`](scripts/daily_tracker_refresh.py) tramite il workflow [`daily-tracker-refresh`](.github/workflows/daily-tracker-refresh.yml).
 - **Log di riferimento**: `logs/traits_tracking.md`, `logs/web_status.md` e i report in `reports/incoming/` documentano l'avanzamento tecnico delle ultime sessioni.
 
-### Recap operativo & prossimi step
-- [ ] Rivedi i log in `reports/incoming/validation/` e apri ticket per eventuali regressioni.
-- [ ] Aggiorna i tracker operativi in [`docs/00-INDEX.md`](docs/00-INDEX.md#tracker-operativi-e-log) dopo ogni sessione.
-- [ ] Riesegui `./scripts/report_incoming.sh --destination sessione-YYYY-MM-DD` al termine di ogni batch di upload.
-- [ ] Condividi su Drive i materiali rigenerati (`docs/presentations/showcase/*`) una volta verificati.
+<!-- tracker-status:start -->
+#### Operativo
+- **███████░░░ 74% · Telemetria VC** — Le milestone operative hanno completato playtest, normalizzazione e documentazione; restano overlay HUD, ribilanciamento XP Cipher e contrasto EVT-03. Vedi [docs/checklist/milestones.md#in-corso](docs/checklist/milestones.md#in-corso).
 
-### Barra di completamento
-<progress value="0.7" max="1"></progress> **70 %** completato — aggiornare dopo il prossimo ciclo di validazione.
+#### Processo
+- **░░░░░░░░░░ 0% · Pipeline deploy web** — Il processo di rilascio è definito ma i riesami settimanali riportano ancora blocchi Playwright e smoke test manuali aperti. Vedi [docs/process/web_pipeline.md](docs/process/web_pipeline.md) e [logs/web_status.md](logs/web_status.md).
+
+#### Log & metriche
+- **██████░░░░ 55% · Inventario trait** — La copertura tratti/specie è riallineata ma restano da integrare appendici e dataset mock aggiuntivi. Vedi [logs/traits_tracking.md](logs/traits_tracking.md).
+
+#### Appendici
+- **█████░░░░░ 50% · Canvas e integrazioni** — Gli appendici A/C/D riportano l'ultima revisione mentre canvas e feature updates conservano follow-up aperti. Vedi [docs/00-INDEX.md#appendici-di-stato](docs/00-INDEX.md#appendici-di-stato) e [docs/Canvas/feature-updates.md](docs/Canvas/feature-updates.md).
+<!-- tracker-status:end -->
 
 ## Documentazione & tracker
 - **Indice operativo**: `docs/00-INDEX.md` aggrega checklist quotidiane, log e roadmap.

--- a/docs/00-INDEX.md
+++ b/docs/00-INDEX.md
@@ -39,14 +39,14 @@
 
 | File | Titolo | Scopo | Owner attuale | Ultimo aggiornamento | Percorso |
 | --- | --- | --- | --- | --- | --- |
-| [action-items.md](docs/checklist/action-items.md) | Action Items — Sintesi operativa | Sintesi quotidiana attività cross-team e follow-up PR giornalieri. | UI Systems · Progression Design · VFX/Lighting · QA Support | 2025-10-28 | `docs/checklist/action-items.md` |
+| [action-items.md](docs/checklist/action-items.md) | Action Items — Sintesi operativa | Sintesi quotidiana attività cross-team e follow-up PR giornalieri. | UI Systems · Progression Design · VFX/Lighting · QA Support | 2025-10-29 | `docs/checklist/action-items.md` |
 | [bug-intake.md](docs/checklist/bug-intake.md) | Bug Intake Checklist | Verifica dati obbligatori prima del triage ticket. | N/D | 2025-10-27 | `docs/checklist/bug-intake.md` |
 | [clone-setup.md](docs/checklist/clone-setup.md) | Procedura di clone e setup iniziale | Istruzioni ambiente standard container /workspace/Game. | Ops/ChatGPT | 2025-10-26 | `docs/checklist/clone-setup.md` |
 | [demo-release.md](docs/checklist/demo-release.md) | Checklist release demo pubblica | Passi di coordinamento per bundle demo Evo Tactics Pack. | N/D | 2025-10-27 | `docs/checklist/demo-release.md` |
-| [milestones.md](docs/checklist/milestones.md) | Checklist Milestone | Stato avanzamento milestone telemetria/dataset/playtest. | N/D | 2025-10-28 | `docs/checklist/milestones.md` |
-| [project-setup-todo.md](docs/checklist/project-setup-todo.md) | TODO Operativo — Avvio completo del progetto | Sequenza end-to-end per rendere operativo il progetto con note storiche. | Ops/ChatGPT · Release Ops · Marketing Ops · Lead Dev Tools | 2025-10-28 | `docs/checklist/project-setup-todo.md` |
-| [telemetry.md](docs/checklist/telemetry.md) | Checklist — Telemetry Export & QA Filters | Controlli giornalieri/settimanali su export telemetria e filtri QA. | N/D | 2025-10-28 | `docs/checklist/telemetry.md` |
-| [vc_playtest_plan.md](docs/checklist/vc_playtest_plan.md) | Playtest VC Mirati alla Telemetria | Piano sessioni mirate agli indici VC e setup strumentazione. | N/D | 2025-10-24 | `docs/checklist/vc_playtest_plan.md` |
+| [milestones.md](docs/checklist/milestones.md) | Checklist Milestone | Stato avanzamento milestone telemetria/dataset/playtest. | N/D | 2025-10-29 | `docs/checklist/milestones.md` |
+| [project-setup-todo.md](docs/checklist/project-setup-todo.md) | TODO Operativo — Avvio completo del progetto | Sequenza end-to-end per rendere operativo il progetto con note storiche. | Ops/ChatGPT · Release Ops · Marketing Ops · Lead Dev Tools | 2025-10-29 | `docs/checklist/project-setup-todo.md` |
+| [telemetry.md](docs/checklist/telemetry.md) | Checklist — Telemetry Export & QA Filters | Controlli giornalieri/settimanali su export telemetria e filtri QA. | N/D | 2025-10-29 | `docs/checklist/telemetry.md` |
+| [vc_playtest_plan.md](docs/checklist/vc_playtest_plan.md) | Playtest VC Mirati alla Telemetria | Piano sessioni mirate agli indici VC e setup strumentazione. | N/D | 2025-10-29 | `docs/checklist/vc_playtest_plan.md` |
 
 ### Processo
 
@@ -54,18 +54,18 @@
 | --- | --- | --- | --- | --- | --- |
 | [incident_reporting_table.md](docs/process/incident_reporting_table.md) | Registro Segnalazioni Cross-Team — Implementazione Operativa | Configurazione tabella Airtable e permessi per segnalazioni condivise. | N/D | 2025-10-27 | `docs/process/incident_reporting_table.md` |
 | [qa_hud.md](docs/process/qa_hud.md) | QA — HUD Smart Alerts | Metriche e pipeline QA per monitorare ack/filter ratio degli alert HUD. | QA lead | 2025-10-27 | `docs/process/qa_hud.md` |
-| [qa_reporting_schema.md](docs/process/qa_reporting_schema.md) | QA Telemetry & Segnalazioni — Schema condiviso | Panorama fonti dati QA, campi disponibili e gap di reporting. | N/D | 2025-10-27 | `docs/process/qa_reporting_schema.md` |
+| [qa_reporting_schema.md](docs/process/qa_reporting_schema.md) | QA Telemetry & Segnalazioni — Schema condiviso | Panorama fonti dati QA, campi disponibili e gap di reporting. | N/D | 2025-10-29 | `docs/process/qa_reporting_schema.md` |
 | [telemetry_ingestion_pipeline.md](docs/process/telemetry_ingestion_pipeline.md) | Pipeline Dati Telemetria → Tabella QA/Design | Flusso di ingestione telemetria, snapshot visuali e modulo QA manuale. | N/D | 2025-10-27 | `docs/process/telemetry_ingestion_pipeline.md` |
-| [traits_checklist.md](docs/process/traits_checklist.md) | Checklist iterativa tratti | Step incrementali per aggiungere/revisionare tratti con controlli dati. | N/D | 2025-10-28 | `docs/process/traits_checklist.md` |
+| [traits_checklist.md](docs/process/traits_checklist.md) | Checklist iterativa tratti | Step incrementali per aggiungere/revisionare tratti con controlli dati. | N/D | 2025-10-29 | `docs/process/traits_checklist.md` |
 | [web_handoff.md](docs/process/web_handoff.md) | Web Handoff · Foodweb Archetypes 2025-11-05 | Nota di consegna verso team web/UI con archetipi ruolo×bioma aggiornati. | N/D | 2025-10-29 | `docs/process/web_handoff.md` |
-| [web_pipeline.md](docs/process/web_pipeline.md) | Pipeline web · Procedura di rilascio | Processo end-to-end per promuovere la web experience su GitHub Pages. | N/D | 2025-10-28 | `docs/process/web_pipeline.md` |
+| [web_pipeline.md](docs/process/web_pipeline.md) | Pipeline web · Procedura di rilascio | Processo end-to-end per promuovere la web experience su GitHub Pages. | N/D | 2025-10-29 | `docs/process/web_pipeline.md` |
 
 ### Log & metriche
 
 | File | Titolo | Scopo | Owner attuale | Ultimo aggiornamento | Percorso |
 | --- | --- | --- | --- | --- | --- |
-| [chatgpt_sync.log](logs/chatgpt_sync.log) | Log sincronizzazione ChatGPT | Cronologia esecuzioni scripts/chatgpt_sync.py e diff generati. | N/D | 2025-10-24 | `logs/chatgpt_sync.log` |
-| [chatgpt_sync_last.json](logs/chatgpt_sync_last.json) | Snapshot ultima sincronizzazione ChatGPT | Esito strutturato dell'ultima run con percorsi export/diff. | N/D | 2025-10-24 | `logs/chatgpt_sync_last.json` |
+| [chatgpt_sync.log](logs/chatgpt_sync.log) | Log sincronizzazione ChatGPT | Cronologia esecuzioni scripts/chatgpt_sync.py e diff generati. | N/D | 2025-10-29 | `logs/chatgpt_sync.log` |
+| [chatgpt_sync_last.json](logs/chatgpt_sync_last.json) | Snapshot ultima sincronizzazione ChatGPT | Esito strutturato dell'ultima run con percorsi export/diff. | N/D | 2025-10-29 | `logs/chatgpt_sync_last.json` |
 | [2025-11-XX-dryrun.json](logs/drive/2025-11-XX-dryrun.json) | Drive sync dry-run | Stato dry-run convertYamlToSheetsDryRun() e azioni suggerite. | N/D | 2025-10-28 | `logs/drive/2025-11-XX-dryrun.json` |
 | [2025-11-08-filter-selections.md](logs/exports/2025-11-08-filter-selections.md) | Telemetry Export — Log interazioni filtri | Audit settimanale applicazione filtri export (Analytics/Support). | Analytics · Support | 2025-10-28 | `logs/exports/2025-11-08-filter-selections.md` |
 | [traits_tracking.md](logs/traits_tracking.md) | Monitoraggio inventario trait | Aggiornamenti periodici copertura trait/specie e risultati validator. | N/D | 2025-10-29 | `logs/traits_tracking.md` |
@@ -79,7 +79,7 @@
 
 | File | Titolo | Scopo | Owner attuale | Ultimo aggiornamento | Percorso |
 | --- | --- | --- | --- | --- | --- |
-| [roadmap.md](docs/piani/roadmap.md) | Roadmap Operativa | Procedura settimanale post-ottobre 2025 con milestone e follow-up. | N/D | 2025-10-28 | `docs/piani/roadmap.md` |
+| [roadmap.md](docs/piani/roadmap.md) | Roadmap Operativa | Procedura settimanale post-ottobre 2025 con milestone e follow-up. | N/D | 2025-10-29 | `docs/piani/roadmap.md` |
 
 ### Appendici di stato
 


### PR DESCRIPTION
## Summary
- restore the tracker status markers around the README operational recap so the refresh script can update it safely
- regenerate the README tracker content and index tables using `scripts/daily_tracker_refresh.py`

## Testing
- `python3 scripts/daily_tracker_refresh.py --readme README.md --index docs/00-INDEX.md`


------
https://chatgpt.com/codex/tasks/task_e_6902cb7bdeb083329a4e12bfec09d735