### PR TITLE
Plan calendar slots for incoming triage

### DIFF
--- a/docs/process/incoming_agent_backlog.md
+++ b/docs/process/incoming_agent_backlog.md
@@ -18,6 +18,16 @@ Questo backlog traduce le iniziative prioritarie emerse dal report di triage in 
 | `ancestors_integration_pack_v0_5` | Da analizzare | `AG-Core` | Richiesto smoke test CLI (`config/cli/staging_incoming.yaml`) prima dello sblocco integrazione. | Pianificare tuning parametri core in backlog `In integrazione`. |
 | `recon_meccaniche.json` | In validazione | `AG-Validation` | Segnato bisogno raccolta stime tempo-analisi e confronto con hook evento correnti. | Consolidare report e passare outcome a `AG-Orchestrator` per decisione. |
 
+### Slot calendario condiviso · settimana 2025-11-10
+
+Prima di ogni blocco `AG-Orchestrator` verifica i prerequisiti indicati per evitare blocchi operativi; al termine applica i controlli post-processo per mantenere sincronizzati board, log e knowledge base.
+
+| Slot (CET) | Card Kanban | Prerequisiti da verificare (pre-slot) | Controlli post-processo |
+| --- | --- | --- | --- |
+| 2025-11-10 10:00–10:45 | `evo_pacchetto_minimo_v7` → focus validazioni | Confermare merge del fix `unzip -o` su `scripts/report_incoming.sh`, rieseguire `./scripts/report_incoming.sh --destination sessione-2025-11-10` e raccogliere i log in `reports/incoming/sessione-2025-11-10/`. | Spostare la card in `In validazione`, allegare il nuovo log nella board, registrare l'esito in `logs/incoming_triage_agenti.md` e aggiornare la sezione corrente di `docs/process/incoming_review_log.md` con summary e link. |
+| 2025-11-10 14:30–15:30 | `ancestors_integration_pack_v0_5` → tuning core | Garantire disponibilità ambiente CLI `staging_incoming`, completare smoke test `scripts/cli_smoke.sh --profile staging_incoming` con output salvato in `logs/incoming_smoke/` e confermare caretaker `AG-Core` reperibile. | Aggiornare la card a `In integrazione` con link al risultato dello smoke test, annotare la decisione e il tuning previsto nel log agentico, integrare il follow-up nel knowledge base (`incoming_review_log.md`). |
+| 2025-11-11 11:00–12:00 | `recon_meccaniche.json` → consolidamento report | Raccogliere le stime tempo-analisi dagli agenti di dominio, esportare i confronti con gli hook evento correnti e predisporre il report `reports/incoming/latest/report.html` per la review finale. | Applicare l'esito (integrazione o archivio) sulla card Kanban, allegare il report consolidato, aggiornare `logs/incoming_triage_agenti.md` con decisione e follow-up e sintetizzare nel knowledge base con eventuali ticket aperti. |
+
 ## 0. Collegare il Support Hub alla pipeline incoming
 - **Agente owner**: `AG-Orchestrator`
 - **Supporto**: `AG-Toolsmith`

--- a/logs/incoming_triage_agenti.md
+++ b/logs/incoming_triage_agenti.md
@@ -1,6 +1,10 @@
 # Canale `#incoming-triage-agenti` — Registro aggiornamenti
 
 <!-- incoming_triage_log:start -->
+## 2025-11-09T08:30:00Z · Pianificazione slot calendario condiviso
+- **Calendario condiviso**: programmati tre slot (10:00, 14:30, 11:00 CET) per le card `evo_pacchetto_minimo_v7`, `ancestors_integration_pack_v0_5` e `recon_meccaniche.json`, collegando ciascun blocco alla tabella "Slot calendario condiviso" nel backlog agentico.【F:docs/process/incoming_agent_backlog.md†L18-L36】
+- **Prerequisiti pre-slot**: verificare prima di ogni blocco il fix `unzip -o` e la rigenerazione log `sessione-2025-11-10`, la disponibilità dell'ambiente `staging_incoming` con smoke test salvato e la raccolta stime/confronti per `recon_meccaniche.json`.【F:docs/process/incoming_agent_backlog.md†L28-L36】
+- **Controlli post-processo**: al termine di ciascun slot aggiornare la colonna della card sul Kanban, allegare evidenze nei log `logs/incoming_triage_agenti.md`/`logs/incoming_smoke/` e sincronizzare la knowledge base (`docs/process/incoming_review_log.md`).【F:docs/process/incoming_agent_backlog.md†L28-L36】
 ## 2025-11-08T09:15:00Z · Aggiornamento assignment caretaker
 - **Audit caretaker**: riallineata la snapshot `reports/data_inventory.md` con i caretaker del playbook per gli asset prioritari (`evo_pacchetto_minimo_v7`, `ancestors_integration_pack_v0_5`, `recon_meccaniche.json`).【F:reports/data_inventory.md†L109-L139】
 - **Kanban**: accodate note prerequisito su ciascuna card (fix `unzip -o`, smoke test CLI staging, raccolta stime analisi) nella sezione backlog dedicata.【F:docs/process/incoming_agent_backlog.md†L9-L21】


### PR DESCRIPTION
## Summary
- add a shared-calendar table that maps upcoming slots to Kanban cards, prerequisites, and post-process controls for the incoming backlog
- log the scheduled slots and required checks in the incoming triage channel record to keep board, logs, and knowledge base aligned

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69032c852ef08332badc35fee514bba3