### PR TITLE
Add incoming triage Slack announcement draft

### DIFF
--- a/logs/incoming_triage_agenti.md
+++ b/logs/incoming_triage_agenti.md
@@ -1,6 +1,10 @@
 # Canale `#incoming-triage-agenti` — Registro aggiornamenti
 
 <!-- incoming_triage_log:start -->
+## 2025-11-10T07:45:00Z · Bozza annuncio piano settimanale
+- **Messaggio Slack**: preparata bozza per `#incoming-triage-agenti` con link a backlog, registro sessioni e roadmap; disponibile in `logs/incoming_triage_slack_plan_2025-11-10.md` pronta per il post manuale.【F:logs/incoming_triage_slack_plan_2025-11-10.md†L1-L23】
+- **Aggiornamenti richiesti**: dopo la pubblicazione ricordarsi di spostare le card Kanban secondo gli highlight e registrare outcome su `docs/process/incoming_review_log.md`.【F:docs/process/incoming_agent_backlog.md†L9-L38】【F:docs/process/incoming_review_log.md†L1-L27】
+- **Prossimi passi**: confermare completamento del fix `unzip -o`, smoke test CLI `staging_incoming` e consolidamento report `recon_meccaniche.json` durante gli slot del 10-11 novembre.【F:docs/process/incoming_agent_backlog.md†L18-L47】
 ## 2025-11-09T08:30:00Z · Pianificazione slot calendario condiviso
 - **Calendario condiviso**: programmati tre slot (10:00, 14:30, 11:00 CET) per le card `evo_pacchetto_minimo_v7`, `ancestors_integration_pack_v0_5` e `recon_meccaniche.json`, collegando ciascun blocco alla tabella "Slot calendario condiviso" nel backlog agentico.【F:docs/process/incoming_agent_backlog.md†L18-L36】
 - **Prerequisiti pre-slot**: verificare prima di ogni blocco il fix `unzip -o` e la rigenerazione log `sessione-2025-11-10`, la disponibilità dell'ambiente `staging_incoming` con smoke test salvato e la raccolta stime/confronti per `recon_meccaniche.json`.【F:docs/process/incoming_agent_backlog.md†L28-L36】

--- a/logs/incoming_triage_slack_plan_2025-11-10.md
+++ b/logs/incoming_triage_slack_plan_2025-11-10.md
@@ -1,0 +1,20 @@
+# Bozza messaggio Slack — #incoming-triage-agenti (2025-11-10)
+
+Ciao caretakers :wave:,
+
+aggiorniamo il ciclo *Incoming Review* con focus sugli asset prioritari del report 2025-10-29. Qui trovate tutto il materiale di riferimento:
+- Backlog agentico: <https://github.com/example-org/Game/blob/main/docs/process/incoming_agent_backlog.md>
+- Registro sessioni & log: <https://github.com/example-org/Game/blob/main/docs/process/incoming_review_log.md>
+- Tabella di marcia / roadmap: <https://github.com/example-org/Game/blob/main/docs/piani/roadmap.md>
+
+**Highlights settimana 2025-11-10**
+1. `evo_pacchetto_minimo_v7` → rieseguire `./scripts/report_incoming.sh --destination sessione-2025-11-10` dopo il fix `unzip -o`; allegare i nuovi log alla card e aggiornare la colonna a `In validazione`.
+2. `ancestors_integration_pack_v0_5` → completare smoke test CLI (`scripts/cli_smoke.sh --profile staging_incoming`) e portare la card in `In integrazione` con log in `logs/incoming_smoke/`.
+3. `recon_meccaniche.json` → consolidare report comparativo con gli hook evento correnti e preparare decisione finale in review dell'11 novembre.
+
+**Promemoria operativi**
+- Aggiornare board Kanban dopo ogni step e allegare evidenze (log, report, snippet) direttamente nelle card.
+- Registrare outcome e follow-up nel registro `docs/process/incoming_review_log.md` subito dopo ogni slot.
+- Se emergono blocchi, aprire ticket in `docs/process/tooling_maintenance_log.md` e pingare `AG-Toolsmith`.
+
+Grazie e buon triage! :rocket:


### PR DESCRIPTION
## Summary
- add a ready-to-post Slack message for #incoming-triage-agenti with links to backlog, log, and roadmap
- record the drafting activity and related follow-ups in the incoming triage log

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690354e67cc48332b5f89e271e7987ac