### PR TITLE
feat(engine): aggiunge “Tri-Sorgente” (Roll + Personalità + Azioni) + schemi + docs + esempi + test

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ node dist/roll_pack.js ENTP invoker --seed demo
 - **Roadmap**: `docs/piani/roadmap.md` con milestone strategiche (telemetria VC, pacchetti PI, mating/nido).
 - **Idea Engine**: changelog e procedure in `docs/ideas/changelog.md`, `docs/ideas/index.html` e `IDEAS_INDEX.md`.
 - **Log tematici**: `logs/traits_tracking.md`, `logs/web_status.md`, `logs/chatgpt_sync.log` per audit tecnici.
+- **Tri-Sorgente (Roll + Personalità + Azioni)** — docs introduttive: [/docs/tri-sorgente/overview.md](docs/tri-sorgente/overview.md) • QA/KPI: [/docs/tri-sorgente/qa.md](docs/tri-sorgente/qa.md)
 
 ## Automazione & workflow
 - **Script principali**:

--- a/docs/tri-sorgente/overview.md
+++ b/docs/tri-sorgente/overview.md
@@ -1,0 +1,28 @@
+# Tri-Sorgente (Roll + Personalità + Azioni)
+
+**Scopo:** dare 3 scelte + Skip post-scontro minore, guidate da:
+- **Roll (Contesto):** bioma/tier -> tabella a dado -> grants carta
+- **Personalità:** Enneagram/MBTI -> pesi preferenze
+- **Azioni recenti:** telemetria -> affinità carte
+
+## Pipeline (riassunto)
+1) Selezione tabella (contesto) → 2) Tiro → 3) Pool R/A/P → 4) Merge → 5) Scoring
+→ 6) Diversità/Sinergia → 7) Sampling softmax(T) → 8) Skip con Frammenti Genetici.
+
+## Formula punteggio (per carta c)
+```
+score(c) = base(c)
++ w_roll*roll_comp + w_pers*pers_comp + w_actions*act_comp
++ w_syn*syn_boost - w_dup*dup_pen - w_excl*excl_pen
+```
+- `base(c)` per rarità; `roll_comp` se dalla entry centrata/adiacente;
+- `pers_comp` somma dei personality_weights compatibili (Enneagram/MBTI);
+- `act_comp` somma clampata affinità azioni;
+- `syn_boost` se `synergy_tags` ∩ tag dominanti;
+- `dup_pen` se oltre max_copies; `excl_pen` per esclusioni hard.
+
+## Motivazioni Design
+- **Agency senza overload:** 3 scelte curate + Skip
+- **Varianza controllata:** roll + softmax
+- **Coerenza build:** ≥1 sinergica garantita
+- **Antipower-creep:** cooldown offerte, max_copies, cap FG

--- a/docs/tri-sorgente/qa.md
+++ b/docs/tri-sorgente/qa.md
@@ -1,0 +1,16 @@
+# QA & KPI
+
+## Test Monte Carlo (per bioma/tier)
+- 10k offerte simulate
+- KPI:
+  - ≥95% offerte con ≥1 sinergica
+  - ≤10% offerte con 3 carte stesso tag
+  - Skip-rate mediano ∈ [18%, 32%]
+  - Entropia di tag medio-alta (0.85–1.10 normalizzato)
+  - Nessuna carta con pick-rate >55% nelle prime 3 offerte
+
+## Failure-modes & Contromisure
+- Dry offers → rimpiazzo peggiore con “ancora di build”
+- Skip-spam → cap per atto + decay consecutivi
+- Combo snowball → max_copies=1 + duplicate_penalty + cooldown
+- Run-rigidity → 10% wildcard da tag non dominanti

--- a/engine/tri_sorgente/card_offer_engine.yaml
+++ b/engine/tri_sorgente/card_offer_engine.yaml
@@ -1,0 +1,28 @@
+engine:
+  offer_mode: "3-pick+skip"
+  context_trigger: "post-scontro-minore"
+  steps:
+    - name: "Selezione Tabella"
+      input: ["bioma","tier","stato_party"]
+      rule: "scegli 1 roll_table pertinente"
+    - name: "Tiro di Dado"
+      rule: "esegui tiro (es. d100) -> entry -> grants"
+    - name: "Pool da Roll (R)"
+      rule: "espandi grants e, se scarso, includi entry adiacenti (R≈4–6)"
+    - name: "Pool da Azioni (A)"
+      rule: "mappa recent_actions alle carte con affinità (A≈3–5)"
+    - name: "Pool da Personalità (P)"
+      rule: "seleziona carte con personality_weights alti (P≈3–5)"
+    - name: "Merge & Dedupe"
+    - name: "Scoring & Pesi"
+      rule: "applica formula score e pesi globali"
+    - name: "Diversità & Sinergia"
+      rule: "≥1 carta sinergica; soft-cap tag ripetuti; ≥2 macro-ruoli"
+    - name: "Sampling"
+      rule: "softmax(T=0.7) sui punteggi z-normalizzati -> 3 carte"
+    - name: "Skip"
+      rule: "Skip => Frammenti Genetici (tier-based) con cap per atto"
+  limits:
+    max_picks_per_bioma: 3
+    max_duplicates_per_card: 1
+    offer_cooldown_encounters: 2

--- a/engine/tri_sorgente/tri_sorgente_config.yaml
+++ b/engine/tri_sorgente/tri_sorgente_config.yaml
@@ -1,0 +1,39 @@
+config:
+  softmax_temperature: 0.7
+  pools:
+    R: 5   # da Roll
+    A: 4   # da Azioni
+    P: 4   # da Personalità
+  weights:
+    w_roll: 0.9
+    w_pers: 1.0
+    w_actions: 1.0
+    w_syn: 1.0
+    w_dup: 1.0
+    w_excl: 3.0
+  base_by_rarity:
+    comune: 0.10
+    non_comune: 0.15
+    rara: 0.20
+    epica: 0.25
+  synergy:
+    base: 0.15
+    extra_per_match: 0.05
+    cap: 0.25
+  skip_economy:
+    fg_by_tier: { "low": 1, "mid": 2, "high": 3 }
+    cap_per_act: 6
+    consecutive_decay: [2,1,0]  # valori FG per 1°, 2°, 3° skip consecutivi
+  diversity:
+    min_sinergiche: 1
+    soft_max_same_primary_tag: 2
+    min_macro_ruoli: 2
+  recent_actions:
+    # definisci il dizionario base; può essere esteso per bioma/tier
+    cariche_effettuate: { per_event: 0.10, cap: 0.20 }
+    salti_lunghi:       { per_event: 0.05, cap: 0.15 }
+    colpi_critici:      { per_event: 0.05, cap: 0.15 }
+    cure_erogate:       { per_event: 0.05, cap: 0.15 }
+    danni_subiti:       { per_event: 0.05, cap: 0.15 }
+    assist:             { per_event: 0.05, cap: 0.15 }
+    colpi_mancati:      { per_event: 0.05, cap: 0.15 }

--- a/examples/biomes/dune_ferrose/cards.yaml
+++ b/examples/biomes/dune_ferrose/cards.yaml
@@ -1,0 +1,166 @@
+cards:
+  - id: CARD-CARAPACE-FERRICO-1
+    name: "Carapace Ferrico"
+    rarity: non_comune
+    tags: [difesa, armatura]
+    synergy_tags: [resilienza]
+    description: "Placche metalliche aumentano la protezione."
+    effect:
+      rules:
+        - "+2 Armatura per 2 turni (no stack)"
+    requirements:
+      level_min: 1
+      exclusions: []
+    personality_weights:
+      enneagram:
+        "6": 0.2
+        "8": 0.3
+      mbti:
+        ISTJ: 0.2
+    action_affinity:
+      recent_actions:
+        danni_subiti:
+          per_event: 0.05
+          cap: 0.15
+    balance:
+      max_copies: 1
+      offer_cooldown_encounters: 2
+
+  - id: CARD-PISTON-LEGS-1
+    name: "Gambe Pistoniche"
+    rarity: rara
+    tags: [mobilità, carica]
+    synergy_tags: [carica, spike]
+    description: "Spinta meccanica per balzi e cariche."
+    effect:
+      rules:
+        - "+3m velocità per 2 turni (stack 2)"
+        - "Carica: +1d6 impatto"
+    requirements:
+      level_min: 1
+      exclusions:
+        - CARD-ANCORE-PEDANE-1
+    personality_weights:
+      enneagram:
+        "3": 0.3
+        "7": 0.2
+      mbti:
+        ENTP: 0.2
+    action_affinity:
+      recent_actions:
+        cariche_effettuate:
+          per_event: 0.10
+          cap: 0.20
+        salti_lunghi:
+          per_event: 0.05
+          cap: 0.15
+    balance:
+      max_copies: 1
+      offer_cooldown_encounters: 2
+
+  - id: CARD-HEM-GLANDS-1
+    name: "Ghiandole Ematiche"
+    rarity: rara
+    tags: [offesa, sanguinamento]
+    synergy_tags: [dot, escalation]
+    description: "Secrezioni che amplificano il sanguinamento."
+    effect:
+      rules:
+        - "Colpi: +1 Bleed (2 turni), se già sanguina -> +1 extra"
+    requirements:
+      level_min: 1
+      exclusions: []
+    personality_weights:
+      enneagram:
+        "8": 0.4
+      mbti:
+        INTJ: 0.2
+    action_affinity:
+      recent_actions:
+        colpi_critici:
+          per_event: 0.05
+          cap: 0.15
+    balance:
+      max_copies: 1
+      offer_cooldown_encounters: 2
+
+  - id: CARD-SAND-EYES-1
+    name: "Occhi Sabbiosi"
+    rarity: comune
+    tags: [controllo, precisione]
+    synergy_tags: [accuracy, reveal]
+    description: "Adatti a tempeste di sabbia."
+    effect:
+      rules:
+        - "Ignora svantaggi da sabbia/polvere; +1 colpire bersagli coperti"
+    requirements:
+      level_min: 1
+      exclusions: []
+    personality_weights:
+      enneagram:
+        "5": 0.2
+        "1": 0.1
+      mbti:
+        INTP: 0.1
+    action_affinity:
+      recent_actions:
+        colpi_mancati:
+          per_event: 0.05
+          cap: 0.15
+    balance:
+      max_copies: 2
+      offer_cooldown_encounters: 1
+
+  - id: CARD-WIND-LOBES-1
+    name: "Lobi Anemometro"
+    rarity: non_comune
+    tags: [utility, scouting]
+    synergy_tags: [tempo, vantaggio]
+    description: "Legge micro-correnti per posizionamento."
+    effect:
+      rules:
+        - "Una volta/encounter: riposiziona 1 alleato di 1m (reazione)"
+    requirements:
+      level_min: 1
+      exclusions: []
+    personality_weights:
+      enneagram:
+        "2": 0.2
+        "6": 0.2
+      mbti:
+        ENFJ: 0.1
+    action_affinity:
+      recent_actions:
+        assist:
+          per_event: 0.05
+          cap: 0.15
+    balance:
+      max_copies: 1
+      offer_cooldown_encounters: 2
+
+  - id: CARD-FERRO-SPINES-1
+    name: "Spine Ferrofile"
+    rarity: epica
+    tags: [offesa, reazione]
+    synergy_tags: [thorns, proximity]
+    description: "Spicole metalliche che reagiscono ai colpi ravvicinati."
+    effect:
+      rules:
+        - "Quando vieni colpito in mischia: infliggi 1d4 spina (1/turno)"
+    requirements:
+      level_min: 1
+      exclusions: []
+    personality_weights:
+      enneagram:
+        "9": 0.1
+        "8": 0.2
+      mbti:
+        ISTP: 0.2
+    action_affinity:
+      recent_actions:
+        danni_subiti:
+          per_event: 0.05
+          cap: 0.15
+    balance:
+      max_copies: 1
+      offer_cooldown_encounters: 3

--- a/examples/biomes/dune_ferrose/roll_table.yaml
+++ b/examples/biomes/dune_ferrose/roll_table.yaml
@@ -1,0 +1,24 @@
+roll_table:
+  id: RT-DUNE-02
+  title: "Mutazioni — Dune Ferrose (Tier 2)"
+  dice: d100
+  scope: "bioma:dune_ferrose:t2"
+  entries:
+    - range: "01-20"
+      name: "Carapace Ferrico"
+      grants: [{type: card_ref, card_id: CARD-CARAPACE-FERRICO-1}]
+    - range: "21-45"
+      name: "Gambe Pistoniche"
+      grants: [{type: card_ref, card_id: CARD-PISTON-LEGS-1}]
+    - range: "46-65"
+      name: "Ghiandole Ematiche"
+      grants: [{type: card_ref, card_id: CARD-HEM-GLANDS-1}]
+    - range: "66-80"
+      name: "Occhi Sabbiosi"
+      grants: [{type: card_ref, card_id: CARD-SAND-EYES-1}]
+    - range: "81-90"
+      name: "Lobi Anemometro"
+      grants: [{type: card_ref, card_id: CARD-WIND-LOBES-1}]
+    - range: "91-100"
+      name: "Spine Ferrofile"
+      grants: [{type: card_ref, card_id: CARD-FERRO-SPINES-1}]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pyyaml
+numpy

--- a/schemas/card_schema.yaml
+++ b/schemas/card_schema.yaml
@@ -1,0 +1,21 @@
+# card_schema.yaml — schema minimo per carte abilità
+card:
+  id: "CARD-ID-1"
+  name: "Nome Carta"
+  rarity: "comune"      # comune|non_comune|rara|epica
+  tags: []
+  synergy_tags: []
+  description: "Testo breve."
+  effect:
+    rules: []           # righe effetto
+  requirements:
+    level_min: 1
+    exclusions: []      # card_id incompatibili
+  personality_weights:  # -1.0 .. +1.0
+    enneagram: {}       # es. {"8": 0.4}
+    mbti: {}            # es. {"ENTP": 0.2}
+  action_affinity:
+    recent_actions: {}  # es. { cariche_effettuate: {per_event: 0.1, cap: 0.2} }
+  balance:
+    max_copies: 1
+    offer_cooldown_encounters: 2

--- a/schemas/roll_table_schema.yaml
+++ b/schemas/roll_table_schema.yaml
@@ -1,0 +1,14 @@
+# roll_table_schema.yaml — schema minimo per tabelle a “tiro di dado”
+roll_table:
+  id: RT-EXAMPLE-001
+  title: "Esempio Tabella"
+  dice: d100            # d100|d20|...
+  scope: "bioma:<id>[:tier]"
+  notes: "Range inclusivi"
+  entries:
+    - range: "01-10"
+      name: "Nome voce"
+      grants:
+        - type: "card_ref"
+          card_id: "CARD-ID-1"
+    # ... fino a coprire tutto l’intervallo del dado

--- a/tests/tri_sorgente_sim.py
+++ b/tests/tri_sorgente_sim.py
@@ -1,0 +1,238 @@
+import pathlib
+import random
+from collections import defaultdict
+
+import numpy as np
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+cfg = yaml.safe_load((ROOT / "engine/tri_sorgente/tri_sorgente_config.yaml").read_text())["config"]
+engine = yaml.safe_load((ROOT / "engine/tri_sorgente/card_offer_engine.yaml").read_text())["engine"]
+roll_table = yaml.safe_load((ROOT / "examples/biomes/dune_ferrose/roll_table.yaml").read_text())["roll_table"]
+cards = {
+    card["id"]: card
+    for card in yaml.safe_load((ROOT / "examples/biomes/dune_ferrose/cards.yaml").read_text())["cards"]
+}
+
+RNG = random.Random(1337)
+NP_RNG = np.random.default_rng(1337)
+
+
+def softmax(z, temperature):
+    values = np.array(z, dtype=float)
+    centered = values - values.mean()
+    scaled = centered / max(values.std(), 1e-6)
+    logits = scaled / max(temperature, 1e-6)
+    exp_values = np.exp(logits - logits.max())
+    return exp_values / exp_values.sum()
+
+
+def parse_range(range_str):
+    lo, hi = [int(bound) for bound in range_str.split("-")]
+    return lo, hi
+
+
+def roll_entry(rt):
+    roll = RNG.randint(1, 100)
+    for idx, entry in enumerate(rt["entries"]):
+        lo, hi = parse_range(entry["range"])
+        if lo <= roll <= hi:
+            return idx, entry, roll
+    return len(rt["entries"]) - 1, rt["entries"][-1], roll
+
+
+def collect_roll_pool(entries, hit_index, target_size, card_sources):
+    ordered_indices = [hit_index]
+    left = hit_index - 1
+    right = hit_index + 1
+    while len(ordered_indices) < target_size and (left >= 0 or right < len(entries)):
+        if left >= 0:
+            ordered_indices.append(left)
+            left -= 1
+        if len(ordered_indices) >= target_size:
+            break
+        if right < len(entries):
+            ordered_indices.append(right)
+            right += 1
+
+    pool = []
+    for idx in ordered_indices:
+        entry = entries[idx]
+        for grant in entry.get("grants", []):
+            if grant.get("type") != "card_ref":
+                continue
+            card_id = grant.get("card_id")
+            if card_id not in cards:
+                continue
+            pool.append(card_id)
+            source_flags = card_sources[card_id]
+            if idx == hit_index:
+                source_flags["roll_primary"] = True
+            else:
+                source_flags["roll_adjacent"] = True
+    return pool
+
+
+def personality_component(card, run_state):
+    personality = card.get("personality_weights", {})
+    enneagram = personality.get("enneagram", {})
+    mbti_weights = personality.get("mbti", {})
+    enneagram_type = str(run_state["personality"].get("enneagram", {}).get("type"))
+    mbti = run_state["personality"].get("mbti")
+
+    score = 0.0
+    if enneagram_type:
+        score += enneagram.get(enneagram_type, 0.0)
+    if mbti:
+        score += mbti_weights.get(mbti, 0.0)
+    return score
+
+
+def collect_personality_pool(run_state, target_size, card_sources):
+    scored = []
+    for card_id, card in cards.items():
+        score = personality_component(card, run_state)
+        if score > 0:
+            scored.append((card_id, score))
+    scored.sort(key=lambda item: item[1], reverse=True)
+    top = [card_id for card_id, _ in scored[:target_size]]
+    for card_id in top:
+        card_sources[card_id]["personality"] = True
+    return top
+
+
+def action_component(card, run_state):
+    card_recent = card.get("action_affinity", {}).get("recent_actions", {})
+    catalog = set(cfg.get("recent_actions", {}).keys()) | set(card_recent.keys())
+    total = 0.0
+    for action_id in catalog:
+        defaults = cfg.get("recent_actions", {}).get(action_id, {})
+        params = card_recent.get(action_id, defaults)
+        per_event = params.get("per_event", defaults.get("per_event", 0.0))
+        cap = params.get("cap", defaults.get("cap", 0.0))
+        count = run_state["recent_actions"].get(action_id, 0)
+        total += min(count * per_event, cap)
+    return total
+
+
+def collect_actions_pool(run_state, target_size, card_sources):
+    scored = []
+    for card_id, card in cards.items():
+        score = action_component(card, run_state)
+        if score > 0:
+            scored.append((card_id, score))
+    scored.sort(key=lambda item: item[1], reverse=True)
+    top = [card_id for card_id, _ in scored[:target_size]]
+    for card_id in top:
+        card_sources[card_id]["actions"] = True
+    return top
+
+
+def synergy_component(card, run_state):
+    dominant = set(run_state["build_profile"].get("dominant_tags", []))
+    syn_tags = set(card.get("synergy_tags", []))
+    overlap = syn_tags & dominant
+    if not overlap:
+        return 0.0
+    extra_matches = max(len(overlap) - 1, 0)
+    extra = min(extra_matches * cfg["synergy"]["extra_per_match"], cfg["synergy"]["cap"])
+    return cfg["synergy"]["base"] + extra
+
+
+def has_synergy(card_id, run_state):
+    card = cards[card_id]
+    return bool(set(card.get("synergy_tags", [])) & set(run_state["build_profile"].get("dominant_tags", [])))
+
+
+def score_card(card_id, run_state, card_sources):
+    card = cards[card_id]
+    base = cfg["base_by_rarity"].get(card["rarity"], 0.1)
+    flags = card_sources[card_id]
+    roll_comp = 0.0
+    if flags.get("roll_primary"):
+        roll_comp = 0.2
+    elif flags.get("roll_adjacent"):
+        roll_comp = 0.1
+
+    pers = personality_component(card, run_state)
+    act = action_component(card, run_state)
+    syn = synergy_component(card, run_state)
+
+    weights = cfg["weights"]
+    total = (
+        base
+        + weights["w_roll"] * roll_comp
+        + weights["w_pers"] * pers
+        + weights["w_actions"] * act
+        + weights["w_syn"] * syn
+    )
+    # Duplicate/exclusion penalties richiedono stato run; nel mock li omettiamo.
+    return total
+
+
+def ensure_synergy_offer(selection, sorted_pool, run_state):
+    if any(has_synergy(card_id, run_state) for card_id in selection):
+        return selection
+    for card_id, _ in sorted_pool:
+        if card_id in selection:
+            continue
+        if has_synergy(card_id, run_state):
+            selection[-1] = card_id
+            break
+    return selection
+
+
+def offer(run_state):
+    card_sources = defaultdict(lambda: defaultdict(bool))
+    hit_index, entry, roll_value = roll_entry(roll_table)
+    entries = roll_table["entries"]
+
+    roll_pool = collect_roll_pool(entries, hit_index, cfg["pools"]["R"], card_sources)
+    actions_pool = collect_actions_pool(run_state, cfg["pools"]["A"], card_sources)
+    personality_pool = collect_personality_pool(run_state, cfg["pools"]["P"], card_sources)
+
+    offer_candidates = list(dict.fromkeys(roll_pool + actions_pool + personality_pool))
+    if not offer_candidates:
+        offer_candidates = list(cards.keys())
+
+    scores = [score_card(card_id, run_state, card_sources) for card_id in offer_candidates]
+    probabilities = softmax(scores, cfg["softmax_temperature"])
+    sample_size = min(3, len(offer_candidates))
+    selection = NP_RNG.choice(offer_candidates, size=sample_size, replace=False, p=probabilities)
+    selection = selection.tolist()
+
+    scored = sorted(zip(offer_candidates, scores), key=lambda item: item[1], reverse=True)
+    selection = ensure_synergy_offer(selection, scored, run_state)
+
+    debug = {
+        "roll_value": roll_value,
+        "roll_entry": entry["name"],
+        "pools": {
+            "roll": roll_pool,
+            "actions": actions_pool,
+            "personality": personality_pool,
+        },
+    }
+    return selection, scored, debug
+
+
+if __name__ == "__main__":
+    MOCK_RUN_STATE = {
+        "recent_actions": {
+            "cariche_effettuate": 3,
+            "salti_lunghi": 1,
+            "colpi_critici": 1,
+            "danni_subiti": 2,
+            "assist": 1,
+            "colpi_mancati": 2,
+        },
+        "build_profile": {"dominant_tags": ["mobilità", "carica"]},
+        "personality": {"enneagram": {"type": 3}, "mbti": "ENTP"},
+    }
+
+    picks, scored_cards, debug_info = offer(MOCK_RUN_STATE)
+    print("Roll d100:", debug_info["roll_value"], "->", debug_info["roll_entry"])
+    print("Pool R/A/P:", debug_info["pools"])
+    print("Offerta (3):", picks)
+    print("Top5 punteggi:", scored_cards[:5])


### PR DESCRIPTION
Questa PR introduce la variante completa “Tri-Sorgente” come fase plug-in post-scontro minore:

- Schemi YAML per tabelle “a dado” (roll_table) e carte abilità (card).
- Motore di offerta 3-pick+Skip: Roll (contesto), Personalità (Enneagram/MBTI), Azioni recenti (telemetria).
- Configurazioni di pesi, limiti e diversità/sinergia.
- Documentazione (overview + QA/KPI + failure-modes).
- Esempi: Bioma “Dune Ferrose” (Tier 2) con 1 tabella e 6 carte seed.
- Test mini (simulatore softmax) + requirements-dev.txt per eseguire i test.

Questa integrazione è pensata come “fase” isolata e non richiede refactor del core.


------
https://chatgpt.com/codex/tasks/task_e_6904ba265d6083329cfd40374361abac