### PR TITLE
Add trait diagnostics sync pipeline and QA surfacing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,9 +185,23 @@ jobs:
       - name: Audit trait catalog consistency
         run: python3 scripts/trait_audit.py --check
 
-      - name: Enforce trait coverage baseline
+      - name: Regenerate trait baseline
         run: |
-          python3 tools/py/report_trait_coverage.py --species-root packs/evo_tactics_pack/data/species --out-csv data/derived/analysis/trait_coverage_matrix.csv
+          python3 tools/py/build_trait_baseline.py \
+            packs/evo_tactics_pack/docs/catalog/env_traits.json \
+            packs/evo_tactics_pack/docs/catalog/trait_reference.json \
+            --trait-glossary data/core/traits/glossary.json \
+            --out data/derived/analysis/trait_baseline.yaml
+
+      - name: Regenerate trait coverage reports
+        run: |
+          python3 tools/py/report_trait_coverage.py \
+            --env-traits packs/evo_tactics_pack/docs/catalog/env_traits.json \
+            --trait-reference packs/evo_tactics_pack/docs/catalog/trait_reference.json \
+            --species-root packs/evo_tactics_pack/data/species \
+            --trait-glossary data/core/traits/glossary.json \
+            --out-json data/derived/analysis/trait_coverage_report.json \
+            --out-csv data/derived/analysis/trait_coverage_matrix.csv
           python3 - <<'PY'
           import json, sys
 

--- a/.github/workflows/deploy-test-interface.yml
+++ b/.github/workflows/deploy-test-interface.yml
@@ -54,6 +54,24 @@ jobs:
       - name: Audit trait catalog consistency
         run: python3 scripts/trait_audit.py --check
 
+      - name: Regenerate trait baseline
+        run: |
+          python3 tools/py/build_trait_baseline.py \
+            packs/evo_tactics_pack/docs/catalog/env_traits.json \
+            packs/evo_tactics_pack/docs/catalog/trait_reference.json \
+            --trait-glossary data/core/traits/glossary.json \
+            --out data/derived/analysis/trait_baseline.yaml
+
+      - name: Regenerate trait coverage reports
+        run: |
+          python3 tools/py/report_trait_coverage.py \
+            --env-traits packs/evo_tactics_pack/docs/catalog/env_traits.json \
+            --trait-reference packs/evo_tactics_pack/docs/catalog/trait_reference.json \
+            --species-root packs/evo_tactics_pack/data/species \
+            --trait-glossary data/core/traits/glossary.json \
+            --out-json data/derived/analysis/trait_coverage_report.json \
+            --out-csv data/derived/analysis/trait_coverage_matrix.csv
+
       - name: Run deploy validation checks
         env:
           DEPLOY_DATA_DIR: ${{ github.workspace }}/data

--- a/server/app.js
+++ b/server/app.js
@@ -6,6 +6,7 @@ const { buildCodexReport } = require('./report');
 const { createBiomeSynthesizer } = require('../services/generation/biomeSynthesizer');
 const { createRuntimeValidator } = require('../services/generation/runtimeValidator');
 const { createGenerationOrchestratorBridge } = require('../services/generation/orchestratorBridge');
+const { createTraitDiagnosticsSync } = require('./traitDiagnostics');
 const ideaTaxonomy = require('../config/idea_engine_taxonomy.json');
 const slugTaxonomy = require('../docs/public/idea-taxonomy.json');
 
@@ -220,6 +221,12 @@ function createApp(options = {}) {
   const generationOrchestrator =
     options.generationOrchestrator ||
     createGenerationOrchestratorBridge(options.orchestratorOptions || {});
+  const traitDiagnosticsSync =
+    options.traitDiagnosticsSync ||
+    createTraitDiagnosticsSync({
+      orchestrator: generationOrchestrator,
+      suppressErrors: true,
+    });
   const app = express();
 
   app.use(cors({ origin: options.corsOrigin || '*' }));
@@ -231,8 +238,36 @@ function createApp(options = {}) {
     });
   }
 
+  traitDiagnosticsSync.load().catch((error) => {
+    console.warn('[trait-diagnostics] preload fallito', error);
+  });
+
   app.get('/api/health', (req, res) => {
     res.json({ status: 'ok', service: 'idea-engine' });
+  });
+
+  app.get('/api/traits/diagnostics', async (req, res) => {
+    const refresh = String(req.query.refresh || '').toLowerCase();
+    const shouldRefresh = refresh === 'true' || refresh === '1';
+    try {
+      if (shouldRefresh) {
+        await traitDiagnosticsSync.load();
+      } else {
+        await traitDiagnosticsSync.ensureLoaded();
+      }
+      const diagnostics = traitDiagnosticsSync.getDiagnostics() || {};
+      const status = traitDiagnosticsSync.getStatus();
+      res.json({
+        diagnostics,
+        meta: {
+          fetched_at: status.fetchedAt,
+          loading: Boolean(status.loading),
+          error: status.error,
+        },
+      });
+    } catch (error) {
+      res.status(500).json({ error: error.message || 'Errore diagnostica tratti' });
+    }
   });
 
   app.get('/api/ideas', async (req, res) => {

--- a/server/traitDiagnostics.js
+++ b/server/traitDiagnostics.js
@@ -1,0 +1,74 @@
+const DEFAULT_STATUS = {
+  fetchedAt: null,
+  error: null,
+};
+
+function createTraitDiagnosticsSync(options = {}) {
+  const orchestrator = options.orchestrator;
+  if (!orchestrator || typeof orchestrator.fetchTraitDiagnostics !== 'function') {
+    throw new Error('Trait diagnostics orchestrator mancante');
+  }
+
+  let cache = null;
+  let status = { ...DEFAULT_STATUS };
+  let loadingPromise = null;
+
+  async function load() {
+    if (loadingPromise) {
+      return loadingPromise;
+    }
+    loadingPromise = orchestrator
+      .fetchTraitDiagnostics()
+      .then((payload) => {
+        const diagnostics = payload?.diagnostics || payload || {};
+        cache = diagnostics;
+        status = {
+          fetchedAt: new Date().toISOString(),
+          error: null,
+        };
+        return diagnostics;
+      })
+      .catch((error) => {
+        status = {
+          fetchedAt: status.fetchedAt,
+          error: error instanceof Error ? error.message : String(error),
+        };
+        throw error;
+      })
+      .finally(() => {
+        loadingPromise = null;
+      });
+    return loadingPromise;
+  }
+
+  async function ensureLoaded() {
+    if (cache) {
+      return cache;
+    }
+    try {
+      return await load();
+    } catch (error) {
+      if (options.suppressErrors) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  function getDiagnostics() {
+    return cache;
+  }
+
+  function getStatus() {
+    return { ...status, loading: Boolean(loadingPromise) };
+  }
+
+  return {
+    load,
+    ensureLoaded,
+    getDiagnostics,
+    getStatus,
+  };
+}
+
+module.exports = { createTraitDiagnosticsSync };

--- a/services/generation/orchestrator.py
+++ b/services/generation/orchestrator.py
@@ -30,6 +30,7 @@ from services.generation.species_builder import (  # noqa: E402
     PathfinderProfileTranslator,
     SpeciesBuilder,
     TraitCatalog,
+    build_trait_diagnostics,
 )
 
 
@@ -458,7 +459,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument(
         "--action",
         required=True,
-        choices=["generate-species", "generate-species-batch"],
+        choices=["generate-species", "generate-species-batch", "trait-diagnostics"],
     )
     parser.add_argument("--input", type=Path, default=None)
     parser.add_argument("--output", type=Path, default=None)
@@ -480,6 +481,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             batch = SpeciesBatchRequest.from_payload(payload)
             result = orchestrator.generate_species_batch(batch.entries)
             _write_output_payload(args.output, result.to_payload())
+            return 0
+        if args.action == "trait-diagnostics":
+            diagnostics = build_trait_diagnostics()
+            _write_output_payload(args.output, diagnostics)
             return 0
     except GenerationError as error:
         logging.getLogger(__name__).error(

--- a/services/generation/orchestratorBridge.js
+++ b/services/generation/orchestratorBridge.js
@@ -99,9 +99,19 @@ function createGenerationOrchestratorBridge(options = {}) {
     });
   }
 
+  async function fetchTraitDiagnostics() {
+    return invokePython({
+      pythonExecutable,
+      scriptPath,
+      action: 'trait-diagnostics',
+      payload: {},
+    });
+  }
+
   return {
     generateSpecies,
     generateSpeciesBatch,
+    fetchTraitDiagnostics,
   };
 }
 

--- a/tests/api/trait-diagnostics.test.js
+++ b/tests/api/trait-diagnostics.test.js
@@ -1,0 +1,65 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../server/app');
+
+function createStubTraitDiagnostics(data) {
+  const diagnostics = data;
+  let loadCalls = 0;
+  return {
+    load: () => {
+      loadCalls += 1;
+      return Promise.resolve(diagnostics);
+    },
+    ensureLoaded: () => Promise.resolve(diagnostics),
+    getDiagnostics: () => diagnostics,
+    getStatus: () => ({ fetchedAt: '2025-01-01T00:00:00Z', loading: false, error: null }),
+    get loadCalls() {
+      return loadCalls;
+    },
+  };
+}
+
+test('GET /api/traits/diagnostics espone coverage e conflitti', async () => {
+  const payload = {
+    summary: {
+      total_traits: 5,
+      glossary_ok: 4,
+      matrix_mismatch: 1,
+      with_conflicts: 2,
+    },
+    traits: [
+      {
+        id: 'artigli_sette_vie',
+        label: 'Artigli a Sette Vie',
+        coverage: { core: 2, optional: 1, synergy: 0 },
+        statuses: { glossary: 'ok', matrix: 'ok' },
+        conflicts: ['rete_neurale_ibrida'],
+        synergies: ['coda_frusta_cinetica'],
+      },
+    ],
+  };
+
+  const stubDiagnostics = createStubTraitDiagnostics(payload);
+  const orchestrator = {
+    generateSpecies: async () => ({ blueprint: {}, validation: {}, meta: {} }),
+    generateSpeciesBatch: async () => ({ results: [], errors: [] }),
+  };
+
+  const { app } = createApp({
+    generationOrchestrator: orchestrator,
+    traitDiagnosticsSync: stubDiagnostics,
+  });
+
+  const response = await request(app)
+    .get('/api/traits/diagnostics')
+    .expect(200);
+
+  assert.deepEqual(response.body.diagnostics.summary, payload.summary);
+  assert.equal(response.body.diagnostics.traits.length, 1);
+  assert.equal(response.body.meta.fetched_at, '2025-01-01T00:00:00Z');
+  assert.equal(stubDiagnostics.loadCalls, 1, 'la prima richiesta usa il payload precaricato');
+
+  await request(app).get('/api/traits/diagnostics?refresh=true').expect(200);
+  assert.equal(stubDiagnostics.loadCalls, 2, 'refresh forza la rigenerazione');
+});

--- a/tests/test_species_builder.py
+++ b/tests/test_species_builder.py
@@ -3,6 +3,7 @@ import unittest
 from pathlib import Path
 
 from services.generation.species_builder import SpeciesBuilder, TraitCatalog
+from services.generation.species_builder import build_trait_diagnostics
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SNAPSHOT_PATH = REPO_ROOT / "tests" / "snapshots" / "species_builder_predatore.json"
@@ -32,6 +33,14 @@ class SpeciesBuilderTests(unittest.TestCase):
         )
         snapshot = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
         self.assertDictEqual(profile, snapshot)
+
+    def test_trait_diagnostics_summary(self) -> None:
+        diagnostics = build_trait_diagnostics()
+        self.assertIn("summary", diagnostics)
+        summary = diagnostics["summary"]
+        self.assertGreater(summary.get("total_traits", 0), 0)
+        self.assertIn("traits", diagnostics)
+        self.assertIsInstance(diagnostics["traits"], list)
 
 
 if __name__ == "__main__":  # pragma: no cover - esecuzione manuale

--- a/webapp/src/components/species/SpeciesBiology.vue
+++ b/webapp/src/components/species/SpeciesBiology.vue
@@ -8,6 +8,7 @@
       <ul class="species-biology__trait-list" data-testid="core-traits">
         <li v-for="trait in coreTraits" :key="trait">{{ trait }}</li>
       </ul>
+      <slot name="synergy-suggestions"></slot>
     </div>
 
     <div v-if="derivedTraits.length" class="species-biology__section">

--- a/webapp/src/components/species/TraitFilterPanel.vue
+++ b/webapp/src/components/species/TraitFilterPanel.vue
@@ -4,9 +4,9 @@
       <h4>Filtra tratti core</h4>
       <ul>
         <li v-for="trait in coreOptions" :key="trait">
-          <label>
+          <label :class="{ 'trait-filter-panel__option--highlight': highlightSet.has(trait) }">
             <input type="checkbox" :value="trait" :checked="model.core.includes(trait)" @change="toggleTrait('core', trait, $event)" />
-            {{ trait }}
+            {{ formatLabel(trait) }}
           </label>
         </li>
       </ul>
@@ -15,14 +15,14 @@
       <h4>Filtra tratti derivati</h4>
       <ul>
         <li v-for="trait in derivedOptions" :key="trait">
-          <label>
+          <label :class="{ 'trait-filter-panel__option--highlight': highlightSet.has(trait) }">
             <input
               type="checkbox"
               :value="trait"
               :checked="model.derived.includes(trait)"
               @change="toggleTrait('derived', trait, $event)"
             />
-            {{ trait }}
+            {{ formatLabel(trait) }}
           </label>
         </li>
       </ul>
@@ -42,6 +42,14 @@ const props = defineProps({
     type: Array,
     default: () => [],
   },
+  labels: {
+    type: Object,
+    default: () => ({}),
+  },
+  highlight: {
+    type: Array,
+    default: () => [],
+  },
   modelValue: {
     type: Object,
     default: () => ({ core: [], derived: [] }),
@@ -49,6 +57,9 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['update:modelValue']);
+
+const labelMap = computed(() => props.labels || {});
+const highlightSet = computed(() => new Set(props.highlight || []));
 
 const model = computed({
   get() {
@@ -61,6 +72,17 @@ const model = computed({
     emit('update:modelValue', value);
   },
 });
+
+function formatLabel(trait) {
+  if (!trait) {
+    return '';
+  }
+  const label = labelMap.value?.[trait];
+  if (label && label !== trait) {
+    return `${trait} · ${label}`;
+  }
+  return trait;
+}
 
 function toggleTrait(bucket, trait, event) {
   const checked = event?.target?.checked;
@@ -105,5 +127,11 @@ function toggleTrait(bucket, trait, event) {
   align-items: center;
   gap: 0.45rem;
   font-size: 0.85rem;
+}
+
+.trait-filter-panel__option--highlight {
+  background: rgba(39, 121, 255, 0.12);
+  border-radius: 6px;
+  padding: 0.2rem 0.35rem;
 }
 </style>

--- a/webapp/src/services/traitDiagnosticsService.js
+++ b/webapp/src/services/traitDiagnosticsService.js
@@ -1,0 +1,31 @@
+const DEFAULT_ENDPOINT = '/api/traits/diagnostics';
+
+function resolveFetch() {
+  if (typeof fetch === 'function') return fetch;
+  if (typeof globalThis !== 'undefined' && typeof globalThis.fetch === 'function') {
+    return globalThis.fetch;
+  }
+  throw new Error('fetch non disponibile per trait diagnostics');
+}
+
+export async function fetchTraitDiagnostics(options = {}) {
+  const endpoint = options.endpoint || DEFAULT_ENDPOINT;
+  const refresh = options.refresh ? '?refresh=true' : '';
+  const fetchImpl = resolveFetch();
+  const response = await fetchImpl(`${endpoint}${refresh}`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    cache: 'no-store',
+  });
+  if (!response.ok) {
+    throw new Error(`Errore caricamento trait diagnostics (${response.status})`);
+  }
+  const payload = await response.json();
+  const diagnostics = payload?.diagnostics || payload || {};
+  return {
+    diagnostics,
+    meta: payload?.meta || {},
+  };
+}
+
+export const __internals__ = { resolveFetch };

--- a/webapp/src/views/FlowShellView.vue
+++ b/webapp/src/views/FlowShellView.vue
@@ -96,6 +96,11 @@ const activeProps = computed(() => {
       requestId: orchestrator.speciesRequestId.value,
       loading: orchestrator.loadingSpecies.value,
       error: orchestrator.speciesError.value,
+      traitCatalog: orchestrator.traitCatalog.value,
+      traitCompliance: orchestrator.traitCompliance.value,
+      traitDiagnosticsLoading: orchestrator.loadingTraitDiagnostics.value,
+      traitDiagnosticsError: orchestrator.traitDiagnosticsError.value,
+      traitDiagnosticsMeta: orchestrator.traitDiagnosticsMeta.value,
     };
   }
   if (id === 'biomeSetup') {


### PR DESCRIPTION
## Summary
- preload trait diagnostics via the orchestrator bridge and expose `/api/traits/diagnostics`
- extend trait catalog utilities/orchestrator CLI to compute diagnostics and update the Vue flow store & views to surface QA badges and synergy filters
- regenerate trait reports in CI/deploy workflows and add coverage tests for the new services

## Testing
- npm run test:api

------
https://chatgpt.com/codex/tasks/task_e_6902d494661483328706cbc2ecc12119