### PR TITLE
Log incoming triage sync status

### DIFF
--- a/logs/incoming_triage_agenti.md
+++ b/logs/incoming_triage_agenti.md
@@ -1,0 +1,8 @@
+# Canale `#incoming-triage-agenti` — Registro aggiornamenti
+
+<!-- incoming_triage_log:start -->
+## 2025-11-08T00:00:00Z · Sincronizzazione stato pipeline
+- **Playbook & backlog**: confermata la distribuzione dei caretaker e il flusso di triage secondo `docs/process/incoming_triage_pipeline.md`, `docs/process/incoming_agent_backlog.md` e `docs/templates/incoming_triage_meeting.md`.
+- **Widget Support Hub**: verificato che `docs/index.html` → sezione "Incoming Pipeline" carichi l'ultima voce di `docs/process/incoming_review_log.md` (report 2025-10-29) tramite `parseLatestIncomingSession` in `docs/site.js`.
+- **Dipendenze**: follow-up aperto per `AG-Toolsmith` sul fix `unzip -o` di `scripts/report_incoming.sh`; necessario per sbloccare la riesecuzione di `AG-Validation` su `evo_tactics_param_synergy_v8_3.zip`.
+<!-- incoming_triage_log:end -->


### PR DESCRIPTION
## Summary
- add a channel log entry for `#incoming-triage-agenti` capturing the latest playbook review, Support Hub widget check, and pending unzip fix dependency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690324131adc83329b04553d4cb5da14