### PR TITLE
Add orchestrator worker pool with heartbeat recovery

### DIFF
--- a/config/orchestrator.json
+++ b/config/orchestrator.json
@@ -1,0 +1,9 @@
+{
+  "pythonPath": "python3",
+  "poolSize": 2,
+  "requestTimeoutMs": 120000,
+  "heartbeatIntervalMs": 5000,
+  "heartbeatTimeoutMs": 15000,
+  "maxTaskRetries": 1,
+  "autoShutdownMs": null
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test:web": "npm --prefix tools/ts run test:web --",
     "build": "npm --prefix tools/ts run build --",
     "test": "npm run test:api && npm --prefix tools/ts run test -- && npm --prefix webapp run test",
-    "test:api": "node --test tests/api/*.test.js && tsx tests/generation/flow-shell.spec.ts",
+    "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 tools/ts/node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 tools/ts/node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts",
     "start:api": "node server/index.js",
     "build:idea-taxonomy": "node scripts/build-idea-taxonomy.js",
     "drive:generate-approved": "node tools/drive/generate-approved-assets.mjs",

--- a/services/generation/worker.py
+++ b/services/generation/worker.py
@@ -1,0 +1,144 @@
+"""Worker persistente per il bridge Node → Python del generation orchestrator."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+import time
+import traceback
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from services.generation.orchestrator import (  # noqa: E402
+    GenerationError,
+    GenerationOrchestrator,
+    SpeciesBatchRequest,
+    SpeciesGenerationRequest,
+    build_trait_diagnostics,
+)
+
+try:  # pragma: no cover - non disponibile su Python < 3.7
+    sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+except AttributeError:  # pragma: no cover - fallback legacy
+    pass
+
+_HEARTBEAT_INTERVAL_MS = max(
+    1000,
+    int(os.environ.get("ORCHESTRATOR_WORKER_HEARTBEAT_INTERVAL_MS", "5000")),
+)
+
+
+def _emit(message: Mapping[str, Any]) -> None:
+    sys.stdout.write(json.dumps(message, ensure_ascii=False))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def _heartbeat_loop(stop_event: threading.Event) -> None:
+    payload = {"type": "heartbeat", "pid": os.getpid()}
+    interval = _HEARTBEAT_INTERVAL_MS / 1000.0
+    while not stop_event.wait(interval):
+        payload["timestamp"] = time.time()
+        try:
+            _emit(payload)
+        except Exception:  # pragma: no cover - log su stderr
+            traceback.print_exc()
+            return
+
+
+def _handle_request(
+    orchestrator: GenerationOrchestrator,
+    message: Mapping[str, Any],
+) -> Dict[str, Any]:
+    request_id = message.get("id")
+    action = message.get("action")
+    payload = message.get("payload") or {}
+
+    response: Dict[str, Any] = {"type": "response", "id": request_id}
+
+    try:
+        if action == "generate-species":
+            request = SpeciesGenerationRequest.from_payload(payload)
+            result = orchestrator.generate_species(request)
+            response["status"] = "ok"
+            response["result"] = result.to_payload()
+            return response
+        if action == "generate-species-batch":
+            batch = SpeciesBatchRequest.from_payload(payload)
+            result = orchestrator.generate_species_batch(batch.entries)
+            response["status"] = "ok"
+            response["result"] = result.to_payload()
+            return response
+        if action == "trait-diagnostics":
+            diagnostics = build_trait_diagnostics()
+            response["status"] = "ok"
+            response["result"] = diagnostics
+            return response
+        if action == "shutdown":
+            response["status"] = "ok"
+            response["result"] = {"message": "shutdown"}
+            return response
+        raise ValueError(f"Azione non supportata: {action}")
+    except GenerationError as error:
+        response["status"] = "error"
+        response["error"] = str(error)
+        response["code"] = "GENERATION_ERROR"
+    except Exception as error:  # pragma: no cover - difetti runtime
+        response["status"] = "error"
+        response["error"] = str(error)
+        response["code"] = "UNEXPECTED_ERROR"
+        traceback.print_exc()
+    return response
+
+
+def main() -> int:
+    orchestrator = GenerationOrchestrator()
+    _emit({"type": "ready", "pid": os.getpid()})
+
+    stop_event = threading.Event()
+    heartbeat_thread = threading.Thread(
+        target=_heartbeat_loop, args=(stop_event,), daemon=True
+    )
+    heartbeat_thread.start()
+
+    try:
+        for raw_line in sys.stdin:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                _emit(
+                    {
+                        "type": "response",
+                        "status": "error",
+                        "code": "INVALID_MESSAGE",
+                        "error": "Messaggio JSON non valido",
+                        "id": None,
+                    }
+                )
+                continue
+
+            if message.get("action") == "shutdown":
+                _emit(_handle_request(orchestrator, message))
+                return 0
+
+            response = _handle_request(orchestrator, message)
+            _emit(response)
+    except KeyboardInterrupt:  # pragma: no cover - terminazione esterna
+        return 0
+    finally:
+        stop_event.set()
+        heartbeat_thread.join(timeout=1.0)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/server/orchestrator-bridge.spec.ts
+++ b/tests/server/orchestrator-bridge.spec.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { before, after, describe, it } from 'node:test';
+
+import { createGenerationOrchestratorBridge } from '../../services/generation/orchestratorBridge';
+
+describe('generation orchestrator bridge worker pool', () => {
+  const traitIds = ['artigli_sette_vie', 'coda_frusta_cinetica', 'scheletro_idro_regolante'];
+  let bridge: ReturnType<typeof createGenerationOrchestratorBridge>;
+  let previousEnv: { nodeEnv?: string; autoClose?: string | undefined };
+
+  before(async () => {
+    previousEnv = {
+      nodeEnv: process.env.NODE_ENV,
+      autoClose: process.env.ORCHESTRATOR_AUTOCLOSE_MS,
+    };
+    process.env.NODE_ENV = 'test';
+    process.env.ORCHESTRATOR_AUTOCLOSE_MS = '0';
+    bridge = createGenerationOrchestratorBridge({
+      poolSize: 2,
+      requestTimeoutMs: 60_000,
+      heartbeatIntervalMs: 1_000,
+      heartbeatTimeoutMs: 5_000,
+      autoShutdownMs: null,
+    });
+  });
+
+  after(async () => {
+    await bridge.close();
+    if (previousEnv.nodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousEnv.nodeEnv;
+    }
+    if (previousEnv.autoClose === undefined) {
+      delete process.env.ORCHESTRATOR_AUTOCLOSE_MS;
+    } else {
+      process.env.ORCHESTRATOR_AUTOCLOSE_MS = previousEnv.autoClose;
+    }
+  });
+
+  it('elabora richieste concorrenti mantenendo la pipeline calda', async () => {
+    const requests = Array.from({ length: 6 }).map((_, index) => ({
+      trait_ids: traitIds,
+      seed: index + 1,
+      request_id: `req-${index + 1}`,
+    }));
+
+    const results = await Promise.all(requests.map((payload) => bridge.generateSpecies(payload)));
+
+    assert.equal(results.length, requests.length);
+    for (const result of results) {
+      assert.ok(result.blueprint, 'blueprint mancante nel risultato');
+      assert.ok(result.meta?.request_id, 'meta.request_id mancante');
+    }
+  });
+
+  it('ripristina un worker dopo un crash improvviso', async () => {
+    const pool = (bridge as any)._pool;
+    assert.ok(pool, 'Pool di worker non disponibile per il test');
+
+    pool.debugKillWorker(0);
+    await new Promise((resolve) => setTimeout(resolve, 750));
+
+    const recoveryResult = await bridge.generateSpecies({
+      trait_ids: traitIds,
+      seed: 42,
+      request_id: 'crash-recovery',
+    });
+
+    assert.ok(recoveryResult.meta?.request_id === 'crash-recovery');
+
+    const stats = pool.getStats();
+    assert.equal(stats.size, 2, 'il pool dovrebbe ripristinare il numero di worker iniziali');
+  });
+});


### PR DESCRIPTION
## Summary
- implement a reusable Python worker pool in the generation orchestrator bridge with heartbeat monitoring, crash recovery, and optional auto-shutdown hooks
- add a persistent Python worker that handles JSON commands, emits heartbeats, and reports structured errors to the bridge
- expose pool sizing and timeout configuration plus new load tests and scripts covering the orchestrator bridge

## Testing
- npm run test:api

------
https://chatgpt.com/codex/tasks/task_e_6903597051d88332809eac5351d75e25