### PR TITLE
Add Nebula overview module with telemetry timeline

### DIFF
--- a/webapp/src/components/flow/NebulaProgressModule.vue
+++ b/webapp/src/components/flow/NebulaProgressModule.vue
@@ -1,0 +1,426 @@
+<template>
+  <section class="nebula-progress">
+    <header class="nebula-progress__header">
+      <div>
+        <p class="nebula-progress__label">Dataset · {{ header.datasetId }}</p>
+        <h2>{{ header.title }}</h2>
+        <p class="nebula-progress__summary">{{ header.summary }}</p>
+      </div>
+      <dl class="nebula-progress__meta">
+        <div>
+          <dt>Release window</dt>
+          <dd>{{ header.releaseWindow }}</dd>
+        </div>
+        <div>
+          <dt>Curator</dt>
+          <dd>{{ header.curator }}</dd>
+        </div>
+      </dl>
+    </header>
+
+    <div class="nebula-progress__cards">
+      <article
+        v-for="card in cards"
+        :key="card.id"
+        class="nebula-progress__card"
+        :data-tone="card.tone"
+      >
+        <h3>{{ card.title }}</h3>
+        <p>{{ card.body }}</p>
+        <div v-if="card.progress !== undefined" class="nebula-progress__bar">
+          <div class="nebula-progress__bar-fill" :style="{ width: `${Math.min(Math.max(card.progress, 0), 100)}%` }"></div>
+        </div>
+      </article>
+    </div>
+
+    <div class="nebula-progress__grid">
+      <NebulaProgressTimeline :entries="timelineEntries" />
+      <section class="nebula-progress__telemetry">
+        <header>
+          <h3>Progress bar evolutiva</h3>
+          <p>Telemetria &amp; readiness sincronizzate con orchestrator.</p>
+        </header>
+        <ul>
+          <li v-for="entry in evolutionMatrix" :key="entry.id">
+            <header class="nebula-progress__telemetry-header">
+              <span class="nebula-progress__species">{{ entry.name }}</span>
+              <span class="nebula-progress__badge" :data-tone="entry.readinessTone">
+                {{ entry.stage }} · {{ entry.readiness }}
+              </span>
+            </header>
+            <SparklineChart :points="entry.telemetryHistory" :color="sparklineColor(entry.readinessTone)" />
+            <div class="nebula-progress__evolution">
+              <div class="nebula-progress__evolution-fill" :style="{ width: `${entry.telemetryCoverage}%` }"></div>
+              <span class="nebula-progress__evolution-label">{{ entry.telemetryLabel }}</span>
+            </div>
+            <footer class="nebula-progress__telemetry-footer">
+              <span>{{ entry.telemetryTimestamp }}</span>
+              <span>Owner: {{ entry.telemetryOwner }}</span>
+            </footer>
+          </li>
+        </ul>
+      </section>
+    </div>
+
+    <footer class="nebula-progress__share">
+      <button type="button" @click="copyEmbed">Copia snippet Canvas</button>
+      <button type="button" @click="downloadJson">Export JSON</button>
+      <output v-if="shareStatus" role="status">{{ shareStatus }}</output>
+    </footer>
+  </section>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import NebulaProgressTimeline from './NebulaProgressTimeline.vue';
+import SparklineChart from '../shared/SparklineChart.vue';
+
+const props = defineProps({
+  header: {
+    type: Object,
+    required: true,
+  },
+  cards: {
+    type: Array,
+    default: () => [],
+  },
+  timelineEntries: {
+    type: Array,
+    default: () => [],
+  },
+  evolutionMatrix: {
+    type: Array,
+    default: () => [],
+  },
+  share: {
+    type: Object,
+    required: true,
+  },
+});
+
+const shareStatus = ref('');
+let shareTimeout = null;
+
+function setShareStatus(message) {
+  shareStatus.value = message;
+  clearTimeout(shareTimeout);
+  shareTimeout = setTimeout(() => {
+    shareStatus.value = '';
+  }, 2500);
+}
+
+function fallbackCopy(text) {
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.setAttribute('readonly', 'readonly');
+  textArea.style.position = 'absolute';
+  textArea.style.left = '-9999px';
+  document.body.appendChild(textArea);
+  textArea.select();
+  let copied = false;
+  try {
+    copied = document.execCommand('copy');
+  } catch (error) {
+    copied = false;
+  }
+  document.body.removeChild(textArea);
+  return copied;
+}
+
+async function copyEmbed() {
+  const snippet = props.share.embedSnippet;
+  try {
+    if (navigator?.clipboard?.writeText) {
+      await navigator.clipboard.writeText(snippet);
+      setShareStatus('Snippet copiato!');
+      return;
+    }
+  } catch (error) {
+    // fallback gestito sotto
+  }
+  if (fallbackCopy(snippet)) {
+    setShareStatus('Snippet copiato!');
+  } else {
+    setShareStatus('Impossibile copiare automaticamente');
+  }
+}
+
+function downloadJson() {
+  const blob = new Blob([props.share.json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `nebula-progress-${props.share.datasetId}.json`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+  setShareStatus('Export JSON generato');
+}
+
+function sparklineColor(tone) {
+  if (tone === 'success') {
+    return '#73ffce';
+  }
+  if (tone === 'warning') {
+    return '#f4c060';
+  }
+  if (tone === 'critical') {
+    return '#ff6982';
+  }
+  return '#61d5ff';
+}
+</script>
+
+<style scoped>
+.nebula-progress {
+  display: grid;
+  gap: 1.5rem;
+  background: radial-gradient(circle at top left, rgba(97, 213, 255, 0.08), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(159, 123, 255, 0.08), transparent 45%),
+    rgba(5, 8, 13, 0.85);
+  padding: 2rem;
+  border-radius: 24px;
+  border: 1px solid rgba(97, 213, 255, 0.25);
+}
+
+.nebula-progress__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.nebula-progress__label {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(224, 237, 255, 0.6);
+}
+
+.nebula-progress__header h2 {
+  margin: 0.35rem 0;
+  font-size: 1.6rem;
+}
+
+.nebula-progress__summary {
+  margin: 0;
+  color: rgba(224, 237, 255, 0.75);
+  max-width: 36rem;
+}
+
+.nebula-progress__meta {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.nebula-progress__meta div {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.nebula-progress__meta dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: rgba(224, 237, 255, 0.55);
+}
+
+.nebula-progress__meta dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.nebula-progress__cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.nebula-progress__card {
+  background: rgba(10, 15, 24, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  min-height: 160px;
+}
+
+.nebula-progress__card[data-tone='success'] {
+  border-color: rgba(115, 255, 206, 0.45);
+}
+
+.nebula-progress__card[data-tone='warning'] {
+  border-color: rgba(255, 196, 96, 0.5);
+}
+
+.nebula-progress__card[data-tone='blocker'] {
+  border-color: rgba(255, 105, 130, 0.6);
+}
+
+.nebula-progress__card[data-tone='objective'] {
+  border-color: rgba(97, 213, 255, 0.45);
+}
+
+.nebula-progress__card h3 {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(224, 237, 255, 0.7);
+}
+
+.nebula-progress__card p {
+  margin: 0;
+  font-size: 1rem;
+  color: #f0f4ff;
+}
+
+.nebula-progress__bar {
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.nebula-progress__bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #61d5ff, #9f7bff);
+}
+
+.nebula-progress__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.nebula-progress__telemetry {
+  background: rgba(10, 15, 22, 0.65);
+  border: 1px solid rgba(159, 123, 255, 0.35);
+  border-radius: 16px;
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.nebula-progress__telemetry header h3 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.95rem;
+}
+
+.nebula-progress__telemetry header p {
+  margin: 0.25rem 0 0;
+  color: rgba(224, 237, 255, 0.7);
+}
+
+.nebula-progress__telemetry ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.nebula-progress__telemetry-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.nebula-progress__species {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.nebula-progress__badge {
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid transparent;
+}
+
+.nebula-progress__badge[data-tone='success'] {
+  border-color: rgba(115, 255, 206, 0.45);
+  color: rgba(180, 255, 230, 0.9);
+}
+
+.nebula-progress__badge[data-tone='warning'] {
+  border-color: rgba(255, 196, 96, 0.5);
+  color: rgba(255, 223, 170, 0.95);
+}
+
+.nebula-progress__badge[data-tone='critical'] {
+  border-color: rgba(255, 105, 130, 0.6);
+  color: rgba(255, 190, 200, 0.95);
+}
+
+.nebula-progress__evolution {
+  position: relative;
+  height: 0.75rem;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  overflow: hidden;
+  margin-top: 0.5rem;
+}
+
+.nebula-progress__evolution-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #61d5ff 0%, #9f7bff 50%, #ff6f91 100%);
+}
+
+.nebula-progress__evolution-label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  color: rgba(12, 18, 28, 0.9);
+  font-weight: 600;
+}
+
+.nebula-progress__telemetry-footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: rgba(224, 237, 255, 0.6);
+  margin-top: 0.4rem;
+}
+
+.nebula-progress__share {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.nebula-progress__share button {
+  background: rgba(9, 14, 20, 0.85);
+  border: 1px solid rgba(97, 213, 255, 0.45);
+  color: #f0f4ff;
+  padding: 0.65rem 1.15rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.nebula-progress__share button:hover {
+  background: rgba(97, 213, 255, 0.18);
+}
+
+.nebula-progress__share output {
+  font-size: 0.8rem;
+  color: rgba(224, 237, 255, 0.8);
+}
+</style>

--- a/webapp/src/components/flow/NebulaProgressTimeline.vue
+++ b/webapp/src/components/flow/NebulaProgressTimeline.vue
@@ -1,0 +1,144 @@
+<template>
+  <section class="nebula-timeline" v-if="entries.length">
+    <h3>Timeline Nebula</h3>
+    <ol class="nebula-timeline__list">
+      <li
+        v-for="entry in orderedEntries"
+        :key="entry.id"
+        class="nebula-timeline__entry"
+        :data-tone="entry.status"
+      >
+        <header class="nebula-timeline__header">
+          <span class="nebula-timeline__title">{{ entry.title }}</span>
+          <time v-if="entry.timestamp" class="nebula-timeline__time">{{ formatTimestamp(entry.timestamp) }}</time>
+        </header>
+        <p class="nebula-timeline__summary">{{ entry.summary }}</p>
+        <p v-if="entry.meta" class="nebula-timeline__meta">{{ entry.meta }}</p>
+      </li>
+    </ol>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  entries: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const orderedEntries = computed(() => {
+  return [...props.entries].sort((a, b) => {
+    const dateA = new Date(a.timestamp || 0).getTime();
+    const dateB = new Date(b.timestamp || 0).getTime();
+    return dateB - dateA;
+  });
+});
+
+function formatTimestamp(timestamp) {
+  if (!timestamp) {
+    return '';
+  }
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return timestamp;
+  }
+  return date.toLocaleString('it-IT', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+</script>
+
+<style scoped>
+.nebula-timeline {
+  background: rgba(12, 18, 28, 0.75);
+  border: 1px solid rgba(97, 213, 255, 0.22);
+  border-radius: 16px;
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.nebula-timeline h3 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.95rem;
+  color: rgba(224, 237, 255, 0.92);
+}
+
+.nebula-timeline__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.nebula-timeline__entry {
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  background: rgba(5, 8, 13, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  gap: 0.5rem;
+  position: relative;
+}
+
+.nebula-timeline__entry::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  pointer-events: none;
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease;
+}
+
+.nebula-timeline__entry[data-tone='success']::before {
+  border-color: rgba(115, 255, 206, 0.45);
+}
+
+.nebula-timeline__entry[data-tone='warning']::before {
+  border-color: rgba(255, 196, 96, 0.5);
+}
+
+.nebula-timeline__entry[data-tone='critical']::before {
+  border-color: rgba(255, 105, 130, 0.6);
+}
+
+.nebula-timeline__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.nebula-timeline__title {
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.nebula-timeline__time {
+  font-size: 0.75rem;
+  color: rgba(224, 237, 255, 0.6);
+}
+
+.nebula-timeline__summary {
+  margin: 0;
+  color: rgba(240, 244, 255, 0.9);
+  line-height: 1.4;
+}
+
+.nebula-timeline__meta {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(224, 237, 255, 0.65);
+}
+</style>

--- a/webapp/src/components/shared/SparklineChart.vue
+++ b/webapp/src/components/shared/SparklineChart.vue
@@ -1,0 +1,103 @@
+<template>
+  <svg
+    v-if="points.length"
+    class="sparkline"
+    :viewBox="`0 0 ${viewBoxWidth} ${viewBoxHeight}`"
+    role="img"
+    aria-label="Andamento metriche"
+    preserveAspectRatio="none"
+  >
+    <polyline
+      class="sparkline__line"
+      :points="polylinePoints"
+      fill="none"
+      :stroke="color"
+      :stroke-width="strokeWidth"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <circle
+      v-if="lastPoint"
+      class="sparkline__pivot"
+      :cx="lastPoint.x"
+      :cy="lastPoint.y"
+      :r="strokeWidth * 1.2"
+      :fill="color"
+    />
+  </svg>
+  <div v-else class="sparkline sparkline--empty" aria-hidden="true"></div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  points: {
+    type: Array,
+    default: () => [],
+  },
+  color: {
+    type: String,
+    default: '#61d5ff',
+  },
+  strokeWidth: {
+    type: Number,
+    default: 2,
+  },
+});
+
+const viewBoxHeight = 40;
+
+const validPoints = computed(() =>
+  (props.points || [])
+    .map((value) => (Number.isFinite(value) ? Number(value) : 0))
+    .filter((value) => Number.isFinite(value))
+);
+
+const viewBoxWidth = computed(() => Math.max((validPoints.value.length - 1) * 24, 24));
+
+const normalizedPoints = computed(() => {
+  if (!validPoints.value.length) {
+    return [];
+  }
+  const min = Math.min(...validPoints.value, 0);
+  const max = Math.max(...validPoints.value, 100);
+  const span = max - min || 1;
+  return validPoints.value.map((value, index) => {
+    const x = (index / Math.max(validPoints.value.length - 1, 1)) * viewBoxWidth.value;
+    const y = viewBoxHeight - ((value - min) / span) * viewBoxHeight;
+    return { x: Math.round(x * 100) / 100, y: Math.round(y * 100) / 100 };
+  });
+});
+
+const polylinePoints = computed(() => normalizedPoints.value.map((point) => `${point.x},${point.y}`).join(' '));
+
+const lastPoint = computed(() => {
+  if (!normalizedPoints.value.length) {
+    return null;
+  }
+  return normalizedPoints.value[normalizedPoints.value.length - 1];
+});
+</script>
+
+<style scoped>
+.sparkline {
+  width: 100%;
+  height: 48px;
+  display: block;
+}
+
+.sparkline--empty {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+}
+
+.sparkline__line {
+  filter: drop-shadow(0 0 4px rgba(97, 213, 255, 0.4));
+}
+
+.sparkline__pivot {
+  stroke: rgba(5, 8, 13, 0.8);
+  stroke-width: 1.25;
+}
+</style>

--- a/webapp/src/state/nebulaProgressModule.js
+++ b/webapp/src/state/nebulaProgressModule.js
@@ -1,0 +1,298 @@
+import { computed } from 'vue';
+import { atlasDataset } from './atlasDataset.js';
+
+function normaliseArray(values) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return values.filter((value) => typeof value === 'string' && value.trim().length > 0);
+}
+
+function readinessTone(readiness) {
+  if (!readiness) {
+    return 'neutral';
+  }
+  const value = readiness.toLowerCase();
+  if (value.includes('approvazione') || value.includes('attesa')) {
+    return 'warning';
+  }
+  if (value.includes('freeze') || value.includes('validazione completata') || value.includes('pronto')) {
+    return 'success';
+  }
+  if (value.includes('richiede')) {
+    return 'critical';
+  }
+  return 'neutral';
+}
+
+function coverageStage(percent) {
+  if (percent >= 85) {
+    return 'Mega';
+  }
+  if (percent >= 70) {
+    return 'Ultimate';
+  }
+  if (percent >= 55) {
+    return 'Champion';
+  }
+  return 'Rookie';
+}
+
+function computeHistory(percent, qaPercent) {
+  const finalPoint = Number.isFinite(percent) ? percent : 0;
+  const qaReference = Number.isFinite(qaPercent) ? qaPercent : finalPoint * 0.6;
+  const baseline = Math.max(Math.min(finalPoint - 12, finalPoint), 0);
+  const history = [
+    Math.max(Math.round(qaReference * 0.6), 0),
+    Math.max(Math.round((qaReference + baseline) / 2), 0),
+    Math.max(Math.round((baseline + finalPoint) / 2), 0),
+    Math.max(Math.round(finalPoint), 0),
+  ];
+  const deduped = history.filter((value, index, array) => index === 0 || value !== array[index - 1]);
+  return deduped.length >= 2 ? deduped : [Math.max(Math.round(finalPoint * 0.6), 0), Math.max(Math.round(finalPoint), 0)];
+}
+
+function formatRelativeTime(timestamp) {
+  if (!timestamp) {
+    return 'Sync non disponibile';
+  }
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return `Sync: ${timestamp}`;
+  }
+  const diff = Date.now() - date.getTime();
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diff < minute) {
+    return 'Sync adesso';
+  }
+  if (diff < hour) {
+    const minutes = Math.round(diff / minute);
+    return `Sync ${minutes} min fa`;
+  }
+  if (diff < day) {
+    const hours = Math.round(diff / hour);
+    return `Sync ${hours}h fa`;
+  }
+  const days = Math.round(diff / day);
+  return `Sync ${days}g fa`;
+}
+
+export function useNebulaProgressModule(sources) {
+  const overview = computed(() => sources?.overview?.value || {});
+  const qualityRelease = computed(() => sources?.qualityRelease?.value || {});
+  const timelineState = computed(() => sources?.timeline?.value || {});
+
+  const dataset = atlasDataset;
+
+  const objectives = computed(() => normaliseArray(overview.value.objectives));
+  const blockers = computed(() => normaliseArray(overview.value.blockers));
+
+  const qaChecks = computed(() => {
+    const checks = qualityRelease.value.checks || {};
+    return Object.entries(checks)
+      .map(([id, entry]) => ({
+        id,
+        passed: Number(entry?.passed) || 0,
+        total: Number(entry?.total) || 0,
+      }))
+      .filter((entry) => entry.total > 0);
+  });
+
+  const qaSummary = computed(() => {
+    const total = qaChecks.value.reduce((acc, entry) => acc + entry.total, 0);
+    const completed = qaChecks.value.reduce((acc, entry) => acc + entry.passed, 0);
+    const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
+    return {
+      total,
+      completed,
+      percent,
+      label: total > 0 ? `${completed}/${total} QA checks` : 'QA checks in setup',
+      lastRun: qualityRelease.value.lastRun || null,
+    };
+  });
+
+  const cards = computed(() => {
+    const entries = [];
+    for (const objective of objectives.value) {
+      entries.push({
+        id: `objective-${entries.length}`,
+        title: 'Obiettivo',
+        body: objective,
+        tone: 'objective',
+      });
+    }
+    for (const blocker of blockers.value) {
+      entries.push({
+        id: `blocker-${entries.length}`,
+        title: 'Blocker',
+        body: blocker,
+        tone: 'blocker',
+      });
+    }
+    entries.push({
+      id: 'qa-progress',
+      title: 'QA Sync',
+      body: qaSummary.value.label,
+      tone: qaSummary.value.percent >= 80 ? 'success' : qaSummary.value.percent >= 50 ? 'warning' : 'neutral',
+      progress: qaSummary.value.percent,
+    });
+    const completion = overview.value?.completion || {};
+    const total = Number(completion.total) || 0;
+    const completed = Number(completion.completed) || 0;
+    const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
+    entries.push({
+      id: 'milestone-progress',
+      title: 'Milestone',
+      body: total > 0 ? `${completed}/${total} milestone confermate` : 'Milestone da definire',
+      tone: percent >= 70 ? 'success' : 'neutral',
+      progress: percent,
+    });
+    return entries;
+  });
+
+  const qaPercent = computed(() => qaSummary.value.percent);
+
+  const evolutionMatrix = computed(() => {
+    return (dataset.species || []).map((species) => {
+      const coverage = Number(species.telemetry?.coverage) || 0;
+      const percent = Math.round(coverage * 100);
+      const stage = coverageStage(percent);
+      const tone = readinessTone(species.readiness);
+      const history = computeHistory(percent, qaPercent.value);
+      return {
+        id: species.id,
+        name: species.name,
+        readiness: species.readiness || 'In progress',
+        readinessTone: tone,
+        telemetryOwner: species.telemetry?.curatedBy || 'QA Core',
+        telemetryCoverage: percent,
+        telemetryHistory: history,
+        telemetryLabel: `${percent}% copertura`,
+        telemetryTimestamp: formatRelativeTime(species.telemetry?.lastValidation),
+        stage,
+      };
+    });
+  });
+
+  const timelineEntries = computed(() => {
+    const entries = [];
+    const referenceTime = qaSummary.value.lastRun || timelineState.value?.lastSync || null;
+
+    objectives.value.forEach((objective, index) => {
+      entries.push({
+        id: `objective-${index}`,
+        title: 'Obiettivo Nebula',
+        status: 'info',
+        summary: objective,
+        timestamp: referenceTime,
+      });
+    });
+
+    (dataset.species || [])
+      .slice()
+      .sort((a, b) => {
+        const timeA = new Date(a.telemetry?.lastValidation || 0).getTime();
+        const timeB = new Date(b.telemetry?.lastValidation || 0).getTime();
+        return timeB - timeA;
+      })
+      .forEach((species) => {
+        entries.push({
+          id: `species-${species.id}`,
+          title: species.name,
+          status: readinessTone(species.readiness),
+          summary: species.readiness || 'Readiness non definita',
+          timestamp: species.telemetry?.lastValidation || referenceTime,
+          meta: species.telemetry?.curatedBy ? `Curato da ${species.telemetry.curatedBy}` : null,
+        });
+      });
+
+    qaChecks.value.forEach((check) => {
+      entries.push({
+        id: `qa-${check.id}`,
+        title: `QA · ${check.id}`,
+        status: check.passed >= check.total ? 'success' : 'warning',
+        summary: `${check.passed}/${check.total} verifiche completate`,
+        timestamp: qaSummary.value.lastRun || referenceTime,
+      });
+    });
+
+    blockers.value.forEach((blocker, index) => {
+      entries.push({
+        id: `blocker-${index}`,
+        title: 'Blocker',
+        status: 'critical',
+        summary: blocker,
+        timestamp: referenceTime,
+      });
+    });
+
+    return entries;
+  });
+
+  const header = computed(() => ({
+    datasetId: dataset.id,
+    title: dataset.title,
+    summary: dataset.summary,
+    releaseWindow: dataset.releaseWindow,
+    curator: dataset.curator,
+  }));
+
+  const share = computed(() => {
+    const payload = {
+      datasetId: dataset.id,
+      generatedAt: new Date().toISOString(),
+      overview: {
+        objectives: objectives.value,
+        blockers: blockers.value,
+        completion: overview.value?.completion || {},
+      },
+      qa: {
+        percent: qaSummary.value.percent,
+        completed: qaSummary.value.completed,
+        total: qaSummary.value.total,
+        lastRun: qaSummary.value.lastRun,
+        checks: qaChecks.value,
+      },
+      timeline: timelineEntries.value.map((entry) => ({
+        id: entry.id,
+        title: entry.title,
+        status: entry.status,
+        summary: entry.summary,
+        timestamp: entry.timestamp,
+        meta: entry.meta || null,
+      })),
+      readiness: evolutionMatrix.value.map((entry) => ({
+        id: entry.id,
+        name: entry.name,
+        stage: entry.stage,
+        readiness: entry.readiness,
+        readinessTone: entry.readinessTone,
+        telemetry: {
+          coverage: entry.telemetryCoverage,
+          history: entry.telemetryHistory,
+          owner: entry.telemetryOwner,
+          label: entry.telemetryLabel,
+          lastSync: entry.telemetryTimestamp,
+        },
+      })),
+    };
+    const json = JSON.stringify(payload, null, 2);
+    const embedSnippet = `<script type="application/json" id="nebula-progress-${dataset.id}">\n${json}\n<\/script>`;
+    return {
+      datasetId: dataset.id,
+      payload,
+      json,
+      embedSnippet,
+    };
+  });
+
+  return {
+    header,
+    cards,
+    timelineEntries,
+    evolutionMatrix,
+    share,
+  };
+}

--- a/webapp/src/views/FlowShellView.vue
+++ b/webapp/src/views/FlowShellView.vue
@@ -85,7 +85,11 @@ const activeView = computed(() => viewMap[currentStep.value.id] || OverviewView)
 const activeProps = computed(() => {
   const id = currentStep.value.id;
   if (id === 'overview') {
-    return { overview: orchestrator.overview.value, timeline: orchestrator.timeline.value };
+    return {
+      overview: orchestrator.overview.value,
+      timeline: orchestrator.timeline.value,
+      qualityRelease: orchestrator.qualityRelease.value,
+    };
   }
   if (id === 'species') {
     return {

--- a/webapp/src/views/OverviewView.vue
+++ b/webapp/src/views/OverviewView.vue
@@ -1,32 +1,19 @@
 <template>
   <section class="flow-view">
-    <header class="flow-view__header">
-      <h2>Snapshot operativo</h2>
-      <p>Coordinamento attuale del workflow narrativo.</p>
-    </header>
-    <div class="flow-view__grid">
-      <article class="flow-card" v-for="objective in objectives" :key="objective">
-        <h3 class="flow-card__title">Obiettivo</h3>
-        <p class="flow-card__body">{{ objective }}</p>
-      </article>
-      <article class="flow-card flow-card--warning" v-for="blocker in blockers" :key="blocker">
-        <h3 class="flow-card__title">Bloccante</h3>
-        <p class="flow-card__body">{{ blocker }}</p>
-      </article>
-      <article class="flow-card flow-card--progress">
-        <h3 class="flow-card__title">Allineamento timeline</h3>
-        <p class="flow-card__body">{{ timeline.label }}</p>
-        <div class="flow-card__progress">
-          <div class="flow-card__progress-bar" :style="{ width: `${timeline.percent}%` }"></div>
-        </div>
-        <small>{{ completion.completed }} su {{ completion.total }} milestone confermate</small>
-      </article>
-    </div>
+    <NebulaProgressModule
+      :header="moduleState.header"
+      :cards="moduleState.cards"
+      :timeline-entries="moduleState.timelineEntries"
+      :evolution-matrix="moduleState.evolutionMatrix"
+      :share="moduleState.share"
+    />
   </section>
 </template>
 
 <script setup>
-import { computed, toRefs } from 'vue';
+import { toRefs } from 'vue';
+import NebulaProgressModule from '../components/flow/NebulaProgressModule.vue';
+import { useNebulaProgressModule } from '../state/nebulaProgressModule.js';
 
 const props = defineProps({
   overview: {
@@ -37,81 +24,23 @@ const props = defineProps({
     type: Object,
     required: true,
   },
+  qualityRelease: {
+    type: Object,
+    default: () => ({}),
+  },
 });
 
-const { overview, timeline } = toRefs(props);
-const completion = computed(() => overview.value.completion || { completed: 0, total: 0 });
-const blockers = computed(() => overview.value.blockers || []);
-const objectives = computed(() => overview.value.objectives || []);
+const { overview, timeline, qualityRelease } = toRefs(props);
+
+const moduleState = useNebulaProgressModule({
+  overview,
+  timeline,
+  qualityRelease,
+});
 </script>
 
 <style scoped>
 .flow-view {
   display: grid;
-  gap: 1.5rem;
-}
-
-.flow-view__header h2 {
-  margin: 0;
-  font-size: 1.45rem;
-}
-
-.flow-view__header p {
-  margin: 0.35rem 0 0;
-  color: rgba(240, 244, 255, 0.7);
-}
-
-.flow-view__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
-}
-
-.flow-card {
-  background: rgba(9, 14, 20, 0.75);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 16px;
-  padding: 1rem;
-  display: grid;
-  gap: 0.5rem;
-}
-
-.flow-card--warning {
-  border-color: rgba(244, 196, 96, 0.55);
-  background: rgba(244, 196, 96, 0.12);
-}
-
-.flow-card--progress {
-  border-color: rgba(96, 213, 255, 0.4);
-}
-
-.flow-card__title {
-  margin: 0;
-  text-transform: uppercase;
-  font-size: 0.85rem;
-  letter-spacing: 0.08em;
-  color: rgba(240, 244, 255, 0.65);
-}
-
-.flow-card__body {
-  margin: 0;
-  font-size: 1rem;
-  color: #f0f4ff;
-}
-
-.flow-card__progress {
-  height: 0.5rem;
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 999px;
-  overflow: hidden;
-}
-
-.flow-card__progress-bar {
-  height: 100%;
-  background: linear-gradient(90deg, #61d5ff 0%, #9f7bff 100%);
-}
-
-small {
-  color: rgba(240, 244, 255, 0.6);
 }
 </style>


### PR DESCRIPTION
## Summary
- build a reusable Nebula progress state module that merges dataset data with orchestrator snapshots
- add UI for cards, sparkline telemetry, and timeline plus sharing controls for Canvas/roadmap embeds
- update the overview flow shell to render the new module and pass quality release data

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_6902dc89e83883328a6cbec5c3fffcf3