### PR TITLE
Add root ecosystem definitions and hazard registry

### DIFF
--- a/data/ecosystems/badlands.ecosystem.yaml
+++ b/data/ecosystems/badlands.ecosystem.yaml
@@ -1,0 +1,59 @@
+schema_version: 1.0
+receipt:
+  source: PTPF.v1.0
+  author: designer
+  date: '2025-10-25'
+  trace_hash: to-fill
+ecosistema:
+  id: BADLANDS
+  label: Brulle Terre Ferrose
+  biome_id: badlands
+  clima:
+    temperatura_C:
+      media_annua: 14.5
+      min_mese_piu_freddo: -8.0
+      max_mese_piu_caldo: 39.5
+    precipitazioni_mm:
+      totale_annuo: 180
+      indice_stagionalita: estivo-debole
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 20.95
+      Ar: 0.93
+      CO2: 0.045
+  abiotico:
+    salinita: salina interna
+    nutrienti:
+      N: basso
+      P: medio
+      K: alto
+  trofico:
+    produttori:
+    - arbusti_xerofili
+    - crostoni_criptofite
+    - cianobatteri
+    consumatori:
+      primari:
+      - sand-burrower
+      - rust-scavenger
+      secondari:
+      - ferrocolonia-magnetotattica
+      - echo-wing
+      terziari:
+      - dune-stalker
+    decompositori:
+    - nano-rust-bloom
+    - evento-tempesta-ferrosa
+  note: Ecosistema desertico magnetizzato con pulse detritici stagionali.
+links:
+  species_dir: packs/evo_tactics_pack/data/species/badlands
+  foodweb: packs/evo_tactics_pack/data/foodwebs/badlands_foodweb.yaml
+rules:
+  at_least:
+    sentient: 1
+    apex: 1
+    keystone: 2
+    bridge: 1
+    threat: 1
+    event: 1

--- a/data/ecosystems/cryosteppe.ecosystem.yaml
+++ b/data/ecosystems/cryosteppe.ecosystem.yaml
@@ -1,0 +1,55 @@
+schema_version: 1.0
+receipt:
+  source: PTPF.v1.0
+  author: designer
+  date: '2025-10-25'
+  trace_hash: to-fill
+ecosistema:
+  id: CRYOSTEPPE
+  label: Cryosteppe Magnetica
+  biome_id: cryosteppe
+  clima:
+    temperatura_C:
+      media_annua: -5.5
+      min_mese_piu_freddo: -32.0
+      max_mese_piu_caldo: 12.5
+    precipitazioni_mm:
+      totale_annuo: 240
+      indice_stagionalita: invernale
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 20.95
+      Ar: 0.93
+      CO2: 0.035
+  abiotico:
+    salinita: brackish
+    nutrienti:
+      N: medio
+      P: medio
+      K: alto
+  trofico:
+    produttori:
+    - licheni_termocromici
+    - muschi_permafrost
+    - alghe_cryofile
+    consumatori:
+      primari:
+      - steppe-bison-mini
+      - aurora-gull
+      secondari:
+      - cryo-lynx
+    decompositori:
+    - thaw-rot
+    - biofilm_criogenico
+  note: Steppe criogenica con gradienti termici magnetici e ponti stagionali di ghiaccio.
+links:
+  species_dir: packs/evo_tactics_pack/data/species/cryosteppe
+  foodweb: packs/evo_tactics_pack/data/foodwebs/cryosteppe_foodweb.yaml
+rules:
+  at_least:
+    apex: 1
+    keystone: 1
+    bridge: 1
+    threat: 1
+    event: 1

--- a/data/ecosystems/deserto_caldo.ecosystem.yaml
+++ b/data/ecosystems/deserto_caldo.ecosystem.yaml
@@ -1,0 +1,58 @@
+schema_version: 1.0
+receipt:
+  source: PTPF.v1.0
+  author: designer
+  date: '2025-10-25'
+  trace_hash: to-fill
+ecosistema:
+  id: DESERTO_CALDO
+  label: Deserto Caldo Vetrificato
+  biome_id: deserto_caldo
+  clima:
+    temperatura_C:
+      media_annua: 32.0
+      min_mese_piu_freddo: 18.0
+      max_mese_piu_caldo: 48.0
+    precipitazioni_mm:
+      totale_annuo: 95
+      indice_stagionalita: estivo
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 20.95
+      Ar: 0.93
+      CO2: 0.03
+  abiotico:
+    salinita: salina interna
+    nutrienti:
+      N: basso
+      P: basso
+      K: medio
+  trofico:
+    produttori:
+    - cactus-weaver
+    - cianobatteri_dune
+    - arbusti_pioneer
+    consumatori:
+      primari:
+      - silica-bloom
+      - arbusti_pioneer_detritivori
+      secondari:
+      - noctule-termico
+      terziari:
+      - thermo-raptor
+    decompositori:
+    - evento-ondata-termica
+    - biofilm_termico
+  note: Deserto iper-arido con lenti magnetiche sotterranee e trasporto di polveri
+    ionizzate.
+links:
+  species_dir: packs/evo_tactics_pack/data/species/deserto_caldo
+  foodweb: packs/evo_tactics_pack/data/foodwebs/deserto_caldo_foodweb.yaml
+rules:
+  at_least:
+    apex: 1
+    keystone: 1
+    bridge: 1
+    threat: 1
+    event: 1

--- a/data/ecosystems/foresta_temperata.ecosystem.yaml
+++ b/data/ecosystems/foresta_temperata.ecosystem.yaml
@@ -1,0 +1,59 @@
+schema_version: 1.0
+receipt:
+  source: PTPF.v1.0
+  author: designer
+  date: '2025-10-25'
+  trace_hash: to-fill
+ecosistema:
+  id: FORESTA_TEMPERATA
+  label: Foresta Temperata Demo
+  biome_id: foresta_temperata
+  clima:
+    temperatura_C:
+      media_annua: 11.2
+      min_mese_piu_freddo: -4.1
+      max_mese_piu_caldo: 27.5
+    precipitazioni_mm:
+      totale_annuo: 950
+      indice_stagionalita: invernale
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 20.95
+      Ar: 0.93
+      CO2: 0.041
+  abiotico:
+    salinita: dolce
+    nutrienti:
+      N: medio
+      P: medio
+      K: medio
+  trofico:
+    produttori:
+    - piante_superiori
+    - alghe
+    - cianobatteri
+    consumatori:
+      primari:
+      - cervidi_erborivori
+      - impollinatori_misti
+      secondari:
+      - lupus-temperatus
+      terziari:
+      - sentinella-radice
+    decompositori:
+    - funghi_micotici
+    - biofilm_detritico
+  note: Ecosistema temperato montano con corridoi fluviali e cicli detritici marcati.
+links:
+  species_dir: packs/evo_tactics_pack/data/species/foresta_temperata
+  foodweb: packs/evo_tactics_pack/data/foodwebs/foresta_temperata_foodweb.yaml
+  npg_dir: packs/evo_tactics_pack/data/npg
+rules:
+  at_least:
+    sentient: 1
+    apex: 1
+    keystone: 2
+    bridge: 1
+    threat: 1
+    event: 1

--- a/tools/config/registries/hazards.yaml
+++ b/tools/config/registries/hazards.yaml
@@ -1,0 +1,96 @@
+schema_version: '1.0'
+hazards:
+- id: vento_forte
+  requires_any_of:
+  - build_cover
+  - guard_stance
+- id: pioggia_torpida
+  requires_any_of:
+  - ignore_fog_penalty
+  - reveal_hidden_radius
+- id: pendenze_instabili
+  requires_any_of:
+  - jump_bonus
+  - pathing_bonus
+- id: whiteout
+  requires_any_of:
+  - ignore_fog_penalty
+  - reveal_hidden_radius
+- id: ghiaccio_sottile
+  requires_any_of:
+  - landing_on_ice
+  - jump_bonus
+- id: tempeste_sabbia
+  requires_any_of:
+  - eye_protection
+  - ignore_fog_penalty
+- id: iron_shards
+  requires_any_of:
+  - dr_impact_cap
+  - build_cover
+  effect: 'schegge ferrose: danno su corsa senza protezione'
+- id: magnetic_patches
+  requires_any_of:
+  - non_metal_gear
+  - seal_vents
+  effect: 'campi magnetici irregolari: penalità a gear metallico'
+- id: shock_termici
+  requires_any_of:
+  - thermal_buffering
+  - res_heat
+  - res_cold
+  effect: sbalzi estremi caldo/freddo che stressano strutture e fluidi
+- id: geiser_criogenici
+  requires_any_of:
+  - pressure_tolerance
+  - cryogenic_shell
+  - geothermal_anchor
+  effect: getti criogenici pressurizzati che congelano e scagliano in aria
+- id: piogge_acide
+  requires_any_of:
+  - res_acid
+  - detox_cycle
+  - corrosion_shell
+  effect: precipitazioni caustiche che dissolvono carapaci e filtri
+- id: aerosol_solfurei
+  requires_any_of:
+  - respiratory_filters
+  - detox_cycle
+  - sealed_respirators
+  effect: nebbie sulfuree irritanti e corrosive per apparati respiratori
+- id: tempeste_salate
+  requires_any_of:
+  - res_salt
+  - sealed_membranes
+  - moisture_harvest
+  effect: sabbie saline abrasive che estraggono acqua dai tessuti
+- id: miraggi_termici
+  requires_any_of:
+  - thermal_navigation
+  - heat_sense
+  - polarized_vision
+  effect: gradienti termici distorcenti che confondono percezione e traiettorie
+- id: fulmini_perpetui
+  requires_any_of:
+  - res_electric
+  - faraday_carapace
+  - lightning_sense
+  effect: scariche costanti e correnti ascendenti che fulminano lenti conduttivi
+- id: shearing_winds
+  requires_any_of:
+  - stability_thrusters
+  - wind_sense
+  - anchor_claws
+  effect: venti a forbice che destabilizzano volo e arrampicata
+- id: sfiati_sulfurei
+  requires_any_of:
+  - res_acid
+  - pressure_tolerance
+  - detox_cycle
+  effect: sfiati supercaldi saturi di zolfo e metalli pesanti
+- id: frane_abissali
+  requires_any_of:
+  - anchor_clamps
+  - seismic_sense
+  - pressure_tolerance
+  effect: crolli sottomarini improvvisi con onde d'urto e detrito


### PR DESCRIPTION
## Summary
- add the missing ecosystem definition files to the repository root so validators that expect Game/data paths resolve correctly
- expose the hazard registry alongside the other tooling configs to satisfy biome validation rules

## Testing
- python packs/evo_tactics_pack/tools/py/validate_ecosistema_v2_0.py packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
- python packs/evo_tactics_pack/tools/py/validate_cross_foodweb_v1_0.py packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
- python packs/evo_tactics_pack/tools/py/validate_bioma_v1_1.py packs/evo_tactics_pack/data/ecosystems/badlands.biome.yaml packs/evo_tactics_pack/tools/config/validator_config.yaml tools/config/registries

------
https://chatgpt.com/codex/tasks/task_e_6902d5d7cb94833291116b97c75b3b0a