### PR TITLE
Add types metadata to trait catalog schemas

### DIFF
--- a/config/schemas/catalog.schema.json
+++ b/config/schemas/catalog.schema.json
@@ -28,6 +28,37 @@
         }
       },
       "additionalProperties": false
+    },
+    "types": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z0-9_]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "index",
+            "traits"
+          ],
+          "properties": {
+            "index": {
+              "type": "string",
+              "minLength": 1
+            },
+            "traits": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^[a-z0-9_]+$"
+              }
+            },
+            "type": {
+              "type": "string",
+              "pattern": "^[a-z0-9_]+$"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/packs/evo_tactics_pack/docs/catalog/trait_catalog.schema.json
+++ b/packs/evo_tactics_pack/docs/catalog/trait_catalog.schema.json
@@ -31,6 +31,34 @@
       "propertyNames": {
         "pattern": "^[a-z0-9_]+$"
       }
+    },
+    "types": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["index", "traits"],
+        "properties": {
+          "index": {
+            "type": "string",
+            "minLength": 1
+          },
+          "traits": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z0-9_]+$"
+            }
+          },
+          "type": {
+            "type": "string",
+            "pattern": "^[a-z0-9_]+$"
+          }
+        }
+      },
+      "propertyNames": {
+        "pattern": "^[a-z0-9_]+$"
+      }
     }
   }
 }

--- a/reports/schema_validation.json
+++ b/reports/schema_validation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2025-10-29T20:29:03Z",
+  "generated_at": "2025-10-31T13:55:58Z",
   "files": [
     {
       "path": "data/traits/index.json",

--- a/tools/py/trait_template_validator.py
+++ b/tools/py/trait_template_validator.py
@@ -77,6 +77,19 @@ def validate() -> int:
         else:
             print(f"[TRAIT] {trait_key}: OK")
 
+    types_section = catalog.get("types")
+    if isinstance(types_section, dict):
+        for type_key, payload in types_section.items():
+            trait_ids = payload.get("traits", [])
+            missing_traits = [trait_id for trait_id in trait_ids if trait_id not in traits]
+            if missing_traits:
+                has_errors = True
+                print(f"[TYPE] {type_key}: FAIL")
+                for trait_id in missing_traits:
+                    print(f" - trait '{trait_id}' is not defined in catalog")
+            else:
+                print(f"[TYPE] {type_key}: OK")
+
     return 1 if has_errors else 0
 
 


### PR DESCRIPTION
## Summary
- extend the Evo Tactics catalog JSON schema with support for the optional `types` map
- mirror the new definition in the canonical catalog schema and add cross-checks in the trait template validator
- regenerate the schema validation report after rerunning the audit

## Testing
- python3 scripts/trait_audit.py --check
- python3 scripts/trait_audit.py


------
https://chatgpt.com/codex/tasks/task_e_6904bf72bf7483328c2dcad67e361301