### PR TITLE
feat: add nebula shell layout and atlas progress

### DIFF
--- a/webapp/src/components/atlas/AtlasCollectionProgress.vue
+++ b/webapp/src/components/atlas/AtlasCollectionProgress.vue
@@ -1,0 +1,236 @@
+<template>
+  <section class="atlas-progress">
+    <header class="atlas-progress__header">
+      <div>
+        <h3>Nebula Atlas · Collezione</h3>
+        <p>Tracking collezionabile basato sul dataset operativo.</p>
+      </div>
+      <ul class="atlas-progress__sprites" aria-label="Preview sprite">
+        <li v-for="sprite in spritePreviews" :key="sprite.id" :style="sprite.style">
+          <span>{{ sprite.initials }}</span>
+        </li>
+      </ul>
+    </header>
+
+    <div class="atlas-progress__meters">
+      <div v-for="entry in progressEntries" :key="entry.id" class="atlas-meter">
+        <header>
+          <h4>{{ entry.label }}</h4>
+          <span>{{ entry.percent }}%</span>
+        </header>
+        <div class="atlas-meter__bar">
+          <div class="atlas-meter__fill" :style="{ width: `${entry.percent}%` }"></div>
+        </div>
+        <p class="atlas-meter__caption">{{ entry.current }} / {{ entry.target }} pronti</p>
+      </div>
+    </div>
+
+    <aside class="atlas-progress__highlights" v-if="highlights.length">
+      <h4>Highlights curatoriali</h4>
+      <ul>
+        <li v-for="item in highlights" :key="item">{{ item }}</li>
+      </ul>
+    </aside>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  metrics: {
+    type: Object,
+    default: () => ({}),
+  },
+  dataset: {
+    type: Object,
+    default: () => ({}),
+  },
+  highlights: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const progressEntries = computed(() => {
+  const targets = props.metrics || {};
+  const entries = [
+    {
+      id: 'species',
+      label: 'Specie',
+      target: targets.species || 0,
+      current: Array.isArray(props.dataset?.species) ? props.dataset.species.length : 0,
+    },
+    {
+      id: 'biomes',
+      label: 'Biomi',
+      target: targets.biomes || 0,
+      current: Array.isArray(props.dataset?.biomes) ? props.dataset.biomes.length : 0,
+    },
+    {
+      id: 'encounters',
+      label: 'Encounter',
+      target: targets.encounters || 0,
+      current: Array.isArray(props.dataset?.encounters) ? props.dataset.encounters.length : 0,
+    },
+  ];
+  return entries.map((entry) => {
+    const percent = !entry.target
+      ? 0
+      : Math.min(100, Math.round((entry.current / entry.target) * 100));
+    return { ...entry, percent };
+  });
+});
+
+const highlights = computed(() => props.highlights || []);
+
+const spritePreviews = computed(() => {
+  const species = Array.isArray(props.dataset?.species) ? props.dataset.species.slice(0, 4) : [];
+  if (!species.length) {
+    return Array.from({ length: 4 }).map((_, index) => buildSprite(`NA-${index + 1}`));
+  }
+  return species.map((entry) => buildSprite(entry.name || entry.id));
+});
+
+function buildSprite(seed) {
+  const colours = ['#38bdf8', '#c084fc', '#f472b6', '#f97316', '#22d3ee'];
+  const index = Math.abs(hashCode(seed)) % colours.length;
+  const gradient = `radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.2), transparent 55%), linear-gradient(135deg, ${colours[index]} 0%, rgba(2, 6, 23, 0.95) 100%)`;
+  const initials = seed
+    .split(' ')
+    .map((chunk) => chunk[0])
+    .join('')
+    .slice(0, 3)
+    .toUpperCase();
+  return {
+    id: seed,
+    initials: initials || 'NA',
+    style: { backgroundImage: gradient },
+  };
+}
+
+function hashCode(text) {
+  let hash = 0;
+  if (!text) return hash;
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash |= 0;
+  }
+  return hash;
+}
+</script>
+
+<style scoped>
+.atlas-progress {
+  display: grid;
+  gap: 1.5rem;
+  background: rgba(248, 250, 252, 0.92);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(191, 219, 254, 0.6);
+  padding: 1.75rem;
+  color: #0f172a;
+}
+
+.atlas-progress__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.atlas-progress__header h3 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.atlas-progress__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.atlas-progress__sprites {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(3rem, 1fr));
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.atlas-progress__sprites li {
+  height: 3.2rem;
+  border-radius: 1.1rem;
+  display: grid;
+  place-items: center;
+  color: rgba(248, 250, 252, 0.92);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 14px 24px rgba(15, 23, 42, 0.18);
+}
+
+.atlas-progress__meters {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.atlas-meter {
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(191, 219, 254, 0.6);
+  border-radius: 1.25rem;
+  padding: 1rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.atlas-meter header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.atlas-meter h4 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.atlas-meter__bar {
+  height: 0.55rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.25);
+  overflow: hidden;
+}
+
+.atlas-meter__fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(135deg, #3b82f6 0%, #a855f7 100%);
+  transition: width 0.3s ease;
+}
+
+.atlas-meter__caption {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(30, 41, 59, 0.7);
+}
+
+.atlas-progress__highlights h4 {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.atlas-progress__highlights ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.45rem;
+  color: rgba(15, 23, 42, 0.75);
+}
+</style>

--- a/webapp/src/components/biomes/BiomeCard.vue
+++ b/webapp/src/components/biomes/BiomeCard.vue
@@ -1,0 +1,148 @@
+<template>
+  <article class="biome-card">
+    <header class="biome-card__header">
+      <div>
+        <p class="biome-card__kicker">Bioma operativo</p>
+        <h3 class="biome-card__title">{{ biome.name }}</h3>
+        <p class="biome-card__subtitle">{{ biome.hazard }}</p>
+      </div>
+      <div class="biome-card__indicators">
+        <TraitChip v-if="biome.climate" :label="biome.climate" variant="climate" />
+        <TraitChip v-if="biome.stability" :label="biome.stability" variant="hazard" icon="☍" />
+      </div>
+    </header>
+
+    <section class="biome-card__lanes" v-if="lanes.length">
+      <h4>Corridoi</h4>
+      <div class="biome-card__chip-grid">
+        <TraitChip v-for="lane in lanes" :key="lane" :label="lane" variant="core" icon="⤴" />
+      </div>
+    </section>
+
+    <section class="biome-card__operations" v-if="operations.length">
+      <h4>Operazioni</h4>
+      <ul>
+        <li v-for="operation in operations" :key="operation">{{ operation }}</li>
+      </ul>
+    </section>
+
+    <section class="biome-card__infiltration" v-if="biome.infiltration">
+      <h4>Infiltrazione</h4>
+      <p>{{ biome.infiltration }}</p>
+    </section>
+
+    <footer class="biome-card__footer">
+      <p>{{ biome.storyHook }}</p>
+      <slot name="footer"></slot>
+    </footer>
+  </article>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import TraitChip from '../shared/TraitChip.vue';
+
+const props = defineProps({
+  biome: {
+    type: Object,
+    required: true,
+  },
+});
+
+const lanes = computed(() => props.biome?.lanes || props.biome?.paths || []);
+const operations = computed(() => props.biome?.operations || props.biome?.opportunities || []);
+</script>
+
+<style scoped>
+.biome-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 1.4rem;
+  border-radius: 1.4rem;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.92), rgba(30, 64, 175, 0.55));
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  color: #e2e8f0;
+  position: relative;
+  overflow: hidden;
+}
+
+.biome-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.25), transparent 60%);
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+.biome-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.biome-card__kicker {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.7rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.biome-card__title {
+  margin: 0.3rem 0 0;
+  font-size: 1.4rem;
+  letter-spacing: 0.02em;
+}
+
+.biome-card__subtitle {
+  margin: 0.25rem 0 0;
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 0.9rem;
+}
+
+.biome-card__indicators {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  align-items: flex-end;
+}
+
+.biome-card__lanes h4,
+.biome-card__operations h4,
+.biome-card__infiltration h4 {
+  margin: 0 0 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.biome-card__chip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.biome-card__operations ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.3rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.biome-card__infiltration p,
+.biome-card__footer p {
+  margin: 0;
+  line-height: 1.5;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.biome-card__footer {
+  display: grid;
+  gap: 0.5rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+}
+</style>

--- a/webapp/src/components/layout/NebulaShell.vue
+++ b/webapp/src/components/layout/NebulaShell.vue
@@ -1,0 +1,274 @@
+<template>
+  <section class="nebula-shell">
+    <div class="nebula-shell__frame">
+      <header class="nebula-shell__header">
+        <div class="nebula-shell__status-grid" v-if="statusIndicators.length">
+          <div
+            v-for="indicator in statusIndicators"
+            :key="indicator.id || indicator.label"
+            class="nebula-shell__status"
+          >
+            <span class="nebula-shell__status-led" :data-tone="indicator.tone || 'neutral'"></span>
+            <div>
+              <p class="nebula-shell__status-label">{{ indicator.label }}</p>
+              <p class="nebula-shell__status-value">{{ indicator.value }}</p>
+            </div>
+          </div>
+        </div>
+        <div class="nebula-shell__actions">
+          <slot name="actions"></slot>
+        </div>
+      </header>
+
+      <div class="nebula-shell__cards">
+        <slot name="cards"></slot>
+      </div>
+
+      <nav v-if="tabs.length" class="nebula-shell__tabs" aria-label="Navigazione schede">
+        <button
+          v-for="tab in tabs"
+          :key="tab.id"
+          type="button"
+          class="nebula-shell__tab"
+          :class="{ 'nebula-shell__tab--active': tab.id === internalTab }"
+          @click="setTab(tab.id)"
+        >
+          <span class="nebula-shell__tab-icon" aria-hidden="true">{{ tab.icon || '◆' }}</span>
+          <span>{{ tab.label }}</span>
+        </button>
+      </nav>
+
+      <div class="nebula-shell__content">
+        <slot :active-tab="internalTab"></slot>
+      </div>
+
+      <footer class="nebula-shell__footer">
+        <slot name="footer"></slot>
+      </footer>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue';
+
+const props = defineProps({
+  tabs: {
+    type: Array,
+    default: () => [],
+  },
+  statusIndicators: {
+    type: Array,
+    default: () => [],
+  },
+  modelValue: {
+    type: String,
+    default: '',
+  },
+});
+
+const emit = defineEmits(['update:modelValue', 'tab-change']);
+
+const firstTab = computed(() => {
+  if (props.modelValue) {
+    return props.modelValue;
+  }
+  const [first] = props.tabs || [];
+  return first?.id || '';
+});
+
+const internalTab = ref(firstTab.value);
+
+watch(
+  firstTab,
+  (value) => {
+    if (!value) {
+      return;
+    }
+    if (internalTab.value !== value) {
+      internalTab.value = value;
+    }
+  },
+);
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    if (value && value !== internalTab.value) {
+      internalTab.value = value;
+    }
+  },
+);
+
+watch(
+  () => props.tabs?.length,
+  () => {
+    if (!props.tabs?.some((tab) => tab.id === internalTab.value)) {
+      internalTab.value = firstTab.value;
+    }
+  },
+);
+
+function setTab(id) {
+  if (internalTab.value === id) {
+    return;
+  }
+  internalTab.value = id;
+  emit('update:modelValue', id);
+  emit('tab-change', id);
+}
+</script>
+
+<style scoped>
+.nebula-shell {
+  position: relative;
+  color: #e2e8f0;
+}
+
+.nebula-shell__frame {
+  position: relative;
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.75rem;
+  border-radius: 2rem;
+  background: radial-gradient(circle at 10% -20%, rgba(96, 213, 255, 0.28), transparent 55%),
+    radial-gradient(circle at 100% 0%, rgba(167, 139, 250, 0.28), transparent 65%),
+    rgba(3, 7, 18, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.15), 0 25px 60px rgba(2, 6, 23, 0.65);
+}
+
+.nebula-shell__frame::after {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border-radius: 2.15rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.35), rgba(14, 165, 233, 0.15));
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.nebula-shell__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.nebula-shell__status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.85rem;
+}
+
+.nebula-shell__status {
+  display: flex;
+  gap: 0.65rem;
+  align-items: center;
+  padding: 0.65rem 0.85rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(56, 189, 248, 0.18);
+}
+
+.nebula-shell__status-led {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  box-shadow: 0 0 12px rgba(125, 211, 252, 0.65);
+  background: rgba(125, 211, 252, 0.95);
+}
+
+.nebula-shell__status-led[data-tone='warning'] {
+  box-shadow: 0 0 12px rgba(251, 191, 36, 0.75);
+  background: rgba(251, 191, 36, 0.9);
+}
+
+.nebula-shell__status-led[data-tone='critical'] {
+  box-shadow: 0 0 12px rgba(248, 113, 113, 0.75);
+  background: rgba(248, 113, 113, 0.9);
+}
+
+.nebula-shell__status-led[data-tone='success'] {
+  box-shadow: 0 0 12px rgba(74, 222, 128, 0.75);
+  background: rgba(74, 222, 128, 0.9);
+}
+
+.nebula-shell__status-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.7rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.nebula-shell__status-value {
+  margin: 0.15rem 0 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.nebula-shell__actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.nebula-shell__cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.nebula-shell__tabs {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(59, 130, 246, 0.25);
+}
+
+.nebula-shell__tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  background: rgba(15, 23, 42, 0.55);
+  color: inherit;
+  cursor: pointer;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  transition: transform 0.18s ease, border-color 0.18s ease;
+}
+
+.nebula-shell__tab:hover {
+  transform: translateY(-1px);
+  border-color: rgba(96, 213, 255, 0.45);
+}
+
+.nebula-shell__tab--active {
+  background: linear-gradient(135deg, rgba(96, 213, 255, 0.45), rgba(167, 139, 250, 0.45));
+  border-color: rgba(96, 213, 255, 0.65);
+  box-shadow: 0 12px 22px rgba(14, 165, 233, 0.25);
+}
+
+.nebula-shell__tab-icon {
+  font-size: 1rem;
+}
+
+.nebula-shell__content {
+  position: relative;
+  padding: 1rem 0 0;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.nebula-shell__footer {
+  min-height: 0.5rem;
+}
+</style>

--- a/webapp/src/components/shared/TraitChip.vue
+++ b/webapp/src/components/shared/TraitChip.vue
@@ -1,0 +1,108 @@
+<template>
+  <span class="trait-chip" :data-variant="variant">
+    <span class="trait-chip__icon" aria-hidden="true">{{ resolvedIcon }}</span>
+    <span class="trait-chip__label">{{ label }}</span>
+  </span>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  label: {
+    type: String,
+    default: '',
+  },
+  variant: {
+    type: String,
+    default: 'default',
+  },
+  icon: {
+    type: String,
+    default: '',
+  },
+});
+
+const iconMap = {
+  core: '✶',
+  derived: '☲',
+  optional: '☰',
+  synergy: '∞',
+  hazard: '⚠',
+  climate: '☁',
+  role: '⚙',
+  validator: '◈',
+  telemetry: '📡',
+  default: '◆',
+};
+
+const resolvedIcon = computed(() => {
+  if (props.icon) {
+    return props.icon;
+  }
+  return iconMap[props.variant] || iconMap.default;
+});
+</script>
+
+<style scoped>
+.trait-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  background: rgba(148, 163, 184, 0.15);
+  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  text-transform: uppercase;
+}
+
+.trait-chip__icon {
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.trait-chip[data-variant='core'] {
+  background: rgba(96, 213, 255, 0.22);
+  border-color: rgba(96, 213, 255, 0.45);
+}
+
+.trait-chip[data-variant='derived'],
+.trait-chip[data-variant='optional'] {
+  background: rgba(196, 181, 253, 0.22);
+  border-color: rgba(167, 139, 250, 0.42);
+}
+
+.trait-chip[data-variant='synergy'] {
+  background: rgba(248, 113, 113, 0.22);
+  border-color: rgba(248, 113, 113, 0.4);
+}
+
+.trait-chip[data-variant='hazard'] {
+  background: rgba(251, 191, 36, 0.22);
+  border-color: rgba(245, 158, 11, 0.4);
+}
+
+.trait-chip[data-variant='climate'] {
+  background: rgba(96, 165, 250, 0.22);
+  border-color: rgba(37, 99, 235, 0.45);
+}
+
+.trait-chip[data-variant='role'] {
+  background: rgba(74, 222, 128, 0.22);
+  border-color: rgba(34, 197, 94, 0.4);
+}
+
+.trait-chip[data-variant='validator'] {
+  background: rgba(234, 179, 8, 0.22);
+  border-color: rgba(217, 119, 6, 0.42);
+}
+
+.trait-chip[data-variant='telemetry'] {
+  background: rgba(96, 165, 250, 0.18);
+  border-color: rgba(56, 189, 248, 0.35);
+}
+</style>

--- a/webapp/src/components/species/SpeciesCard.vue
+++ b/webapp/src/components/species/SpeciesCard.vue
@@ -1,0 +1,202 @@
+<template>
+  <article class="species-card">
+    <header class="species-card__header">
+      <div>
+        <p class="species-card__kicker">{{ archetype }}</p>
+        <h3 class="species-card__title">{{ name }}</h3>
+      </div>
+      <div class="species-card__badges">
+        <TraitChip v-if="rarity" :label="rarity" variant="core" icon="✦" />
+        <TraitChip v-if="threat" :label="`T${threat}`" variant="hazard" icon="⚡" />
+      </div>
+    </header>
+
+    <p v-if="synopsis" class="species-card__synopsis">{{ synopsis }}</p>
+
+    <section class="species-card__traits" aria-label="Tratti principali">
+      <div>
+        <h4>Core</h4>
+        <div class="species-card__trait-grid">
+          <TraitChip
+            v-for="trait in traits.core"
+            :key="`core-${trait}`"
+            :label="trait"
+            variant="core"
+          />
+        </div>
+      </div>
+      <div>
+        <h4>Derivati</h4>
+        <div class="species-card__trait-grid">
+          <TraitChip
+            v-for="trait in traits.derived"
+            :key="`derived-${trait}`"
+            :label="trait"
+            variant="derived"
+          />
+        </div>
+      </div>
+      <div v-if="traits.optional.length">
+        <h4>Optional</h4>
+        <div class="species-card__trait-grid">
+          <TraitChip
+            v-for="trait in traits.optional"
+            :key="`optional-${trait}`"
+            :label="trait"
+            variant="optional"
+          />
+        </div>
+      </div>
+    </section>
+
+    <footer class="species-card__footer">
+      <div class="species-card__info-block">
+        <span class="species-card__label">Energia</span>
+        <span>{{ energyProfile }}</span>
+      </div>
+      <div class="species-card__info-block">
+        <span class="species-card__label">Habitat</span>
+        <span>{{ habitats.join(', ') }}</span>
+      </div>
+      <div class="species-card__info-block" v-if="coverage">
+        <span class="species-card__label">Coverage QA</span>
+        <span>{{ coverage }}</span>
+      </div>
+    </footer>
+  </article>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import TraitChip from '../shared/TraitChip.vue';
+
+const props = defineProps({
+  species: {
+    type: Object,
+    default: () => ({}),
+  },
+});
+
+const name = computed(() => props.species?.display_name || props.species?.name || props.species?.id || 'Specie');
+const archetype = computed(() => props.species?.archetype || props.species?.role || 'Profilo non definito');
+const rarity = computed(() => props.species?.rarity || props.species?.statistics?.rarity || '');
+const threat = computed(() => {
+  const tier = props.species?.threatTier || props.species?.statistics?.threat_tier || props.species?.balance?.threat_tier;
+  if (!tier) return '';
+  return String(tier).replace(/^T/i, '');
+});
+const synopsis = computed(() => props.species?.synopsis || props.species?.summary || '');
+const traits = computed(() => ({
+  core: props.species?.traits?.core || props.species?.core_traits || [],
+  derived: props.species?.traits?.derived || props.species?.derived_traits || [],
+  optional: props.species?.traits?.optional || props.species?.optional_traits || [],
+}));
+const energyProfile = computed(
+  () => props.species?.energyProfile || props.species?.energy_profile || props.species?.statistics?.energy_profile || '—',
+);
+const habitats = computed(() => props.species?.habitats || props.species?.habitat || props.species?.morphology?.environments || []);
+const coverage = computed(() => {
+  const value = props.species?.telemetry?.coverage || props.species?.statistics?.coverage;
+  if (typeof value !== 'number') return '';
+  return `${Math.round(value * 100)}%`;
+});
+</script>
+
+<style scoped>
+.species-card {
+  position: relative;
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  border-radius: 1.5rem;
+  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.22), rgba(15, 23, 42, 0.92));
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  color: #f8fafc;
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.45);
+}
+
+.species-card::after {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: 1.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.species-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.species-card__kicker {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.species-card__title {
+  margin: 0.35rem 0 0;
+  font-size: 1.6rem;
+}
+
+.species-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.species-card__synopsis {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.species-card__traits {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.species-card__traits h4 {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.species-card__trait-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.species-card__footer {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.species-card__info-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 0.9rem;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+}
+
+.species-card__label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.7rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+</style>

--- a/webapp/src/components/species/SpeciesSynergyCard.vue
+++ b/webapp/src/components/species/SpeciesSynergyCard.vue
@@ -1,0 +1,113 @@
+<template>
+  <button type="button" class="synergy-card" :class="{ 'synergy-card--flipped': flipped }" @click="toggle">
+    <div class="synergy-card__face synergy-card__face--front">
+      <span class="synergy-card__icon" aria-hidden="true">∞</span>
+      <p class="synergy-card__title">{{ title }}</p>
+      <p class="synergy-card__hint">Tocca per dettagli</p>
+    </div>
+    <div class="synergy-card__face synergy-card__face--back">
+      <p class="synergy-card__title">{{ title }}</p>
+      <p class="synergy-card__detail">{{ safeDetail }}</p>
+    </div>
+  </button>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue';
+
+const props = defineProps({
+  title: {
+    type: String,
+    default: '',
+  },
+  detail: {
+    type: String,
+    default: '',
+  },
+});
+
+const flipped = ref(false);
+
+const safeDetail = computed(() => {
+  if (props.detail) {
+    return props.detail;
+  }
+  return 'Sinergia tracciata: benchmark QA non annotato. Consultare telemetry per approfondimenti.';
+});
+
+function toggle() {
+  flipped.value = !flipped.value;
+}
+</script>
+
+<style scoped>
+.synergy-card {
+  position: relative;
+  width: 180px;
+  height: 140px;
+  border: none;
+  perspective: 1000px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.synergy-card__face {
+  position: absolute;
+  inset: 0;
+  border-radius: 18px;
+  padding: 1rem;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  backface-visibility: hidden;
+  transition: transform 0.55s ease;
+}
+
+.synergy-card__face--front {
+  background: radial-gradient(circle at top, rgba(96, 213, 255, 0.3), rgba(14, 165, 233, 0.08));
+  border: 1px solid rgba(59, 130, 246, 0.32);
+  color: #e0f2fe;
+}
+
+.synergy-card__face--back {
+  background: radial-gradient(circle at bottom, rgba(56, 189, 248, 0.28), rgba(15, 23, 42, 0.92));
+  border: 1px solid rgba(59, 130, 246, 0.5);
+  color: #f8fafc;
+  transform: rotateY(180deg);
+}
+
+.synergy-card__icon {
+  font-size: 2.4rem;
+  text-shadow: 0 0 18px rgba(125, 211, 252, 0.75);
+}
+
+.synergy-card__title {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+}
+
+.synergy-card__hint {
+  margin: 0;
+  font-size: 0.75rem;
+  opacity: 0.75;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.synergy-card__detail {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  opacity: 0.9;
+}
+
+.synergy-card--flipped .synergy-card__face--front {
+  transform: rotateY(180deg);
+}
+
+.synergy-card--flipped .synergy-card__face--back {
+  transform: rotateY(360deg);
+}
+</style>

--- a/webapp/src/views/BiomesView.vue
+++ b/webapp/src/views/BiomesView.vue
@@ -1,46 +1,68 @@
 <template>
-  <section class="flow-view">
-    <header class="flow-view__header">
-      <h2>Biomi candidati</h2>
-      <p>Panoramica degli ambienti approvati e del grado di prontezza.</p>
-    </header>
-    <div class="flow-view__grid">
-      <article class="biome-card" v-for="biome in biomes" :key="biome.id">
-        <header>
-          <h3>{{ biome.name }}</h3>
-          <span class="biome-card__badge">{{ biome.climate }}</span>
-        </header>
-        <p class="biome-card__focus">{{ biome.focus }}</p>
-        <p class="biome-card__hazard"><strong>Hazard:</strong> {{ biome.hazard }}</p>
-        <ul>
-          <li v-for="item in biome.opportunities" :key="item">{{ item }}</li>
-        </ul>
-        <ul class="biome-card__validators">
-          <li
-            v-for="validator in biome.validators || []"
-            :key="validator.id"
-            :class="`validator validator--${validator.status}`"
-          >
-            <span class="validator__marker"></span>
-            <div>
-              <strong>{{ validator.label }}</strong>
-              <p>{{ validator.message }}</p>
-            </div>
-          </li>
-        </ul>
-        <footer>
-          <div class="biome-card__meter">
-            <div class="biome-card__meter-fill" :style="{ width: `${readinessPercent(biome)}%` }"></div>
-          </div>
-          <small>Readiness {{ biome.readiness }} / {{ biome.total }} · Rischio {{ biome.risk }}</small>
-        </footer>
-      </article>
-    </div>
+  <section class="biomes-view">
+    <NebulaShell :tabs="tabs" v-model="activeTab" :status-indicators="statusIndicators">
+      <template #cards>
+        <div class="biomes-view__hazards">
+          <TraitChip
+            v-for="highlight in hazardHighlights"
+            :key="highlight.key"
+            :label="highlight.label"
+            :variant="highlight.variant"
+            :icon="highlight.icon"
+          />
+        </div>
+      </template>
+
+      <template #default="{ activeTab: currentTab }">
+        <div v-if="currentTab === 'grid'" class="biomes-view__grid">
+          <BiomeCard v-for="biome in biomes" :key="biome.id" :biome="biome">
+            <template #footer>
+              <div class="biomes-view__metrics">
+                <div>
+                  <strong>Readiness</strong>
+                  <span>{{ formatReadiness(biome) }}</span>
+                </div>
+                <TraitChip :label="`Rischio ${biome.risk}`" variant="hazard" icon="⚠" />
+              </div>
+              <ul class="biomes-view__validators" v-if="(biome.validators || []).length">
+                <li
+                  v-for="validator in biome.validators"
+                  :key="validator.id"
+                  :class="`validator validator--${validator.status}`"
+                >
+                  <TraitChip :label="validator.label" variant="validator" :icon="statusIcon(validator.status)" />
+                  <span>{{ validator.message }}</span>
+                </li>
+              </ul>
+            </template>
+          </BiomeCard>
+        </div>
+
+        <div v-else class="biomes-view__validator-feed">
+          <header>
+            <h3>Feed validator runtime</h3>
+            <p>Monitoraggio incrociato di tutte le anomalie.</p>
+          </header>
+          <ul>
+            <li v-for="entry in validatorDigest" :key="entry.id" :class="`validator validator--${entry.status}`">
+              <div>
+                <strong>{{ entry.biome }}</strong>
+                <span>{{ entry.label }}</span>
+              </div>
+              <p>{{ entry.message }}</p>
+            </li>
+          </ul>
+        </div>
+      </template>
+    </NebulaShell>
   </section>
 </template>
 
 <script setup>
-import { toRefs } from 'vue';
+import { computed, ref, toRefs } from 'vue';
+import NebulaShell from '../components/layout/NebulaShell.vue';
+import BiomeCard from '../components/biomes/BiomeCard.vue';
+import TraitChip from '../components/shared/TraitChip.vue';
 
 const props = defineProps({
   biomes: {
@@ -51,165 +73,209 @@ const props = defineProps({
 
 const { biomes } = toRefs(props);
 
-const readinessPercent = (biome) => {
+const activeTab = ref('grid');
+
+const tabs = [
+  { id: 'grid', label: 'Biomi', icon: '🌌' },
+  { id: 'validators', label: 'Validatori', icon: '🛡' },
+];
+
+const totals = computed(() => {
+  const list = Array.isArray(biomes.value) ? biomes.value : [];
+  const readiness = list.reduce((acc, biome) => acc + (Number(biome.readiness) || 0), 0);
+  const capacity = list.reduce((acc, biome) => acc + (Number(biome.total) || 0), 0);
+  const risk = list.reduce((acc, biome) => acc + (Number(biome.risk) || 0), 0);
+  return {
+    count: list.length,
+    readiness,
+    capacity,
+    riskAverage: list.length ? Math.round((risk / list.length) * 10) / 10 : 0,
+  };
+});
+
+const statusIndicators = computed(() => {
+  const items = [];
+  if (totals.value.count) {
+    items.push({ id: 'count', label: 'Biomi attivi', value: totals.value.count, tone: 'neutral' });
+  }
+  if (totals.value.capacity) {
+    const percent = Math.min(100, Math.round((totals.value.readiness / totals.value.capacity) * 100));
+    let tone = 'warning';
+    if (percent >= 80) tone = 'success';
+    else if (percent < 50) tone = 'critical';
+    items.push({ id: 'readiness', label: 'Copertura readiness', value: `${percent}%`, tone });
+  }
+  items.push({ id: 'risk', label: 'Rischio medio', value: totals.value.riskAverage || '0', tone: 'warning' });
+  return items;
+});
+
+const hazardHighlights = computed(() => {
+  const seen = new Set();
+  const list = [];
+  (biomes.value || []).forEach((biome) => {
+    const hazard = biome.hazard || 'Hazard n/d';
+    if (seen.has(hazard)) return;
+    seen.add(hazard);
+    list.push({ key: `${biome.id}-hazard`, label: hazard, variant: 'hazard', icon: '⚠' });
+    if (biome.climate) {
+      list.push({ key: `${biome.id}-climate`, label: biome.climate, variant: 'climate', icon: '☁' });
+    }
+  });
+  return list.slice(0, 4);
+});
+
+const validatorDigest = computed(() => {
+  return (biomes.value || []).flatMap((biome) =>
+    (biome.validators || []).map((validator) => ({
+      id: `${biome.id}-${validator.id}`,
+      biome: biome.name,
+      status: validator.status || 'info',
+      label: validator.label,
+      message: validator.message,
+    })),
+  );
+});
+
+function readinessPercent(biome) {
   const total = Number.isFinite(biome.total) ? biome.total : 0;
   const readiness = Number.isFinite(biome.readiness) ? biome.readiness : 0;
   if (!total) {
     return 0;
   }
   return Math.min(100, Math.round((readiness / total) * 100));
-};
+}
+
+function formatReadiness(biome) {
+  const percent = readinessPercent(biome);
+  return `${biome.readiness || 0} / ${biome.total || 0} · ${percent}%`;
+}
+
+function statusIcon(status) {
+  if (!status) return '◈';
+  if (status === 'passed') return '✔';
+  if (status === 'warning') return '⚠';
+  if (status === 'failed') return '✖';
+  return '◈';
+}
 </script>
 
 <style scoped>
-.flow-view {
+.biomes-view {
   display: grid;
   gap: 1.5rem;
 }
 
-.flow-view__header h2 {
-  margin: 0;
-  font-size: 1.45rem;
+.biomes-view__hazards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
-.flow-view__header p {
-  margin: 0.35rem 0 0;
-  color: rgba(240, 244, 255, 0.7);
-}
-
-.flow-view__grid {
+.biomes-view__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
 }
 
-.biome-card {
-  background: rgba(9, 14, 20, 0.75);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 16px;
-  padding: 1rem;
+.biomes-view__metrics {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.biomes-view__metrics strong {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.biomes-view__metrics span {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.biomes-view__validators {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
   display: grid;
   gap: 0.65rem;
 }
 
-.biome-card header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.biome-card h3 {
-  margin: 0;
-  font-size: 1.1rem;
-}
-
-.biome-card__badge {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  background: rgba(96, 213, 255, 0.15);
-  border: 1px solid rgba(96, 213, 255, 0.4);
-  border-radius: 999px;
-  padding: 0.25rem 0.6rem;
-}
-
-.biome-card__focus {
-  margin: 0;
-  color: rgba(240, 244, 255, 0.75);
-}
-
-.biome-card__hazard {
-  margin: 0;
-  font-size: 0.85rem;
-  color: rgba(240, 244, 255, 0.65);
-}
-
-.biome-card__hazard strong {
-  color: rgba(240, 244, 255, 0.85);
-}
-
-.biome-card ul {
-  margin: 0;
-  padding-left: 1.25rem;
-  color: rgba(240, 244, 255, 0.85);
-  display: grid;
-  gap: 0.35rem;
-}
-
-.biome-card__meter {
-  height: 0.45rem;
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 999px;
-  overflow: hidden;
-}
-
-.biome-card__meter-fill {
-  height: 100%;
-  background: linear-gradient(90deg, #57ca8a 0%, #61d5ff 100%);
-}
-
-small {
-  color: rgba(240, 244, 255, 0.6);
-}
-
-.biome-card__validators {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.5rem;
-}
-
 .validator {
   display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.55rem;
-  padding: 0.5rem 0.6rem;
-  border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(12, 18, 26, 0.75);
-}
-
-.validator strong {
-  font-size: 0.8rem;
-  color: rgba(240, 244, 255, 0.9);
-}
-
-.validator p {
-  margin: 0.15rem 0 0;
-  font-size: 0.75rem;
-  color: rgba(240, 244, 255, 0.7);
-}
-
-.validator__marker {
-  width: 0.65rem;
-  height: 0.65rem;
-  border-radius: 50%;
-  margin-top: 0.2rem;
-  background: rgba(240, 244, 255, 0.35);
+  gap: 0.4rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.9rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  color: rgba(226, 232, 240, 0.85);
 }
 
 .validator--passed {
   border-color: rgba(129, 255, 199, 0.55);
 }
 
-.validator--passed .validator__marker {
-  background: rgba(129, 255, 199, 0.85);
-}
-
 .validator--warning {
   border-color: rgba(255, 210, 130, 0.6);
-}
-
-.validator--warning .validator__marker {
-  background: rgba(255, 210, 130, 0.85);
 }
 
 .validator--failed {
   border-color: rgba(255, 135, 135, 0.6);
 }
 
-.validator--failed .validator__marker {
-  background: rgba(255, 135, 135, 0.85);
+.biomes-view__validator-feed {
+  display: grid;
+  gap: 1rem;
+}
+
+.biomes-view__validator-feed header h3 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.biomes-view__validator-feed header p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.biomes-view__validator-feed ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.biomes-view__validator-feed li {
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.6);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.biomes-view__validator-feed li strong {
+  display: block;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.biomes-view__validator-feed li span {
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.biomes-view__validator-feed li p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.75);
 }
 </style>

--- a/webapp/src/views/atlas/AtlasLayoutView.vue
+++ b/webapp/src/views/atlas/AtlasLayoutView.vue
@@ -24,11 +24,10 @@
         <h3>Finestra di release</h3>
         <p class="atlas-layout__release">{{ dataset.releaseWindow }}</p>
         <p class="atlas-layout__curator">Curatori · {{ dataset.curator }}</p>
-        <ul>
-          <li v-for="highlight in dataset.highlights" :key="highlight">{{ highlight }}</li>
-        </ul>
       </aside>
     </header>
+
+    <AtlasCollectionProgress :metrics="dataset.metrics" :dataset="dataset" :highlights="dataset.highlights" />
 
     <nav class="atlas-layout__nav" aria-label="Sottosezioni atlas">
       <RouterLink
@@ -52,6 +51,7 @@
 import { computed } from 'vue';
 import { RouterLink, RouterView, useRoute } from 'vue-router';
 import { atlasDataset, atlasTotals } from '../../state/atlasDataset.js';
+import AtlasCollectionProgress from '../../components/atlas/AtlasCollectionProgress.vue';
 
 const dataset = atlasDataset;
 const totals = atlasTotals;
@@ -155,12 +155,6 @@ function forwardNotification(payload) {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-}
-
-.atlas-layout__aside ul {
-  margin: 0;
-  padding-left: 1.25rem;
-  color: rgba(15, 23, 42, 0.7);
 }
 
 .atlas-layout__release {

--- a/webapp/tests/GenerationFlow.spec.ts
+++ b/webapp/tests/GenerationFlow.spec.ts
@@ -64,7 +64,7 @@ function orchestrateSpeciesBatch() {
 }
 
 describe('Generation flow orchestrato', () => {
-  it('renderizza il blueprint orchestrato', () => {
+  it('renderizza il blueprint orchestrato', async () => {
     const response = orchestrateSpecies();
     const batch = orchestrateSpeciesBatch();
     const wrapper = mount(SpeciesPanel, {
@@ -80,6 +80,15 @@ describe('Generation flow orchestrato', () => {
     expect(wrapper.text()).toContain('Predatore Snapshot');
     expect(response.meta.fallback_used).toBe(false);
     expect(Array.isArray(response.validation.messages)).toBe(true);
+
+    const synergyTab = wrapper
+      .findAll('button')
+      .find((button) => button.text().toLowerCase().includes('sinergie'));
+    expect(synergyTab).toBeDefined();
+    if (synergyTab) {
+      await synergyTab.trigger('click');
+    }
+
     expect(wrapper.text()).toContain('Anteprime sintetiche');
     expect(wrapper.html()).toMatchSnapshot();
   });

--- a/webapp/tests/SpeciesPanel.spec.ts
+++ b/webapp/tests/SpeciesPanel.spec.ts
@@ -49,7 +49,12 @@ describe('SpeciesPanel', () => {
       props: { species: BASE_SPECIES, validation: VALIDATION, autoPreview: false },
     });
     expect(wrapper.text()).toContain('Predatore / Coda a Frusta Cinetica');
-    expect(wrapper.text()).toContain('Tratti derivati');
+    expect(wrapper.text()).toContain('Derivati');
+    const telemetryTab = wrapper
+      .findAll('button')
+      .find((button) => button.text().toLowerCase().includes('telemetry'));
+    expect(telemetryTab).toBeDefined();
+    await telemetryTab!.trigger('click');
     expect(wrapper.text()).toContain('Revisioni validate');
     expect(wrapper.html()).toMatchSnapshot();
   });
@@ -63,8 +68,13 @@ describe('SpeciesPanel', () => {
     const wrapper = mount(SpeciesPanel, {
       props: { species: BASE_SPECIES, autoPreview: false },
     });
-    await wrapper.find('button').trigger('click');
-    await wrapper.findAll('button')[1].trigger('click');
+    const buttons = wrapper.findAll('button');
+    const exportButton = buttons.find((button) => button.text().includes('Esporta'));
+    const saveButton = buttons.find((button) => button.text().includes('Salva'));
+    expect(exportButton).toBeDefined();
+    expect(saveButton).toBeDefined();
+    await exportButton!.trigger('click');
+    await saveButton!.trigger('click');
     expect(wrapper.emitted('export')).toBeTruthy();
     expect(wrapper.emitted('save')).toBeTruthy();
   });
@@ -77,6 +87,12 @@ describe('SpeciesPanel', () => {
     await vi.waitFor(() => {
       expect(requestSpeciesPreviewBatch).toHaveBeenCalled();
     });
+    const biologyTab = wrapper
+      .findAll('button')
+      .find((button) => button.text().toLowerCase().includes('biologia'));
+    expect(biologyTab).toBeDefined();
+    await biologyTab!.trigger('click');
+    await flushPromises();
     const checkbox = wrapper.find('input[type="checkbox"]');
     expect(checkbox.exists()).toBe(true);
     const callCount = requestSpeciesPreviewBatch.mock.calls.length;

--- a/webapp/tests/__snapshots__/GenerationFlow.spec.ts.snap
+++ b/webapp/tests/__snapshots__/GenerationFlow.spec.ts.snap
@@ -2,173 +2,109 @@
 
 exports[`Generation flow orchestrato > renderizza il blueprint orchestrato 1`] = `
 "<section data-v-73eb6eb5="" class="species-panel">
-  <header data-v-f805145c="" data-v-73eb6eb5="" class="species-overview">
-    <div data-v-f805145c="" class="species-overview__heading">
-      <h2 data-v-f805145c="" class="species-overview__title">Predatore Snapshot / Scheletro Idro-Regolante</h2>
-      <p data-v-f805145c="" class="species-overview__summary">Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante</p>
-    </div>
-    <p data-v-f805145c="" class="species-overview__description">Sintesi genetica focalizzata su Artigli a Sette Vie e Coda a Frusta Cinetica con impronta morfologica defensive, locomotor, omeostatico, prehensile, structural; comportamento climber. Ottimizzata per biomi: caverna_risonante.</p>
-    <div data-v-78ecd3ce="" data-v-73eb6eb5="" class="species-quick-actions"><button data-v-78ecd3ce="" type="button" class="species-quick-actions__button"> Esporta scheda </button><button data-v-78ecd3ce="" type="button" class="species-quick-actions__button species-quick-actions__button--secondary"> Salva nel pack </button></div>
-  </header>
-  <div data-v-73eb6eb5="" class="species-panel__layout">
-    <section data-v-ae611db0="" data-v-73eb6eb5="" class="species-biology">
-      <div data-v-ae611db0="" class="species-biology__section">
-        <header data-v-ae611db0="" class="species-biology__header">
-          <h3 data-v-ae611db0="">Tratti fondamentali</h3>
-          <div data-v-13adf612="" data-v-73eb6eb5="" class="trait-filter-panel">
-            <div data-v-13adf612="" class="trait-filter-panel__group">
-              <h4 data-v-13adf612="">Filtra tratti core</h4>
-              <ul data-v-13adf612="">
-                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="artigli_sette_vie"> artigli_sette_vie</label></li>
-                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="coda_frusta_cinetica"> coda_frusta_cinetica</label></li>
-                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="scheletro_idro_regolante"> scheletro_idro_regolante</label></li>
-              </ul>
-            </div>
-            <div data-v-13adf612="" class="trait-filter-panel__group">
-              <h4 data-v-13adf612="">Filtra tratti derivati</h4>
-              <ul data-v-13adf612="">
-                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="artigli_sette_vie"> artigli_sette_vie</label></li>
-                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="sacche_galleggianti_ascensoriali"> sacche_galleggianti_ascensoriali</label></li>
-                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="struttura_elastica_amorfa"> struttura_elastica_amorfa</label></li>
-              </ul>
+  <section data-v-966c492d="" data-v-73eb6eb5="" class="nebula-shell">
+    <div data-v-966c492d="" class="nebula-shell__frame">
+      <header data-v-966c492d="" class="nebula-shell__header">
+        <div data-v-966c492d="" class="nebula-shell__status-grid">
+          <div data-v-966c492d="" class="nebula-shell__status"><span data-v-966c492d="" class="nebula-shell__status-led" data-tone="neutral"></span>
+            <div data-v-966c492d="">
+              <p data-v-966c492d="" class="nebula-shell__status-label">Rarità</p>
+              <p data-v-966c492d="" class="nebula-shell__status-value">R1</p>
             </div>
           </div>
-        </header>
-        <ul data-v-ae611db0="" class="species-biology__trait-list" data-testid="core-traits">
-          <li data-v-ae611db0="">artigli_sette_vie</li>
-          <li data-v-ae611db0="">coda_frusta_cinetica</li>
-          <li data-v-ae611db0="">scheletro_idro_regolante</li>
-        </ul>
+          <div data-v-966c492d="" class="nebula-shell__status"><span data-v-966c492d="" class="nebula-shell__status-led" data-tone="neutral"></span>
+            <div data-v-966c492d="">
+              <p data-v-966c492d="" class="nebula-shell__status-label">Threat tier</p>
+              <p data-v-966c492d="" class="nebula-shell__status-value">T1</p>
+            </div>
+          </div>
+          <div data-v-966c492d="" class="nebula-shell__status"><span data-v-966c492d="" class="nebula-shell__status-led" data-tone="critical"></span>
+            <div data-v-966c492d="">
+              <p data-v-966c492d="" class="nebula-shell__status-label">Allineamento</p>
+              <p data-v-966c492d="" class="nebula-shell__status-value">17%</p>
+            </div>
+          </div>
+        </div>
+        <div data-v-966c492d="" class="nebula-shell__actions">
+          <div data-v-78ecd3ce="" data-v-73eb6eb5="" class="species-quick-actions"><button data-v-78ecd3ce="" type="button" class="species-quick-actions__button"> Esporta scheda </button><button data-v-78ecd3ce="" type="button" class="species-quick-actions__button species-quick-actions__button--secondary"> Salva nel pack </button></div>
+        </div>
+      </header>
+      <div data-v-966c492d="" class="nebula-shell__cards">
+        <article data-v-1960f20b="" data-v-73eb6eb5="" class="species-card">
+          <header data-v-1960f20b="" class="species-card__header">
+            <div data-v-1960f20b="">
+              <p data-v-1960f20b="" class="species-card__kicker">Profilo non definito</p>
+              <h3 data-v-1960f20b="" class="species-card__title">Predatore Snapshot / Scheletro Idro-Regolante</h3>
+            </div>
+            <div data-v-1960f20b="" class="species-card__badges"><span data-v-48844140="" data-v-1960f20b="" class="trait-chip" data-variant="core"><span data-v-48844140="" class="trait-chip__icon" aria-hidden="true">✦</span><span data-v-48844140="" class="trait-chip__label">R1</span></span><span data-v-48844140="" data-v-1960f20b="" class="trait-chip" data-variant="hazard"><span data-v-48844140="" class="trait-chip__icon" aria-hidden="true">⚡</span><span data-v-48844140="" class="trait-chip__label">T1</span></span></div>
+          </header>
+          <p data-v-1960f20b="" class="species-card__synopsis">Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante</p>
+          <section data-v-1960f20b="" class="species-card__traits" aria-label="Tratti principali">
+            <div data-v-1960f20b="">
+              <h4 data-v-1960f20b="">Core</h4>
+              <div data-v-1960f20b="" class="species-card__trait-grid"><span data-v-48844140="" data-v-1960f20b="" class="trait-chip" data-variant="core"><span data-v-48844140="" class="trait-chip__icon" aria-hidden="true">✶</span><span data-v-48844140="" class="trait-chip__label">artigli_sette_vie</span></span><span data-v-48844140="" data-v-1960f20b="" class="trait-chip" data-variant="core"><span data-v-48844140="" class="trait-chip__icon" aria-hidden="true">✶</span><span data-v-48844140="" class="trait-chip__label">coda_frusta_cinetica</span></span><span data-v-48844140="" data-v-1960f20b="" class="trait-chip" data-variant="core"><span data-v-48844140="" class="trait-chip__icon" aria-hidden="true">✶</span><span data-v-48844140="" class="trait-chip__label">scheletro_idro_regolante</span></span></div>
+            </div>
+            <div data-v-1960f20b="">
+              <h4 data-v-1960f20b="">Derivati</h4>
+              <div data-v-1960f20b="" class="species-card__trait-grid"><span data-v-48844140="" data-v-1960f20b="" class="trait-chip" data-variant="derived"><span data-v-48844140="" class="trait-chip__icon" aria-hidden="true">☲</span><span data-v-48844140="" class="trait-chip__label">artigli_sette_vie</span></span><span data-v-48844140="" data-v-1960f20b="" class="trait-chip" data-variant="derived"><span data-v-48844140="" class="trait-chip__icon" aria-hidden="true">☲</span><span data-v-48844140="" class="trait-chip__label">sacche_galleggianti_ascensoriali</span></span><span data-v-48844140="" data-v-1960f20b="" class="trait-chip" data-variant="derived"><span data-v-48844140="" class="trait-chip__icon" aria-hidden="true">☲</span><span data-v-48844140="" class="trait-chip__label">struttura_elastica_amorfa</span></span></div>
+            </div>
+            <!--v-if-->
+          </section>
+          <footer data-v-1960f20b="" class="species-card__footer">
+            <div data-v-1960f20b="" class="species-card__info-block"><span data-v-1960f20b="" class="species-card__label">Energia</span><span data-v-1960f20b="">medio</span></div>
+            <div data-v-1960f20b="" class="species-card__info-block"><span data-v-1960f20b="" class="species-card__label">Habitat</span><span data-v-1960f20b="">caverna_risonante</span></div>
+            <!--v-if-->
+          </footer>
+        </article>
       </div>
-      <div data-v-ae611db0="" class="species-biology__section">
-        <h3 data-v-ae611db0="">Tratti derivati</h3>
-        <ul data-v-ae611db0="" class="species-biology__trait-list species-biology__trait-list--derived" data-testid="derived-traits">
-          <li data-v-ae611db0="">artigli_sette_vie</li>
-          <li data-v-ae611db0="">sacche_galleggianti_ascensoriali</li>
-          <li data-v-ae611db0="">struttura_elastica_amorfa</li>
-        </ul>
+      <nav data-v-966c492d="" class="nebula-shell__tabs" aria-label="Navigazione schede"><button data-v-966c492d="" type="button" class="nebula-shell__tab"><span data-v-966c492d="" class="nebula-shell__tab-icon" aria-hidden="true">🧬</span><span data-v-966c492d="">Scheda</span></button><button data-v-966c492d="" type="button" class="nebula-shell__tab"><span data-v-966c492d="" class="nebula-shell__tab-icon" aria-hidden="true">🌿</span><span data-v-966c492d="">Biologia</span></button><button data-v-966c492d="" type="button" class="nebula-shell__tab"><span data-v-966c492d="" class="nebula-shell__tab-icon" aria-hidden="true">📡</span><span data-v-966c492d="">Telemetry</span></button><button data-v-966c492d="" type="button" class="nebula-shell__tab nebula-shell__tab--active"><span data-v-966c492d="" class="nebula-shell__tab-icon" aria-hidden="true">∞</span><span data-v-966c492d="">Sinergie</span></button></nav>
+      <div data-v-966c492d="" class="nebula-shell__content">
+        <div data-v-73eb6eb5="" class="species-panel__section species-panel__section--synergy">
+          <p data-v-73eb6eb5="" class="species-panel__empty">Nessuna sinergia registrata per questa specie.</p>
+          <section data-v-38b0498e="" data-v-73eb6eb5="" class="species-preview-grid species-panel__previews">
+            <header data-v-38b0498e="" class="species-preview-grid__header">
+              <h3 data-v-38b0498e="">Anteprime sintetiche</h3><button data-v-73eb6eb5="" type="button" class="species-panel__refresh"> Aggiorna batch </button>
+            </header>
+            <div data-v-38b0498e="" class="species-preview-grid__cards">
+              <article data-v-38b0498e="" class="species-preview-card">
+                <header data-v-38b0498e="" class="species-preview-card__header">
+                  <h4 data-v-38b0498e="">Predatore Snapshot / Scheletro Idro-Regolante</h4><span data-v-38b0498e="" class="species-preview-card__badge">T1</span>
+                </header>
+                <p data-v-38b0498e="" class="species-preview-card__summary">Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante</p>
+                <dl data-v-38b0498e="" class="species-preview-card__stats">
+                  <div data-v-38b0498e="">
+                    <dt data-v-38b0498e="">Energia</dt>
+                    <dd data-v-38b0498e="">medio</dd>
+                  </div>
+                  <div data-v-38b0498e="">
+                    <dt data-v-38b0498e="">Rarità</dt>
+                    <dd data-v-38b0498e="">R1</dd>
+                  </div>
+                </dl>
+                <p data-v-38b0498e="" class="species-preview-card__traits">artigli_sette_vie, coda_frusta_cinetica, scheletro_idro_regolante</p>
+              </article>
+              <article data-v-38b0498e="" class="species-preview-card">
+                <header data-v-38b0498e="" class="species-preview-card__header">
+                  <h4 data-v-38b0498e="">Predatore Variant / Coda a Frusta Cinetica</h4><span data-v-38b0498e="" class="species-preview-card__badge">T1</span>
+                </header>
+                <p data-v-38b0498e="" class="species-preview-card__summary">Artigli a Sette Vie, Coda a Frusta Cinetica</p>
+                <dl data-v-38b0498e="" class="species-preview-card__stats">
+                  <div data-v-38b0498e="">
+                    <dt data-v-38b0498e="">Energia</dt>
+                    <dd data-v-38b0498e="">medio</dd>
+                  </div>
+                  <div data-v-38b0498e="">
+                    <dt data-v-38b0498e="">Rarità</dt>
+                    <dd data-v-38b0498e="">R1</dd>
+                  </div>
+                </dl>
+                <p data-v-38b0498e="" class="species-preview-card__traits">artigli_sette_vie, coda_frusta_cinetica</p>
+              </article>
+            </div>
+          </section>
+        </div>
       </div>
-      <div data-v-ae611db0="" class="species-biology__section">
-        <h3 data-v-ae611db0="">Adattamenti</h3>
-        <ul data-v-ae611db0="" class="species-biology__list">
-          <li data-v-ae611db0="">Dita lunghe e segmentate con punte a uncino multiplo.</li>
-          <li data-v-ae611db0="">Precauzione: Angoli di presa limitati se la superficie è perfettamente liscia.</li>
-          <li data-v-ae611db0="">Muscolatura della coda densa con tendini e fibre che agiscono come molle.</li>
-          <li data-v-ae611db0="">Precauzione: Richiede un periodo di inattività o movimento preparatorio per massimizzare il danno.</li>
-          <li data-v-ae611db0="">Struttura ossea porosa capace di scambio rapido di fluidi.</li>
-          <li data-v-ae611db0="">Precauzione: Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio.</li>
-        </ul>
-      </div>
-      <div data-v-ae611db0="" class="species-biology__section">
-        <h3 data-v-ae611db0="">Comportamento</h3>
-        <p data-v-ae611db0="" class="species-biology__behaviour-tags">climber</p>
-        <ul data-v-ae611db0="" class="species-biology__list">
-          <li data-v-ae611db0="">Afferrare superfici irregolari o oggetti multipli.</li>
-          <li data-v-ae611db0="">Arrampicarsi su pareti rocciose o vegetazione densa.</li>
-          <li data-v-ae611db0="">Immagazzinare energia da ogni movimento per un colpo finale potente.</li>
-          <li data-v-ae611db0="">Necessità di un attacco di "sfondamento" dopo movimento preparatorio.</li>
-          <li data-v-ae611db0="">Assorbire o espellere rapidamente acqua dai tessuti ossei per modificare il peso.</li>
-          <li data-v-ae611db0="">Alternare vita terrestre e vita acquatica/aerea.</li>
-        </ul>
-      </div>
-    </section>
-    <aside data-v-73eb6eb5="" class="species-panel__sidebar">
-      <section data-v-e6469edf="" data-v-73eb6eb5="" class="species-statistics">
-        <h3 data-v-e6469edf="">Statistiche</h3>
-        <dl data-v-e6469edf="" class="species-statistics__grid">
-          <div data-v-e6469edf="" class="species-statistics__stat">
-            <dt data-v-e6469edf="">Minaccia</dt>
-            <dd data-v-e6469edf="">T1</dd>
-          </div>
-          <div data-v-e6469edf="" class="species-statistics__stat">
-            <dt data-v-e6469edf="">Rarità</dt>
-            <dd data-v-e6469edf="">R1</dd>
-          </div>
-          <div data-v-e6469edf="" class="species-statistics__stat">
-            <dt data-v-e6469edf="">Energia</dt>
-            <dd data-v-e6469edf="">medio</dd>
-          </div>
-          <div data-v-e6469edf="" class="species-statistics__stat">
-            <dt data-v-e6469edf="">Sinergia</dt>
-            <dd data-v-e6469edf="">17%</dd>
-          </div>
-        </dl>
-        <p data-v-73eb6eb5="" class="species-panel__meta">Tentativi: 1 · Fallback: no</p>
-      </section>
-      <section data-v-5b00ee54="" data-v-73eb6eb5="" class="species-timeline">
-        <h3 data-v-5b00ee54="">Revisioni validate</h3>
-        <ol data-v-5b00ee54="" class="species-timeline__list">
-          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--info">
-            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Info</strong><span data-v-5b00ee54="" class="species-timeline__code">species.schema_version.defaulted</span></header>
-            <p data-v-5b00ee54="">schema_version mancante: impostato a 1.7</p>
-          </li>
-          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--info">
-            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Info</strong><span data-v-5b00ee54="" class="species-timeline__code">species.receipt.defaulted</span></header>
-            <p data-v-5b00ee54="">receipt mancante: impostato a sorgente runtime-generator</p>
-          </li>
-          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--info">
-            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Info</strong><span data-v-5b00ee54="" class="species-timeline__code">species.role.normalized</span></header>
-            <p data-v-5b00ee54="">role_trofico normalizzato a 'evento_ecologico'</p>
-          </li>
-          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--info">
-            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Info</strong><span data-v-5b00ee54="" class="species-timeline__code">species.spawn_rules.density</span></header>
-            <p data-v-5b00ee54="">densita default impostata a moderata</p>
-          </li>
-          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--info">
-            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Info</strong><span data-v-5b00ee54="" class="species-timeline__code">species.balance.encounter_role</span></header>
-            <p data-v-5b00ee54="">encounter_role default impostato a minion</p>
-          </li>
-          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--warning">
-            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Avviso</strong><span data-v-5b00ee54="" class="species-timeline__code">species.environment_affinity.missing</span></header>
-            <p data-v-5b00ee54="">environment_affinity non presente</p>
-          </li>
-          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--warning">
-            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Avviso</strong><span data-v-5b00ee54="" class="species-timeline__code">species.derived_from_environment.missing</span></header>
-            <p data-v-5b00ee54="">derived_from_environment non presente</p>
-          </li>
-        </ol>
-      </section>
-    </aside>
-  </div>
-  <section data-v-38b0498e="" data-v-73eb6eb5="" class="species-preview-grid">
-    <header data-v-38b0498e="" class="species-preview-grid__header">
-      <h3 data-v-38b0498e="">Anteprime sintetiche</h3><button data-v-73eb6eb5="" type="button" class="species-panel__refresh"> Aggiorna batch </button>
-    </header>
-    <div data-v-38b0498e="" class="species-preview-grid__cards">
-      <article data-v-38b0498e="" class="species-preview-card">
-        <header data-v-38b0498e="" class="species-preview-card__header">
-          <h4 data-v-38b0498e="">Predatore Snapshot / Scheletro Idro-Regolante</h4><span data-v-38b0498e="" class="species-preview-card__badge">T1</span>
-        </header>
-        <p data-v-38b0498e="" class="species-preview-card__summary">Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante</p>
-        <dl data-v-38b0498e="" class="species-preview-card__stats">
-          <div data-v-38b0498e="">
-            <dt data-v-38b0498e="">Energia</dt>
-            <dd data-v-38b0498e="">medio</dd>
-          </div>
-          <div data-v-38b0498e="">
-            <dt data-v-38b0498e="">Rarità</dt>
-            <dd data-v-38b0498e="">R1</dd>
-          </div>
-        </dl>
-        <p data-v-38b0498e="" class="species-preview-card__traits">artigli_sette_vie, coda_frusta_cinetica, scheletro_idro_regolante</p>
-      </article>
-      <article data-v-38b0498e="" class="species-preview-card">
-        <header data-v-38b0498e="" class="species-preview-card__header">
-          <h4 data-v-38b0498e="">Predatore Variant / Coda a Frusta Cinetica</h4><span data-v-38b0498e="" class="species-preview-card__badge">T1</span>
-        </header>
-        <p data-v-38b0498e="" class="species-preview-card__summary">Artigli a Sette Vie, Coda a Frusta Cinetica</p>
-        <dl data-v-38b0498e="" class="species-preview-card__stats">
-          <div data-v-38b0498e="">
-            <dt data-v-38b0498e="">Energia</dt>
-            <dd data-v-38b0498e="">medio</dd>
-          </div>
-          <div data-v-38b0498e="">
-            <dt data-v-38b0498e="">Rarità</dt>
-            <dd data-v-38b0498e="">R1</dd>
-          </div>
-        </dl>
-        <p data-v-38b0498e="" class="species-preview-card__traits">artigli_sette_vie, coda_frusta_cinetica</p>
-      </article>
+      <footer data-v-966c492d="" class="nebula-shell__footer"></footer>
     </div>
   </section>
 </section>"

--- a/webapp/tests/__snapshots__/SpeciesPanel.spec.ts.snap
+++ b/webapp/tests/__snapshots__/SpeciesPanel.spec.ts.snap
@@ -2,105 +2,104 @@
 
 exports[`SpeciesPanel > renders species narrative and mechanics 1`] = `
 "<section data-v-73eb6eb5="" class="species-panel">
-  <header data-v-f805145c="" data-v-73eb6eb5="" class="species-overview">
-    <div data-v-f805145c="" class="species-overview__heading">
-      <h2 data-v-f805145c="" class="species-overview__title">Predatore / Coda a Frusta Cinetica</h2>
-      <p data-v-f805145c="" class="species-overview__summary">Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante</p>
+  <section data-v-966c492d="" data-v-73eb6eb5="" class="nebula-shell">
+    <div data-v-966c492d="" class="nebula-shell__frame">
+      <header data-v-966c492d="" class="nebula-shell__header">
+        <div data-v-966c492d="" class="nebula-shell__status-grid">
+          <div data-v-966c492d="" class="nebula-shell__status"><span data-v-966c492d="" class="nebula-shell__status-led" data-tone="neutral"></span>
+            <div data-v-966c492d="">
+              <p data-v-966c492d="" class="nebula-shell__status-label">Rarità</p>
+              <p data-v-966c492d="" class="nebula-shell__status-value">R2</p>
+            </div>
+          </div>
+          <div data-v-966c492d="" class="nebula-shell__status"><span data-v-966c492d="" class="nebula-shell__status-led" data-tone="critical"></span>
+            <div data-v-966c492d="">
+              <p data-v-966c492d="" class="nebula-shell__status-label">Threat tier</p>
+              <p data-v-966c492d="" class="nebula-shell__status-value">T3</p>
+            </div>
+          </div>
+          <div data-v-966c492d="" class="nebula-shell__status"><span data-v-966c492d="" class="nebula-shell__status-led" data-tone="critical"></span>
+            <div data-v-966c492d="">
+              <p data-v-966c492d="" class="nebula-shell__status-label">Allineamento</p>
+              <p data-v-966c492d="" class="nebula-shell__status-value">42%</p>
+            </div>
+          </div>
+        </div>
+        <div data-v-966c492d="" class="nebula-shell__actions">
+          <div data-v-78ecd3ce="" data-v-73eb6eb5="" class="species-quick-actions"><button data-v-78ecd3ce="" type="button" class="species-quick-actions__button"> Esporta scheda </button><button data-v-78ecd3ce="" type="button" class="species-quick-actions__button species-quick-actions__button--secondary"> Salva nel pack </button></div>
+        </div>
+      </header>
+      <div data-v-966c492d="" class="nebula-shell__cards">
+        <article data-v-1960f20b="" data-v-73eb6eb5="" class="species-card">
+          <header data-v-1960f20b="" class="species-card__header">
+            <div data-v-1960f20b="">
+              <p data-v-1960f20b="" class="species-card__kicker">Profilo non definito</p>
+              <h3 data-v-1960f20b="" class="species-card__title">Predatore / Coda a Frusta Cinetica</h3>
+            </div>
+            <div data-v-1960f20b="" class="species-card__badges"><span data-v-48844140="" data-v-1960f20b="" class="trait-chip" data-variant="core"><span data-v-48844140="" class="trait-chip__icon" aria-hidden="true">✦</span><span data-v-48844140="" class="trait-chip__label">R2</span></span><span data-v-48844140="" data-v-1960f20b="" class="trait-chip" data-variant="hazard"><span data-v-48844140="" class="trait-chip__icon" aria-hidden="true">⚡</span><span data-v-48844140="" class="trait-chip__label">T3</span></span></div>
+          </header>
+          <p data-v-1960f20b="" class="species-card__synopsis">Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante</p>
+          <section data-v-1960f20b="" class="species-card__traits" aria-label="Tratti principali">
+            <div data-v-1960f20b="">
+              <h4 data-v-1960f20b="">Core</h4>
+              <div data-v-1960f20b="" class="species-card__trait-grid"><span data-v-48844140="" data-v-1960f20b="" class="trait-chip" data-variant="core"><span data-v-48844140="" class="trait-chip__icon" aria-hidden="true">✶</span><span data-v-48844140="" class="trait-chip__label">Artigli a Sette Vie</span></span><span data-v-48844140="" data-v-1960f20b="" class="trait-chip" data-variant="core"><span data-v-48844140="" class="trait-chip__icon" aria-hidden="true">✶</span><span data-v-48844140="" class="trait-chip__label">Coda a Frusta Cinetica</span></span><span data-v-48844140="" data-v-1960f20b="" class="trait-chip" data-variant="core"><span data-v-48844140="" class="trait-chip__icon" aria-hidden="true">✶</span><span data-v-48844140="" class="trait-chip__label">Scheletro Idro-Regolante</span></span></div>
+            </div>
+            <div data-v-1960f20b="">
+              <h4 data-v-1960f20b="">Derivati</h4>
+              <div data-v-1960f20b="" class="species-card__trait-grid"><span data-v-48844140="" data-v-1960f20b="" class="trait-chip" data-variant="derived"><span data-v-48844140="" class="trait-chip__icon" aria-hidden="true">☲</span><span data-v-48844140="" class="trait-chip__label">struttura_elastica_amorfa</span></span><span data-v-48844140="" data-v-1960f20b="" class="trait-chip" data-variant="derived"><span data-v-48844140="" class="trait-chip__icon" aria-hidden="true">☲</span><span data-v-48844140="" class="trait-chip__label">sacche_galleggianti_ascensoriali</span></span></div>
+            </div>
+            <!--v-if-->
+          </section>
+          <footer data-v-1960f20b="" class="species-card__footer">
+            <div data-v-1960f20b="" class="species-card__info-block"><span data-v-1960f20b="" class="species-card__label">Energia</span><span data-v-1960f20b="">medio</span></div>
+            <div data-v-1960f20b="" class="species-card__info-block"><span data-v-1960f20b="" class="species-card__label">Habitat</span><span data-v-1960f20b=""></span></div>
+            <!--v-if-->
+          </footer>
+        </article>
+      </div>
+      <nav data-v-966c492d="" class="nebula-shell__tabs" aria-label="Navigazione schede"><button data-v-966c492d="" type="button" class="nebula-shell__tab"><span data-v-966c492d="" class="nebula-shell__tab-icon" aria-hidden="true">🧬</span><span data-v-966c492d="">Scheda</span></button><button data-v-966c492d="" type="button" class="nebula-shell__tab"><span data-v-966c492d="" class="nebula-shell__tab-icon" aria-hidden="true">🌿</span><span data-v-966c492d="">Biologia</span></button><button data-v-966c492d="" type="button" class="nebula-shell__tab nebula-shell__tab--active"><span data-v-966c492d="" class="nebula-shell__tab-icon" aria-hidden="true">📡</span><span data-v-966c492d="">Telemetry</span></button><button data-v-966c492d="" type="button" class="nebula-shell__tab"><span data-v-966c492d="" class="nebula-shell__tab-icon" aria-hidden="true">∞</span><span data-v-966c492d="">Sinergie</span></button></nav>
+      <div data-v-966c492d="" class="nebula-shell__content">
+        <div data-v-73eb6eb5="" class="species-panel__section species-panel__section--columns">
+          <section data-v-e6469edf="" data-v-73eb6eb5="" class="species-statistics">
+            <h3 data-v-e6469edf="">Statistiche</h3>
+            <dl data-v-e6469edf="" class="species-statistics__grid">
+              <div data-v-e6469edf="" class="species-statistics__stat">
+                <dt data-v-e6469edf="">Minaccia</dt>
+                <dd data-v-e6469edf="">T3</dd>
+              </div>
+              <div data-v-e6469edf="" class="species-statistics__stat">
+                <dt data-v-e6469edf="">Rarità</dt>
+                <dd data-v-e6469edf="">R2</dd>
+              </div>
+              <div data-v-e6469edf="" class="species-statistics__stat">
+                <dt data-v-e6469edf="">Energia</dt>
+                <dd data-v-e6469edf="">medio</dd>
+              </div>
+              <div data-v-e6469edf="" class="species-statistics__stat">
+                <dt data-v-e6469edf="">Sinergia</dt>
+                <dd data-v-e6469edf="">42%</dd>
+              </div>
+            </dl>
+          </section>
+          <section data-v-5b00ee54="" data-v-73eb6eb5="" class="species-timeline">
+            <h3 data-v-5b00ee54="">Revisioni validate</h3>
+            <ol data-v-5b00ee54="" class="species-timeline__list">
+              <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--info">
+                <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Info</strong><span data-v-5b00ee54="" class="species-timeline__code">species.schema_version.defaulted</span></header>
+                <p data-v-5b00ee54="">schema_version mancante</p>
+              </li>
+              <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--warning">
+                <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Avviso</strong><span data-v-5b00ee54="" class="species-timeline__code">species.environment_affinity.missing</span></header>
+                <p data-v-5b00ee54="">environment_affinity non presente</p>
+              </li>
+            </ol>
+          </section>
+          <!--v-if-->
+          <!--v-if-->
+        </div>
+      </div>
+      <footer data-v-966c492d="" class="nebula-shell__footer"></footer>
     </div>
-    <p data-v-f805145c="" class="species-overview__description">Sintesi genetica focalizzata su Artigli a Sette Vie e Coda a Frusta Cinetica con impronta morfologica defensive, locomotor, omeostatico, prehensile, structural; comportamento climber. Ottimizzata per biomi: caverna_risonante.</p>
-    <div data-v-78ecd3ce="" data-v-73eb6eb5="" class="species-quick-actions"><button data-v-78ecd3ce="" type="button" class="species-quick-actions__button"> Esporta scheda </button><button data-v-78ecd3ce="" type="button" class="species-quick-actions__button species-quick-actions__button--secondary"> Salva nel pack </button></div>
-  </header>
-  <div data-v-73eb6eb5="" class="species-panel__layout">
-    <section data-v-ae611db0="" data-v-73eb6eb5="" class="species-biology">
-      <div data-v-ae611db0="" class="species-biology__section">
-        <header data-v-ae611db0="" class="species-biology__header">
-          <h3 data-v-ae611db0="">Tratti fondamentali</h3>
-          <div data-v-13adf612="" data-v-73eb6eb5="" class="trait-filter-panel">
-            <div data-v-13adf612="" class="trait-filter-panel__group">
-              <h4 data-v-13adf612="">Filtra tratti core</h4>
-              <ul data-v-13adf612="">
-                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="Artigli a Sette Vie"> Artigli a Sette Vie</label></li>
-                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="Coda a Frusta Cinetica"> Coda a Frusta Cinetica</label></li>
-                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="Scheletro Idro-Regolante"> Scheletro Idro-Regolante</label></li>
-              </ul>
-            </div>
-            <div data-v-13adf612="" class="trait-filter-panel__group">
-              <h4 data-v-13adf612="">Filtra tratti derivati</h4>
-              <ul data-v-13adf612="">
-                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="struttura_elastica_amorfa"> struttura_elastica_amorfa</label></li>
-                <li data-v-13adf612=""><label data-v-13adf612=""><input data-v-13adf612="" type="checkbox" checked="" value="sacche_galleggianti_ascensoriali"> sacche_galleggianti_ascensoriali</label></li>
-              </ul>
-            </div>
-          </div>
-        </header>
-        <ul data-v-ae611db0="" class="species-biology__trait-list" data-testid="core-traits">
-          <li data-v-ae611db0="">Artigli a Sette Vie</li>
-          <li data-v-ae611db0="">Coda a Frusta Cinetica</li>
-          <li data-v-ae611db0="">Scheletro Idro-Regolante</li>
-        </ul>
-      </div>
-      <div data-v-ae611db0="" class="species-biology__section">
-        <h3 data-v-ae611db0="">Tratti derivati</h3>
-        <ul data-v-ae611db0="" class="species-biology__trait-list species-biology__trait-list--derived" data-testid="derived-traits">
-          <li data-v-ae611db0="">struttura_elastica_amorfa</li>
-          <li data-v-ae611db0="">sacche_galleggianti_ascensoriali</li>
-        </ul>
-      </div>
-      <div data-v-ae611db0="" class="species-biology__section">
-        <h3 data-v-ae611db0="">Adattamenti</h3>
-        <ul data-v-ae611db0="" class="species-biology__list">
-          <li data-v-ae611db0="">Dita lunghe</li>
-          <li data-v-ae611db0="">Precauzione: vulnerabile ai veleni</li>
-        </ul>
-      </div>
-      <div data-v-ae611db0="" class="species-biology__section">
-        <h3 data-v-ae611db0="">Comportamento</h3>
-        <p data-v-ae611db0="" class="species-biology__behaviour-tags">climber</p>
-        <!--v-if-->
-      </div>
-    </section>
-    <aside data-v-73eb6eb5="" class="species-panel__sidebar">
-      <section data-v-e6469edf="" data-v-73eb6eb5="" class="species-statistics">
-        <h3 data-v-e6469edf="">Statistiche</h3>
-        <dl data-v-e6469edf="" class="species-statistics__grid">
-          <div data-v-e6469edf="" class="species-statistics__stat">
-            <dt data-v-e6469edf="">Minaccia</dt>
-            <dd data-v-e6469edf="">T3</dd>
-          </div>
-          <div data-v-e6469edf="" class="species-statistics__stat">
-            <dt data-v-e6469edf="">Rarità</dt>
-            <dd data-v-e6469edf="">R2</dd>
-          </div>
-          <div data-v-e6469edf="" class="species-statistics__stat">
-            <dt data-v-e6469edf="">Energia</dt>
-            <dd data-v-e6469edf="">medio</dd>
-          </div>
-          <div data-v-e6469edf="" class="species-statistics__stat">
-            <dt data-v-e6469edf="">Sinergia</dt>
-            <dd data-v-e6469edf="">42%</dd>
-          </div>
-        </dl>
-      </section>
-      <section data-v-5b00ee54="" data-v-73eb6eb5="" class="species-timeline">
-        <h3 data-v-5b00ee54="">Revisioni validate</h3>
-        <ol data-v-5b00ee54="" class="species-timeline__list">
-          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--info">
-            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Info</strong><span data-v-5b00ee54="" class="species-timeline__code">species.schema_version.defaulted</span></header>
-            <p data-v-5b00ee54="">schema_version mancante</p>
-          </li>
-          <li data-v-5b00ee54="" class="species-timeline__entry species-timeline__entry--warning">
-            <header data-v-5b00ee54=""><strong data-v-5b00ee54="">Avviso</strong><span data-v-5b00ee54="" class="species-timeline__code">species.environment_affinity.missing</span></header>
-            <p data-v-5b00ee54="">environment_affinity non presente</p>
-          </li>
-        </ol>
-      </section>
-    </aside>
-  </div>
-  <section data-v-38b0498e="" data-v-73eb6eb5="" class="species-preview-grid">
-    <header data-v-38b0498e="" class="species-preview-grid__header">
-      <h3 data-v-38b0498e="">Anteprime sintetiche</h3><button data-v-73eb6eb5="" type="button" class="species-panel__refresh"> Aggiorna batch </button>
-    </header>
-    <p data-v-38b0498e="" class="species-preview-grid__empty">Nessuna anteprima disponibile.</p>
   </section>
 </section>"
 `;


### PR DESCRIPTION
## Summary
- introduce a reusable NebulaShell layout plus species and biome cards with synergy flipping
- rework the biomes and biome setup workflows to share trait chips and new cards
- wire the atlas layout to a collection progress tracker with sprite previews from atlasDataset
- update species flow tests to follow the tabbed navigation

## Testing
- npm test -- -u

------
https://chatgpt.com/codex/tasks/task_e_6902d16c8b1c8332b555a88b08be3d22