### PR TITLE
Add incoming inventory report and backlog references

### DIFF
--- a/docs/process/incoming_agent_backlog.md
+++ b/docs/process/incoming_agent_backlog.md
@@ -12,11 +12,13 @@ Questo backlog traduce le iniziative prioritarie emerse dal report di triage in 
 
 ### Note Kanban 2025-11-08
 
-| Card | Colonna | Caretaker | Prerequisiti accodati | Next step |
-| --- | --- | --- | --- | --- |
-| `evo_pacchetto_minimo_v7` | Da analizzare | `AG-Biome` | Annotato fix `unzip -o` come blocco e rimando al pacchetto validazione di `AG-Toolsmith`. | Rieseguire validazioni automatiche dopo il fix e allegare log aggiornati. |
-| `ancestors_integration_pack_v0_5` | Da analizzare | `AG-Core` | Richiesto smoke test CLI (`config/cli/staging_incoming.yaml`) prima dello sblocco integrazione. | Pianificare tuning parametri core in backlog `In integrazione`. |
-| `recon_meccaniche.json` | In validazione | `AG-Validation` | Segnato bisogno raccolta stime tempo-analisi e confronto con hook evento correnti. | Consolidare report e passare outcome a `AG-Orchestrator` per decisione. |
+Consultare l'[inventario aggiornato al 2025-10-30](../../reports/incoming/inventory-2025-10-30.md) per il dettaglio completo degli asset presenti in `incoming/` prima di procedere con i task.
+
+| Card | Colonna | Caretaker | Prerequisiti accodati | Next step | Riferimento pre-esecuzione |
+| --- | --- | --- | --- | --- | --- |
+| `evo_pacchetto_minimo_v7` | Da analizzare | `AG-Biome` | Annotato fix `unzip -o` come blocco e rimando al pacchetto validazione di `AG-Toolsmith`. | Rieseguire validazioni automatiche dopo il fix e allegare log aggiornati. | [Report sessione-2025-10-29](../../reports/incoming/sessione-2025-10-29/report.html) |
+| `ancestors_integration_pack_v0_5` | Da analizzare | `AG-Core` | Richiesto smoke test CLI (`config/cli/staging_incoming.yaml`) prima dello sblocco integrazione. | Pianificare tuning parametri core in backlog `In integrazione`. | [`scripts/cli_smoke.sh`](../../scripts/cli_smoke.sh) |
+| `recon_meccaniche.json` | In validazione | `AG-Validation` | Segnato bisogno raccolta stime tempo-analisi e confronto con hook evento correnti. | Consolidare report e passare outcome a `AG-Orchestrator` per decisione. | [Report latest](../../reports/incoming/latest/report.html) |
 
 ### Slot calendario condiviso · settimana 2025-11-10
 

--- a/incoming/incoming_inventory.json
+++ b/incoming/incoming_inventory.json
@@ -1,0 +1,776 @@
+[
+  {
+    "percorso": "Ancestors_Neurons_Attack_Dodge_SelfControl_Ambulation_Partial_v0_6.csv",
+    "tipo": "file",
+    "dettagli": "6.6 KiB; .csv",
+    "stato": "CSV (non validato)"
+  },
+  {
+    "percorso": "Ennagramma",
+    "tipo": "directory",
+    "dettagli": "0 cartelle; 7 file; 19.8 KiB",
+    "stato": "OK"
+  },
+  {
+    "percorso": "Ennagramma/README_ENNEAGRAMMA.md",
+    "tipo": "file",
+    "dettagli": "3.3 KiB; .md",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "Ennagramma/enneagramma_dataset.json",
+    "tipo": "file",
+    "dettagli": "11.5 KiB; .json",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "Ennagramma/enneagramma_master.csv",
+    "tipo": "file",
+    "dettagli": "2.2 KiB; .csv",
+    "stato": "CSV (non validato)"
+  },
+  {
+    "percorso": "Ennagramma/enneagramma_stackings.csv",
+    "tipo": "file",
+    "dettagli": "0.3 KiB; .csv",
+    "stato": "CSV (non validato)"
+  },
+  {
+    "percorso": "Ennagramma/enneagramma_triadi_complete.csv",
+    "tipo": "file",
+    "dettagli": "0.7 KiB; .csv",
+    "stato": "CSV (non validato)"
+  },
+  {
+    "percorso": "Ennagramma/enneagramma_varianti_istintive.csv",
+    "tipo": "file",
+    "dettagli": "0.4 KiB; .csv",
+    "stato": "CSV (non validato)"
+  },
+  {
+    "percorso": "Ennagramma/enneagramma_wings.csv",
+    "tipo": "file",
+    "dettagli": "1.4 KiB; .csv",
+    "stato": "CSV (non validato)"
+  },
+  {
+    "percorso": "EvoTactics_DevKit.zip",
+    "tipo": "file",
+    "dettagli": "5.3 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "EvoTactics_FullRepo_v1.0.zip",
+    "tipo": "file",
+    "dettagli": "1372.3 KiB; .0.zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "FEATURE_MAP_EVO_TACTICS.md",
+    "tipo": "file",
+    "dettagli": "6.3 KiB; .md",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "GAME_COMPAT_README.md",
+    "tipo": "file",
+    "dettagli": "1.7 KiB; .md",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "IDEA-001_ecosistema_template.yaml",
+    "tipo": "file",
+    "dettagli": "0.7 KiB; .yaml",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "Img",
+    "tipo": "directory",
+    "dettagli": "1 cartelle; 11 file; 524.1 KiB",
+    "stato": "OK"
+  },
+  {
+    "percorso": "Img/ENFJ Eroe.svg",
+    "tipo": "file",
+    "dettagli": "26.0 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/ENFP Crociato.svg",
+    "tipo": "file",
+    "dettagli": "38.2 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/ENTJ Comandante.svg",
+    "tipo": "file",
+    "dettagli": "12.4 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/ENTP Visionario.svg",
+    "tipo": "file",
+    "dettagli": "23.3 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/ESFJ Ambasciatore.svg",
+    "tipo": "file",
+    "dettagli": "60.6 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/ESFP Intrattenitore.svg",
+    "tipo": "file",
+    "dettagli": "27.4 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/ESTJ Esecutivo.svg",
+    "tipo": "file",
+    "dettagli": "48.5 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/ESTP Ribelle.svg",
+    "tipo": "file",
+    "dettagli": "23.4 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/Enneagrammi",
+    "tipo": "directory",
+    "dettagli": "0 cartelle; 9 file; 182.1 KiB",
+    "stato": "OK"
+  },
+  {
+    "percorso": "Img/Enneagrammi/Tipo 1 Perfezionista.svg",
+    "tipo": "file",
+    "dettagli": "15.7 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/Enneagrammi/Tipo 2 Aiutante.svg",
+    "tipo": "file",
+    "dettagli": "18.7 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/Enneagrammi/Tipo 3 Vincete.svg",
+    "tipo": "file",
+    "dettagli": "15.1 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/Enneagrammi/Tipo 4 Individualista.svg",
+    "tipo": "file",
+    "dettagli": "27.0 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/Enneagrammi/Tipo 5 Investigatore.svg",
+    "tipo": "file",
+    "dettagli": "21.7 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/Enneagrammi/Tipo 6 Lealista.svg",
+    "tipo": "file",
+    "dettagli": "18.2 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/Enneagrammi/Tipo 6 Visionario.svg",
+    "tipo": "file",
+    "dettagli": "21.3 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/Enneagrammi/Tipo 7 Entusista.svg",
+    "tipo": "file",
+    "dettagli": "19.4 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/Enneagrammi/Tipo 9 Mediatore.svg",
+    "tipo": "file",
+    "dettagli": "24.9 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/INFJ Guardiano.svg",
+    "tipo": "file",
+    "dettagli": "30.2 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/INFP Mediatore.svg",
+    "tipo": "file",
+    "dettagli": "23.4 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Img/INTJ Stratega.svg",
+    "tipo": "file",
+    "dettagli": "28.6 KiB; .svg",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "Inserisci questi parametri nella tabella e dammi i....docx",
+    "tipo": "file",
+    "dettagli": "13.1 KiB; ....docx",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "MODELLI_RIF_EVO_TACTICS.md",
+    "tipo": "file",
+    "dettagli": "4.7 KiB; .md",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "README.md",
+    "tipo": "file",
+    "dettagli": "1.4 KiB; .md",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "README_INTEGRAZIONE_MECCANICHE.md",
+    "tipo": "file",
+    "dettagli": "0.7 KiB; .md",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "README_SCAN_STAT_EVENTI.md",
+    "tipo": "file",
+    "dettagli": "0.9 KiB; .md",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "ancestors_branches_totals_v0.3.csv",
+    "tipo": "file",
+    "dettagli": "1.3 KiB; .3.csv",
+    "stato": "CSV (non validato)"
+  },
+  {
+    "percorso": "ancestors_evo_pack_v1_3.zip",
+    "tipo": "file",
+    "dettagli": "7.5 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "ancestors_integration_pack_v0_1.zip",
+    "tipo": "file",
+    "dettagli": "7.9 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "ancestors_integration_pack_v0_2.zip",
+    "tipo": "file",
+    "dettagli": "3.5 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "ancestors_integration_pack_v0_3.zip",
+    "tipo": "file",
+    "dettagli": "3.8 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "ancestors_integration_pack_v0_4.zip",
+    "tipo": "file",
+    "dettagli": "3.1 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "ancestors_integration_pack_v0_5.zip",
+    "tipo": "file",
+    "dettagli": "4.2 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "ancestors_neuronal_v0_3.zip",
+    "tipo": "file",
+    "dettagli": "4.3 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "ancestors_neurons_dump_v0.3__DEXTERITY.csv",
+    "tipo": "file",
+    "dettagli": "7.4 KiB; .3__DEXTERITY.csv",
+    "stato": "CSV (non validato)"
+  },
+  {
+    "percorso": "ancestors_neurons_dump_v0_6.zip",
+    "tipo": "file",
+    "dettagli": "7.3 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "ancestors_neurons_pack_v1_2.zip",
+    "tipo": "file",
+    "dettagli": "8.1 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "archive",
+    "tipo": "directory",
+    "dettagli": "0 cartelle; 1 file; 0.9 KiB",
+    "stato": "OK"
+  },
+  {
+    "percorso": "archive/INDEX.md",
+    "tipo": "file",
+    "dettagli": "0.9 KiB; .md",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "compat_map (1).json",
+    "tipo": "file",
+    "dettagli": "3.9 KiB; .json",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "compat_map.json",
+    "tipo": "file",
+    "dettagli": "3.6 KiB; .json",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "decompressed",
+    "tipo": "directory",
+    "dettagli": "0 cartelle; 2 file; 0.4 KiB",
+    "stato": "OK"
+  },
+  {
+    "percorso": "decompressed/.gitkeep",
+    "tipo": "file",
+    "dettagli": "0.0 KiB; ",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "decompressed/README.md",
+    "tipo": "file",
+    "dettagli": "0.4 KiB; .md",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "docs",
+    "tipo": "directory",
+    "dettagli": "0 cartelle; 11 file; 13.8 KiB",
+    "stato": "OK"
+  },
+  {
+    "percorso": "docs/Evo Tactics Game Template.md",
+    "tipo": "file",
+    "dettagli": "2.9 KiB; .md",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "docs/VISION_AND_STRUCTURE.md",
+    "tipo": "file",
+    "dettagli": "1.9 KiB; .md",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "docs/ascii_matrix_methods.py",
+    "tipo": "file",
+    "dettagli": "0.8 KiB; .py",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "docs/auto_eval_from_yaml.py",
+    "tipo": "file",
+    "dettagli": "1.6 KiB; .py",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "docs/bioma_encounters.yaml",
+    "tipo": "file",
+    "dettagli": "0.6 KiB; .yaml",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "docs/drift_check.js",
+    "tipo": "file",
+    "dettagli": "1.2 KiB; .js",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "docs/installer.sh",
+    "tipo": "file",
+    "dettagli": "1.1 KiB; .sh",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "docs/obsidian_template.md",
+    "tipo": "file",
+    "dettagli": "0.7 KiB; .md",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "docs/readme.md",
+    "tipo": "file",
+    "dettagli": "1.2 KiB; .md",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "docs/readme_devkit.txt",
+    "tipo": "file",
+    "dettagli": "1.0 KiB; .txt",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "docs/yaml_validator.py",
+    "tipo": "file",
+    "dettagli": "1.0 KiB; .py",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "engine_events.schema.json",
+    "tipo": "file",
+    "dettagli": "0.4 KiB; .schema.json",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "enneagramma_mechanics_registry.template.json",
+    "tipo": "file",
+    "dettagli": "6.3 KiB; .template.json",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "et_alignment_scanner.zip",
+    "tipo": "file",
+    "dettagli": "3.4 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics-badlands-addon-v1.7.zip",
+    "tipo": "file",
+    "dettagli": "43.2 KiB; .7.zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics-badlands-ecosystem-it-v1.zip",
+    "tipo": "file",
+    "dettagli": "9.4 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics-final (1).zip",
+    "tipo": "file",
+    "dettagli": "75.7 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics-final.zip",
+    "tipo": "file",
+    "dettagli": "75.7 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics-interconnect-addon-v1.7.1.zip",
+    "tipo": "file",
+    "dettagli": "48.7 KiB; .7.1.zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics-merged.zip",
+    "tipo": "file",
+    "dettagli": "70.4 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics-normalized.zip",
+    "tipo": "file",
+    "dettagli": "72.1 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics-starter.zip",
+    "tipo": "file",
+    "dettagli": "11.0 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics-unified-pack-v1.9.zip",
+    "tipo": "file",
+    "dettagli": "68.4 KiB; .9.zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics-unified-plus-validators-v1.9.6.zip",
+    "tipo": "file",
+    "dettagli": "85.5 KiB; .9.6.zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics-unified-v1.9.7-ecosistema.zip",
+    "tipo": "file",
+    "dettagli": "90.6 KiB; .9.7-ecosistema.zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics-unified-v1.9.8-ecosistema-catalog.zip",
+    "tipo": "file",
+    "dettagli": "94.6 KiB; .9.8-ecosistema-catalog.zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics-unified-v2.0.0-site-tools.zip",
+    "tipo": "file",
+    "dettagli": "338.4 KiB; .0.0-site-tools.zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics-unified-v2.0.1-site-tools.zip",
+    "tipo": "file",
+    "dettagli": "346.0 KiB; .0.1-site-tools.zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics-validator-pack-v1.5.zip",
+    "tipo": "file",
+    "dettagli": "15.4 KiB; .5.zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo-tactics.zip",
+    "tipo": "file",
+    "dettagli": "22.6 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_enneagram_addon_v1.zip",
+    "tipo": "file",
+    "dettagli": "15.4 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_pacchetto_minimo.zip",
+    "tipo": "file",
+    "dettagli": "10.6 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_pacchetto_minimo_v2.zip",
+    "tipo": "file",
+    "dettagli": "17.8 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_pacchetto_minimo_v3.zip",
+    "tipo": "file",
+    "dettagli": "23.9 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_pacchetto_minimo_v4.zip",
+    "tipo": "file",
+    "dettagli": "31.5 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_pacchetto_minimo_v5.zip",
+    "tipo": "file",
+    "dettagli": "41.6 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_pacchetto_minimo_v6.zip",
+    "tipo": "file",
+    "dettagli": "45.5 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_pacchetto_minimo_v7.zip",
+    "tipo": "file",
+    "dettagli": "65.2 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_pacchetto_minimo_v8.zip",
+    "tipo": "file",
+    "dettagli": "71.6 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_sentience_branch_layout_v0_1.zip",
+    "tipo": "file",
+    "dettagli": "3.6 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_sentience_rfc_pack_v0_1.zip",
+    "tipo": "file",
+    "dettagli": "5.0 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_tactics_ancestors_repo_pack_v1.0 (1).zip",
+    "tipo": "file",
+    "dettagli": "12.1 KiB; .0 (1).zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_tactics_ancestors_repo_pack_v1.0.zip",
+    "tipo": "file",
+    "dettagli": "11.4 KiB; .0.zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_tactics_badlands_IT.zip",
+    "tipo": "file",
+    "dettagli": "11.1 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_tactics_badlands_PTPF_IT.zip",
+    "tipo": "file",
+    "dettagli": "14.7 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_tactics_deduped_v8_1.zip",
+    "tipo": "file",
+    "dettagli": "166.3 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_tactics_ecosystem_badlands.zip",
+    "tipo": "file",
+    "dettagli": "7.5 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_tactics_ecosystems_pack.zip",
+    "tipo": "file",
+    "dettagli": "3.8 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_tactics_merged_final.zip",
+    "tipo": "file",
+    "dettagli": "155.0 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_tactics_param_synergy_v8_3.zip",
+    "tipo": "file",
+    "dettagli": "166.3 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "evo_tactics_tables_v8_3.xlsx",
+    "tipo": "file",
+    "dettagli": "21.3 KiB; .xlsx",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "game_repo_map.json",
+    "tipo": "file",
+    "dettagli": "0.8 KiB; .json",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "generator.html",
+    "tipo": "file",
+    "dettagli": "5.0 KiB; .html",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "hook_bindings.ts",
+    "tipo": "file",
+    "dettagli": "1.4 KiB; .ts",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "idea_catalog.csv",
+    "tipo": "file",
+    "dettagli": "1.2 KiB; .csv",
+    "stato": "CSV (non validato)"
+  },
+  {
+    "percorso": "idea_intake_site_package.zip",
+    "tipo": "file",
+    "dettagli": "7.0 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "index (1).html",
+    "tipo": "file",
+    "dettagli": "15.4 KiB; .html",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "index.html",
+    "tipo": "file",
+    "dettagli": "15.1 KiB; .html",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "last_report.html",
+    "tipo": "file",
+    "dettagli": "4.6 KiB; .html",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "last_report.json",
+    "tipo": "file",
+    "dettagli": "7.0 KiB; .json",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "logs_48354746845.zip",
+    "tipo": "file",
+    "dettagli": "9.2 KiB; .zip",
+    "stato": "ZIP integro"
+  },
+  {
+    "percorso": "pack_biome_jobs_v8_alt.json",
+    "tipo": "file",
+    "dettagli": "20.5 KiB; .json",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "pathfinder",
+    "tipo": "directory",
+    "dettagli": "0 cartelle; 1 file; 141.4 KiB",
+    "stato": "OK"
+  },
+  {
+    "percorso": "pathfinder/bestiary1e_index.csv",
+    "tipo": "file",
+    "dettagli": "141.4 KiB; .csv",
+    "stato": "CSV (non validato)"
+  },
+  {
+    "percorso": "personality_module.v1.json",
+    "tipo": "file",
+    "dettagli": "24.2 KiB; .v1.json",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "recon_meccaniche.json",
+    "tipo": "file",
+    "dettagli": "1.8 KiB; .json",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "scan_engine_idents.py",
+    "tipo": "file",
+    "dettagli": "3.0 KiB; .py",
+    "stato": "File generico"
+  },
+  {
+    "percorso": "sensienti_traits_v0.1.yaml",
+    "tipo": "file",
+    "dettagli": "3.8 KiB; .1.yaml",
+    "stato": "Documento testo"
+  },
+  {
+    "percorso": "species_index.html",
+    "tipo": "file",
+    "dettagli": "3.5 KiB; .html",
+    "stato": "Documento testo"
+  }
+]

--- a/reports/incoming/inventory-2025-10-30.md
+++ b/reports/incoming/inventory-2025-10-30.md
@@ -1,0 +1,133 @@
+# Inventario cartella incoming — 2025-10-30
+
+| Percorso | Tipo | Dettagli | Stato |
+| --- | --- | --- | --- |
+| `Ancestors_Neurons_Attack_Dodge_SelfControl_Ambulation_Partial_v0_6.csv` | file | 6.6 KiB; .csv | CSV (non validato) |
+| `Ennagramma` | directory | 0 cartelle; 7 file; 19.8 KiB | OK |
+| `Ennagramma/README_ENNEAGRAMMA.md` | file | 3.3 KiB; .md | Documento testo |
+| `Ennagramma/enneagramma_dataset.json` | file | 11.5 KiB; .json | Documento testo |
+| `Ennagramma/enneagramma_master.csv` | file | 2.2 KiB; .csv | CSV (non validato) |
+| `Ennagramma/enneagramma_stackings.csv` | file | 0.3 KiB; .csv | CSV (non validato) |
+| `Ennagramma/enneagramma_triadi_complete.csv` | file | 0.7 KiB; .csv | CSV (non validato) |
+| `Ennagramma/enneagramma_varianti_istintive.csv` | file | 0.4 KiB; .csv | CSV (non validato) |
+| `Ennagramma/enneagramma_wings.csv` | file | 1.4 KiB; .csv | CSV (non validato) |
+| `EvoTactics_DevKit.zip` | file | 5.3 KiB; .zip | ZIP integro |
+| `EvoTactics_FullRepo_v1.0.zip` | file | 1372.3 KiB; .0.zip | ZIP integro |
+| `FEATURE_MAP_EVO_TACTICS.md` | file | 6.3 KiB; .md | Documento testo |
+| `GAME_COMPAT_README.md` | file | 1.7 KiB; .md | Documento testo |
+| `IDEA-001_ecosistema_template.yaml` | file | 0.7 KiB; .yaml | Documento testo |
+| `Img` | directory | 1 cartelle; 11 file; 524.1 KiB | OK |
+| `Img/ENFJ Eroe.svg` | file | 26.0 KiB; .svg | File generico |
+| `Img/ENFP Crociato.svg` | file | 38.2 KiB; .svg | File generico |
+| `Img/ENTJ Comandante.svg` | file | 12.4 KiB; .svg | File generico |
+| `Img/ENTP Visionario.svg` | file | 23.3 KiB; .svg | File generico |
+| `Img/ESFJ Ambasciatore.svg` | file | 60.6 KiB; .svg | File generico |
+| `Img/ESFP Intrattenitore.svg` | file | 27.4 KiB; .svg | File generico |
+| `Img/ESTJ Esecutivo.svg` | file | 48.5 KiB; .svg | File generico |
+| `Img/ESTP Ribelle.svg` | file | 23.4 KiB; .svg | File generico |
+| `Img/Enneagrammi` | directory | 0 cartelle; 9 file; 182.1 KiB | OK |
+| `Img/Enneagrammi/Tipo 1 Perfezionista.svg` | file | 15.7 KiB; .svg | File generico |
+| `Img/Enneagrammi/Tipo 2 Aiutante.svg` | file | 18.7 KiB; .svg | File generico |
+| `Img/Enneagrammi/Tipo 3 Vincete.svg` | file | 15.1 KiB; .svg | File generico |
+| `Img/Enneagrammi/Tipo 4 Individualista.svg` | file | 27.0 KiB; .svg | File generico |
+| `Img/Enneagrammi/Tipo 5 Investigatore.svg` | file | 21.7 KiB; .svg | File generico |
+| `Img/Enneagrammi/Tipo 6 Lealista.svg` | file | 18.2 KiB; .svg | File generico |
+| `Img/Enneagrammi/Tipo 6 Visionario.svg` | file | 21.3 KiB; .svg | File generico |
+| `Img/Enneagrammi/Tipo 7 Entusista.svg` | file | 19.4 KiB; .svg | File generico |
+| `Img/Enneagrammi/Tipo 9 Mediatore.svg` | file | 24.9 KiB; .svg | File generico |
+| `Img/INFJ Guardiano.svg` | file | 30.2 KiB; .svg | File generico |
+| `Img/INFP Mediatore.svg` | file | 23.4 KiB; .svg | File generico |
+| `Img/INTJ Stratega.svg` | file | 28.6 KiB; .svg | File generico |
+| `Inserisci questi parametri nella tabella e dammi i....docx` | file | 13.1 KiB; ....docx | Documento testo |
+| `MODELLI_RIF_EVO_TACTICS.md` | file | 4.7 KiB; .md | Documento testo |
+| `README.md` | file | 1.4 KiB; .md | Documento testo |
+| `README_INTEGRAZIONE_MECCANICHE.md` | file | 0.7 KiB; .md | Documento testo |
+| `README_SCAN_STAT_EVENTI.md` | file | 0.9 KiB; .md | Documento testo |
+| `ancestors_branches_totals_v0.3.csv` | file | 1.3 KiB; .3.csv | CSV (non validato) |
+| `ancestors_evo_pack_v1_3.zip` | file | 7.5 KiB; .zip | ZIP integro |
+| `ancestors_integration_pack_v0_1.zip` | file | 7.9 KiB; .zip | ZIP integro |
+| `ancestors_integration_pack_v0_2.zip` | file | 3.5 KiB; .zip | ZIP integro |
+| `ancestors_integration_pack_v0_3.zip` | file | 3.8 KiB; .zip | ZIP integro |
+| `ancestors_integration_pack_v0_4.zip` | file | 3.1 KiB; .zip | ZIP integro |
+| `ancestors_integration_pack_v0_5.zip` | file | 4.2 KiB; .zip | ZIP integro |
+| `ancestors_neuronal_v0_3.zip` | file | 4.3 KiB; .zip | ZIP integro |
+| `ancestors_neurons_dump_v0.3__DEXTERITY.csv` | file | 7.4 KiB; .3__DEXTERITY.csv | CSV (non validato) |
+| `ancestors_neurons_dump_v0_6.zip` | file | 7.3 KiB; .zip | ZIP integro |
+| `ancestors_neurons_pack_v1_2.zip` | file | 8.1 KiB; .zip | ZIP integro |
+| `archive` | directory | 0 cartelle; 1 file; 0.9 KiB | OK |
+| `archive/INDEX.md` | file | 0.9 KiB; .md | Documento testo |
+| `compat_map (1).json` | file | 3.9 KiB; .json | Documento testo |
+| `compat_map.json` | file | 3.6 KiB; .json | Documento testo |
+| `decompressed` | directory | 0 cartelle; 2 file; 0.4 KiB | OK |
+| `decompressed/.gitkeep` | file | 0.0 KiB;  | File generico |
+| `decompressed/README.md` | file | 0.4 KiB; .md | Documento testo |
+| `docs` | directory | 0 cartelle; 11 file; 13.8 KiB | OK |
+| `docs/Evo Tactics Game Template.md` | file | 2.9 KiB; .md | Documento testo |
+| `docs/VISION_AND_STRUCTURE.md` | file | 1.9 KiB; .md | Documento testo |
+| `docs/ascii_matrix_methods.py` | file | 0.8 KiB; .py | File generico |
+| `docs/auto_eval_from_yaml.py` | file | 1.6 KiB; .py | File generico |
+| `docs/bioma_encounters.yaml` | file | 0.6 KiB; .yaml | Documento testo |
+| `docs/drift_check.js` | file | 1.2 KiB; .js | File generico |
+| `docs/installer.sh` | file | 1.1 KiB; .sh | File generico |
+| `docs/obsidian_template.md` | file | 0.7 KiB; .md | Documento testo |
+| `docs/readme.md` | file | 1.2 KiB; .md | Documento testo |
+| `docs/readme_devkit.txt` | file | 1.0 KiB; .txt | File generico |
+| `docs/yaml_validator.py` | file | 1.0 KiB; .py | File generico |
+| `engine_events.schema.json` | file | 0.4 KiB; .schema.json | Documento testo |
+| `enneagramma_mechanics_registry.template.json` | file | 6.3 KiB; .template.json | Documento testo |
+| `et_alignment_scanner.zip` | file | 3.4 KiB; .zip | ZIP integro |
+| `evo-tactics-badlands-addon-v1.7.zip` | file | 43.2 KiB; .7.zip | ZIP integro |
+| `evo-tactics-badlands-ecosystem-it-v1.zip` | file | 9.4 KiB; .zip | ZIP integro |
+| `evo-tactics-final (1).zip` | file | 75.7 KiB; .zip | ZIP integro |
+| `evo-tactics-final.zip` | file | 75.7 KiB; .zip | ZIP integro |
+| `evo-tactics-interconnect-addon-v1.7.1.zip` | file | 48.7 KiB; .7.1.zip | ZIP integro |
+| `evo-tactics-merged.zip` | file | 70.4 KiB; .zip | ZIP integro |
+| `evo-tactics-normalized.zip` | file | 72.1 KiB; .zip | ZIP integro |
+| `evo-tactics-starter.zip` | file | 11.0 KiB; .zip | ZIP integro |
+| `evo-tactics-unified-pack-v1.9.zip` | file | 68.4 KiB; .9.zip | ZIP integro |
+| `evo-tactics-unified-plus-validators-v1.9.6.zip` | file | 85.5 KiB; .9.6.zip | ZIP integro |
+| `evo-tactics-unified-v1.9.7-ecosistema.zip` | file | 90.6 KiB; .9.7-ecosistema.zip | ZIP integro |
+| `evo-tactics-unified-v1.9.8-ecosistema-catalog.zip` | file | 94.6 KiB; .9.8-ecosistema-catalog.zip | ZIP integro |
+| `evo-tactics-unified-v2.0.0-site-tools.zip` | file | 338.4 KiB; .0.0-site-tools.zip | ZIP integro |
+| `evo-tactics-unified-v2.0.1-site-tools.zip` | file | 346.0 KiB; .0.1-site-tools.zip | ZIP integro |
+| `evo-tactics-validator-pack-v1.5.zip` | file | 15.4 KiB; .5.zip | ZIP integro |
+| `evo-tactics.zip` | file | 22.6 KiB; .zip | ZIP integro |
+| `evo_enneagram_addon_v1.zip` | file | 15.4 KiB; .zip | ZIP integro |
+| `evo_pacchetto_minimo.zip` | file | 10.6 KiB; .zip | ZIP integro |
+| `evo_pacchetto_minimo_v2.zip` | file | 17.8 KiB; .zip | ZIP integro |
+| `evo_pacchetto_minimo_v3.zip` | file | 23.9 KiB; .zip | ZIP integro |
+| `evo_pacchetto_minimo_v4.zip` | file | 31.5 KiB; .zip | ZIP integro |
+| `evo_pacchetto_minimo_v5.zip` | file | 41.6 KiB; .zip | ZIP integro |
+| `evo_pacchetto_minimo_v6.zip` | file | 45.5 KiB; .zip | ZIP integro |
+| `evo_pacchetto_minimo_v7.zip` | file | 65.2 KiB; .zip | ZIP integro |
+| `evo_pacchetto_minimo_v8.zip` | file | 71.6 KiB; .zip | ZIP integro |
+| `evo_sentience_branch_layout_v0_1.zip` | file | 3.6 KiB; .zip | ZIP integro |
+| `evo_sentience_rfc_pack_v0_1.zip` | file | 5.0 KiB; .zip | ZIP integro |
+| `evo_tactics_ancestors_repo_pack_v1.0 (1).zip` | file | 12.1 KiB; .0 (1).zip | ZIP integro |
+| `evo_tactics_ancestors_repo_pack_v1.0.zip` | file | 11.4 KiB; .0.zip | ZIP integro |
+| `evo_tactics_badlands_IT.zip` | file | 11.1 KiB; .zip | ZIP integro |
+| `evo_tactics_badlands_PTPF_IT.zip` | file | 14.7 KiB; .zip | ZIP integro |
+| `evo_tactics_deduped_v8_1.zip` | file | 166.3 KiB; .zip | ZIP integro |
+| `evo_tactics_ecosystem_badlands.zip` | file | 7.5 KiB; .zip | ZIP integro |
+| `evo_tactics_ecosystems_pack.zip` | file | 3.8 KiB; .zip | ZIP integro |
+| `evo_tactics_merged_final.zip` | file | 155.0 KiB; .zip | ZIP integro |
+| `evo_tactics_param_synergy_v8_3.zip` | file | 166.3 KiB; .zip | ZIP integro |
+| `evo_tactics_tables_v8_3.xlsx` | file | 21.3 KiB; .xlsx | File generico |
+| `game_repo_map.json` | file | 0.8 KiB; .json | Documento testo |
+| `generator.html` | file | 5.0 KiB; .html | Documento testo |
+| `hook_bindings.ts` | file | 1.4 KiB; .ts | Documento testo |
+| `idea_catalog.csv` | file | 1.2 KiB; .csv | CSV (non validato) |
+| `idea_intake_site_package.zip` | file | 7.0 KiB; .zip | ZIP integro |
+| `index (1).html` | file | 15.4 KiB; .html | Documento testo |
+| `index.html` | file | 15.1 KiB; .html | Documento testo |
+| `last_report.html` | file | 4.6 KiB; .html | Documento testo |
+| `last_report.json` | file | 7.0 KiB; .json | Documento testo |
+| `logs_48354746845.zip` | file | 9.2 KiB; .zip | ZIP integro |
+| `pack_biome_jobs_v8_alt.json` | file | 20.5 KiB; .json | Documento testo |
+| `pathfinder` | directory | 0 cartelle; 1 file; 141.4 KiB | OK |
+| `pathfinder/bestiary1e_index.csv` | file | 141.4 KiB; .csv | CSV (non validato) |
+| `personality_module.v1.json` | file | 24.2 KiB; .v1.json | Documento testo |
+| `recon_meccaniche.json` | file | 1.8 KiB; .json | Documento testo |
+| `scan_engine_idents.py` | file | 3.0 KiB; .py | File generico |
+| `sensienti_traits_v0.1.yaml` | file | 3.8 KiB; .1.yaml | Documento testo |
+| `species_index.html` | file | 3.5 KiB; .html | Documento testo |


### PR DESCRIPTION
## Summary
- generate an inventory snapshot of the `incoming/` directory (JSON + Markdown) with status information for every asset
- reference the new inventory and required reports/scripts inside the shared incoming backlog table

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6903645e09bc83329f422dc43114bbda