### PR TITLE
harvest: Spore wave01 (complexity budget, parts scaling, terraforming bands, stages)

### DIFF
--- a/biomes/terraforming_bands.yaml
+++ b/biomes/terraforming_bands.yaml
@@ -1,0 +1,12 @@
+version: 1
+system: terraforming_bands
+description: "Bande di vitalità del bioma e sblocco slot."
+bands:
+  T0: { slots: 0, stable: false }
+  T1: { slots: 1, stable: true }
+  T2: { slots: 2, stable: true }
+  T3: { slots: 3, stable: true }
+env_params: [temperature, atmosphere, biomass, humidity]
+telemetry:
+  events: [biome_param_changed, band_reached, slot_unlocked]
+TODO: "Definire funzioni di drift e strumenti ambientali."

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,3 @@
+# Ricerche & Riferimenti
+Questo modulo raccoglie dossier giochi di riferimento, feature card e matrici comparative per l'harvest in Evo Tactics.
+Struttura: refs/ (RGD), matrices/ (CSV), templates/ (md/yaml), notes/ (citazioni & appunti).

--- a/docs/research/matrices/feature_harvest.csv
+++ b/docs/research/matrices/feature_harvest.csv
@@ -1,0 +1,5 @@
+game_slug,feature_id,feature_title,category,adopt_adapt_avoid,coerenza,innovazione,compat_telemetria,drift_risk,elasticita,costo,rischio_tecnico,score_weighted,catalog_impacts,notes
+spore,spore__complexity_budget,"Budget di complessità per build","Progression|Buildcraft|UX",Adopt,5,4,5,4,5,3,3,55,"rules/build_budget.yaml","RGD §SPEC"
+spore,spore__part_based_scaling,"Scaling statistico basato su parti","Combat|Buildcraft|Status",Adopt,5,4,5,4,4,3,3,52,"traits/parts_scaling.yaml","RGD §SPEC"
+spore,spore__terraforming_bands,"Terraforming a bande con slot","Map|Economy|World",Adopt,5,4,5,4,4,3,3,53,"biomes/terraforming_bands.yaml","RGD §SPEC"
+spore,spore__stage_gated_progression,"Progressione ad archi con carry-over","Progression|Structure|Meta",Adapt,4,4,5,3,3,2,3,41,"rules/stages.yaml","RGD §SPEC"

--- a/docs/research/refs/2008_spore.md
+++ b/docs/research/refs/2008_spore.md
@@ -1,0 +1,35 @@
+# Spore (2008) — Maxis/EA — PC/Mac — Premium
+
+## Pillars & Fantasy
+- Player Promise: crescere da cellula a civiltà spaziale con creatività guidata da editor a parti.
+- Pillars: Creazione libera · Evoluzione per parti · Progressione a stadi · UGC/Condivisione · Simulazione leggera.
+
+## Loop (core/meta/session)
+[Progetta/Modifica] → [Gioca Stage] → [Raccogli DNA/Risorse] → [Sblocchi] → [Nuova Modifica] → [Avanza]
+Meta: carry-over scelte tra stadi; economia strumenti in Tribù/Civ/Spazio.
+Sessione tipo: alternanza editor/run (30–90’).
+
+## Systems Inventory (estratto funzionale)
+Movimento realtime · Abilità per parti e livelli (Bite/Strike/Charge/Spit; Social Sing/Dance/Charm/Pose) ·
+Terraforming a bande T0–T3 (atmosfera+temperatura → slot/colonie) · UGC/Sporepedia.
+
+## Meccaniche chiave (SPEC)
+- Budget di complessità: Σc_p ≤ C_max; blocco parti oltre soglia.
+- Scaling per parti: stats/abilità = f(parti, livello).
+- Terraforming a bande: raggiungere T1–T3 sblocca slot insediativi; stabilità ecologica richiesta.
+- Progressione “a stadi”: soglie → passaggio a fase successiva; carry-over selettivo.
+
+## Mappatura su Evo Tactics
+- Adopt: build_budget, parts_scaling, terraforming_bands.
+- Adapt: stages → “archi” di campagna/bioma (evitare deriva multi-genere).
+- Impatti: rules/build_budget.yaml · traits/parts_scaling.yaml · biomes/terraforming_bands.yaml · rules/stages.yaml.
+
+## Valutazione (0–5) & Score
+Coerenza 5 · Innovazione 5 · Compatibilità Telemetria 5 · Drift Risk 3 · Elasticità 4 · Costo 3 · Rischio Tecnico 3  
+Score = 55 (3C + 2I + 2Compat + 2Elast + Costo + Rischio + 2Drift)
+
+## Fonti di riferimento (sintesi, citazioni nel dossier principale del progetto)
+- Complexity Meter (limiti, scopo, cheat freedom): SporeWiki. 
+- Abilità e livelli (Bite/Charge/Strike/Spit; social): SporeWiki.
+- T-score T0–T3 e slot/colonie: SporeWiki.
+- Procedural animation & UGC pipeline: interviste Will Wright / overview enciclopediche.

--- a/docs/research/refs/spore__complexity_budget.yaml
+++ b/docs/research/refs/spore__complexity_budget.yaml
@@ -1,0 +1,38 @@
+id: "spore__complexity_budget"
+source_game: "spore"
+title: "Budget di complessità per build"
+category: "Progression|Buildcraft|UX"
+summary: "Un misuratore di complessità limita numero e livello delle parti, imponendo trade-off di design."
+adopt_adapt_avoid: "Adopt"
+spec:
+  mechanics: |
+    Ogni parte/modulo ha un costo di complessità c_p.
+    La build è valida se Σ c_p ≤ C_max (dipende da bioma/stadio/tech).
+    Sblocchi o set riducono c_p o aumentano C_max.
+  parameters:
+    - { name: "C_max", type: "int", formula: "limite complessità per contesto", range: { min: 5, max: 100, step: 1 } }
+    - { name: "c_p",   type: "int", formula: "costo unitario per parte/modulo", range: { min: 1, max: 10, step: 1 } }
+    - { name: "discount_set", type: "percent", formula: "riduzione costo per set sinergico", range: { min: 0, max: 50, step: 5 } }
+ux:
+  notes: "Gauge visibile; warning vicino alla soglia; suggerimenti trade-off."
+  accessibility: "Tooltip con impatto statistico per parte."
+telemetry_map:
+  events: [ "build_opened", "part_added", "part_removed", "build_committed" ]
+  axes_impact: { E: 2, N: 1, T: 4, P: 3 }
+impact:
+  catalogs: [ "rules/build_budget.yaml" ]
+  dependencies: [ "traits/parts_index.yaml" ]
+  risks:
+    - "Over-tuning di C_max frena creatività"
+    - "Meta su set a basso costo"
+  open_questions:
+    - "C_max fisso per bioma o scalato per progressione?"
+score:
+  coerenza: 5
+  innovazione: 4
+  compatibilita_telemetria: 5
+  drift_risk: 4
+  elasticita: 5
+  costo: 3
+  rischio_tecnico: 3
+  weighted: 55

--- a/docs/research/refs/spore__part_based_scaling.yaml
+++ b/docs/research/refs/spore__part_based_scaling.yaml
@@ -1,0 +1,33 @@
+id: "spore__part_based_scaling"
+source_game: "spore"
+title: "Scaling statistico basato su parti"
+category: "Combat|Buildcraft|Status"
+summary: "Stats e abilità derivano da parti equipaggiate e dai loro livelli."
+adopt_adapt_avoid: "Adopt"
+spec:
+  mechanics: |
+    Le stats si calcolano dalla somma e dal livello delle parti attive.
+    Le abilità esistono solo se la parte è presente; i livelli aumentano efficacia/CD/range.
+  parameters:
+    - { name: "level_max", type: "int", formula: "livello massimo parte", range: { min: 1, max: 5, step: 1 } }
+    - { name: "part_multiplier", type: "float", formula: "moltiplicatore per livello su stat", range: { min: 1.0, max: 3.0, step: 0.1 } }
+ux:
+  notes: "Anteprima in editor con breakdown per parte; icone abilità attive."
+  accessibility: "Requisiti di attivazione chiari."
+telemetry_map:
+  events: [ "stat_preview_opened", "ability_unlocked", "ability_used" ]
+  axes_impact: { E: 2, N: 1, T: 5, P: 3 }
+impact:
+  catalogs: [ "traits/parts_scaling.yaml" ]
+  dependencies: [ "rules/build_budget.yaml" ]
+  risks: [ "Overlay di stats tra famiglie di parti" ]
+  open_questions: [ "Hard caps vs diminishing returns?" ]
+score:
+  coerenza: 5
+  innovazione: 4
+  compatibilita_telemetria: 5
+  drift_risk: 4
+  elasticita: 4
+  costo: 3
+  rischio_tecnico: 3
+  weighted: 52

--- a/docs/research/refs/spore__stage_gated_progression.yaml
+++ b/docs/research/refs/spore__stage_gated_progression.yaml
@@ -1,0 +1,33 @@
+id: "spore__stage_gated_progression"
+source_game: "spore"
+title: "Progressione ad archi con carry-over"
+category: "Progression|Structure|Meta"
+summary: "Fasi distinte con soglie di avanzamento e trasferimento parziale di scelte pregresse."
+adopt_adapt_avoid: "Adapt"
+spec:
+  mechanics: |
+    Il percorso è suddiviso in archi con set di obiettivi e sistemi parzialmente differenti.
+    Il passaggio avviene a soglia; carry-over selettivo (X% di stats/feature).
+  parameters:
+    - { name: "stage_threshold", type: "int", formula: "soglia progresso", range: { min: 1, max: 100, step: 1 } }
+    - { name: "carry_over_ratio", type: "percent", formula: "percentuale trasferita", range: { min: 0, max: 100, step: 5 } }
+ux:
+  notes: "Roadmap archi; elenco chiaro di cosa viene trasferito."
+  accessibility: "Suggerimenti se build penalizza archi futuri."
+telemetry_map:
+  events: [ "stage_threshold_reached", "stage_transition" ]
+  axes_impact: { E: 4, N: 2, T: 4, P: 4 }
+impact:
+  catalogs: [ "rules/stages.yaml" ]
+  dependencies: [ "telemetry/stage_events.yaml" ]
+  risks: [ "Scope creep tra sistemi eterogenei" ]
+  open_questions: [ "Quanti archi minimi senza diluire il focus?" ]
+score:
+  coerenza: 4
+  innovazione: 4
+  compatibilita_telemetria: 5
+  drift_risk: 3
+  elasticita: 3
+  costo: 2
+  rischio_tecnico: 3
+  weighted: 41

--- a/docs/research/refs/spore__terraforming_bands.yaml
+++ b/docs/research/refs/spore__terraforming_bands.yaml
@@ -1,0 +1,34 @@
+id: "spore__terraforming_bands"
+source_game: "spore"
+title: "Terraforming a bande con slot"
+category: "Map|Economy|World"
+summary: "Biomi con bande di vitalità; strumenti spostano parametri ambientali e sbloccano slot."
+adopt_adapt_avoid: "Adopt"
+spec:
+  mechanics: |
+    Ogni bioma ha T-bands (T0–T3) definite da atmosfera+temperatura.
+    Bande superiori sbloccano slot insediativi/add-on; instabilità può far retrocedere di banda.
+  parameters:
+    - { name: "band", type: "enum", formula: "T0,T1,T2,T3" }
+    - { name: "env_params", type: "enum", formula: "temperatura, atmosfera, biomassa, umidità" }
+    - { name: "slots_per_band", type: "int", formula: "slot per banda", range: { min: 0, max: 6, step: 1 } }
+ux:
+  notes: "Gauge ambientali; indicatori drift/stabilità; suggerimenti strumenti."
+  accessibility: "Preset consigliati per raggiungere band target."
+telemetry_map:
+  events: [ "biome_param_changed", "band_reached", "slot_unlocked" ]
+  axes_impact: { E: 5, N: 1, T: 3, P: 4 }
+impact:
+  catalogs: [ "biomes/terraforming_bands.yaml", "rules/colony_slots.yaml" ]
+  dependencies: [ "telemetry/biome_events.yaml" ]
+  risks: [ "Loop di tuning grindy" ]
+  open_questions: [ "Persistenza banda vs eventi dinamici?" ]
+score:
+  coerenza: 5
+  innovazione: 4
+  compatibilita_telemetria: 5
+  drift_risk: 4
+  elasticita: 4
+  costo: 3
+  rischio_tecnico: 3
+  weighted: 53

--- a/rules/build_budget.yaml
+++ b/rules/build_budget.yaml
@@ -1,0 +1,13 @@
+version: 1
+system: build_budget
+description: "Regole e soglie per il budget di complessità delle build."
+params:
+  C_max_by_context:
+    default: 20
+    by_biome: {}
+    by_stage: {}
+  discounts:
+    set_completed: 0
+telemetry:
+  events: [build_opened, part_added, part_removed, build_committed]
+TODO: "Definire mapping da parti (traits) a c_p e bonus set."

--- a/rules/stages.yaml
+++ b/rules/stages.yaml
@@ -1,0 +1,15 @@
+version: 1
+system: stages
+description: "Archi di progressione con soglie e carry-over selettivo."
+stages:
+  - id: arc01
+    label: "Seme"
+    threshold: 10
+    carry_over_ratio: 25
+  - id: arc02
+    label: "Fioritura"
+    threshold: 25
+    carry_over_ratio: 35
+telemetry:
+  events: [stage_threshold_reached, stage_transition]
+TODO: "Definire numero archi e mapping narrativo per biomi."

--- a/traits/parts_scaling.yaml
+++ b/traits/parts_scaling.yaml
@@ -1,0 +1,12 @@
+version: 1
+system: parts_scaling
+description: "Derivazione stats/abilità da parti e livelli."
+stats:
+  speed: { base: 0, per_level: 0.5 }
+  attack: { base: 0, per_level: 1.0 }
+abilities:
+  bite:    { level_max: 5, cd: "short" }
+  strike:  { level_max: 5, cd: "long", cleave: true }
+  charge:  { level_max: 5, stun: true }
+  spit:    { level_max: 5, dot: true, cd: "medium" }
+TODO: "Allineare famiglie di parti e moltiplicatori."


### PR DESCRIPTION
## Summary
- add research README plus a Spore RGD dossier and four feature cards to capture adopt/adapt intent
- append the Spore features to the harvest matrix with weighted scoring and catalog impacts
- scaffold placeholder YAMLs for build budgets, part-based scaling, terraforming bands, and stage arcs with telemetry events noted

## Testing
- not run (documentation and placeholders only)

------
https://chatgpt.com/codex/tasks/task_e_6904c9885ecc83329441eb4fb8ff47ea