### PR TITLE
Add Evo Tactics pack trait reference mirror and sync docs

### DIFF
--- a/data/derived/analysis/trait_baseline.yaml
+++ b/data/derived/analysis/trait_baseline.yaml
@@ -1,10 +1,10 @@
 schema_version: '1.0'
 source:
   env_traits: packs/evo_tactics_pack/docs/catalog/env_traits.json
-  trait_reference: data/traits/index.json
+  trait_reference: packs/evo_tactics_pack/docs/catalog/trait_reference.json
   trait_glossary: data/core/traits/glossary.json
 summary:
-  total_traits: 302
+  total_traits: 306
   missing_metadata: 132
 traits:
   ali_fulminee:
@@ -273,6 +273,24 @@ traits:
     biomi:
       abisso_vulcanico: 1
     missing_metadata: false
+  armatura_pietra_planare:
+    label: Armatura di Pietra Planare
+    label_en: Planar Stone Plating
+    description_it: Corazza risonante scolpita da roccia extradimensionale che smorza
+      onde d'urto.
+    description_en: Resonant plating carved from extradimensional stone that dampens
+      shockwaves.
+    tier: T2
+    archetype: difesa
+    occurrences: 0
+    famiglia_tipologia: Difesa/Strutturale
+    fattore_mantenimento_energetico: Basso (Risonanza geodetica stabile)
+    sinergie:
+    - carapace_fase_variabile
+    conflitti:
+    - frusta_fiammeggiante
+    biomi: {}
+    missing_metadata: false
   artigli_acidofagi:
     label: Artigli Acidofagi
     label_en: Artigli Acidofagi
@@ -405,6 +423,25 @@ traits:
     conflitti: []
     biomi:
       caldera_glaciale: 1
+    missing_metadata: false
+  aura_scudo_radianza:
+    label: Aura Scudo di Radianza
+    label_en: Radiant Shield Aura
+    description_it: Campo fotoplasmatico che devia danni planari e sincronizza i battiti
+      della squadra.
+    description_en: Photoplasmic field that deflects planar damage while syncing squad
+      vitals.
+    tier: T3
+    archetype: supporto
+    occurrences: 0
+    famiglia_tipologia: Supporto/Difesa
+    fattore_mantenimento_energetico: Alto (Canalizzazione fotonica continua)
+    sinergie:
+    - empatia_coordinativa
+    - risonanza_di_branco
+    conflitti:
+    - mantello_meteoritico
+    biomi: {}
     missing_metadata: false
   baffi_mareomotori:
     label: Baffi Mareomotori
@@ -852,7 +889,23 @@ traits:
     famiglia_tipologia: Strutturale/Difensivo
     fattore_mantenimento_energetico: Alto (Richiede energia per il cambio di fase)
     sinergie:
+    - ali_membrana_sonica
+    - appendici_risonanti_marea
+    - armatura_pietra_planare
+    - barriere_miasma_glaciale
+    - branchie_microfiltri
+    - capsule_paracadute
     - cartilagine_flessotermica_venti
+    - circolazione_bifasica
+    - coda_coppia_retroattiva
+    - cute_resistente_sali
+    - enzimi_antipredatori_algali
+    - filtri_planctonici
+    - ghiandole_fango_coesivo
+    - giunti_antitorsione
+    - lingua_cristallina
+    - mantello_meteoritico
+    - mucose_barofile
     - sensori_geomagnetici
     conflitti:
     - struttura_elastica_amorfa
@@ -1302,7 +1355,34 @@ traits:
     famiglia_tipologia: Locomotorio/Difensivo
     fattore_mantenimento_energetico: Medio (Mantenimento dell'energia accumulata)
     sinergie:
+    - ali_ioniche
+    - antenne_flusso_mareale
+    - antenne_wideband
+    - artigli_induzione
     - artigli_sette_vie
+    - barbigli_sensori_plasma
+    - biochip_memoria
+    - branchie_metalloidi
+    - camere_anticorrosione
+    - capillari_fotovoltaici
+    - cartilagini_biofibre
+    - chemiorecettori_bromuro
+    - circolazione_supercritica
+    - coda_contrappeso
+    - coda_stabilizzatrice_vortex
+    - cuscinetti_elettrostatici
+    - denti_chelatanti
+    - enzimi_antifase_termica
+    - enzimi_metanoossidanti
+    - filamenti_termoconduzione
+    - foliaggio_spugna
+    - ghiandole_fango_calde
+    - ghiandole_iodoattive
+    - ghiandole_ventosa
+    - gusci_magnesio
+    - linfa_tampone
+    - mantelli_geotermici
+    - mucose_aderenza_sonica
     conflitti: []
     biomi:
       dorsale_termale_tropicale: 1
@@ -1662,7 +1742,21 @@ traits:
     famiglia_tipologia: Supporto/Empatico
     fattore_mantenimento_energetico: Medio (Feedback costante dai compagni)
     sinergie:
+    - antenne_eco_turbina
+    - artigli_acidofagi
+    - aura_scudo_radianza
+    - batteri_termofili_endosimbiosi
+    - branchie_turbina
+    - carapaci_ferruginosi
     - cavita_risonanti_tundra
+    - circolazione_doppia
+    - coda_stabilizzatrice_geiser
+    - cuticole_neutralizzanti
+    - enzimi_chelatori_rapidi
+    - foliage_fotocatodico
+    - ghiandole_inchiostro_luce
+    - gusci_criovetro
+    - luminescenza_hydrotermica
     conflitti: []
     biomi:
       foresta_miceliale: 1
@@ -1811,6 +1905,19 @@ traits:
     famiglia_tipologia: Digestivo/Escretorio
     fattore_mantenimento_energetico: Basso (Passivo)
     sinergie:
+    - antenne_dustsense
+    - appendici_thermotattiche
+    - batteri_endosimbionti_chemio
+    - branchie_solfatiche
+    - carapace_segmenti_logici
+    - circolazione_cooling_loop
+    - coda_stabilizzatrice_filo
+    - cuticole_cerose
+    - enzimi_chelanti
+    - flagelli_ancoranti
+    - ghiandole_grafene
+    - grassi_termici
+    - luminescenza_aurorale
     - ventriglio_gastroliti
     conflitti: []
     biomi:
@@ -1921,12 +2028,27 @@ traits:
     description_it: Cortex biforcato che mantiene due minacce in sorveglianza attiva.
     description_en: Split cortex keeps two threats under active surveillance.
     tier: T1
-    archetype: controllo
+    archetype: strategia
     occurrences: 3
-    famiglia_tipologia: Tattico/Controllo
+    famiglia_tipologia: Strategico/Psionico
     fattore_mantenimento_energetico: Medio (Dividere l'attenzione su più canali)
     sinergie:
+    - ali_fulminee
     - antenne_plasmatiche_tempesta
+    - antenne_waveguide
+    - baffi_mareomotori
+    - branchie_eoliche
+    - capillari_fluoridici
+    - cervelletto_equilibrio_statico
+    - coda_balanciere
+    - cuore_multicamera_bassa_pressione
+    - echi_risonanti
+    - filamenti_superconduttivi
+    - frusta_fiammeggiante
+    - ghiandole_eco_mappanti
+    - ghiandole_resina_conduttiva
+    - lamine_scudo_silice
+    - midollo_antivibrazione
     conflitti: []
     biomi:
       canopia_psionica_leggera: 1
@@ -1971,6 +2093,24 @@ traits:
     conflitti: []
     biomi:
       mangrovieto_cinetico: 1
+    missing_metadata: false
+  frusta_fiammeggiante:
+    label: Frusta Fiammeggiante
+    label_en: Flame Lash
+    description_it: Appendice di plasma vincolato capace di arpionare e incendiare
+      bersagli.
+    description_en: Bound plasma appendage that can hook and ignite targets.
+    tier: T2
+    archetype: offensiva
+    occurrences: 0
+    famiglia_tipologia: Offensivo/Controllo
+    fattore_mantenimento_energetico: Medio (Filamenti di plasma vincolato)
+    sinergie:
+    - focus_frazionato
+    - mantello_meteoritico
+    conflitti:
+    - armatura_pietra_planare
+    biomi: {}
     missing_metadata: false
   ghiaccio_piezoelettrico:
     label: Ghiaccio Piezoelettrico
@@ -2533,6 +2673,25 @@ traits:
     biomi:
       caldera_glaciale: 1
     missing_metadata: false
+  mantello_meteoritico:
+    label: Mantello Meteoritico
+    label_en: Meteoric Mantle
+    description_it: Strati ablativi rigeneranti che vaporizzano l'impatto convertendolo
+      in impulso termico.
+    description_en: Regenerating ablative layers that vaporize impacts into thermal
+      pulses.
+    tier: T3
+    archetype: difesa
+    occurrences: 0
+    famiglia_tipologia: Difesa/Termoregolazione
+    fattore_mantenimento_energetico: Alto (Rivestimento ablativo rigenerante)
+    sinergie:
+    - carapace_fase_variabile
+    - frusta_fiammeggiante
+    conflitti:
+    - aura_scudo_radianza
+    biomi: {}
+    missing_metadata: false
   membrane_captura_rugiada:
     label: Membrane Captura Rugiada
     label_en: Membrane Captura Rugiada
@@ -2636,7 +2795,21 @@ traits:
     famiglia_tipologia: Tegumentario/Difensivo
     fattore_mantenimento_energetico: Basso (Fase passiva)
     sinergie:
+    - ali_membrana_sonica
+    - appendici_risonanti_marea
     - artigli_sette_vie
+    - barriere_miasma_glaciale
+    - branchie_microfiltri
+    - capsule_paracadute
+    - circolazione_bifasica
+    - coda_coppia_retroattiva
+    - cute_resistente_sali
+    - enzimi_antipredatori_algali
+    - filtri_planctonici
+    - ghiandole_fango_coesivo
+    - giunti_antitorsione
+    - lingua_cristallina
+    - mucose_barofile
     - struttura_elastica_amorfa
     conflitti: []
     biomi:
@@ -2655,8 +2828,21 @@ traits:
     famiglia_tipologia: Simbiotico/Difensivo
     fattore_mantenimento_energetico: Medio (Coltura simbiotica costante)
     sinergie:
+    - antenne_reagenti
+    - artigli_scivolo_silente
+    - biofilm_iperarido
     - branchie_osmotiche_salmastra
+    - camere_nutrienti_vent
+    - cartilagini_flessoacustiche
     - circolazione_bifasica_palude
+    - ciste_salmastre
+    - coralli_partner
+    - denti_silice_termici
+    - epitelio_fosforescente
+    - ghiandole_cambio_salino
+    - ghiandole_nebbia_acida
+    - lamelle_sincroniche
+    - membrane_planata_vectored
     - nodi_micorrizici_oracolari
     conflitti:
     - ghiandola_caustica
@@ -2801,8 +2987,21 @@ traits:
     famiglia_tipologia: Simbiotico/Nervoso
     fattore_mantenimento_energetico: Medio (Scambio continuo di segnali con simbionti)
     sinergie:
+    - antenne_reagenti
+    - artigli_scivolo_silente
+    - biofilm_iperarido
     - bulbi_radici_permafrost
+    - camere_nutrienti_vent
+    - cartilagini_flessoacustiche
     - chioma_parassita_canopica
+    - ciste_salmastre
+    - coralli_partner
+    - denti_silice_termici
+    - epitelio_fosforescente
+    - ghiandole_cambio_salino
+    - ghiandole_nebbia_acida
+    - lamelle_sincroniche
+    - membrane_planata_vectored
     - mucillagine_simbionte_mangrovie
     conflitti:
     - spore_psichiche_silenziate
@@ -3438,9 +3637,22 @@ traits:
     tier: T1
     archetype: strategia
     occurrences: 1
-    famiglia_tipologia: Strategico/Comando
+    famiglia_tipologia: Strategico/Tattico
     fattore_mantenimento_energetico: Medio (Analisi continua di stato squadre)
-    sinergie: []
+    sinergie:
+    - antenne_microonde_cavernose
+    - artigli_radice
+    - biofilm_glow
+    - camere_mirage
+    - cartilagini_desertiche
+    - ciste_riduttive
+    - colonne_vibromagnetiche
+    - denti_ossidoferro
+    - epidermide_dielettrica
+    - ghiaccio_piezoelettrico
+    - ghiandole_minerali
+    - lamelle_shear
+    - membrane_captura_rugiada
     conflitti: []
     biomi:
       foresta_miceliale: 1
@@ -4070,12 +4282,26 @@ traits:
     tier: T1
     archetype: supporto
     occurrences: 1
-    famiglia_tipologia: Supporto/Armonico
+    famiglia_tipologia: Supporto/Coordinativo
     fattore_mantenimento_energetico: Basso (Richiede mantenimento empatico)
     sinergie:
+    - antenne_eco_turbina
     - antenne_plasmatiche_tempesta
+    - artigli_acidofagi
+    - aura_scudo_radianza
+    - batteri_termofili_endosimbiosi
+    - branchie_turbina
     - carapace_luminiscente_abissale
+    - carapaci_ferruginosi
     - cavita_risonanti_tundra
+    - circolazione_doppia
+    - coda_stabilizzatrice_geiser
+    - cuticole_neutralizzanti
+    - enzimi_chelatori_rapidi
+    - foliage_fotocatodico
+    - ghiandole_inchiostro_luce
+    - gusci_criovetro
+    - luminescenza_hydrotermica
     conflitti: []
     biomi:
       foresta_miceliale: 1
@@ -4229,12 +4455,25 @@ traits:
     description_it: Fluido ematico che incendia l'aria colpendo chi perfora la corazza.
     description_en: Blood ignites on air contact, burning would-be piercers.
     tier: T1
-    archetype: sopravvivenza
+    archetype: offensiva
     occurrences: 2
-    famiglia_tipologia: Circolatorio/Difensivo
+    famiglia_tipologia: Offensivo/Cinetico
     fattore_mantenimento_energetico: Medio (Sintesi dei composti)
     sinergie:
+    - antenne_flusso_mareale
+    - artigli_induzione
+    - biochip_memoria
+    - camere_anticorrosione
+    - cartilagini_biofibre
+    - circolazione_supercritica
+    - coda_stabilizzatrice_vortex
+    - denti_chelatanti
+    - enzimi_metanoossidanti
+    - foliaggio_spugna
+    - ghiandole_iodoattive
+    - gusci_magnesio
     - lamelle_termoforetiche
+    - mantelli_geotermici
     conflitti:
     - criostasi_adattiva
     - scheletro_idro_regolante
@@ -4283,7 +4522,20 @@ traits:
     famiglia_tipologia: Strutturale/Omeostatico
     fattore_mantenimento_energetico: Medio (Scambio rapido di fluidi)
     sinergie:
+    - antenne_tesla
+    - artigli_vetrificati
+    - branchie_dual_mode
     - branchie_osmotiche_salmastra
+    - capillari_criogenici
+    - cartilagini_pseudometalliche
+    - cisti_iperbariche
+    - cromofori_alert_acido
+    - denti_tuning_fork
+    - filamenti_magnetotrofi
+    - ghiandole_condensa_ozono
+    - ghiandole_nebbia_ionica
+    - lamine_filtranti_aeree
+    - membrane_pneumatofori
     - sacche_galleggianti_ascensoriali
     - struttura_elastica_amorfa
     conflitti:
@@ -4576,8 +4828,22 @@ traits:
     famiglia_tipologia: Simbiotico/Comunicazione
     fattore_mantenimento_energetico: Medio (Scambio continuo di impulsi corallini)
     sinergie:
+    - ali_fulminee
     - antenne_plasmatiche_tempesta
+    - antenne_waveguide
+    - baffi_mareomotori
+    - branchie_eoliche
+    - capillari_fluoridici
     - carapace_luminiscente_abissale
+    - cervelletto_equilibrio_statico
+    - coda_balanciere
+    - cuore_multicamera_bassa_pressione
+    - echi_risonanti
+    - filamenti_superconduttivi
+    - ghiandole_eco_mappanti
+    - ghiandole_resina_conduttiva
+    - lamine_scudo_silice
+    - midollo_antivibrazione
     conflitti:
     - spore_psichiche_silenziate
     biomi: {}
@@ -4735,7 +5001,20 @@ traits:
     famiglia_tipologia: Strutturale/Locomotorio
     fattore_mantenimento_energetico: Basso (Passivo)
     sinergie:
+    - antenne_tesla
     - artigli_sette_vie
+    - artigli_vetrificati
+    - branchie_dual_mode
+    - capillari_criogenici
+    - cartilagini_pseudometalliche
+    - cisti_iperbariche
+    - cromofori_alert_acido
+    - denti_tuning_fork
+    - filamenti_magnetotrofi
+    - ghiandole_condensa_ozono
+    - ghiandole_nebbia_ionica
+    - lamine_filtranti_aeree
+    - membrane_pneumatofori
     - mimetismo_cromatico_passivo
     - sacche_galleggianti_ascensoriali
     - scheletro_idro_regolante
@@ -4754,10 +5033,23 @@ traits:
     tier: T1
     archetype: strategia
     occurrences: 1
-    famiglia_tipologia: Strategico/Supporto
+    famiglia_tipologia: Strategico/Tattico
     fattore_mantenimento_energetico: Medio (Broadcast continuo di segnali)
     sinergie:
+    - antenne_microonde_cavernose
+    - artigli_radice
     - artigli_sette_vie
+    - biofilm_glow
+    - camere_mirage
+    - cartilagini_desertiche
+    - ciste_riduttive
+    - colonne_vibromagnetiche
+    - denti_ossidoferro
+    - epidermide_dielettrica
+    - ghiaccio_piezoelettrico
+    - ghiandole_minerali
+    - lamelle_shear
+    - membrane_captura_rugiada
     conflitti: []
     biomi:
       foresta_miceliale: 1
@@ -4998,7 +5290,20 @@ traits:
     famiglia_tipologia: Digestivo/Alimentare
     fattore_mantenimento_energetico: Medio (Contrazione muscolare costante)
     sinergie:
+    - antenne_dustsense
+    - appendici_thermotattiche
+    - batteri_endosimbionti_chemio
+    - branchie_solfatiche
+    - carapace_segmenti_logici
+    - circolazione_cooling_loop
+    - coda_stabilizzatrice_filo
+    - cuticole_cerose
+    - enzimi_chelanti
     - filamenti_digestivi_compattanti
+    - flagelli_ancoranti
+    - ghiandole_grafene
+    - grassi_termici
+    - luminescenza_aurorale
     conflitti: []
     biomi:
       dorsale_termale_tropicale: 1
@@ -5075,7 +5380,21 @@ traits:
     famiglia_tipologia: Mobilità/Cinetico
     fattore_mantenimento_energetico: Basso (Carica elastica a turni alterni)
     sinergie:
+    - ali_ioniche
+    - antenne_wideband
     - artigli_sghiaccio_glaciale
+    - barbigli_sensori_plasma
+    - branchie_metalloidi
+    - capillari_fotovoltaici
+    - chemiorecettori_bromuro
+    - coda_contrappeso
+    - cuscinetti_elettrostatici
+    - enzimi_antifase_termica
+    - filamenti_termoconduzione
+    - ghiandole_fango_calde
+    - ghiandole_ventosa
+    - linfa_tampone
+    - mucose_aderenza_sonica
     conflitti: []
     biomi: {}
     missing_metadata: false
@@ -5145,15 +5464,12 @@ archetypes:
     total: 1
     traits:
     - random
-  controllo:
-    total: 1
-    traits:
-    - focus_frazionato
   difesa:
-    total: 19
+    total: 21
     traits:
     - ali_membrana_sonica
     - appendici_risonanti_marea
+    - armatura_pietra_planare
     - barriere_miasma_glaciale
     - branchie_microfiltri
     - capsule_paracadute
@@ -5165,6 +5481,7 @@ archetypes:
     - ghiandole_fango_coesivo
     - giunti_antitorsione
     - lingua_cristallina
+    - mantello_meteoritico
     - mimetismo_cromatico_passivo
     - mucose_barofile
     - piume_solari_fotovoltaiche
@@ -5356,7 +5673,7 @@ archetypes:
     - zoccoli_resina_ionica
     - zoccoli_stabilita_dinamica
   offensiva:
-    total: 14
+    total: 16
     traits:
     - antenne_flusso_mareale
     - artigli_induzione
@@ -5368,10 +5685,12 @@ archetypes:
     - denti_chelatanti
     - enzimi_metanoossidanti
     - foliaggio_spugna
+    - frusta_fiammeggiante
     - ghiandola_caustica
     - ghiandole_iodoattive
     - gusci_magnesio
     - mantelli_geotermici
+    - sangue_piroforico
   sensoriale:
     total: 22
     traits:
@@ -5420,16 +5739,15 @@ archetypes:
     - sacche_spore_stratosferiche
     - sinapsi_coraline_polifoniche
   sopravvivenza:
-    total: 6
+    total: 5
     traits:
     - branchie_osmotiche_salmastra
     - lamelle_termoforetiche
     - membrane_eliofiltranti
     - polmoni_cristallini_alta_quota
     - respiro_a_scoppio
-    - sangue_piroforico
   strategia:
-    total: 15
+    total: 16
     traits:
     - antenne_microonde_cavernose
     - artigli_radice
@@ -5440,6 +5758,7 @@ archetypes:
     - colonne_vibromagnetiche
     - denti_ossidoferro
     - epidermide_dielettrica
+    - focus_frazionato
     - ghiaccio_piezoelettrico
     - ghiandole_minerali
     - lamelle_shear
@@ -5467,10 +5786,11 @@ archetypes:
     - scheletro_idro_regolante
     - struttura_elastica_amorfa
   supporto:
-    total: 16
+    total: 17
     traits:
     - antenne_eco_turbina
     - artigli_acidofagi
+    - aura_scudo_radianza
     - batteri_termofili_endosimbiosi
     - branchie_turbina
     - carapaci_ferruginosi

--- a/data/derived/analysis/trait_coverage_matrix.csv
+++ b/data/derived/analysis/trait_coverage_matrix.csv
@@ -26,6 +26,8 @@ appendici_risonanti_marea,Appendici Risonanti Marea,Appendici Risonanti Marea,la
 appendici_risonanti_marea,Appendici Risonanti Marea,Appendici Risonanti Marea,laguna_bioreattiva,cursoriale_quadrupede,0,1
 appendici_thermotattiche,Appendici Thermotattiche,Appendici Thermotattiche,abisso_vulcanico,,1,1
 appendici_thermotattiche,Appendici Thermotattiche,Appendici Thermotattiche,abisso_vulcanico,cursoriale_quadrupede,0,1
+armatura_pietra_planare,Armatura di Pietra Planare,Planar Stone Plating,rovine_planari,cursoriale_quadrupede,0,1
+armatura_pietra_planare,Armatura di Pietra Planare,Planar Stone Plating,rovine_planari,scavenger_corazzato,0,1
 artigli_acidofagi,Artigli Acidofagi,Artigli Acidofagi,foresta_acida,,1,1
 artigli_acidofagi,Artigli Acidofagi,Artigli Acidofagi,foresta_acida,cursoriale_quadrupede,0,1
 artigli_induzione,Artigli Induzione,Artigli Induzione,canopia_ionica,,1,1
@@ -38,9 +40,11 @@ artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,caverna_risonante,,1,2
 artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,caverna_risonante,cursoriale_quadrupede,0,2
 artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,dorsale_termale_tropicale,cursoriale_quadrupede,1,2
 artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,mezzanotte_orbitale,cursoriale_quadrupede,1,1
+artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,rovine_planari,cursoriale_quadrupede,0,2
 artigli_sghiaccio_glaciale,Artigli Sghiaccio Glaciale,Artigli Sghiaccio Glaciale,calotte_glaciali,cursoriale_quadrupede,0,1
 artigli_vetrificati,Artigli Vetrificati,Artigli Vetrificati,caldera_glaciale,,1,1
 artigli_vetrificati,Artigli Vetrificati,Artigli Vetrificati,caldera_glaciale,cursoriale_quadrupede,0,1
+aura_scudo_radianza,Aura Scudo di Radianza,Radiant Shield Aura,rovine_planari,volatore_planatore,0,1
 baffi_mareomotori,Baffi Mareomotori,Baffi Mareomotori,mangrovieto_cinetico,,1,1
 baffi_mareomotori,Baffi Mareomotori,Baffi Mareomotori,mangrovieto_cinetico,cursoriale_quadrupede,0,1
 barbigli_sensori_plasma,Barbigli Sensori Plasma,Barbigli Sensori Plasma,stratosfera_tempestosa,,1,1
@@ -88,6 +92,8 @@ capsule_paracadute,Capsule Paracadute,Capsule Paracadute,stratosfera_tempestosa,
 carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,canopia_psionica_leggera,cursoriale_quadrupede,0,1
 carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,falde_magnetiche_psioniche,cursoriale_quadrupede,0,1
 carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,mezzanotte_orbitale,cursoriale_quadrupede,1,1
+carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,rovine_planari,cursoriale_quadrupede,0,1
+carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,rovine_planari,scavenger_corazzato,0,1
 carapace_luminiscente_abissale,Carapace Luminiscente Abissale,Carapace Luminiscente Abissale,abisso_luminescente,cursoriale_quadrupede,0,1
 carapace_segmenti_logici,Carapace Segmenti Logici,Carapace Segmenti Logici,steppe_algoritmiche,,1,1
 carapace_segmenti_logici,Carapace Segmenti Logici,Carapace Segmenti Logici,steppe_algoritmiche,cursoriale_quadrupede,0,1
@@ -132,6 +138,7 @@ coda_coppia_retroattiva,Coda Coppia Retroattiva,Coda Coppia Retroattiva,steppe_a
 coda_frusta_cinetica,Coda a Frusta Cinetica,Kinetic Lash Tail,dorsale_termale_tropicale,cursoriale_quadrupede,1,3
 coda_frusta_cinetica,Coda a Frusta Cinetica,Kinetic Lash Tail,falde_magnetiche_psioniche,cursoriale_quadrupede,0,1
 coda_frusta_cinetica,Coda a Frusta Cinetica,Kinetic Lash Tail,orbita_psionica_inversa,cursoriale_quadrupede,0,1
+coda_frusta_cinetica,Coda a Frusta Cinetica,Kinetic Lash Tail,rovine_planari,cursoriale_quadrupede,0,2
 coda_stabilizzatrice_filo,Coda Stabilizzatrice Filo,Coda Stabilizzatrice Filo,canopia_ionica,,1,1
 coda_stabilizzatrice_filo,Coda Stabilizzatrice Filo,Coda Stabilizzatrice Filo,canopia_ionica,cursoriale_quadrupede,0,1
 coda_stabilizzatrice_geiser,Coda Stabilizzatrice Geiser,Coda Stabilizzatrice Geiser,dorsale_termale_tropicale,,1,1
@@ -181,6 +188,8 @@ eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,falde_magnet
 eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,mezzanotte_orbitale,volatore_planatore,1,3
 empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,foresta_miceliale,,1,3
 empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,foresta_miceliale,scavenger_corazzato,0,2
+empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,rovine_planari,cursoriale_quadrupede,0,1
+empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,rovine_planari,volatore_planatore,0,2
 enzimi_antifase_termica,Enzimi Antifase Termica,Enzimi Antifase Termica,caldera_glaciale,,1,1
 enzimi_antifase_termica,Enzimi Antifase Termica,Enzimi Antifase Termica,caldera_glaciale,cursoriale_quadrupede,0,1
 enzimi_antipredatori_algali,Enzimi Antipredatori Algali,Enzimi Antipredatori Algali,reef_luminescente,,1,1
@@ -223,6 +232,7 @@ foliage_fotocatodico,Foliage Fotocatodico,Foliage Fotocatodico,foresta_acida,,1,
 foliage_fotocatodico,Foliage Fotocatodico,Foliage Fotocatodico,foresta_acida,cursoriale_quadrupede,0,1
 foliaggio_spugna,Foliaggio Spugna,Foliaggio Spugna,mangrovieto_cinetico,,1,1
 foliaggio_spugna,Foliaggio Spugna,Foliaggio Spugna,mangrovieto_cinetico,cursoriale_quadrupede,0,1
+frusta_fiammeggiante,Frusta Fiammeggiante,Flame Lash,rovine_planari,cursoriale_quadrupede,0,1
 ghiaccio_piezoelettrico,Ghiaccio Piezoelettrico,Ghiaccio Piezoelettrico,caldera_glaciale,,1,1
 ghiaccio_piezoelettrico,Ghiaccio Piezoelettrico,Ghiaccio Piezoelettrico,caldera_glaciale,cursoriale_quadrupede,0,1
 ghiandola_caustica,Ghiandola Caustica,Caustic Gland,foresta_miceliale,,1,1
@@ -269,6 +279,7 @@ lamelle_shear,Lamelle Shear,Lamelle Shear,stratosfera_tempestosa,,1,1
 lamelle_shear,Lamelle Shear,Lamelle Shear,stratosfera_tempestosa,cursoriale_quadrupede,0,1
 lamelle_sincroniche,Lamelle Sincroniche,Lamelle Sincroniche,steppe_algoritmiche,,1,1
 lamelle_sincroniche,Lamelle Sincroniche,Lamelle Sincroniche,steppe_algoritmiche,cursoriale_quadrupede,0,1
+lamelle_termoforetiche,Lamelle Termoforetiche,Thermophoretic Lamellae,rovine_planari,cursoriale_quadrupede,0,1
 lamelle_termoforetiche,Lamelle Termoforetiche,Thermophoretic Lamellae,sorgenti_geotermiche,cursoriale_quadrupede,0,1
 lamine_filtranti_aeree,Lamine Filtranti Aeree,Lamine Filtranti Aeree,mangrovieto_cinetico,,1,1
 lamine_filtranti_aeree,Lamine Filtranti Aeree,Lamine Filtranti Aeree,mangrovieto_cinetico,cursoriale_quadrupede,0,1
@@ -286,6 +297,7 @@ luminescenza_hydrotermica,Luminescenza Hydrotermica,Luminescenza Hydrotermica,ab
 luminescenza_hydrotermica,Luminescenza Hydrotermica,Luminescenza Hydrotermica,abisso_vulcanico,cursoriale_quadrupede,0,1
 mantelli_geotermici,Mantelli Geotermici,Mantelli Geotermici,caldera_glaciale,,1,1
 mantelli_geotermici,Mantelli Geotermici,Mantelli Geotermici,caldera_glaciale,cursoriale_quadrupede,0,1
+mantello_meteoritico,Mantello Meteoritico,Meteoric Mantle,rovine_planari,cursoriale_quadrupede,0,1
 membrane_captura_rugiada,Membrane Captura Rugiada,Membrane Captura Rugiada,pianura_salina_iperarida,,1,1
 membrane_captura_rugiada,Membrane Captura Rugiada,Membrane Captura Rugiada,pianura_salina_iperarida,cursoriale_quadrupede,0,1
 membrane_eliofiltranti,Membrane Eliofiltranti,Membrane Eliofiltranti,laghi_alcalini,cursoriale_quadrupede,0,1
@@ -331,6 +343,7 @@ respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,caverna_risonante,cu
 respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,dorsale_termale_tropicale,scavenger_corazzato,1,1
 respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,mezzanotte_orbitale,cursoriale_quadrupede,1,1
 risonanza_di_branco,Risonanza di Branco,Pack Resonance,foresta_miceliale,,1,1
+risonanza_di_branco,Risonanza di Branco,Pack Resonance,rovine_planari,volatore_planatore,0,1
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,canopia_psionica_leggera,,1,2
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,canopia_psionica_leggera,cursoriale_quadrupede,0,1
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,canopia_psionica_leggera,volatore_planatore,0,1
@@ -347,9 +360,12 @@ scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,cave
 scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,dorsale_termale_tropicale,cursoriale_quadrupede,1,3
 scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,dorsale_termale_tropicale,scavenger_corazzato,1,1
 scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,mezzanotte_orbitale,cursoriale_quadrupede,1,1
+scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,rovine_planari,cursoriale_quadrupede,0,1
 secrezione_rallentante_palmi,Mani secernano liquido rallentante,Retarding Palm Secretions,caverna_risonante,cursoriale_quadrupede,0,1
 secrezione_rallentante_palmi,Mani secernano liquido rallentante,Retarding Palm Secretions,dorsale_termale_tropicale,ingegnere_radicante,1,1
 sensori_geomagnetici,Sensori a Risonanza Geomagnetica,Geomagnetic Resonance Sensors,pianure_magnetiche,cursoriale_quadrupede,0,1
+sensori_geomagnetici,Sensori a Risonanza Geomagnetica,Geomagnetic Resonance Sensors,rovine_planari,cursoriale_quadrupede,0,2
+sensori_geomagnetici,Sensori a Risonanza Geomagnetica,Geomagnetic Resonance Sensors,rovine_planari,volatore_planatore,0,1
 sinapsi_coraline_polifoniche,Sinapsi Coraline Polifoniche,Sinapsi Coraline Polifoniche,barriere_coralline_psioniche,cursoriale_quadrupede,0,1
 sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,caverna_risonante,cursoriale_quadrupede,0,1
 sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,dorsale_termale_tropicale,volatore_planatore,1,1

--- a/data/derived/analysis/trait_coverage_report.json
+++ b/data/derived/analysis/trait_coverage_report.json
@@ -1,23 +1,26 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-10-29T14:54:29+00:00",
+  "generated_at": "2025-10-31T13:50:14+00:00",
   "sources": {
     "env_traits": "packs/evo_tactics_pack/docs/catalog/env_traits.json",
-    "trait_reference": "data/traits/index.json",
-    "trait_glossary": "/workspace/Game/data/core/traits/glossary.json",
+    "trait_reference": "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
+    "trait_glossary": "data/core/traits/glossary.json",
     "species_root": "packs/evo_tactics_pack/data/species"
   },
   "summary": {
-    "traits_total": 170,
+    "traits_total": 174,
     "traits_with_rules": 147,
-    "traits_with_species": 168,
+    "traits_with_species": 172,
     "rule_combos_total": 177,
-    "species_combos_total": 375,
+    "species_combos_total": 391,
     "rules_missing_species_total": 0,
     "traits_missing_species": [],
     "traits_missing_rules": [
       "antenne_plasmatiche_tempesta",
+      "armatura_pietra_planare",
+      "artigli_sette_vie",
       "artigli_sghiaccio_glaciale",
+      "aura_scudo_radianza",
       "branchie_osmotiche_salmastra",
       "bulbi_radici_permafrost",
       "carapace_fase_variabile",
@@ -31,11 +34,14 @@
       "cute_resistente_sali",
       "cuticole_cerose",
       "eco_interno_riflesso",
+      "empatia_coordinativa",
       "enzimi_chelanti",
       "filamenti_digestivi_compattanti",
+      "frusta_fiammeggiante",
       "grassi_termici",
       "lamelle_termoforetiche",
       "lingua_tattile_trama",
+      "mantello_meteoritico",
       "membrane_eliofiltranti",
       "mimetismo_cromatico_passivo",
       "mucillagine_simbionte_mangrovie",
@@ -45,6 +51,7 @@
       "piume_solari_fotovoltaiche",
       "polmoni_cristallini_alta_quota",
       "respiro_a_scoppio",
+      "risonanza_di_branco",
       "sacche_spore_stratosferiche",
       "sangue_piroforico",
       "scheletro_idro_regolante",
@@ -625,6 +632,50 @@
         "missing_in_rules": []
       }
     },
+    "armatura_pietra_planare": {
+      "label_it": "Armatura di Pietra Planare",
+      "label_en": "Planar Stone Plating",
+      "description_it": "Corazza risonante scolpita da roccia extradimensionale che smorza onde d'urto.",
+      "description_en": "Resonant plating carved from extradimensional stone that dampens shockwaves.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 2,
+        "coverage": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "balor-fission"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "golem-runico"
+            ]
+          }
+        ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato"
+          }
+        ]
+      }
+    },
     "artigli_acidofagi": {
       "label_it": "Artigli Acidofagi",
       "label_en": "Artigli Acidofagi",
@@ -815,7 +866,7 @@
         ]
       },
       "species": {
-        "total": 7,
+        "total": 9,
         "coverage": [
           {
             "biome": "caverna_risonante",
@@ -851,12 +902,26 @@
             "examples": [
               "cryo-lynx"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 2,
+            "examples": [
+              "balor-fission",
+              "marilith-vault"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ]
       }
     },
     "artigli_sghiaccio_glaciale": {
@@ -930,6 +995,38 @@
       "diff": {
         "missing_in_species": [],
         "missing_in_rules": []
+      }
+    },
+    "aura_scudo_radianza": {
+      "label_it": "Aura Scudo di Radianza",
+      "label_en": "Radiant Shield Aura",
+      "description_it": "Campo fotoplasmatico che devia danni planari e sincronizza i battiti della squadra.",
+      "description_en": "Photoplasmic field that deflects planar damage while syncing squad vitals.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "archon-solare"
+            ]
+          }
+        ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore"
+          }
+        ]
       }
     },
     "baffi_mareomotori": {
@@ -1873,7 +1970,7 @@
         ]
       },
       "species": {
-        "total": 3,
+        "total": 5,
         "coverage": [
           {
             "biome": "canopia_psionica_leggera",
@@ -1898,6 +1995,22 @@
             "examples": [
               "cryo-lynx"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "balor-fission"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "golem-runico"
+            ]
           }
         ]
       },
@@ -1911,6 +2024,14 @@
           {
             "biome": "falde_magnetiche_psioniche",
             "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato"
           }
         ]
       }
@@ -2829,7 +2950,7 @@
         ]
       },
       "species": {
-        "total": 5,
+        "total": 7,
         "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
@@ -2856,6 +2977,15 @@
             "examples": [
               "orbita-psionica-inversa-trait-keeper"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 2,
+            "examples": [
+              "bulette-fase",
+              "marilith-vault"
+            ]
           }
         ]
       },
@@ -2868,6 +2998,10 @@
           },
           {
             "biome": "orbita_psionica_inversa",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
             "morphotype": "cursoriale_quadrupede"
           }
         ]
@@ -3772,7 +3906,7 @@
         ]
       },
       "species": {
-        "total": 5,
+        "total": 8,
         "coverage": [
           {
             "biome": "foresta_miceliale",
@@ -3792,12 +3926,38 @@
               "glowcap-weaver",
               "myco-spire-warden"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "rakshasa-corte"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore",
+            "count": 2,
+            "examples": [
+              "archon-solare",
+              "couatl-aurora"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore"
+          }
+        ]
       }
     },
     "enzimi_antifase_termica": {
@@ -4573,6 +4733,38 @@
       "diff": {
         "missing_in_species": [],
         "missing_in_rules": []
+      }
+    },
+    "frusta_fiammeggiante": {
+      "label_it": "Frusta Fiammeggiante",
+      "label_en": "Flame Lash",
+      "description_it": "Appendice di plasma vincolato capace di arpionare e incendiare bersagli.",
+      "description_en": "Bound plasma appendage that can hook and ignite targets.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "balor-fission"
+            ]
+          }
+        ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ]
       }
     },
     "ghiaccio_piezoelettrico": {
@@ -5500,8 +5692,16 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "bulette-fase"
+            ]
+          },
           {
             "biome": "sorgenti_geotermiche",
             "morphotype": "cursoriale_quadrupede",
@@ -5515,6 +5715,10 @@
       "diff": {
         "missing_in_species": [],
         "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          },
           {
             "biome": "sorgenti_geotermiche",
             "morphotype": "cursoriale_quadrupede"
@@ -5853,6 +6057,38 @@
       "diff": {
         "missing_in_species": [],
         "missing_in_rules": []
+      }
+    },
+    "mantello_meteoritico": {
+      "label_it": "Mantello Meteoritico",
+      "label_en": "Meteoric Mantle",
+      "description_it": "Strati ablativi rigeneranti che vaporizzano l'impatto convertendolo in impulso termico.",
+      "description_en": "Regenerating ablative layers that vaporize impacts into thermal pulses.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "balor-fission"
+            ]
+          }
+        ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ]
       }
     },
     "membrane_captura_rugiada": {
@@ -6750,7 +6986,7 @@
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
           {
             "biome": "foresta_miceliale",
@@ -6759,12 +6995,25 @@
             "examples": [
               "lupus-temperatus"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "archon-solare"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore"
+          }
+        ]
       }
     },
     "sacche_galleggianti_ascensoriali": {
@@ -6991,7 +7240,7 @@
         ]
       },
       "species": {
-        "total": 6,
+        "total": 7,
         "coverage": [
           {
             "biome": "caverna_risonante",
@@ -7026,6 +7275,14 @@
             "examples": [
               "steppe-bison-mini"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "bulette-fase"
+            ]
           }
         ]
       },
@@ -7034,6 +7291,10 @@
         "missing_in_rules": [
           {
             "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
             "morphotype": "cursoriale_quadrupede"
           }
         ]
@@ -7095,7 +7356,7 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
+        "total": 4,
         "coverage": [
           {
             "biome": "pianure_magnetiche",
@@ -7103,6 +7364,23 @@
             "count": 1,
             "examples": [
               "pianure-magnetiche-trait-keeper"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 2,
+            "examples": [
+              "bulette-fase",
+              "marilith-vault"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "couatl-aurora"
             ]
           }
         ]
@@ -7113,6 +7391,14 @@
           {
             "biome": "pianure_magnetiche",
             "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore"
           }
         ]
       }
@@ -7611,7 +7897,7 @@
     },
     "roles": {
       "dispersore_ponte": {
-        "total_species": 5,
+        "total_species": 7,
         "biomes": {
           "abisso_vulcanico": {
             "count": 1,
@@ -7682,6 +7968,32 @@
                 "source": "packs/evo_tactics_pack/data/species/cryosteppe/zephyr-spore-courier.yaml"
               }
             ]
+          },
+          "rovine_planari": {
+            "count": 2,
+            "playable_count": 2,
+            "meets_threshold": true,
+            "species": [
+              {
+                "id": "archon-solare",
+                "playable_unit": true,
+                "core_traits": [
+                  "empatia_coordinativa",
+                  "risonanza_di_branco",
+                  "aura_scudo_radianza"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/archon-solare.yaml"
+              },
+              {
+                "id": "couatl-aurora",
+                "playable_unit": true,
+                "core_traits": [
+                  "empatia_coordinativa",
+                  "sensori_geomagnetici"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/couatl-aurora.yaml"
+              }
+            ]
           }
         },
         "biomes_missing_threshold": [
@@ -7690,7 +8002,7 @@
         ]
       },
       "erbivoro_primario": {
-        "total_species": 1,
+        "total_species": 2,
         "biomes": {
           "dorsale_termale_tropicale": {
             "count": 1,
@@ -7708,14 +8020,32 @@
                 "source": "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml"
               }
             ]
+          },
+          "rovine_planari": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "bulette-fase",
+                "playable_unit": false,
+                "core_traits": [
+                  "scheletro_idro_regolante",
+                  "sensori_geomagnetici",
+                  "coda_frusta_cinetica"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml"
+              }
+            ]
           }
         },
         "biomes_missing_threshold": [
-          "dorsale_termale_tropicale"
+          "dorsale_termale_tropicale",
+          "rovine_planari"
         ]
       },
       "evento_ecologico": {
-        "total_species": 4,
+        "total_species": 5,
         "biomes": {
           "abisso_vulcanico": {
             "count": 1,
@@ -7777,384 +8107,31 @@
                 "source": "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml"
               }
             ]
+          },
+          "rovine_planari": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "banshee-risonante",
+                "playable_unit": false,
+                "core_traits": [],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/banshee-risonante.yaml"
+              }
+            ]
           }
         },
         "biomes_missing_threshold": [
           "abisso_vulcanico",
           "dorsale_termale_tropicale",
           "foresta_miceliale",
-          "mezzanotte_orbitale"
+          "mezzanotte_orbitale",
+          "rovine_planari"
         ]
       },
       "ingegneri_ecosistema": {
-        "total_species": 7,
-        "biomes": {
-          "abisso_vulcanico": {
-            "count": 1,
-            "playable_count": 1,
-            "meets_threshold": false,
-            "species": [
-              {
-                "id": "cactus-weaver",
-                "playable_unit": true,
-                "core_traits": [
-                  "cuticole_cerose",
-                  "grassi_termici"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml"
-              }
-            ]
-          },
-          "canopia_psionica_leggera": {
-            "count": 1,
-            "playable_count": 1,
-            "meets_threshold": false,
-            "species": [
-              {
-                "id": "psionic-canopy-scout",
-                "playable_unit": true,
-                "core_traits": [
-                  "focus_frazionato",
-                  "mimetismo_cromatico_passivo",
-                  "sacche_galleggianti_ascensoriali"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/canopia_psionica_leggera/psionic-canopy-scout.yaml"
-              }
-            ]
-          },
-          "dorsale_termale_tropicale": {
-            "count": 1,
-            "playable_count": 1,
-            "meets_threshold": false,
-            "species": [
-              {
-                "id": "rust-scavenger",
-                "playable_unit": true,
-                "core_traits": [
-                  "ventriglio_gastroliti",
-                  "respiro_a_scoppio",
-                  "filamenti_digestivi_compattanti"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml"
-              }
-            ]
-          },
-          "foresta_miceliale": {
-            "count": 3,
-            "playable_count": 2,
-            "meets_threshold": true,
-            "species": [
-              {
-                "id": "glowcap-weaver",
-                "playable_unit": false,
-                "core_traits": [
-                  "filamenti_digestivi_compattanti",
-                  "empatia_coordinativa",
-                  "struttura_elastica_amorfa"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/glowcap-weaver.yaml"
-              },
-              {
-                "id": "myco-spire-warden",
-                "playable_unit": true,
-                "core_traits": [
-                  "filamenti_digestivi_compattanti",
-                  "empatia_coordinativa",
-                  "struttura_elastica_amorfa"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/myco-spire-warden.yaml"
-              },
-              {
-                "id": "sentinella-radice",
-                "playable_unit": true,
-                "core_traits": [
-                  "focus_frazionato",
-                  "pathfinder",
-                  "pianificatore"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml"
-              }
-            ]
-          },
-          "mezzanotte_orbitale": {
-            "count": 1,
-            "playable_count": 1,
-            "meets_threshold": false,
-            "species": [
-              {
-                "id": "steppe-bison-mini",
-                "playable_unit": true,
-                "core_traits": [
-                  "ventriglio_gastroliti",
-                  "scheletro_idro_regolante",
-                  "respiro_a_scoppio"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml"
-              }
-            ]
-          }
-        },
-        "biomes_missing_threshold": [
-          "abisso_vulcanico",
-          "canopia_psionica_leggera",
-          "dorsale_termale_tropicale",
-          "mezzanotte_orbitale"
-        ]
-      },
-      "minaccia_microbica": {
-        "total_species": 4,
-        "biomes": {
-          "abisso_vulcanico": {
-            "count": 1,
-            "playable_count": 0,
-            "meets_threshold": false,
-            "species": [
-              {
-                "id": "silica-bloom",
-                "playable_unit": false,
-                "core_traits": [
-                  "cuticole_cerose",
-                  "grassi_termici"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml"
-              }
-            ]
-          },
-          "dorsale_termale_tropicale": {
-            "count": 1,
-            "playable_count": 0,
-            "meets_threshold": false,
-            "species": [
-              {
-                "id": "nano-rust-bloom",
-                "playable_unit": false,
-                "core_traits": [
-                  "filamenti_digestivi_compattanti",
-                  "spore_psichiche_silenziate",
-                  "scheletro_idro_regolante"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml"
-              }
-            ]
-          },
-          "foresta_miceliale": {
-            "count": 1,
-            "playable_count": 0,
-            "meets_threshold": false,
-            "species": [
-              {
-                "id": "blight-micotico",
-                "playable_unit": false,
-                "core_traits": [
-                  "spore_psichiche_silenziate",
-                  "lingua_tattile_trama",
-                  "ghiandola_caustica"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml"
-              }
-            ]
-          },
-          "mezzanotte_orbitale": {
-            "count": 1,
-            "playable_count": 0,
-            "meets_threshold": false,
-            "species": [
-              {
-                "id": "thaw-rot",
-                "playable_unit": false,
-                "core_traits": [
-                  "filamenti_digestivi_compattanti",
-                  "spore_psichiche_silenziate",
-                  "sangue_piroforico"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml"
-              }
-            ]
-          }
-        },
-        "biomes_missing_threshold": [
-          "abisso_vulcanico",
-          "dorsale_termale_tropicale",
-          "foresta_miceliale",
-          "mezzanotte_orbitale"
-        ]
-      },
-      "predatore_regolatore_simbionte": {
-        "total_species": 2,
-        "biomes": {
-          "dorsale_termale_tropicale": {
-            "count": 1,
-            "playable_count": 1,
-            "meets_threshold": false,
-            "species": [
-              {
-                "id": "ferrocolonia-magnetotattica",
-                "playable_unit": true,
-                "core_traits": [
-                  "mimetismo_cromatico_passivo",
-                  "sangue_piroforico",
-                  "secrezione_rallentante_palmi"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml"
-              }
-            ]
-          },
-          "falde_magnetiche_psioniche": {
-            "count": 1,
-            "playable_count": 0,
-            "meets_threshold": false,
-            "species": [
-              {
-                "id": "magnet-fathom-surveyor",
-                "playable_unit": false,
-                "core_traits": [
-                  "filamenti_digestivi_compattanti",
-                  "nucleo_ovomotore_rotante",
-                  "olfatto_risonanza_magnetica"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/magnet-fathom-surveyor.yaml"
-              }
-            ]
-          }
-        },
-        "biomes_missing_threshold": [
-          "dorsale_termale_tropicale",
-          "falde_magnetiche_psioniche"
-        ]
-      },
-      "predatore_terziario_apex": {
-        "total_species": 8,
-        "biomes": {
-          "abisso_vulcanico": {
-            "count": 1,
-            "playable_count": 0,
-            "meets_threshold": false,
-            "species": [
-              {
-                "id": "thermo-raptor",
-                "playable_unit": false,
-                "core_traits": [
-                  "cuticole_cerose",
-                  "grassi_termici"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml"
-              }
-            ]
-          },
-          "caverna_risonante": {
-            "count": 1,
-            "playable_count": 0,
-            "meets_threshold": false,
-            "species": [
-              {
-                "id": "resonant-claw-hunter",
-                "playable_unit": false,
-                "core_traits": [
-                  "artigli_sette_vie"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/caverna_risonante/resonant-claw-hunter.yaml"
-              }
-            ]
-          },
-          "dorsale_termale_tropicale": {
-            "count": 3,
-            "playable_count": 1,
-            "meets_threshold": true,
-            "species": [
-              {
-                "id": "dune-stalker",
-                "playable_unit": false,
-                "core_traits": [
-                  "artigli_sette_vie",
-                  "coda_frusta_cinetica",
-                  "scheletro_idro_regolante"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml"
-              },
-              {
-                "id": "magneto-ridge-hunter",
-                "playable_unit": true,
-                "core_traits": [
-                  "coda_frusta_cinetica",
-                  "scheletro_idro_regolante",
-                  "artigli_sette_vie"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/badlands/magneto-ridge-hunter.yaml"
-              },
-              {
-                "id": "slag-veil-ambusher",
-                "playable_unit": false,
-                "core_traits": [
-                  "coda_frusta_cinetica",
-                  "struttura_elastica_amorfa",
-                  "olfatto_risonanza_magnetica"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/badlands/slag-veil-ambusher.yaml"
-              }
-            ]
-          },
-          "foresta_miceliale": {
-            "count": 1,
-            "playable_count": 0,
-            "meets_threshold": false,
-            "species": [
-              {
-                "id": "lupus-temperatus",
-                "playable_unit": false,
-                "core_traits": [
-                  "empatia_coordinativa",
-                  "tattiche_di_branco",
-                  "risonanza_di_branco"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml"
-              }
-            ]
-          },
-          "mezzanotte_orbitale": {
-            "count": 1,
-            "playable_count": 0,
-            "meets_threshold": false,
-            "species": [
-              {
-                "id": "cryo-lynx",
-                "playable_unit": false,
-                "core_traits": [
-                  "artigli_sette_vie",
-                  "carapace_fase_variabile",
-                  "olfatto_risonanza_magnetica"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml"
-              }
-            ]
-          },
-          "orbita_psionica_inversa": {
-            "count": 1,
-            "playable_count": 1,
-            "meets_threshold": false,
-            "species": [
-              {
-                "id": "orbital-ascendant",
-                "playable_unit": true,
-                "core_traits": [
-                  "focus_frazionato",
-                  "nucleo_ovomotore_rotante",
-                  "olfatto_risonanza_magnetica"
-                ],
-                "source": "packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbital-ascendant.yaml"
-              }
-            ]
-          }
-        },
-        "biomes_missing_threshold": [
-          "abisso_vulcanico",
-          "caverna_risonante",
-          "foresta_miceliale",
-          "mezzanotte_orbitale",
-          "orbita_psionica_inversa"
-        ]
-      },
-      "supporto_specialista": {
-        "total_species": 37,
+        "total_species": 47,
         "biomes": {
           "abisso_luminescente": {
             "count": 1,
@@ -8172,9 +8149,9 @@
             ]
           },
           "abisso_vulcanico": {
-            "count": 1,
-            "playable_count": 0,
-            "meets_threshold": false,
+            "count": 2,
+            "playable_count": 1,
+            "meets_threshold": true,
             "species": [
               {
                 "id": "abisso-vulcanico-trait-keeper",
@@ -8185,6 +8162,15 @@
                   "branchie_metalloidi"
                 ],
                 "source": "packs/evo_tactics_pack/data/species/abisso_vulcanico/abisso-vulcanico-trait-keeper.yaml"
+              },
+              {
+                "id": "cactus-weaver",
+                "playable_unit": true,
+                "core_traits": [
+                  "cuticole_cerose",
+                  "grassi_termici"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml"
               }
             ]
           },
@@ -8283,9 +8269,9 @@
             ]
           },
           "canopia_psionica_leggera": {
-            "count": 1,
-            "playable_count": 0,
-            "meets_threshold": false,
+            "count": 2,
+            "playable_count": 1,
+            "meets_threshold": true,
             "species": [
               {
                 "id": "canopia-psionica-leggera-trait-keeper",
@@ -8296,6 +8282,16 @@
                   "eco_interno_riflesso"
                 ],
                 "source": "packs/evo_tactics_pack/data/species/canopia_psionica_leggera/canopia-psionica-leggera-trait-keeper.yaml"
+              },
+              {
+                "id": "psionic-canopy-scout",
+                "playable_unit": true,
+                "core_traits": [
+                  "focus_frazionato",
+                  "mimetismo_cromatico_passivo",
+                  "sacche_galleggianti_ascensoriali"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/canopia_psionica_leggera/psionic-canopy-scout.yaml"
               }
             ]
           },
@@ -8362,9 +8358,9 @@
             ]
           },
           "dorsale_termale_tropicale": {
-            "count": 1,
-            "playable_count": 0,
-            "meets_threshold": false,
+            "count": 2,
+            "playable_count": 1,
+            "meets_threshold": true,
             "species": [
               {
                 "id": "dorsale-termale-tropicale-trait-keeper",
@@ -8375,6 +8371,16 @@
                   "branchie_turbina"
                 ],
                 "source": "packs/evo_tactics_pack/data/species/dorsale_termale_tropicale/dorsale-termale-tropicale-trait-keeper.yaml"
+              },
+              {
+                "id": "rust-scavenger",
+                "playable_unit": true,
+                "core_traits": [
+                  "ventriglio_gastroliti",
+                  "respiro_a_scoppio",
+                  "filamenti_digestivi_compattanti"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml"
               }
             ]
           },
@@ -8424,6 +8430,43 @@
                   "camere_anticorrosione"
                 ],
                 "source": "packs/evo_tactics_pack/data/species/foresta_acida/foresta-acida-trait-keeper.yaml"
+              }
+            ]
+          },
+          "foresta_miceliale": {
+            "count": 3,
+            "playable_count": 2,
+            "meets_threshold": true,
+            "species": [
+              {
+                "id": "glowcap-weaver",
+                "playable_unit": false,
+                "core_traits": [
+                  "filamenti_digestivi_compattanti",
+                  "empatia_coordinativa",
+                  "struttura_elastica_amorfa"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/glowcap-weaver.yaml"
+              },
+              {
+                "id": "myco-spire-warden",
+                "playable_unit": true,
+                "core_traits": [
+                  "filamenti_digestivi_compattanti",
+                  "empatia_coordinativa",
+                  "struttura_elastica_amorfa"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/myco-spire-warden.yaml"
+              },
+              {
+                "id": "sentinella-radice",
+                "playable_unit": true,
+                "core_traits": [
+                  "focus_frazionato",
+                  "pathfinder",
+                  "pianificatore"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml"
               }
             ]
           },
@@ -8518,6 +8561,23 @@
                   "coda_contrappeso"
                 ],
                 "source": "packs/evo_tactics_pack/data/species/mangrovieto_cinetico/mangrovieto-cinetico-trait-keeper.yaml"
+              }
+            ]
+          },
+          "mezzanotte_orbitale": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "steppe-bison-mini",
+                "playable_unit": true,
+                "core_traits": [
+                  "ventriglio_gastroliti",
+                  "scheletro_idro_regolante",
+                  "respiro_a_scoppio"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml"
               }
             ]
           },
@@ -8647,6 +8707,34 @@
               }
             ]
           },
+          "rovine_planari": {
+            "count": 3,
+            "playable_count": 0,
+            "meets_threshold": true,
+            "species": [
+              {
+                "id": "golem-runico",
+                "playable_unit": false,
+                "core_traits": [
+                  "carapace_fase_variabile",
+                  "armatura_pietra_planare"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml"
+              },
+              {
+                "id": "otyugh-sentinella",
+                "playable_unit": false,
+                "core_traits": [],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/otyugh-sentinella.yaml"
+              },
+              {
+                "id": "treant-portale",
+                "playable_unit": false,
+                "core_traits": [],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/treant-portale.yaml"
+              }
+            ]
+          },
           "sorgenti_geotermiche": {
             "count": 1,
             "playable_count": 0,
@@ -8744,19 +8832,16 @@
         },
         "biomes_missing_threshold": [
           "abisso_luminescente",
-          "abisso_vulcanico",
           "altipiani_solari",
           "badlands",
           "barriere_coralline_psioniche",
           "caldera_glaciale",
           "calotte_glaciali",
           "canopia_ionica",
-          "canopia_psionica_leggera",
           "canopie_sospese",
           "caverna_risonante",
           "cicloni_psionici",
           "delta_salmastri",
-          "dorsale_termale_tropicale",
           "dune_cristalline",
           "falde_magnetiche_psioniche",
           "foresta_acida",
@@ -8766,6 +8851,7 @@
           "laguna_bioreattiva",
           "mangrovie_risonanti",
           "mangrovieto_cinetico",
+          "mezzanotte_orbitale",
           "orbita_psionica_inversa",
           "paludi_gas_luminescenti",
           "permafrost_psionico",
@@ -8780,6 +8866,301 @@
           "stratosfera_portante",
           "stratosfera_tempestosa",
           "tundra_risonante"
+        ]
+      },
+      "minaccia_microbica": {
+        "total_species": 5,
+        "biomes": {
+          "abisso_vulcanico": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "silica-bloom",
+                "playable_unit": false,
+                "core_traits": [
+                  "cuticole_cerose",
+                  "grassi_termici"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml"
+              }
+            ]
+          },
+          "dorsale_termale_tropicale": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "nano-rust-bloom",
+                "playable_unit": false,
+                "core_traits": [
+                  "filamenti_digestivi_compattanti",
+                  "spore_psichiche_silenziate",
+                  "scheletro_idro_regolante"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml"
+              }
+            ]
+          },
+          "foresta_miceliale": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "blight-micotico",
+                "playable_unit": false,
+                "core_traits": [
+                  "spore_psichiche_silenziate",
+                  "lingua_tattile_trama",
+                  "ghiandola_caustica"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml"
+              }
+            ]
+          },
+          "mezzanotte_orbitale": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "thaw-rot",
+                "playable_unit": false,
+                "core_traits": [
+                  "filamenti_digestivi_compattanti",
+                  "spore_psichiche_silenziate",
+                  "sangue_piroforico"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml"
+              }
+            ]
+          },
+          "rovine_planari": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "rakshasa-corte",
+                "playable_unit": false,
+                "core_traits": [
+                  "empatia_coordinativa"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/rakshasa-corte.yaml"
+              }
+            ]
+          }
+        },
+        "biomes_missing_threshold": [
+          "abisso_vulcanico",
+          "dorsale_termale_tropicale",
+          "foresta_miceliale",
+          "mezzanotte_orbitale",
+          "rovine_planari"
+        ]
+      },
+      "predatore_regolatore_simbionte": {
+        "total_species": 2,
+        "biomes": {
+          "dorsale_termale_tropicale": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "ferrocolonia-magnetotattica",
+                "playable_unit": true,
+                "core_traits": [
+                  "mimetismo_cromatico_passivo",
+                  "sangue_piroforico",
+                  "secrezione_rallentante_palmi"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml"
+              }
+            ]
+          },
+          "falde_magnetiche_psioniche": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "magnet-fathom-surveyor",
+                "playable_unit": false,
+                "core_traits": [
+                  "filamenti_digestivi_compattanti",
+                  "nucleo_ovomotore_rotante",
+                  "olfatto_risonanza_magnetica"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/magnet-fathom-surveyor.yaml"
+              }
+            ]
+          }
+        },
+        "biomes_missing_threshold": [
+          "dorsale_termale_tropicale",
+          "falde_magnetiche_psioniche"
+        ]
+      },
+      "predatore_terziario_apex": {
+        "total_species": 10,
+        "biomes": {
+          "abisso_vulcanico": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "thermo-raptor",
+                "playable_unit": false,
+                "core_traits": [
+                  "cuticole_cerose",
+                  "grassi_termici"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml"
+              }
+            ]
+          },
+          "caverna_risonante": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "resonant-claw-hunter",
+                "playable_unit": false,
+                "core_traits": [
+                  "artigli_sette_vie"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/caverna_risonante/resonant-claw-hunter.yaml"
+              }
+            ]
+          },
+          "dorsale_termale_tropicale": {
+            "count": 3,
+            "playable_count": 1,
+            "meets_threshold": true,
+            "species": [
+              {
+                "id": "dune-stalker",
+                "playable_unit": false,
+                "core_traits": [
+                  "artigli_sette_vie",
+                  "coda_frusta_cinetica",
+                  "scheletro_idro_regolante"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml"
+              },
+              {
+                "id": "magneto-ridge-hunter",
+                "playable_unit": true,
+                "core_traits": [
+                  "coda_frusta_cinetica",
+                  "scheletro_idro_regolante",
+                  "artigli_sette_vie"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/magneto-ridge-hunter.yaml"
+              },
+              {
+                "id": "slag-veil-ambusher",
+                "playable_unit": false,
+                "core_traits": [
+                  "coda_frusta_cinetica",
+                  "struttura_elastica_amorfa",
+                  "olfatto_risonanza_magnetica"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/slag-veil-ambusher.yaml"
+              }
+            ]
+          },
+          "foresta_miceliale": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "lupus-temperatus",
+                "playable_unit": false,
+                "core_traits": [
+                  "empatia_coordinativa",
+                  "tattiche_di_branco",
+                  "risonanza_di_branco"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml"
+              }
+            ]
+          },
+          "mezzanotte_orbitale": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "cryo-lynx",
+                "playable_unit": false,
+                "core_traits": [
+                  "artigli_sette_vie",
+                  "carapace_fase_variabile",
+                  "olfatto_risonanza_magnetica"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml"
+              }
+            ]
+          },
+          "orbita_psionica_inversa": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "orbital-ascendant",
+                "playable_unit": true,
+                "core_traits": [
+                  "focus_frazionato",
+                  "nucleo_ovomotore_rotante",
+                  "olfatto_risonanza_magnetica"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbital-ascendant.yaml"
+              }
+            ]
+          },
+          "rovine_planari": {
+            "count": 2,
+            "playable_count": 0,
+            "meets_threshold": true,
+            "species": [
+              {
+                "id": "balor-fission",
+                "playable_unit": false,
+                "core_traits": [
+                  "artigli_sette_vie",
+                  "frusta_fiammeggiante",
+                  "armatura_pietra_planare"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml"
+              },
+              {
+                "id": "marilith-vault",
+                "playable_unit": false,
+                "core_traits": [
+                  "artigli_sette_vie",
+                  "coda_frusta_cinetica",
+                  "sensori_geomagnetici"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml"
+              }
+            ]
+          }
+        },
+        "biomes_missing_threshold": [
+          "abisso_vulcanico",
+          "caverna_risonante",
+          "foresta_miceliale",
+          "mezzanotte_orbitale",
+          "orbita_psionica_inversa"
         ]
       }
     }

--- a/docs/README_TRAITS.md
+++ b/docs/README_TRAITS.md
@@ -13,6 +13,7 @@ data/traits/
 ├─ …                             # altre tipologie (sensoriale, metabolico, ecc.)
 
 packs/evo_tactics_pack/docs/catalog/
+├─ trait_reference.json          # copia del catalogo core inclusa nel bundle del pack (sync con data/traits/index.json)
 ├─ trait_entry.schema.json       # schema per ogni voce trait (compatibile con il dataset legacy)
 ├─ trait_catalog.schema.json     # schema per l'intero catalogo (header + mappa)
 └─ archive/

--- a/docs/process/trait_data_reference.md
+++ b/docs/process/trait_data_reference.md
@@ -7,7 +7,7 @@ Questa guida riassume dove risiedono i dati dei tratti e quali script utilizzare
 | Percorso | Contenuto | Note |
 | --- | --- | --- |
 | `data/core/traits/glossary.json` | Glossario condiviso con label ufficiali, descrizioni sintetiche e collegamento al reference principale. | Usato da strumenti ETL e validazione. |
-| `data/traits/index.json` | Sorgente autorevole per tier, slot, sinergie, requisiti ambientali e metadati PI. | Duplicato in `docs/evo-tactics-pack/trait-reference.json` per distribuzione web. |
+| `data/traits/index.json` | Sorgente autorevole per tier, slot, sinergie, requisiti ambientali e metadati PI. | Duplicato in `docs/evo-tactics-pack/trait-reference.json` (web) e `packs/evo_tactics_pack/docs/catalog/trait_reference.json` (bundle pack); **tutte le copie vanno aggiornate insieme**. |
 | `packs/evo_tactics_pack/docs/catalog/env_traits.json` | Mappa le condizioni ambientali (biomi, hazard, ecc.) ai tratti disponibili. | Necessario per report di coverage. |
 | `logs/trait_audit.md` | Output dell'audit di coerenza; deve essere privo di warning prima di aprire una PR. | Generato da `scripts/trait_audit.py`. |
 | `data/derived/analysis/trait_baseline.yaml` & `data/derived/analysis/trait_coverage_report.json` | Baseline e report di coverage aggiornati dagli script ETL. | Utili per verificare la copertura sui nove assi. |
@@ -15,7 +15,7 @@ Questa guida riassume dove risiedono i dati dei tratti e quali script utilizzare
 ## Workflow di aggiornamento
 
 1. **Allineare il glossario** – aggiungere o aggiornare le voci in `data/core/traits/glossary.json`, assicurandosi che `trait_reference` punti a `data/traits/index.json`.
-2. **Aggiornare il trait reference** – editare `data/traits/index.json` (e sincronizzare la copia in `docs/evo-tactics-pack/trait-reference.json`).
+2. **Aggiornare il trait reference** – editare `data/traits/index.json` e sincronizzare le copie in `docs/evo-tactics-pack/trait-reference.json` **e** `packs/evo_tactics_pack/docs/catalog/trait_reference.json`.
    - Popolare i campi obbligatori: `tier`, `slot`, `slot_profile`, `sinergie`, `conflitti`, `requisiti_ambientali`, `mutazione_indotta`, `uso_funzione`, `spinta_selettiva`, `debolezza`.
    - Ogni sinergia deve essere **reciproca**: se il tratto A elenca il tratto B, anche B deve elencare A.
 3. **Aggiornare le regole ambientali** – se necessario, associare il tratto in `packs/evo_tactics_pack/docs/catalog/env_traits.json`.
@@ -23,7 +23,7 @@ Questa guida riassume dove risiedono i dati dei tratti e quali script utilizzare
    ```bash
    python tools/py/build_trait_baseline.py \
      packs/evo_tactics_pack/docs/catalog/env_traits.json \
-     data/traits/index.json \
+     packs/evo_tactics_pack/docs/catalog/trait_reference.json \
      --trait-glossary data/core/traits/glossary.json
    ```
    Questo aggiorna `data/derived/analysis/trait_baseline.yaml`.
@@ -31,7 +31,7 @@ Questa guida riassume dove risiedono i dati dei tratti e quali script utilizzare
    ```bash
    python tools/py/report_trait_coverage.py \
      --env-traits packs/evo_tactics_pack/docs/catalog/env_traits.json \
-     --trait-reference data/traits/index.json \
+     --trait-reference packs/evo_tactics_pack/docs/catalog/trait_reference.json \
      --trait-glossary data/core/traits/glossary.json \
      --out-json data/derived/analysis/trait_coverage_report.json \
      --out-csv data/derived/analysis/trait_coverage_matrix.csv

--- a/docs/tools/cli.md
+++ b/docs/tools/cli.md
@@ -112,7 +112,7 @@ alla validazione degli asset incoming vengono salvati in
 - `python tools/traits.py validate --matrix docs/catalog/species_trait_matrix.json` — confronta automaticamente i tratti proposti dalle specie/eventi con la matrice curata, segnalando divergenze di archetipi o requisiti di bioma.【F:tools/traits.py†L1-L236】【F:docs/catalog/species_trait_matrix.json†L1-L240】
 
 ### Flusso end-to-end
-1. Definisci il tratto nel glossario (`data/core/traits/glossary.json`) e sincronizza i registri (`env_traits.json`, `data/traits/index.json`).
+1. Definisci il tratto nel glossario (`data/core/traits/glossary.json`) e sincronizza i registri (`env_traits.json`, `data/traits/index.json`, `docs/evo-tactics-pack/trait-reference.json`, `packs/evo_tactics_pack/docs/catalog/trait_reference.json`).
 2. Aggiorna la matrice specie (`docs/catalog/species_trait_matrix.json`) e validala con `python tools/traits.py validate --matrix docs/catalog/species_trait_matrix.json` per prevenire incompatibilità su biomi e morfotipi.【F:docs/catalog/species_trait_matrix.json†L1-L240】【F:tools/traits.py†L1-L236】
 3. Ricostruisci baseline e nomenclature (`build_trait_baseline.py`, `validate_registry_naming.py`) per mantenere allineati tier, slug e riferimenti dataset.【F:tools/py/build_trait_baseline.py†L1-L46】【F:tools/py/validate_registry_naming.py†L1-L270】
 4. Genera coverage (`report_trait_coverage.py`) e ispeziona i diff JSON/CSV per verificare che il tratto compaia nei biomi previsti; prima di chiudere l'iterazione esegui gli smoke test (`scripts/cli_smoke.sh`) e logga i risultati nei report di playtest.【F:tools/py/report_trait_coverage.py†L1-L85】【F:data/derived/analysis/trait_coverage_matrix.csv†L1-L40】【F:scripts/cli_smoke.sh†L1-L120】

--- a/packs/evo_tactics_pack/docs/catalog/trait_reference.json
+++ b/packs/evo_tactics_pack/docs/catalog/trait_reference.json
@@ -1,0 +1,7619 @@
+{
+  "schema_version": "2.0",
+  "trait_glossary": "data/core/traits/glossary.json",
+  "traits": {
+    "ali_fulminee": {
+      "label": "Ali Fulminee",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ali Fulminee ottimizza le operazioni sensoriale nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ali_ioniche": {
+      "label": "Ali Ioniche",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ali Ioniche ottimizza le operazioni locomotorio nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ali_membrana_sonica": {
+      "label": "Ali Membrana Sonica",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ali Membrana Sonica ottimizza le operazioni difensivo nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "antenne_dustsense": {
+      "label": "Antenne Dustsense",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Dustsense ottimizza le operazioni metabolico nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "antenne_eco_turbina": {
+      "label": "Antenne Eco Turbina",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Eco Turbina ottimizza le operazioni supporto nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "antenne_flusso_mareale": {
+      "label": "Antenne Flusso Mareale",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laguna_bioreattiva"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Flusso Mareale ottimizza le operazioni offensivo nelle condizioni di laguna bioreattiva.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "antenne_microonde_cavernose": {
+      "label": "Antenne Microonde Cavernose",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Microonde Cavernose ottimizza le operazioni strategia nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "antenne_plasmatiche_tempesta": {
+      "label": "Antenne Plasmatiche di Tempesta",
+      "famiglia_tipologia": "Sensoriale/Offensivo",
+      "fattore_mantenimento_energetico": "Alto (Canalizzazione costante di plasma atmosferico)",
+      "tier": "T3",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "offensivo",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "carapace_luminiscente_abissale",
+        "focus_frazionato",
+        "risonanza_di_branco",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "cicloni_psionici"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Occhi di tempesta permanenti che concentrano elettricità e onde psioniche."
+          }
+        }
+      ],
+      "mutazione_indotta": "Flagelli coronati da nodi plasma-sensibili che captano e deviano fulmini.",
+      "uso_funzione": "Canalizza scariche atmosferiche in attacchi direzionati o scudi ionici.",
+      "spinta_selettiva": "Comandare fulmini e navigare in cieli turbolenti durante campagne aeree.",
+      "debolezza": "Scariche elettriche massicce possono bruciare i recettori e compromettere la coordinazione.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "boardgame:Evolution/Camouflage-Ambush",
+          "hud:StormMeshPsi",
+          "bioma:cicloni_psionici"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "Forma:Tempestarii",
+          "HUD:Fulcro_Tempesta"
+        ],
+        "tabelle_random": [
+          "tabella:fulmini_empatici"
+        ]
+      }
+    },
+    "antenne_reagenti": {
+      "label": "Antenne Reagenti",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Reagenti ottimizza le operazioni simbiotico nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "antenne_tesla": {
+      "label": "Antenne Tesla",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Tesla ottimizza le operazioni strutturale nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "antenne_waveguide": {
+      "label": "Antenne Waveguide",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Waveguide ottimizza le operazioni sensoriale nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "antenne_wideband": {
+      "label": "Antenne Wideband",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_algoritmiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Wideband ottimizza le operazioni locomotorio nelle condizioni di steppe algoritmiche.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "appendici_risonanti_marea": {
+      "label": "Appendici Risonanti Marea",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laguna_bioreattiva"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Appendici Risonanti Marea ottimizza le operazioni difensivo nelle condizioni di laguna bioreattiva.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "appendici_thermotattiche": {
+      "label": "Appendici Thermotattiche",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Appendici Thermotattiche ottimizza le operazioni metabolico nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "armatura_pietra_planare": {
+      "label": "Armatura di Pietra Planare",
+      "famiglia_tipologia": "Difesa/Strutturale",
+      "fattore_mantenimento_energetico": "Basso (Risonanza geodetica stabile)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "strutturale",
+        "core": "difesa"
+      },
+      "sinergie": [
+        "carapace_fase_variabile"
+      ],
+      "conflitti": [
+        "frusta_fiammeggiante"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [
+            "deploy_barrier"
+          ],
+          "condizioni": {
+            "biome_class": "rovine_planari"
+          },
+          "fonte": "pathfinder_import",
+          "meta": {
+            "expansion": "pathfinder_dataset",
+            "notes": "Plasmazione del substrato lapideo proveniente da fratture planari.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "mutazione_indotta": "Cristallizza il dermascheletro con nodi rune che deviano energia.",
+      "uso_funzione": "Offre schermatura massiva e ancoraggio durante le aperture dimensionali.",
+      "spinta_selettiva": "Stabilizzare varchi e proteggere infrastrutture dalle onde d'urto.",
+      "debolezza": "Pesante: riduce mobilità in ambienti non supportati o a bassa gravità.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "artigli_acidofagi": {
+      "label": "Artigli Acidofagi",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Artigli Acidofagi ottimizza le operazioni supporto nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "artigli_induzione": {
+      "label": "Artigli Induzione",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Artigli Induzione ottimizza le operazioni offensivo nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "artigli_radice": {
+      "label": "Artigli Radice",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovieto_cinetico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Artigli Radice ottimizza le operazioni strategia nelle condizioni di mangrovieto cinetico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "artigli_scivolo_silente": {
+      "label": "Artigli Scivolo Silente",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Artigli Scivolo Silente ottimizza le operazioni simbiotico nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "artigli_sette_vie": {
+      "label": "Artigli a Sette Vie",
+      "famiglia_tipologia": "Locomotorio/Prensile",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "prensile",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "mimetismo_cromatico_passivo",
+        "struttura_elastica_amorfa",
+        "tattiche_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+          }
+        }
+      ],
+      "mutazione_indotta": "Dita lunghe e segmentate con punte a uncino multiplo.",
+      "uso_funzione": "Afferrare superfici irregolari o oggetti multipli.",
+      "spinta_selettiva": "Arrampicarsi su pareti rocciose o vegetazione densa.",
+      "debolezza": "Angoli di presa limitati se la superficie è perfettamente liscia.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "boardgame:Evolution/Aggression-Camouflage",
+          "boardgame:DominantSpecies/Competition",
+          "hud:GripNode_Psion"
+        ],
+        "combo_totale": 4,
+        "forme": [
+          "Forma:Predatore_Tessuto",
+          "HUD:GrappleBurst"
+        ],
+        "tabelle_random": [
+          "tabella:predazione_multicanale"
+        ]
+      }
+    },
+    "artigli_sghiaccio_glaciale": {
+      "label": "Artigli Sghiaccio Glaciale",
+      "famiglia_tipologia": "Locomotorio/Predatorio",
+      "fattore_mantenimento_energetico": "Medio (Raffreddamento endogeno controllato)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "predatorio",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "cartilagine_flessotermica_venti",
+        "sonno_emisferico_alternato",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "calotte_glaciali"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Calotte di ghiaccio psionico che reagiscono alle vibrazioni e amplificano le lame criogeniche."
+          }
+        }
+      ],
+      "mutazione_indotta": "Falangi rivestite da ghiaccio strutturale che si espande creando lame traslucide.",
+      "uso_funzione": "Scalza e immobilizza i bersagli congelandoli al contatto.",
+      "spinta_selettiva": "Cacciare su superfici gelate e pareti verticali di ghiaccio vivo.",
+      "debolezza": "In ambienti temperati i tessuti subiscono microfratture e richiedono continue riparazioni.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "boardgame:DominantSpecies/Glaciation",
+          "boardgame:Evolution/Hibernation",
+          "hud:GlacierClaw_UI"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "Forma:Assaltatore_Criogenico"
+        ],
+        "tabelle_random": [
+          "tabella:presa_criostatica"
+        ]
+      }
+    },
+    "artigli_vetrificati": {
+      "label": "Artigli Vetrificati",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Artigli Vetrificati ottimizza le operazioni strutturale nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "aura_scudo_radianza": {
+      "label": "Aura Scudo di Radianza",
+      "famiglia_tipologia": "Supporto/Difesa",
+      "fattore_mantenimento_energetico": "Alto (Canalizzazione fotonica continua)",
+      "tier": "T3",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "difesa",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [
+        "mantello_meteoritico"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [
+            "flight"
+          ],
+          "condizioni": {
+            "biome_class": "rovine_planari"
+          },
+          "fonte": "pathfinder_import",
+          "meta": {
+            "expansion": "pathfinder_dataset",
+            "notes": "Richiede catalizzatori di luce stabili nelle rovine planari.",
+            "tier": "T3"
+          }
+        }
+      ],
+      "mutazione_indotta": "Innesta organi fotoplasmatici che diffondono uno scudo radiante sugli alleati vicini.",
+      "uso_funzione": "Proietta schermature luminose sincronizzate con i segnali tattici della squadra.",
+      "spinta_selettiva": "Proteggere gli hub di evacuazione durante tempeste di energia planare.",
+      "debolezza": "Soffre saturazione se esposta a ombre gravitazionali o zone di antimagia.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "baffi_mareomotori": {
+      "label": "Baffi Mareomotori",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovieto_cinetico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Baffi Mareomotori ottimizza le operazioni sensoriale nelle condizioni di mangrovieto cinetico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "barbigli_sensori_plasma": {
+      "label": "Barbigli Sensori Plasma",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Barbigli Sensori Plasma ottimizza le operazioni locomotorio nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "barriere_miasma_glaciale": {
+      "label": "Barriere Miasma Glaciale",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Barriere Miasma Glaciale ottimizza le operazioni difensivo nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "batteri_endosimbionti_chemio": {
+      "label": "Batteri Endosimbionti Chemio",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Batteri Endosimbionti Chemio ottimizza le operazioni metabolico nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "batteri_termofili_endosimbiosi": {
+      "label": "Batteri Termofili Endosimbiosi",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Batteri Termofili Endosimbiosi ottimizza le operazioni supporto nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "biochip_memoria": {
+      "label": "Biochip Memoria",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_algoritmiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Biochip Memoria ottimizza le operazioni offensivo nelle condizioni di steppe algoritmiche.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "biofilm_glow": {
+      "label": "Biofilm Glow",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Biofilm Glow ottimizza le operazioni strategia nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "biofilm_iperarido": {
+      "label": "Biofilm Iperarido",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Biofilm Iperarido ottimizza le operazioni simbiotico nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "branchie_dual_mode": {
+      "label": "Branchie Dual Mode",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laguna_bioreattiva"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Branchie Dual Mode ottimizza le operazioni strutturale nelle condizioni di laguna bioreattiva.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "branchie_eoliche": {
+      "label": "Branchie Eoliche",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Branchie Eoliche ottimizza le operazioni sensoriale nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "branchie_metalloidi": {
+      "label": "Branchie Metalloidi",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Branchie Metalloidi ottimizza le operazioni locomotorio nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "branchie_microfiltri": {
+      "label": "Branchie Microfiltri",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Branchie Microfiltri ottimizza le operazioni difensivo nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "branchie_osmotiche_salmastra": {
+      "label": "Branchie Osmotiche Salmastre",
+      "famiglia_tipologia": "Respiratorio/Osmoregolazione",
+      "fattore_mantenimento_energetico": "Medio (Pompe ioniche attive)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "osmoregolazione",
+        "core": "respiratorio"
+      },
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "scheletro_idro_regolante"
+      ],
+      "conflitti": [
+        "polmoni_cristallini_alta_quota"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "delta_salmastri"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Estuari psionici dove l'acqua dolce e marina si mescolano creando gradienti forti."
+          }
+        }
+      ],
+      "mutazione_indotta": "Lamelle branchiali multilivello con valvole che separano sali e tossine.",
+      "uso_funzione": "Bilancia sali e tossine sfruttando microvalvole controllate psionicamente.",
+      "spinta_selettiva": "Colonizzare mangrovie psioniche e barriere di estuario soggette a maree estreme.",
+      "debolezza": "Richiede accesso costante ad acqua salmastra; ambienti d'acqua dolce provocano stress ionico.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "boardgame:Evolution/Symbiosis",
+          "boardgame:DominantSpecies/Adaptation",
+          "hud:EstuarioPsi"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "Forma:Amfibio_Oracolare"
+        ],
+        "tabelle_random": [
+          "tabella:osmosi_psionica"
+        ]
+      }
+    },
+    "branchie_solfatiche": {
+      "label": "Branchie Solfatiche",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Branchie Solfatiche ottimizza le operazioni metabolico nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "branchie_turbina": {
+      "label": "Branchie Turbina",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Branchie Turbina ottimizza le operazioni supporto nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "bulbi_radici_permafrost": {
+      "label": "Bulbi Radici del Permafrost",
+      "famiglia_tipologia": "Simbiotico/Nutrizione",
+      "fattore_mantenimento_energetico": "Medio (Accumulo e rilascio lento di nutrienti)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "nutrizione",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "chioma_parassita_canopica",
+        "nodi_micorrizici_oracolari",
+        "vello_condensatore_nebbie"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "permafrost_psionico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Suoli congelati con vene energetiche che alimentano radici coscienti."
+          }
+        }
+      ],
+      "mutazione_indotta": "Bulbi radicali multipli che immagazzinano energia nelle stagioni fredde per rilasciarla durante le missioni.",
+      "uso_funzione": "Rilascia energia e calore agli alleati radicati nella stessa rete subglaciale.",
+      "spinta_selettiva": "Sostenere campagne lunghe in climi artici con riserve nutrizionali concentrate.",
+      "debolezza": "Disgeli improvvisi trasformano i bulbi in masse gelatinose che rallentano i movimenti.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "boardgame:DominantSpecies/Fertility",
+          "boardgame:Evolution/Cooperation",
+          "hud:RootMesh_Psi"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "Forma:Archivio_Subglaciale",
+          "HUD:Radice_Proxy"
+        ],
+        "tabelle_random": [
+          "tabella:riserva_empatica"
+        ]
+      }
+    },
+    "camere_anticorrosione": {
+      "label": "Camere Anticorrosione",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Camere Anticorrosione ottimizza le operazioni offensivo nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "camere_mirage": {
+      "label": "Camere Mirage",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Camere Mirage ottimizza le operazioni strategia nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "camere_nutrienti_vent": {
+      "label": "Camere Nutrienti Vent",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Camere Nutrienti Vent ottimizza le operazioni simbiotico nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "capillari_criogenici": {
+      "label": "Capillari Criogenici",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Capillari Criogenici ottimizza le operazioni strutturale nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "capillari_fluoridici": {
+      "label": "Capillari Fluoridici",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Capillari Fluoridici ottimizza le operazioni sensoriale nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "capillari_fotovoltaici": {
+      "label": "Capillari Fotovoltaici",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Capillari Fotovoltaici ottimizza le operazioni locomotorio nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "capsule_paracadute": {
+      "label": "Capsule Paracadute",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Capsule Paracadute ottimizza le operazioni difensivo nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "carapace_fase_variabile": {
+      "label": "Carapace a Variazione di Fase",
+      "famiglia_tipologia": "Strutturale/Difensivo",
+      "fattore_mantenimento_energetico": "Alto (Richiede energia per il cambio di fase)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "difensivo",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "ali_membrana_sonica",
+        "appendici_risonanti_marea",
+        "barriere_miasma_glaciale",
+        "branchie_microfiltri",
+        "capsule_paracadute",
+        "cartilagine_flessotermica_venti",
+        "circolazione_bifasica",
+        "coda_coppia_retroattiva",
+        "cute_resistente_sali",
+        "enzimi_antipredatori_algali",
+        "filtri_planctonici",
+        "ghiandole_fango_coesivo",
+        "giunti_antitorsione",
+        "lingua_cristallina",
+        "mucose_barofile",
+        "sensori_geomagnetici",
+        "armatura_pietra_planare",
+        "mantello_meteoritico"
+      ],
+      "conflitti": [
+        "struttura_elastica_amorfa"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_psionica_leggera"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "T1 di acclimatazione nelle canopie conduttrici a bassa intensità.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Percorso T2 che aggiunge gradienti magnetici per pattern cromatici complessi.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "mutazione_indotta": "Strutture minerali a legame reversibile o micro-strutture a rigidità controllata.",
+      "uso_funzione": "Durezza/densità del guscio modificabile rapidamente.",
+      "spinta_selettiva": "Alternanza tra ambienti con attacchi cinetici pesanti e ambienti che richiedono velocità.",
+      "debolezza": "Debolezza strutturale durante la transizione tra le fasi di durezza.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "boardgame:DominantSpecies/Defense",
+          "boardgame:Evolution/Shell",
+          "hud:PhaseShift_Plate"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "Forma:Guardiano_Cangiante",
+          "HUD:Placca_Sintonica"
+        ],
+        "tabelle_random": [
+          "tabella:assetto_fase"
+        ]
+      }
+    },
+    "carapace_luminiscente_abissale": {
+      "label": "Carapace Luminiscente Abissale",
+      "famiglia_tipologia": "Strutturale/Sensoriale",
+      "fattore_mantenimento_energetico": "Alto (Bioluminescenza controllata)",
+      "tier": "T3",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "sensoriale",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "antenne_plasmatiche_tempesta",
+        "risonanza_di_branco",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [
+        "carapace_fase_variabile"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Gole oceaniche illuminate da coralli psionici e scariche elettrostatiche."
+          }
+        }
+      ],
+      "mutazione_indotta": "Placche chitino-minerali con microrganismi luminescenti che comunicano in pattern.",
+      "uso_funzione": "Emette segnali di branco e devia attacchi grazie a pattern luminosi cangianti.",
+      "spinta_selettiva": "Comunicare e mimetizzarsi nelle profondità prive di luce naturale.",
+      "debolezza": "Luce intensa di superficie sovraccarica i biofotoni rendendo la corazza fragile.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "boardgame:Evolution/WarningCall",
+          "boardgame:DominantSpecies/Initiative",
+          "hud:AbyssLight_Array"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "Forma:Lanterna_Abissale",
+          "HUD:LuminaNet"
+        ],
+        "tabelle_random": [
+          "tabella:segnali_bioluminosi"
+        ]
+      }
+    },
+    "carapace_segmenti_logici": {
+      "label": "Carapace Segmenti Logici",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_algoritmiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Carapace Segmenti Logici ottimizza le operazioni metabolico nelle condizioni di steppe algoritmiche.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "carapaci_ferruginosi": {
+      "label": "Carapaci Ferruginosi",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Carapaci Ferruginosi ottimizza le operazioni supporto nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "cartilagine_flessotermica_venti": {
+      "label": "Cartilagine Flessotermica dei Venti",
+      "famiglia_tipologia": "Locomotorio/Adattivo",
+      "fattore_mantenimento_energetico": "Medio (Richiede frequenti riallineamenti fibrosi)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "adattivo",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "artigli_sghiaccio_glaciale",
+        "carapace_fase_variabile",
+        "sacche_galleggianti_ascensoriali",
+        "zoccoli_risonanti_steppe"
+      ],
+      "conflitti": [
+        "scheletro_idro_regolante"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "gole_ventose"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Canyon sospesi dove venti caldi e freddi si alternano in pattern ciclici."
+          }
+        }
+      ],
+      "mutazione_indotta": "Giunzioni cartilaginee che cambiano rigidità in risposta a gradienti termici e eolici.",
+      "uso_funzione": "Modula elasticità e rigidità muscolo-scheletrica per manovre evasive rapide.",
+      "spinta_selettiva": "Scalare falesie e planare tra correnti ascensionali turbolente.",
+      "debolezza": "Temperature stabili riducono la reattività della cartilagine rendendo l'organismo lento.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "boardgame:DominantSpecies/Wind",
+          "boardgame:Evolution/Flight",
+          "hud:VentSplice_Halo"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "Forma:Planatore_Psionico"
+        ],
+        "tabelle_random": [
+          "tabella:assetto_eolico"
+        ]
+      }
+    },
+    "cartilagini_biofibre": {
+      "label": "Cartilagini Biofibre",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cartilagini Biofibre ottimizza le operazioni offensivo nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "cartilagini_desertiche": {
+      "label": "Cartilagini Desertiche",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cartilagini Desertiche ottimizza le operazioni strategia nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "cartilagini_flessoacustiche": {
+      "label": "Cartilagini Flessoacustiche",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cartilagini Flessoacustiche ottimizza le operazioni simbiotico nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "cartilagini_pseudometalliche": {
+      "label": "Cartilagini Pseudometalliche",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cartilagini Pseudometalliche ottimizza le operazioni strutturale nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "cavita_risonanti_tundra": {
+      "label": "Cavità Risonanti della Tundra",
+      "famiglia_tipologia": "Sensoriale/Supporto",
+      "fattore_mantenimento_energetico": "Basso (Camere di risonanza statiche)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "supporto",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "criostasi_adattiva",
+        "eco_interno_riflesso",
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "tundra_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Steppe gelate che trasmettono vibrazioni psioniche a chilometri di distanza."
+          }
+        }
+      ],
+      "mutazione_indotta": "Camere toraciche espanse che amplificano vibrazioni subsoniche nel permafrost.",
+      "uso_funzione": "Amplifica segnali acustici per comunicazioni a lungo raggio nel gelo.",
+      "spinta_selettiva": "Coordinare branchi in lande aperte dove la visibilità è ridotta da bufere di ghiaccio.",
+      "debolezza": "In ambienti temperati l'eco interna produce rumori udibili che rivelano la posizione.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "boardgame:Evolution/Communication",
+          "boardgame:DominantSpecies/Initiative",
+          "hud:TundraPulse"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "Forma:Cantore_Tundra",
+          "HUD:EchoGrid"
+        ],
+        "tabelle_random": [
+          "tabella:canti_ipersonici"
+        ]
+      }
+    },
+    "cervelletto_equilibrio_statico": {
+      "label": "Cervelletto Equilibrio Statico",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cervelletto Equilibrio Statico ottimizza le operazioni sensoriale nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "chemiorecettori_bromuro": {
+      "label": "Chemiorecettori Bromuro",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Chemiorecettori Bromuro ottimizza le operazioni locomotorio nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "chioma_parassita_canopica": {
+      "label": "Chioma Parassita Canopica",
+      "famiglia_tipologia": "Simbiotico/Utility",
+      "fattore_mantenimento_energetico": "Medio (Nutrimento condiviso con l'ospite arboreo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "utility",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "bulbi_radici_permafrost",
+        "nodi_micorrizici_oracolari"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopie_sospese"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Foreste verticali multilivello con alberi levitanti e liane sensibili."
+          }
+        }
+      ],
+      "mutazione_indotta": "Filamenti vegetali che si intrecciano con la canopia ospite fornendo punti d'ancoraggio e energia.",
+      "uso_funzione": "Crea passaggi e nodi energetici condivisi nella canopia per movimenti rapidi.",
+      "spinta_selettiva": "Stabilizzare piattaforme mobili e reti di trasporto tra gli alberi viventi.",
+      "debolezza": "Se la pianta ospite muore la chioma psionica collassa causando shock sistemico.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "circolazione_bifasica": {
+      "label": "Circolazione Bifasica",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Circolazione Bifasica ottimizza le operazioni difensivo nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "circolazione_bifasica_palude": {
+      "label": "Circolazione Bifasica di Palude",
+      "famiglia_tipologia": "Metabolico/Resilienza",
+      "fattore_mantenimento_energetico": "Medio (Doppio circuito emolinfa/linfa)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "metabolico"
+      },
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie"
+      ],
+      "conflitti": [
+        "sangue_piroforico"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "paludi_gas_luminescenti"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Paludi bioluminescenti piene di gas nervini e batteri simbionti."
+          }
+        }
+      ],
+      "mutazione_indotta": "Cuori gemelli che pompano separatamente emolinfa ossigenata e linfa detossificante.",
+      "uso_funzione": "Gestisce due circuiti circolatori per filtrare veleni e mantenere prestazioni elevate.",
+      "spinta_selettiva": "Resistere a tossine e anossia tipiche delle paludi psioniche.",
+      "debolezza": "Zone asciutte e calde causano stagnazione del circuito linfatico portando a tossicosi.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "circolazione_cooling_loop": {
+      "label": "Circolazione Cooling Loop",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_algoritmiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Circolazione Cooling Loop ottimizza le operazioni metabolico nelle condizioni di steppe algoritmiche.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "circolazione_doppia": {
+      "label": "Circolazione Doppia",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Circolazione Doppia ottimizza le operazioni supporto nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "circolazione_supercritica": {
+      "label": "Circolazione Supercritica",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Circolazione Supercritica ottimizza le operazioni offensivo nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ciste_riduttive": {
+      "label": "Ciste Riduttive",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laguna_bioreattiva"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ciste Riduttive ottimizza le operazioni strategia nelle condizioni di laguna bioreattiva.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ciste_salmastre": {
+      "label": "Ciste Salmastre",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ciste Salmastre ottimizza le operazioni simbiotico nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "cisti_iperbariche": {
+      "label": "Cisti Iperbariche",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cisti Iperbariche ottimizza le operazioni strutturale nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "coda_balanciere": {
+      "label": "Coda Balanciere",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Coda Balanciere ottimizza le operazioni sensoriale nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "coda_contrappeso": {
+      "label": "Coda Contrappeso",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovieto_cinetico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Coda Contrappeso ottimizza le operazioni locomotorio nelle condizioni di mangrovieto cinetico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "coda_coppia_retroattiva": {
+      "label": "Coda Coppia Retroattiva",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_algoritmiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Coda Coppia Retroattiva ottimizza le operazioni difensivo nelle condizioni di steppe algoritmiche.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "coda_frusta_cinetica": {
+      "label": "Coda a Frusta Cinetica",
+      "famiglia_tipologia": "Locomotorio/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Mantenimento dell'energia accumulata)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "difensivo",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "ali_ioniche",
+        "antenne_flusso_mareale",
+        "antenne_wideband",
+        "artigli_induzione",
+        "artigli_sette_vie",
+        "barbigli_sensori_plasma",
+        "biochip_memoria",
+        "branchie_metalloidi",
+        "camere_anticorrosione",
+        "capillari_fotovoltaici",
+        "cartilagini_biofibre",
+        "chemiorecettori_bromuro",
+        "circolazione_supercritica",
+        "coda_contrappeso",
+        "coda_stabilizzatrice_vortex",
+        "cuscinetti_elettrostatici",
+        "denti_chelatanti",
+        "enzimi_antifase_termica",
+        "enzimi_metanoossidanti",
+        "filamenti_termoconduzione",
+        "foliaggio_spugna",
+        "ghiandole_fango_calde",
+        "ghiandole_iodoattive",
+        "ghiandole_ventosa",
+        "gusci_magnesio",
+        "linfa_tampone",
+        "mantelli_geotermici",
+        "mucose_aderenza_sonica"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Corridore T2 per intercettare campi magnetici psionici sulle dorsali.",
+            "tier": "T2"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante T3 calibrata alle camere di gravità invertita e ai flussi orbitali.",
+            "tier": "T3"
+          }
+        }
+      ],
+      "mutazione_indotta": "Muscolatura della coda densa con tendini e fibre che agiscono come molle.",
+      "uso_funzione": "Immagazzinare energia da ogni movimento per un colpo finale potente.",
+      "spinta_selettiva": "Necessità di un attacco di \"sfondamento\" dopo movimento preparatorio.",
+      "debolezza": "Richiede un periodo di inattività o movimento preparatorio per massimizzare il danno.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "coda_stabilizzatrice_filo": {
+      "label": "Coda Stabilizzatrice Filo",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Coda Stabilizzatrice Filo ottimizza le operazioni metabolico nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "coda_stabilizzatrice_geiser": {
+      "label": "Coda Stabilizzatrice Geiser",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Coda Stabilizzatrice Geiser ottimizza le operazioni supporto nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "coda_stabilizzatrice_vortex": {
+      "label": "Coda Stabilizzatrice Vortex",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Coda Stabilizzatrice Vortex ottimizza le operazioni offensivo nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "colonne_vibromagnetiche": {
+      "label": "Colonne Vibromagnetiche",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Colonne Vibromagnetiche ottimizza le operazioni strategia nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "coralli_partner": {
+      "label": "Coralli Partner",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Coralli Partner ottimizza le operazioni simbiotico nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "criostasi_adattiva": {
+      "label": "Criostasi",
+      "famiglia_tipologia": "Metabolico/Difensivo",
+      "fattore_mantenimento_energetico": "Alto (Fase di risveglio/inizio) / Basso (Fase Criostasi).",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "difensivo",
+        "core": "metabolico"
+      },
+      "sinergie": [
+        "cavita_risonanti_tundra"
+      ],
+      "conflitti": [
+        "sangue_piroforico",
+        "sacche_galleggianti_ascensoriali"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_psionica_leggera"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Fase T1 controllata: micro-canopie sospese usate per cicli brevi di ibernazione.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante apex T3 in camere orbitali a gravità invertita per stasi prolungate.",
+            "tier": "T3"
+          }
+        }
+      ],
+      "mutazione_indotta": "Sviluppo di enzimi crioprotettivi e tessuto adiposo isolante.",
+      "uso_funzione": "Sopravvivenza a condizioni ambientali estreme.",
+      "spinta_selettiva": "Inverni prolungati o lunghi periodi di scarsità di cibo.",
+      "debolezza": "Vulnerabilità estrema agli attacchi chimici (veleni) in fase Criostasi.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "cromofori_alert_acido": {
+      "label": "Cromofori Alert Acido",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cromofori Alert Acido ottimizza le operazioni strutturale nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "cuore_multicamera_bassa_pressione": {
+      "label": "Cuore Multicamera Bassa Pressione",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cuore Multicamera Bassa Pressione ottimizza le operazioni sensoriale nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "cuscinetti_elettrostatici": {
+      "label": "Cuscinetti Elettrostatici",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cuscinetti Elettrostatici ottimizza le operazioni locomotorio nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "cute_resistente_sali": {
+      "label": "Cute Resistente Sali",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Attivazione situazionale)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "badlands"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cute Resistente Sali ottimizza le operazioni difensivo nelle condizioni di badlands.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "cuticole_cerose": {
+      "label": "Cuticole Cerose",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [],
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "cuticole_neutralizzanti": {
+      "label": "Cuticole Neutralizzanti",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cuticole Neutralizzanti ottimizza le operazioni supporto nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "denti_chelatanti": {
+      "label": "Denti Chelatanti",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Denti Chelatanti ottimizza le operazioni offensivo nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "denti_ossidoferro": {
+      "label": "Denti Ossidoferro",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Denti Ossidoferro ottimizza le operazioni strategia nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "denti_silice_termici": {
+      "label": "Denti Silice Termici",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Denti Silice Termici ottimizza le operazioni simbiotico nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "denti_tuning_fork": {
+      "label": "Denti Tuning Fork",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Denti Tuning Fork ottimizza le operazioni strutturale nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "echi_risonanti": {
+      "label": "Echi Risonanti",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Echi Risonanti ottimizza le operazioni sensoriale nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "eco_interno_riflesso": {
+      "label": "Riflesso dell'Eco Interno",
+      "famiglia_tipologia": "Sensoriale/Nervoso",
+      "fattore_mantenimento_energetico": "Medio (Emissioni e ricezione continua)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "nervoso",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "cavita_risonanti_tundra",
+        "olfatto_risonanza_magnetica",
+        "sensori_geomagnetici"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_psionica_leggera"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Start T1 nelle canopie conduttrici per apprendere deformazioni controllate.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Upgrade T2 sulle dorsali magnetiche per mantenere elasticità sotto stress.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "mutazione_indotta": "Organi interni che emettono ultrasuoni e li captano tramite lo scheletro.",
+      "uso_funzione": "Utilizzo di onde sonore emesse internamente per mappare l'ambiente.",
+      "spinta_selettiva": "Orientamento in ambienti completamente privi di luce.",
+      "debolezza": "Estremamente disorientato da suoni o vibrazioni esterne forti e continue.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "empatia_coordinativa": {
+      "label": "Empatia Coordinativa",
+      "famiglia_tipologia": "Supporto/Empatico",
+      "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
+      "tier": "T1",
+      "slot": [
+        "A"
+      ],
+      "slot_profile": {
+        "complementare": "coordinazione",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "antenne_eco_turbina",
+        "artigli_acidofagi",
+        "batteri_termofili_endosimbiosi",
+        "branchie_turbina",
+        "carapaci_ferruginosi",
+        "cavita_risonanti_tundra",
+        "circolazione_doppia",
+        "coda_stabilizzatrice_geiser",
+        "cuticole_neutralizzanti",
+        "enzimi_chelatori_rapidi",
+        "foliage_fotocatodico",
+        "ghiandole_inchiostro_luce",
+        "gusci_criovetro",
+        "luminescenza_hydrotermica",
+        "aura_scudo_radianza"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [],
+      "mutazione_indotta": "Circuiti sensorio-emotivi collegati al feed HUD PI.",
+      "uso_funzione": "Collega cooldown difensivi e cura quando la squadra entra in finestra rischio.",
+      "spinta_selettiva": "Turni lunghi con rischio alto in cui serve mitigare tilt e HP critici.",
+      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "job_ability:Warden/Scudo_di_Risonanza"
+        ],
+        "combo_totale": 1,
+        "forme": [
+          "INFP"
+        ],
+        "tabelle_random": []
+      }
+    },
+    "enzimi_antifase_termica": {
+      "label": "Enzimi Antifase Termica",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Enzimi Antifase Termica ottimizza le operazioni locomotorio nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "enzimi_antipredatori_algali": {
+      "label": "Enzimi Antipredatori Algali",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Enzimi Antipredatori Algali ottimizza le operazioni difensivo nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "enzimi_chelanti": {
+      "label": "Enzimi Chelanti",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [],
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "enzimi_chelatori_rapidi": {
+      "label": "Enzimi Chelatori Rapidi",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Enzimi Chelatori Rapidi ottimizza le operazioni supporto nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "enzimi_metanoossidanti": {
+      "label": "Enzimi Metanoossidanti",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Enzimi Metanoossidanti ottimizza le operazioni offensivo nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "epidermide_dielettrica": {
+      "label": "Epidermide Dielettrica",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Epidermide Dielettrica ottimizza le operazioni strategia nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "epitelio_fosforescente": {
+      "label": "Epitelio Fosforescente",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Epitelio Fosforescente ottimizza le operazioni simbiotico nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "filamenti_digestivi_compattanti": {
+      "label": "Filamento materiali digeriti",
+      "famiglia_tipologia": "Digestivo/Escretorio",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "escretorio",
+        "core": "digestivo"
+      },
+      "sinergie": [
+        "antenne_dustsense",
+        "appendici_thermotattiche",
+        "batteri_endosimbionti_chemio",
+        "branchie_solfatiche",
+        "carapace_segmenti_logici",
+        "circolazione_cooling_loop",
+        "coda_stabilizzatrice_filo",
+        "cuticole_cerose",
+        "enzimi_chelanti",
+        "flagelli_ancoranti",
+        "ghiandole_grafene",
+        "grassi_termici",
+        "luminescenza_aurorale",
+        "ventriglio_gastroliti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante T2 che sfrutta falde magnetiche per compattare residui ad alta densità.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "mutazione_indotta": "Muscolatura rettale ipertrofica e organo appendice dedicato.",
+      "uso_funzione": "Espulsione compatta e ordinata di scorie.",
+      "spinta_selettiva": "Necessità di mantenere la pulizia del territorio/nido.",
+      "debolezza": "Blocco intestinale se la dieta è priva di materiale 'legante'.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "filamenti_magnetotrofi": {
+      "label": "Filamenti Magnetotrofi",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Filamenti Magnetotrofi ottimizza le operazioni strutturale nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "filamenti_superconduttivi": {
+      "label": "Filamenti Superconduttivi",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Filamenti Superconduttivi ottimizza le operazioni sensoriale nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "filamenti_termoconduzione": {
+      "label": "Filamenti Termoconduzione",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Filamenti Termoconduzione ottimizza le operazioni locomotorio nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "filtri_planctonici": {
+      "label": "Filtri Planctonici",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laguna_bioreattiva"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Filtri Planctonici ottimizza le operazioni difensivo nelle condizioni di laguna bioreattiva.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "flagelli_ancoranti": {
+      "label": "Flagelli Ancoranti",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laguna_bioreattiva"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Flagelli Ancoranti ottimizza le operazioni metabolico nelle condizioni di laguna bioreattiva.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "focus_frazionato": {
+      "label": "Focus Frazionato",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Medio (Dividere l'attenzione su più canali)",
+      "tier": "T1",
+      "slot": [
+        "A",
+        "C"
+      ],
+      "slot_profile": {
+        "complementare": "psionico",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "ali_fulminee",
+        "antenne_plasmatiche_tempesta",
+        "antenne_waveguide",
+        "baffi_mareomotori",
+        "branchie_eoliche",
+        "capillari_fluoridici",
+        "cervelletto_equilibrio_statico",
+        "coda_balanciere",
+        "cuore_multicamera_bassa_pressione",
+        "echi_risonanti",
+        "filamenti_superconduttivi",
+        "ghiandole_eco_mappanti",
+        "ghiandole_resina_conduttiva",
+        "lamine_scudo_silice",
+        "midollo_antivibrazione",
+        "frusta_fiammeggiante"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [],
+      "mutazione_indotta": "Processore di priorità multi-thread per bersagli e obiettivi.",
+      "uso_funzione": "Permette di gestire due ingaggi paralleli senza perdere efficienza.",
+      "spinta_selettiva": "Comunicazioni piatte dove occorre coprire minacce su più fronti.",
+      "debolezza": "Rischio di overload mentale se tilt e aggro salgono oltre le soglie HUD.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "PE",
+          "cap_pt",
+          "job_ability:Invoker/Sincronia",
+          "sigillo_forma",
+          "starter_bioma"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "ENTP",
+          "INFJ",
+          "INTP"
+        ],
+        "tabelle_random": []
+      }
+    },
+    "foliage_fotocatodico": {
+      "label": "Foliage Fotocatodico",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Foliage Fotocatodico ottimizza le operazioni supporto nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "foliaggio_spugna": {
+      "label": "Foliaggio Spugna",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovieto_cinetico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Foliaggio Spugna ottimizza le operazioni offensivo nelle condizioni di mangrovieto cinetico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "frusta_fiammeggiante": {
+      "label": "Frusta Fiammeggiante",
+      "famiglia_tipologia": "Offensivo/Controllo",
+      "fattore_mantenimento_energetico": "Medio (Filamenti di plasma vincolato)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "controllo",
+        "core": "offensivo"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "mantello_meteoritico"
+      ],
+      "conflitti": [
+        "armatura_pietra_planare"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [
+            "void_stride"
+          ],
+          "condizioni": {
+            "biome_class": "rovine_planari"
+          },
+          "fonte": "pathfinder_import",
+          "meta": {
+            "expansion": "pathfinder_dataset",
+            "notes": "Necessita condotti di stabilizzazione infernale nelle rovine planari.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "mutazione_indotta": "Genera appendici tentacolari avvolte da plasma infernale controllato.",
+      "uso_funzione": "Afferra e disarma avversari o sigilla varchi planari con tagli di energia.",
+      "spinta_selettiva": "Creare distanza di sicurezza contro predatori d'élite nelle zone instabili.",
+      "debolezza": "Consumante: richiede costante dissipazione termica per non bruciare la matrice portante.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ghiaccio_piezoelettrico": {
+      "label": "Ghiaccio Piezoelettrico",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiaccio Piezoelettrico ottimizza le operazioni strategia nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ghiandola_caustica": {
+      "label": "Ghiandola Caustica",
+      "famiglia_tipologia": "Offensivo/Chimico",
+      "fattore_mantenimento_energetico": "Medio (Produzione reagenti)",
+      "tier": "T1",
+      "slot": [
+        "A"
+      ],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "sinergie": [],
+      "conflitti": [],
+      "requisiti_ambientali": [],
+      "mutazione_indotta": "Sintesi rapida di composti caustici nei moduli d'attacco.",
+      "uso_funzione": "Sblocco early di danni da acido per rompere armature leggere.",
+      "spinta_selettiva": "Squadre che devono rispondere a guardie situazionali al turno 1-2.",
+      "debolezza": "Gestione accurata delle riserve per non calare sotto i budget PE previsto.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "PE",
+          "guardia_situazionale"
+        ],
+        "combo_totale": 1,
+        "forme": [
+          "ISTP"
+        ],
+        "tabelle_random": []
+      }
+    },
+    "ghiandole_cambio_salino": {
+      "label": "Ghiandole Cambio Salino",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laguna_bioreattiva"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Cambio Salino ottimizza le operazioni simbiotico nelle condizioni di laguna bioreattiva.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ghiandole_condensa_ozono": {
+      "label": "Ghiandole Condensa Ozono",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Condensa Ozono ottimizza le operazioni strutturale nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ghiandole_eco_mappanti": {
+      "label": "Ghiandole Eco Mappanti",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Eco Mappanti ottimizza le operazioni sensoriale nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ghiandole_fango_calde": {
+      "label": "Ghiandole Fango Calde",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Fango Calde ottimizza le operazioni locomotorio nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ghiandole_fango_coesivo": {
+      "label": "Ghiandole Fango Coesivo",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovieto_cinetico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Fango Coesivo ottimizza le operazioni difensivo nelle condizioni di mangrovieto cinetico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ghiandole_grafene": {
+      "label": "Ghiandole Grafene",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_algoritmiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Grafene ottimizza le operazioni metabolico nelle condizioni di steppe algoritmiche.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ghiandole_inchiostro_luce": {
+      "label": "Ghiandole Inchiostro Luce",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Inchiostro Luce ottimizza le operazioni supporto nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ghiandole_iodoattive": {
+      "label": "Ghiandole Iodoattive",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Iodoattive ottimizza le operazioni offensivo nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ghiandole_minerali": {
+      "label": "Ghiandole Minerali",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Minerali ottimizza le operazioni strategia nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ghiandole_nebbia_acida": {
+      "label": "Ghiandole Nebbia Acida",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Nebbia Acida ottimizza le operazioni simbiotico nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ghiandole_nebbia_ionica": {
+      "label": "Ghiandole Nebbia Ionica",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Nebbia Ionica ottimizza le operazioni strutturale nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ghiandole_resina_conduttiva": {
+      "label": "Ghiandole Resina Conduttiva",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Resina Conduttiva ottimizza le operazioni sensoriale nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ghiandole_ventosa": {
+      "label": "Ghiandole Ventosa",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Ventosa ottimizza le operazioni locomotorio nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "giunti_antitorsione": {
+      "label": "Giunti Antitorsione",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovieto_cinetico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Giunti Antitorsione ottimizza le operazioni difensivo nelle condizioni di mangrovieto cinetico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "grassi_termici": {
+      "label": "Grassi Termici",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [],
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "gusci_criovetro": {
+      "label": "Gusci Criovetro",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Gusci Criovetro ottimizza le operazioni supporto nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "gusci_magnesio": {
+      "label": "Gusci Magnesio",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Gusci Magnesio ottimizza le operazioni offensivo nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "lamelle_shear": {
+      "label": "Lamelle Shear",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Lamelle Shear ottimizza le operazioni strategia nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "lamelle_sincroniche": {
+      "label": "Lamelle Sincroniche",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_algoritmiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Lamelle Sincroniche ottimizza le operazioni simbiotico nelle condizioni di steppe algoritmiche.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "lamelle_termoforetiche": {
+      "label": "Lamelle Termoforetiche",
+      "famiglia_tipologia": "Respiratorio/Termoregolazione",
+      "fattore_mantenimento_energetico": "Medio (Flusso continuo di fluidi caldi)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "termoregolazione",
+        "core": "respiratorio"
+      },
+      "sinergie": [
+        "sangue_piroforico"
+      ],
+      "conflitti": [
+        "criostasi_adattiva"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "sorgenti_geotermiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Habitat idrotermali psionici dove il calore e la pressione variano rapidamente."
+          }
+        }
+      ],
+      "mutazione_indotta": "Canali lamellari mineralizzati che convogliano fluidi caldi tra branchie interne.",
+      "uso_funzione": "Regola lo scambio gassoso sfruttando gradienti termici controllati.",
+      "spinta_selettiva": "Sopravvivere a fluidi tossici e temperature estreme nelle fumarole geotermiche.",
+      "debolezza": "Rende instabile la fisiologia in ambienti a gelo improvviso, con rischio di microfratture vascolari.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "lamine_filtranti_aeree": {
+      "label": "Lamine Filtranti Aeree",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovieto_cinetico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Lamine Filtranti Aeree ottimizza le operazioni strutturale nelle condizioni di mangrovieto cinetico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "lamine_scudo_silice": {
+      "label": "Lamine Scudo Silice",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Lamine Scudo Silice ottimizza le operazioni sensoriale nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "linfa_tampone": {
+      "label": "Linfa Tampone",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Linfa Tampone ottimizza le operazioni locomotorio nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "lingua_cristallina": {
+      "label": "Lingua Cristallina",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Lingua Cristallina ottimizza le operazioni difensivo nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "lingua_tattile_trama": {
+      "label": "Lingua Tattile Trama-Sensibile",
+      "famiglia_tipologia": "Sensoriale/Alimentare",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "alimentare",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "olfatto_risonanza_magnetica"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+          }
+        }
+      ],
+      "mutazione_indotta": "Lingua sottile con papille tattili e meccanocettori avanzati.",
+      "uso_funzione": "\"Leggere\" la tessitura delle superfici per vibrazioni o micro-fratture.",
+      "spinta_selettiva": "Individuare movimenti sismici o cibi sepolti.",
+      "debolezza": "Estrema vulnerabilità della lingua a contaminanti chimici o acidi.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "luminescenza_aurorale": {
+      "label": "Luminescenza Aurorale",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Luminescenza Aurorale ottimizza le operazioni metabolico nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "luminescenza_hydrotermica": {
+      "label": "Luminescenza Hydrotermica",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Luminescenza Hydrotermica ottimizza le operazioni supporto nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "mantelli_geotermici": {
+      "label": "Mantelli Geotermici",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Mantelli Geotermici ottimizza le operazioni offensivo nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "mantello_meteoritico": {
+      "label": "Mantello Meteoritico",
+      "famiglia_tipologia": "Difesa/Termoregolazione",
+      "fattore_mantenimento_energetico": "Alto (Rivestimento ablativo rigenerante)",
+      "tier": "T3",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "termico",
+        "core": "difesa"
+      },
+      "sinergie": [
+        "frusta_fiammeggiante",
+        "carapace_fase_variabile"
+      ],
+      "conflitti": [
+        "aura_scudo_radianza"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [
+            "fire_resist"
+          ],
+          "condizioni": {
+            "biome_class": "rovine_planari"
+          },
+          "fonte": "pathfinder_import",
+          "meta": {
+            "expansion": "pathfinder_dataset",
+            "notes": "Richiede continue docce di plasma per mantenere la matrice ablativa.",
+            "tier": "T3"
+          }
+        }
+      ],
+      "mutazione_indotta": "Deposita strati sovrapposti di materiale meteorico che vaporizzano l'impatto e rilasciano radianza.",
+      "uso_funzione": "Assorbe colpi energetici estremi e converte il surplus in impulsi offensivi.",
+      "spinta_selettiva": "Sopravvivere a bombardamenti planari e piogge di meteore dimensionali.",
+      "debolezza": "Vulnerabile a scariche di freddo gravitazionale che irrigidiscono il mantello.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "membrane_captura_rugiada": {
+      "label": "Membrane Captura Rugiada",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Membrane Captura Rugiada ottimizza le operazioni strategia nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "membrane_eliofiltranti": {
+      "label": "Membrane Eliofiltranti",
+      "famiglia_tipologia": "Respiratorio/Protezione",
+      "fattore_mantenimento_energetico": "Basso (Auto-riparazione lenta)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "respiratorio"
+      },
+      "sinergie": [
+        "piume_solari_fotovoltaiche",
+        "polmoni_cristallini_alta_quota"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laghi_alcalini"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Bacini alcalini sospesi dove la luce viene rifratta da vapori metallici."
+          }
+        }
+      ],
+      "mutazione_indotta": "Strati di mucopolisaccaridi trasparenti che filtrano radiazioni e microrganismi sospesi.",
+      "uso_funzione": "Filtra l'aria e i flussi luminosi rendendoli sicuri per tessuti delicati.",
+      "spinta_selettiva": "Proteggersi da radiazioni e agenti patogeni in altopiani ipersalini.",
+      "debolezza": "Atmosfere acide degradano rapidamente il film eliofiltrante.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "membrane_planata_vectored": {
+      "label": "Membrane Planata Vectored",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Membrane Planata Vectored ottimizza le operazioni simbiotico nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "membrane_pneumatofori": {
+      "label": "Membrane Pneumatofori",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovieto_cinetico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Membrane Pneumatofori ottimizza le operazioni strutturale nelle condizioni di mangrovieto cinetico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "midollo_antivibrazione": {
+      "label": "Midollo Antivibrazione",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Midollo Antivibrazione ottimizza le operazioni sensoriale nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "mimetismo_cromatico_passivo": {
+      "label": "Ghiandole di Mimetismo Cromatico Passivo",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Fase passiva)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "difensivo",
+        "core": "tegumentario"
+      },
+      "sinergie": [
+        "ali_membrana_sonica",
+        "appendici_risonanti_marea",
+        "artigli_sette_vie",
+        "barriere_miasma_glaciale",
+        "branchie_microfiltri",
+        "capsule_paracadute",
+        "circolazione_bifasica",
+        "coda_coppia_retroattiva",
+        "cute_resistente_sali",
+        "enzimi_antipredatori_algali",
+        "filtri_planctonici",
+        "ghiandole_fango_coesivo",
+        "giunti_antitorsione",
+        "lingua_cristallina",
+        "mucose_barofile",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_psionica_leggera"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "T1 di acclimatazione nelle canopie conduttrici a bassa intensità.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Percorso T2 che aggiunge gradienti magnetici per pattern cromatici complessi.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "mutazione_indotta": "Cromatofori che richiedono un input tattile prolungato per la ricarica.",
+      "uso_funzione": "Assorbire e replicare il colore dell'ambiente circostante dopo contatto.",
+      "spinta_selettiva": "Ambiente con pattern cromatici molto variabili che cambiano lentamente.",
+      "debolezza": "La colorazione è fissa finché non c'è un nuovo contatto prolungato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "mucillagine_simbionte_mangrovie": {
+      "label": "Mucillagine Simbionte delle Mangrovie",
+      "famiglia_tipologia": "Simbiotico/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Coltura simbiotica costante)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "difensivo",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "antenne_reagenti",
+        "artigli_scivolo_silente",
+        "biofilm_iperarido",
+        "branchie_osmotiche_salmastra",
+        "camere_nutrienti_vent",
+        "cartilagini_flessoacustiche",
+        "circolazione_bifasica_palude",
+        "ciste_salmastre",
+        "coralli_partner",
+        "denti_silice_termici",
+        "epitelio_fosforescente",
+        "ghiandole_cambio_salino",
+        "ghiandole_nebbia_acida",
+        "lamelle_sincroniche",
+        "membrane_planata_vectored",
+        "nodi_micorrizici_oracolari"
+      ],
+      "conflitti": [
+        "ghiandola_caustica"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovie_risonanti"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Foreste di mangrovie ipersature dove le radici cantano frequenze psioniche."
+          }
+        }
+      ],
+      "mutazione_indotta": "Strati mucosi che ospitano microfauna detossificante proveniente dalle radici di mangrovia.",
+      "uso_funzione": "Forma una barriera viva che neutralizza veleni e sigilla ferite.",
+      "spinta_selettiva": "Respinge tossine e predatori microbici tipici dei delta paludosi.",
+      "debolezza": "Acque eccessivamente pure diluiscono la mucillagine riducendo la protezione.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "mucose_aderenza_sonica": {
+      "label": "Mucose Aderenza Sonica",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Mucose Aderenza Sonica ottimizza le operazioni locomotorio nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "mucose_barofile": {
+      "label": "Mucose Barofile",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Mucose Barofile ottimizza le operazioni difensivo nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "nodi_micorrizici_oracolari": {
+      "label": "Nodi Micorrizici Oracolari",
+      "famiglia_tipologia": "Simbiotico/Nervoso",
+      "fattore_mantenimento_energetico": "Medio (Scambio continuo di segnali con simbionti)",
+      "tier": "T3",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "nervoso",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "antenne_reagenti",
+        "artigli_scivolo_silente",
+        "biofilm_iperarido",
+        "bulbi_radici_permafrost",
+        "camere_nutrienti_vent",
+        "cartilagini_flessoacustiche",
+        "chioma_parassita_canopica",
+        "ciste_salmastre",
+        "coralli_partner",
+        "denti_silice_termici",
+        "epitelio_fosforescente",
+        "ghiandole_cambio_salino",
+        "ghiandole_nebbia_acida",
+        "lamelle_sincroniche",
+        "membrane_planata_vectored",
+        "mucillagine_simbionte_mangrovie"
+      ],
+      "conflitti": [
+        "spore_psichiche_silenziate"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reti_micorriziche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Sottoboschi viventi con reti fungine coscienti che emettono segnali premonitori."
+          }
+        }
+      ],
+      "mutazione_indotta": "Radici dermiche che intrecciano funghi psionici capaci di predire variazioni ambientali.",
+      "uso_funzione": "Riceve presagi e segnali tattici dalla rete fungina per coordinare manovre di squadra.",
+      "spinta_selettiva": "Anticipare frane psioniche e predatori guidati da reti vegetali senzienti.",
+      "debolezza": "Se la rete micorrizica viene recisa, l'organismo soffre crisi percettive e perdita di orientamento.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "nucleo_ovomotore_rotante": {
+      "label": "Uovo rotaia, uovo grande e uova piccole dentro...",
+      "famiglia_tipologia": "Riproduttivo/Locomotorio",
+      "fattore_mantenimento_energetico": "Alto (Rotolamento)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "locomotorio",
+        "core": "riproduttivo"
+      },
+      "sinergie": [],
+      "conflitti": [
+        "secrezione_rallentante_palmi"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+          }
+        }
+      ],
+      "mutazione_indotta": "Massa globulare rigida con giunto sferico al centro del petto.",
+      "uso_funzione": "Organo Motorio Rotante: usato come 'ruota' centrale per il rotolamento.",
+      "spinta_selettiva": "Necessità di spostarsi rapidamente su terreni uniformi in assenza di arti.",
+      "debolezza": "Impossibilità di muoversi su superfici irregolari o in salita ripida.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "occhi_infrarosso_composti": {
+      "label": "Occhi Composti ad Infrarosso",
+      "famiglia_tipologia": "Sensoriale/Visivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "visivo",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "sonno_emisferico_alternato"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+          }
+        }
+      ],
+      "mutazione_indotta": "Sviluppo di un secondo strato retinico sensibile all'infrarosso.",
+      "uso_funzione": "Vista specializzata che percepisce il calore corporeo.",
+      "spinta_selettiva": "Caccia notturna o nell'oscurità totale basata sul gradiente termico.",
+      "debolezza": "Accecamento temporaneo da fonti di calore intenso e concentrato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "olfatto_risonanza_magnetica": {
+      "label": "Olfatto di Risonanza Magnetica",
+      "famiglia_tipologia": "Sensoriale/Nervoso",
+      "fattore_mantenimento_energetico": "Medio (Elaborazione sensoriale costante)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "nervoso",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "eco_interno_riflesso",
+        "lingua_tattile_trama"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Corridore T2 per intercettare campi magnetici psionici sulle dorsali.",
+            "tier": "T2"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante T3 calibrata alle camere di gravità invertita e ai flussi orbitali.",
+            "tier": "T3"
+          }
+        }
+      ],
+      "mutazione_indotta": "Organi sensoriali elettrorecettori concentrati su muso o antenne.",
+      "uso_funzione": "Percepire la direzione e la composizione di metalli o campi energetici.",
+      "spinta_selettiva": "Orientamento in ambienti sotterranei senza luce o caccia a prede metallifere.",
+      "debolezza": "Sensibilità a forti interferenze elettromagnetiche (es. fulmini o minerali magnetici).",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "pathfinder": {
+      "label": "Pathfinder",
+      "famiglia_tipologia": "Esplorazione/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Sincronizzazione con HUD di esplorazione)",
+      "tier": "T1",
+      "slot": [
+        "A"
+      ],
+      "slot_profile": {
+        "complementare": "ricognizione",
+        "core": "strategia"
+      },
+      "sinergie": [],
+      "conflitti": [],
+      "requisiti_ambientali": [],
+      "mutazione_indotta": "Suite sensoriale orientata a scouting e lettura minacce.",
+      "uso_funzione": "Ottimizza esplorazione e controllo mappe multi-bioma.",
+      "spinta_selettiva": "Missioni con indice explore alto e opzioni opzionali da capitalizzare.",
+      "debolezza": "Valore ridotto in scenari a corridoio o con tilt già stabilizzato.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "PE",
+          "cap_pt",
+          "starter_bioma"
+        ],
+        "combo_totale": 1,
+        "forme": [
+          "ENFP"
+        ],
+        "tabelle_random": []
+      }
+    },
+    "pianificatore": {
+      "label": "Pianificatore",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Medio (Analisi continua di stato squadre)",
+      "tier": "T1",
+      "slot": [
+        "A",
+        "C"
+      ],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "antenne_microonde_cavernose",
+        "artigli_radice",
+        "biofilm_glow",
+        "camere_mirage",
+        "cartilagini_desertiche",
+        "ciste_riduttive",
+        "colonne_vibromagnetiche",
+        "denti_ossidoferro",
+        "epidermide_dielettrica",
+        "ghiaccio_piezoelettrico",
+        "ghiandole_minerali",
+        "lamelle_shear",
+        "membrane_captura_rugiada"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [],
+      "mutazione_indotta": "Protocollo decisionale adattivo con buffer informativi dedicati.",
+      "uso_funzione": "Coordina finestre di danno e difesa, mantenendo la squadra allineata al piano PI.",
+      "spinta_selettiva": "Squadre che devono mantenere priorità multiple su turni lunghi.",
+      "debolezza": "Rigidità tattica se gli input di telemetria arrivano in ritardo.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "PE",
+          "cap_pt",
+          "guardia_situazionale",
+          "sigillo_forma",
+          "starter_bioma"
+        ],
+        "combo_totale": 6,
+        "forme": [
+          "ENTJ",
+          "ENTP",
+          "ESTJ",
+          "INTJ",
+          "ISTJ"
+        ],
+        "tabelle_random": []
+      }
+    },
+    "piume_solari_fotovoltaiche": {
+      "label": "Piume Solari Fotovoltaiche",
+      "famiglia_tipologia": "Tegumentario/Energetico",
+      "fattore_mantenimento_energetico": "Alto (Richiede manutenzione delle lamine fotoreattive)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energetico",
+        "core": "tegumentario"
+      },
+      "sinergie": [
+        "membrane_eliofiltranti",
+        "sacche_spore_stratosferiche"
+      ],
+      "conflitti": [
+        "criostasi_adattiva"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "altipiani_solari"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Altipiani ad alta insolazione dove le correnti psioniche amplificano la luce."
+          }
+        }
+      ],
+      "mutazione_indotta": "Piumaggio stratificato con pigmenti piezo-fotovoltaici che immagazzinano luce.",
+      "uso_funzione": "Convertire la radiazione solare in riserve energetiche per abilità a lungo raggio.",
+      "spinta_selettiva": "Massimizzare l'autonomia energetica per migrazioni aeree sopra deserti e oceani.",
+      "debolezza": "Ombre prolungate o polveri dense riducono drasticamente la produzione energetica.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "polmoni_cristallini_alta_quota": {
+      "label": "Polmoni Cristallini d'Alta Quota",
+      "famiglia_tipologia": "Respiratorio/Aerobico",
+      "fattore_mantenimento_energetico": "Medio (Pulizia periodica dei cristalli)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "aerobico",
+        "core": "respiratorio"
+      },
+      "sinergie": [
+        "membrane_eliofiltranti"
+      ],
+      "conflitti": [
+        "branchie_osmotiche_salmastra"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "picchi_cristallini"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Catene montuose sospese dove i cristalli amplificano l'aria rarefatta."
+          }
+        }
+      ],
+      "mutazione_indotta": "Sistemi alveolari irrobustiti da strutture cristalline che catturano ossigeno rarefatto.",
+      "uso_funzione": "Massimizza l'assorbimento di ossigeno rarefatto e filtra agenti nocivi.",
+      "spinta_selettiva": "Operare in missioni d'alta quota senza supporto logistico esterno.",
+      "debolezza": "Particolato pesante o sabbia vulcanica graffia i cristalli riducendo l'efficienza respiratoria.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "random": {
+      "label": "Trait Random",
+      "famiglia_tipologia": "Flessibile/Generico",
+      "fattore_mantenimento_energetico": "Variabile (Dipende dal tratto estratto)",
+      "tier": "T1",
+      "slot": [
+        "A",
+        "B"
+      ],
+      "slot_profile": {
+        "complementare": "adattivo",
+        "core": "strategia"
+      },
+      "sinergie": [],
+      "conflitti": [],
+      "requisiti_ambientali": [],
+      "mutazione_indotta": "Selezione casuale da pool controllata per esperimenti di build.",
+      "uso_funzione": "Slot jolly per testing o pareggiare budget PI quando serve varietà.",
+      "spinta_selettiva": "Draft rapidi o recuperi quando il tavolo necessita sorprese adattive.",
+      "debolezza": "Bassa affidabilità: richiede slot aggiuntivi per mitigare risultati sfavorevoli.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "cap_pt",
+          "guardia_situazionale",
+          "job_ability:Random"
+        ],
+        "combo_totale": 2,
+        "forme": [
+          "NEUTRA"
+        ],
+        "tabelle_random": []
+      }
+    },
+    "respiro_a_scoppio": {
+      "label": "Respiro a scoppio",
+      "famiglia_tipologia": "Respiratorio/Propulsivo",
+      "fattore_mantenimento_energetico": "Alto (Richiede ricarica polmonare)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "propulsivo",
+        "core": "respiratorio"
+      },
+      "sinergie": [
+        "sacche_galleggianti_ascensoriali",
+        "squame_rifrangenti_deserto"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+          }
+        }
+      ],
+      "mutazione_indotta": "Polmoni o sacche aeree ad alta pressione con valvole di rilascio rapide.",
+      "uso_funzione": "Rilasciare grandi quantità d'aria o energia in un getto potente.",
+      "spinta_selettiva": "Spostamento rapido tramite getto d'aria in ambienti a bassa resistenza.",
+      "debolezza": "Vulnerabilità respiratoria subito dopo l'utilizzo (tempo di ricarica).",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "risonanza_di_branco": {
+      "label": "Risonanza di Branco",
+      "famiglia_tipologia": "Supporto/Coordinativo",
+      "fattore_mantenimento_energetico": "Basso (Richiede mantenimento empatico)",
+      "tier": "T1",
+      "slot": [
+        "A",
+        "B",
+        "C"
+      ],
+      "slot_profile": {
+        "complementare": "coordinazione",
+        "core": "supporto"
+      },
+      "sinergie": [
+        "antenne_eco_turbina",
+        "antenne_plasmatiche_tempesta",
+        "artigli_acidofagi",
+        "batteri_termofili_endosimbiosi",
+        "branchie_turbina",
+        "carapace_luminiscente_abissale",
+        "carapaci_ferruginosi",
+        "cavita_risonanti_tundra",
+        "circolazione_doppia",
+        "coda_stabilizzatrice_geiser",
+        "cuticole_neutralizzanti",
+        "enzimi_chelatori_rapidi",
+        "foliage_fotocatodico",
+        "ghiandole_inchiostro_luce",
+        "gusci_criovetro",
+        "luminescenza_hydrotermica",
+        "aura_scudo_radianza"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [],
+      "mutazione_indotta": "Reticolo empatico che collega i canali PI cooperativi.",
+      "uso_funzione": "Amplifica buff condivisi sincronizzando i timer di squadra.",
+      "spinta_selettiva": "Forme che eccellono in difesa coordinata e scudi sovrapposti.",
+      "debolezza": "Stress elevato se la coesione cala sotto i target di telemetria.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "PE",
+          "cap_pt",
+          "guardia_situazionale",
+          "starter_bioma"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "ENFJ",
+          "INFP",
+          "ISFJ"
+        ],
+        "tabelle_random": []
+      }
+    },
+    "sacche_galleggianti_ascensoriali": {
+      "label": "Sacche galleggianti ascensoriali",
+      "famiglia_tipologia": "Idrostatico/Locomotorio",
+      "fattore_mantenimento_energetico": "Medio (Per il controllo della pressione)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "locomotorio",
+        "core": "idrostatico"
+      },
+      "sinergie": [
+        "cartilagine_flessotermica_venti",
+        "respiro_a_scoppio",
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_psionica_leggera"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Fase T1 in canopie sospese per calibrare pompaggio e feedback pressorio.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Apex T3 su piattaforme orbitali a gravità invertita per ascese rapide.",
+            "tier": "T3"
+          }
+        }
+      ],
+      "mutazione_indotta": "Sacche ripiene di gas leggeri con pompe muscolari.",
+      "uso_funzione": "Controllo preciso della profondità e del movimento verticale.",
+      "spinta_selettiva": "Vivere in un ambiente acquatico con forti correnti verticali.",
+      "debolezza": "Rischio di barotrauma se la pressione esterna cambia troppo rapidamente.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "sacche_spore_stratosferiche": {
+      "label": "Sacche di Spore Stratosferiche",
+      "famiglia_tipologia": "Simbiotico/Supporto",
+      "fattore_mantenimento_energetico": "Alto (Coltura continua di spore portanti)",
+      "tier": "T3",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "supporto",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "piume_solari_fotovoltaiche"
+      ],
+      "conflitti": [
+        "respiro_a_scoppio"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_portante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Correnti ascendenti permanenti che trasportano semi e spore su larga scala."
+          }
+        }
+      ],
+      "mutazione_indotta": "Vescicole dermiche che rilasciano spore portatrici capaci di galleggiare per chilometri.",
+      "uso_funzione": "Distribuisce simbionti di supporto e crea corridoi di movimento per la squadra.",
+      "spinta_selettiva": "Dispersone genetica rapida tra arcipelaghi aerei e piattaforme galleggianti.",
+      "debolezza": "Correnti ionizzate possono incendiare le sacche rendendo l'organismo instabile.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "sangue_piroforico": {
+      "label": "Sangue che prende fuoco a contatto con l'ossigeno",
+      "famiglia_tipologia": "Offensivo/Cinetico",
+      "fattore_mantenimento_energetico": "Medio (Sintesi dei composti)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "impatto",
+        "core": "offensivo"
+      },
+      "sinergie": [
+        "antenne_flusso_mareale",
+        "artigli_induzione",
+        "biochip_memoria",
+        "camere_anticorrosione",
+        "cartilagini_biofibre",
+        "circolazione_supercritica",
+        "coda_stabilizzatrice_vortex",
+        "denti_chelatanti",
+        "enzimi_metanoossidanti",
+        "foliaggio_spugna",
+        "ghiandole_iodoattive",
+        "gusci_magnesio",
+        "lamelle_termoforetiche",
+        "mantelli_geotermici"
+      ],
+      "conflitti": [
+        "criostasi_adattiva",
+        "scheletro_idro_regolante"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+          }
+        }
+      ],
+      "mutazione_indotta": "Presenza di composti piroforici nel sangue.",
+      "uso_funzione": "Meccanismo di difesa termico o chimico che si attiva con l'aria.",
+      "spinta_selettiva": "Difesa contro predatori che tentano di estrarre fluidi corporei.",
+      "debolezza": "Rischio di auto-combustione in caso di ferita profonda in atmosfera ricca di ossigeno.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "scheletro_idro_regolante": {
+      "label": "Scheletro Idro-Regolante",
+      "famiglia_tipologia": "Strutturale/Omeostatico",
+      "fattore_mantenimento_energetico": "Medio (Scambio rapido di fluidi)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "omeostatico",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "antenne_tesla",
+        "artigli_vetrificati",
+        "branchie_dual_mode",
+        "branchie_osmotiche_salmastra",
+        "capillari_criogenici",
+        "cartilagini_pseudometalliche",
+        "cisti_iperbariche",
+        "cromofori_alert_acido",
+        "denti_tuning_fork",
+        "filamenti_magnetotrofi",
+        "ghiandole_condensa_ozono",
+        "ghiandole_nebbia_ionica",
+        "lamine_filtranti_aeree",
+        "membrane_pneumatofori",
+        "sacche_galleggianti_ascensoriali",
+        "struttura_elastica_amorfa"
+      ],
+      "conflitti": [
+        "sangue_piroforico"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+          }
+        }
+      ],
+      "mutazione_indotta": "Struttura ossea porosa capace di scambio rapido di fluidi.",
+      "uso_funzione": "Assorbire o espellere rapidamente acqua dai tessuti ossei per modificare il peso.",
+      "spinta_selettiva": "Alternare vita terrestre e vita acquatica/aerea.",
+      "debolezza": "Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "secrezione_rallentante_palmi": {
+      "label": "Mani secernano liquido rallentante",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Produzione del liquido)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "difensivo",
+        "core": "tegumentario"
+      },
+      "sinergie": [],
+      "conflitti": [
+        "carapace_fase_variabile",
+        "nucleo_ovomotore_rotante"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+          }
+        }
+      ],
+      "mutazione_indotta": "Ghiandole mucose modificate sulle superfici prensili.",
+      "uso_funzione": "Neutralizzare o immobilizzare prede/nemici.",
+      "spinta_selettiva": "Cattura di prede veloci o difesa da aggressori corpo a corpo.",
+      "debolezza": "Esaurimento rapido delle riserve di liquido con tempo di ricarica prolungato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "sensori_geomagnetici": {
+      "label": "Sensori Geomagnetici",
+      "famiglia_tipologia": "Sensoriale/Navigazione",
+      "fattore_mantenimento_energetico": "Basso (Ricettori passivi)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "navigazione",
+        "core": "sensoriale"
+      },
+      "sinergie": [
+        "carapace_fase_variabile",
+        "eco_interno_riflesso"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianure_magnetiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Distese pianeggianti con vortici geomagnetici da sfruttare per la navigazione."
+          }
+        }
+      ],
+      "mutazione_indotta": "Cristalli ferromagnetici allineati lungo il cranio che fungono da bussola psionica.",
+      "uso_funzione": "Traccia linee di campo e memorizza corridoi magnetici per la migrazione.",
+      "spinta_selettiva": "Orientarsi in steppe polarizzate e tunnel sotterranei privi di riferimenti visivi.",
+      "debolezza": "Tempeste solari possono saturare il segnale magnetico, causando disorientamento prolungato.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "sinapsi_coraline_polifoniche": {
+      "label": "Sinapsi Coraline Polifoniche",
+      "famiglia_tipologia": "Simbiotico/Comunicazione",
+      "fattore_mantenimento_energetico": "Medio (Scambio continuo di impulsi corallini)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "comunicazione",
+        "core": "simbiotico"
+      },
+      "sinergie": [
+        "ali_fulminee",
+        "antenne_plasmatiche_tempesta",
+        "antenne_waveguide",
+        "baffi_mareomotori",
+        "branchie_eoliche",
+        "capillari_fluoridici",
+        "carapace_luminiscente_abissale",
+        "cervelletto_equilibrio_statico",
+        "coda_balanciere",
+        "cuore_multicamera_bassa_pressione",
+        "echi_risonanti",
+        "filamenti_superconduttivi",
+        "ghiandole_eco_mappanti",
+        "ghiandole_resina_conduttiva",
+        "lamine_scudo_silice",
+        "midollo_antivibrazione"
+      ],
+      "conflitti": [
+        "spore_psichiche_silenziate"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "barriere_coralline_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Scogliere viventi che rispondono a canti psionici e onde sonore."
+          }
+        }
+      ],
+      "mutazione_indotta": "Fibre nervose intrecciate con coralli sonori che trasmettono ordini tramite armoniche.",
+      "uso_funzione": "Trasmette comandi e pattern tattici sfruttando armoniche subacquee.",
+      "spinta_selettiva": "Coordinare banchi e alleati in ambienti tridimensionali complessi.",
+      "debolezza": "Vibrazioni sintonizzate male possono generare feedback dolorosi e perdita di coscienza.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "sonno_emisferico_alternato": {
+      "label": "Dormire con solo metà cervello alla volta",
+      "famiglia_tipologia": "Nervoso/Omeostatico",
+      "fattore_mantenimento_energetico": "Medio (Mantenimento attivo di metà cervello)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "omeostatico",
+        "core": "nervoso"
+      },
+      "sinergie": [
+        "artigli_sghiaccio_glaciale",
+        "occhi_infrarosso_composti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+          }
+        }
+      ],
+      "mutazione_indotta": "Encefalizzazione asimmetrica o due lobi cerebrali separati.",
+      "uso_funzione": "Vigilanza continua pur garantendo riposo.",
+      "spinta_selettiva": "Monitoraggio costante dei predatori in ambienti ad alto rischio.",
+      "debolezza": "Vulnerabilità a suoni/stimoli che colpiscono entrambi i lobi contemporaneamente.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "spore_psichiche_silenziate": {
+      "label": "Spora Psichica Silenziosa",
+      "famiglia_tipologia": "Escretorio/Psichico",
+      "fattore_mantenimento_energetico": "Alto (Produzione e rilascio)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "psichico",
+        "core": "escretorio"
+      },
+      "sinergie": [],
+      "conflitti": [
+        "respiro_a_scoppio"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+          }
+        }
+      ],
+      "mutazione_indotta": "Pori che rilasciano nano-particelle attive chimicamente o psichicamente.",
+      "uso_funzione": "Indurre uno stato di confusione o letargia negli individui vicini.",
+      "spinta_selettiva": "Neutralizzare gruppi di prede o predatori senza impegnare in combattimento.",
+      "debolezza": "Funzionalità ridotta in presenza di vento forte o umidità elevata.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "squame_rifrangenti_deserto": {
+      "label": "Squame Rifrangenti del Deserto",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Richiede riallineamento delle placche)",
+      "tier": "T2",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "difensivo",
+        "core": "tegumentario"
+      },
+      "sinergie": [
+        "respiro_a_scoppio"
+      ],
+      "conflitti": [
+        "mimetismo_cromatico_passivo"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dune_cristalline"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Deserti di quarzo e vetro dove le tempeste solari vengono amplificate."
+          }
+        }
+      ],
+      "mutazione_indotta": "Placche cristalline sovrapposte che deviano luce e calore lungo superfici multiple.",
+      "uso_funzione": "Rifrange la luce generando miraggi e dissipando attacchi energetici.",
+      "spinta_selettiva": "Sopravvivere a intensi flare termici e accecanti miraggi desertici.",
+      "debolezza": "Soffre danni da feedback termico se colpito da raggi concentrati o laser.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "struttura_elastica_amorfa": {
+      "label": "Struttura elastica, allungabile, amorfa, retrattile",
+      "famiglia_tipologia": "Strutturale/Locomotorio",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "locomotorio",
+        "core": "strutturale"
+      },
+      "sinergie": [
+        "antenne_tesla",
+        "artigli_sette_vie",
+        "artigli_vetrificati",
+        "branchie_dual_mode",
+        "capillari_criogenici",
+        "cartilagini_pseudometalliche",
+        "cisti_iperbariche",
+        "cromofori_alert_acido",
+        "denti_tuning_fork",
+        "filamenti_magnetotrofi",
+        "ghiandole_condensa_ozono",
+        "ghiandole_nebbia_ionica",
+        "lamine_filtranti_aeree",
+        "membrane_pneumatofori",
+        "mimetismo_cromatico_passivo",
+        "sacche_galleggianti_ascensoriali",
+        "scheletro_idro_regolante"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_psionica_leggera"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Start T1 nelle canopie conduttrici per apprendere deformazioni controllate.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Upgrade T2 sulle dorsali magnetiche per mantenere elasticità sotto stress.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "mutazione_indotta": "Tessuto con matrice di proteine elastiche iper-modificate.",
+      "uso_funzione": "Flessibilità estrema e capacità di assumere forme diverse.",
+      "spinta_selettiva": "Fuga rapida da predatori in spazi confinati.",
+      "debolezza": "Vulnerabilità a danni da taglio o perforazione (difficile cauterizzazione).",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "tattiche_di_branco": {
+      "label": "Tattiche di Branco",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Medio (Broadcast continuo di segnali)",
+      "tier": "T1",
+      "slot": [
+        "B"
+      ],
+      "slot_profile": {
+        "complementare": "coordinazione",
+        "core": "strategia"
+      },
+      "sinergie": [
+        "antenne_microonde_cavernose",
+        "artigli_radice",
+        "artigli_sette_vie",
+        "biofilm_glow",
+        "camere_mirage",
+        "cartilagini_desertiche",
+        "ciste_riduttive",
+        "colonne_vibromagnetiche",
+        "denti_ossidoferro",
+        "epidermide_dielettrica",
+        "ghiaccio_piezoelettrico",
+        "ghiandole_minerali",
+        "lamelle_shear",
+        "membrane_captura_rugiada"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [],
+      "mutazione_indotta": "Canale condiviso per marcature e ingaggi simultanei.",
+      "uso_funzione": "Coordina prese e focus bersaglio condividendo segnali di priorità.",
+      "spinta_selettiva": "Squadre che puntano a style bonus tramite assist e controllo spazio.",
+      "debolezza": "Richiede formazione stabile; cala se la coesione precipita sotto il target.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "PE",
+          "cap_pt",
+          "guardia_situazionale",
+          "sigillo_forma",
+          "starter_bioma"
+        ],
+        "combo_totale": 2,
+        "forme": [
+          "ESFJ",
+          "ESFP"
+        ],
+        "tabelle_random": []
+      }
+    },
+    "vello_condensatore_nebbie": {
+      "label": "Vello Condensatore di Nebbie",
+      "famiglia_tipologia": "Tegumentario/Idratazione",
+      "fattore_mantenimento_energetico": "Basso (Strutture passive a microfilo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "idratazione",
+        "core": "tegumentario"
+      },
+      "sinergie": [
+        "bulbi_radici_permafrost"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foreste_nubose"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Canopie immerse in nebbia costante con risonanza umida e lampi bioluminescenti."
+          }
+        }
+      ],
+      "mutazione_indotta": "Peli cavi microstriati che catturano e canalizzano la bruma atmosferica.",
+      "uso_funzione": "Condensa acqua atmosferica per supportare abilità metaboliche ad alto consumo.",
+      "spinta_selettiva": "Garantire idratazione in climi montani dove l'acqua liquida è scarsa ma la nebbia abbondante.",
+      "debolezza": "In ambienti aridi accumula detriti che riducono la capacità di condensa.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "ventriglio_gastroliti": {
+      "label": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
+      "famiglia_tipologia": "Digestivo/Alimentare",
+      "fattore_mantenimento_energetico": "Medio (Contrazione muscolare costante)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "alimentare",
+        "core": "digestivo"
+      },
+      "sinergie": [
+        "antenne_dustsense",
+        "appendici_thermotattiche",
+        "batteri_endosimbionti_chemio",
+        "branchie_solfatiche",
+        "carapace_segmenti_logici",
+        "circolazione_cooling_loop",
+        "coda_stabilizzatrice_filo",
+        "cuticole_cerose",
+        "enzimi_chelanti",
+        "filamenti_digestivi_compattanti",
+        "flagelli_ancoranti",
+        "ghiandole_grafene",
+        "grassi_termici",
+        "luminescenza_aurorale"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+          }
+        }
+      ],
+      "mutazione_indotta": "Sviluppo di un organo muscolare (ventriglio) con gastroliti.",
+      "uso_funzione": "Macinazione di cibo duro all'interno di un ventriglio.",
+      "spinta_selettiva": "Dieta basata su semi, conchiglie o insetti corazzati.",
+      "debolezza": "Usura e rottura del ventriglio se i gastroliti sono esauriti o troppo lisci.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    },
+    "zampe_a_molla": {
+      "label": "Zampe a Molla",
+      "famiglia_tipologia": "Mobilità/Cinetico",
+      "fattore_mantenimento_energetico": "Basso (Carica elastica a turni alterni)",
+      "tier": "T1",
+      "slot": [
+        "A",
+        "B"
+      ],
+      "slot_profile": {
+        "complementare": "propulsione",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "ali_ioniche",
+        "antenne_wideband",
+        "artigli_sghiaccio_glaciale",
+        "barbigli_sensori_plasma",
+        "branchie_metalloidi",
+        "capillari_fotovoltaici",
+        "chemiorecettori_bromuro",
+        "coda_contrappeso",
+        "cuscinetti_elettrostatici",
+        "enzimi_antifase_termica",
+        "filamenti_termoconduzione",
+        "ghiandole_fango_calde",
+        "ghiandole_ventosa",
+        "linfa_tampone",
+        "mucose_aderenza_sonica"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [],
+      "mutazione_indotta": "Arti potenziati con ammortizzatori ad alta compressione.",
+      "uso_funzione": "Dash esplosivi per mantenere il ritmo di ingaggio o disimpegno.",
+      "spinta_selettiva": "Metagame con forte pressione di aggro e necessità di riposizionamento.",
+      "debolezza": "Perdita di valore su mappe con spazi stretti o controllo setup elevato.",
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "cap_pt",
+          "guardia_situazionale",
+          "job_ability:Skirmisher/Dash_Cut"
+        ],
+        "combo_totale": 2,
+        "forme": [
+          "ESTP",
+          "ISFP"
+        ],
+        "tabelle_random": []
+      }
+    },
+    "zoccoli_risonanti_steppe": {
+      "label": "Zoccoli Risonanti delle Steppe",
+      "famiglia_tipologia": "Locomotorio/Supporto",
+      "fattore_mantenimento_energetico": "Basso (Vibrazione passiva del suolo)",
+      "tier": "T1",
+      "slot": [],
+      "slot_profile": {
+        "complementare": "supporto",
+        "core": "locomotorio"
+      },
+      "sinergie": [
+        "cartilagine_flessotermica_venti"
+      ],
+      "conflitti": [
+        "zampe_a_molla"
+      ],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_risonanti"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Praterie ventose dove il suolo amplifica vibrazioni utili alla comunicazione di branco."
+          }
+        }
+      ],
+      "mutazione_indotta": "Placche cornee cave che emettono onde sismiche ritmiche al contatto con il terreno.",
+      "uso_funzione": "Propaga segnali ritmici che sincronizzano movimenti e abilità di squadra.",
+      "spinta_selettiva": "Mantenere coesione di branchi su grandi distanze e rilevare predatori sotterranei.",
+      "debolezza": "Suoli cedevoli come sabbie mobili annullano la vibrazione e riducono la trazione.",
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      }
+    }
+  },
+  "types": {
+    "difensivo": {
+      "index": "difensivo/index.json",
+      "traits": [
+        "ali_membrana_sonica",
+        "appendici_risonanti_marea",
+        "barriere_miasma_glaciale",
+        "branchie_microfiltri",
+        "capsule_paracadute",
+        "circolazione_bifasica",
+        "coda_coppia_retroattiva",
+        "cute_resistente_sali",
+        "enzimi_antipredatori_algali",
+        "filtri_planctonici",
+        "ghiandole_fango_coesivo",
+        "giunti_antitorsione",
+        "lingua_cristallina",
+        "mucose_barofile"
+      ],
+      "type": "difensivo"
+    },
+    "difesa": {
+      "index": "difesa/index.json",
+      "traits": [
+        "armatura_pietra_planare",
+        "mantello_meteoritico"
+      ],
+      "type": "difesa"
+    },
+    "digestivo": {
+      "index": "digestivo/index.json",
+      "traits": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "type": "digestivo"
+    },
+    "escretorio": {
+      "index": "escretorio/index.json",
+      "traits": [
+        "spore_psichiche_silenziate"
+      ],
+      "type": "escretorio"
+    },
+    "idrostatico": {
+      "index": "idrostatico/index.json",
+      "traits": [
+        "sacche_galleggianti_ascensoriali"
+      ],
+      "type": "idrostatico"
+    },
+    "locomotorio": {
+      "index": "locomotorio/index.json",
+      "traits": [
+        "ali_ioniche",
+        "antenne_wideband",
+        "artigli_sette_vie",
+        "artigli_sghiaccio_glaciale",
+        "barbigli_sensori_plasma",
+        "branchie_metalloidi",
+        "capillari_fotovoltaici",
+        "cartilagine_flessotermica_venti",
+        "chemiorecettori_bromuro",
+        "coda_contrappeso",
+        "coda_frusta_cinetica",
+        "cuscinetti_elettrostatici",
+        "enzimi_antifase_termica",
+        "filamenti_termoconduzione",
+        "ghiandole_fango_calde",
+        "ghiandole_ventosa",
+        "linfa_tampone",
+        "mucose_aderenza_sonica",
+        "zampe_a_molla",
+        "zoccoli_risonanti_steppe"
+      ],
+      "type": "locomotorio"
+    },
+    "metabolico": {
+      "index": "metabolico/index.json",
+      "traits": [
+        "antenne_dustsense",
+        "appendici_thermotattiche",
+        "batteri_endosimbionti_chemio",
+        "branchie_solfatiche",
+        "carapace_segmenti_logici",
+        "circolazione_bifasica_palude",
+        "circolazione_cooling_loop",
+        "coda_stabilizzatrice_filo",
+        "criostasi_adattiva",
+        "cuticole_cerose",
+        "enzimi_chelanti",
+        "flagelli_ancoranti",
+        "ghiandole_grafene",
+        "grassi_termici",
+        "luminescenza_aurorale"
+      ],
+      "type": "metabolico"
+    },
+    "nervoso": {
+      "index": "nervoso/index.json",
+      "traits": [
+        "sonno_emisferico_alternato"
+      ],
+      "type": "nervoso"
+    },
+    "offensivo": {
+      "index": "offensivo/index.json",
+      "traits": [
+        "antenne_flusso_mareale",
+        "artigli_induzione",
+        "biochip_memoria",
+        "camere_anticorrosione",
+        "cartilagini_biofibre",
+        "circolazione_supercritica",
+        "coda_stabilizzatrice_vortex",
+        "denti_chelatanti",
+        "enzimi_metanoossidanti",
+        "foliaggio_spugna",
+        "frusta_fiammeggiante",
+        "ghiandola_caustica",
+        "ghiandole_iodoattive",
+        "gusci_magnesio",
+        "mantelli_geotermici",
+        "sangue_piroforico"
+      ],
+      "type": "offensivo"
+    },
+    "respiratorio": {
+      "index": "respiratorio/index.json",
+      "traits": [
+        "branchie_osmotiche_salmastra",
+        "lamelle_termoforetiche",
+        "membrane_eliofiltranti",
+        "polmoni_cristallini_alta_quota",
+        "respiro_a_scoppio"
+      ],
+      "type": "respiratorio"
+    },
+    "riproduttivo": {
+      "index": "riproduttivo/index.json",
+      "traits": [
+        "nucleo_ovomotore_rotante"
+      ],
+      "type": "riproduttivo"
+    },
+    "sensoriale": {
+      "index": "sensoriale/index.json",
+      "traits": [
+        "ali_fulminee",
+        "antenne_plasmatiche_tempesta",
+        "antenne_waveguide",
+        "baffi_mareomotori",
+        "branchie_eoliche",
+        "capillari_fluoridici",
+        "cavita_risonanti_tundra",
+        "cervelletto_equilibrio_statico",
+        "coda_balanciere",
+        "cuore_multicamera_bassa_pressione",
+        "echi_risonanti",
+        "eco_interno_riflesso",
+        "filamenti_superconduttivi",
+        "ghiandole_eco_mappanti",
+        "ghiandole_resina_conduttiva",
+        "lamine_scudo_silice",
+        "lingua_tattile_trama",
+        "midollo_antivibrazione",
+        "occhi_infrarosso_composti",
+        "olfatto_risonanza_magnetica",
+        "sensori_geomagnetici"
+      ],
+      "type": "sensoriale"
+    },
+    "simbiotico": {
+      "index": "simbiotico/index.json",
+      "traits": [
+        "antenne_reagenti",
+        "artigli_scivolo_silente",
+        "biofilm_iperarido",
+        "bulbi_radici_permafrost",
+        "camere_nutrienti_vent",
+        "cartilagini_flessoacustiche",
+        "chioma_parassita_canopica",
+        "ciste_salmastre",
+        "coralli_partner",
+        "denti_silice_termici",
+        "epitelio_fosforescente",
+        "ghiandole_cambio_salino",
+        "ghiandole_nebbia_acida",
+        "lamelle_sincroniche",
+        "membrane_planata_vectored",
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari",
+        "sacche_spore_stratosferiche",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "type": "simbiotico"
+    },
+    "strategia": {
+      "index": "strategia/index.json",
+      "traits": [
+        "antenne_microonde_cavernose",
+        "artigli_radice",
+        "biofilm_glow",
+        "camere_mirage",
+        "cartilagini_desertiche",
+        "ciste_riduttive",
+        "colonne_vibromagnetiche",
+        "denti_ossidoferro",
+        "epidermide_dielettrica",
+        "focus_frazionato",
+        "ghiaccio_piezoelettrico",
+        "ghiandole_minerali",
+        "lamelle_shear",
+        "membrane_captura_rugiada",
+        "pathfinder",
+        "pianificatore",
+        "random",
+        "tattiche_di_branco"
+      ],
+      "type": "strategia"
+    },
+    "strutturale": {
+      "index": "strutturale/index.json",
+      "traits": [
+        "antenne_tesla",
+        "artigli_vetrificati",
+        "branchie_dual_mode",
+        "capillari_criogenici",
+        "carapace_fase_variabile",
+        "carapace_luminiscente_abissale",
+        "cartilagini_pseudometalliche",
+        "cisti_iperbariche",
+        "cromofori_alert_acido",
+        "denti_tuning_fork",
+        "filamenti_magnetotrofi",
+        "ghiandole_condensa_ozono",
+        "ghiandole_nebbia_ionica",
+        "lamine_filtranti_aeree",
+        "membrane_pneumatofori",
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "type": "strutturale"
+    },
+    "supporto": {
+      "index": "supporto/index.json",
+      "traits": [
+        "antenne_eco_turbina",
+        "artigli_acidofagi",
+        "aura_scudo_radianza",
+        "batteri_termofili_endosimbiosi",
+        "branchie_turbina",
+        "carapaci_ferruginosi",
+        "circolazione_doppia",
+        "coda_stabilizzatrice_geiser",
+        "cuticole_neutralizzanti",
+        "empatia_coordinativa",
+        "enzimi_chelatori_rapidi",
+        "foliage_fotocatodico",
+        "ghiandole_inchiostro_luce",
+        "gusci_criovetro",
+        "luminescenza_hydrotermica",
+        "risonanza_di_branco"
+      ],
+      "type": "supporto"
+    },
+    "tegumentario": {
+      "index": "tegumentario/index.json",
+      "traits": [
+        "mimetismo_cromatico_passivo",
+        "piume_solari_fotovoltaiche",
+        "secrezione_rallentante_palmi",
+        "squame_rifrangenti_deserto",
+        "vello_condensatore_nebbie"
+      ],
+      "type": "tegumentario"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a copy of the core trait reference under `packs/evo_tactics_pack/docs/catalog/trait_reference.json`
- document that the web and pack copies of the trait reference must stay aligned when updating data
- regenerate the trait baseline and coverage outputs using the pack-local reference file

## Testing
- python tools/py/build_trait_baseline.py packs/evo_tactics_pack/docs/catalog/env_traits.json packs/evo_tactics_pack/docs/catalog/trait_reference.json --trait-glossary data/core/traits/glossary.json --out data/derived/analysis/trait_baseline.yaml
- python tools/py/report_trait_coverage.py --env-traits packs/evo_tactics_pack/docs/catalog/env_traits.json --trait-reference packs/evo_tactics_pack/docs/catalog/trait_reference.json --trait-glossary data/core/traits/glossary.json --out-json data/derived/analysis/trait_coverage_report.json --out-csv data/derived/analysis/trait_coverage_matrix.csv

------
https://chatgpt.com/codex/tasks/task_e_6904be3d4fe08332b08069bb0d8a61ad