### PR TITLE
Add matchmaking filters UI and filtered API support

### DIFF
--- a/analytics/matchmaking.ts
+++ b/analytics/matchmaking.ts
@@ -1,0 +1,50 @@
+import type { MatchmakingFilter } from '../src/api/matchmaking';
+import { flattenFilters } from '../src/api/matchmaking';
+
+export const MATCHMAKING_FILTER_APPLIED = 'matchmaking.filter_applied';
+export const MATCHMAKING_FILTER_RESET = 'matchmaking.filter_reset';
+
+export interface AnalyticsAdapter {
+  track(eventName: string, payload?: Record<string, unknown>): void;
+}
+
+export interface FilterAppliedEvent {
+  filters: MatchmakingFilter;
+  resultCount?: number;
+  source?: string;
+  latencyMs?: number;
+}
+
+export interface FilterResetEvent {
+  source?: string;
+}
+
+export interface MatchmakingAnalytics {
+  recordFilterApplied(event: FilterAppliedEvent): void;
+  recordFilterReset(event?: FilterResetEvent): void;
+}
+
+const normalizeFilters = (filters: MatchmakingFilter): Record<string, string | number | boolean> => {
+  return flattenFilters(filters);
+};
+
+export function createMatchmakingAnalytics(adapter: AnalyticsAdapter): MatchmakingAnalytics {
+  const track = (eventName: string, payload: Record<string, unknown> = {}): void => {
+    adapter.track(eventName, payload);
+  };
+
+  return {
+    recordFilterApplied(event: FilterAppliedEvent): void {
+      const { filters, ...rest } = event;
+      track(MATCHMAKING_FILTER_APPLIED, {
+        ...rest,
+        filters: normalizeFilters(filters),
+      });
+    },
+    recordFilterReset(event?: FilterResetEvent): void {
+      track(MATCHMAKING_FILTER_RESET, event ? { ...event } : {});
+    },
+  };
+}
+
+export default createMatchmakingAnalytics;

--- a/public/ui/matchmaking/Controls.tsx
+++ b/public/ui/matchmaking/Controls.tsx
@@ -1,0 +1,255 @@
+import React from 'react';
+
+export interface SkillBracketProps {
+  readonly min?: number;
+  readonly max?: number;
+  readonly lowerBound?: number;
+  readonly upperBound?: number;
+}
+
+export interface MatchmakingControlsProps {
+  readonly regions: string[];
+  readonly gameModes: string[];
+  readonly selectedRegion?: string;
+  readonly selectedMode?: string;
+  readonly skillBracket?: SkillBracketProps;
+  readonly teamSizeOptions?: number[];
+  readonly selectedTeamSize?: number;
+  readonly crossplayEnabled?: boolean;
+  readonly isFiltered?: boolean;
+  readonly isFetching?: boolean;
+  readonly activePlayers?: number;
+  readonly averageWaitTime?: number;
+  readonly onRegionChange?: (region: string) => void;
+  readonly onModeChange?: (mode: string) => void;
+  readonly onSkillBracketChange?: (bracket: { min?: number; max?: number }) => void;
+  readonly onTeamSizeChange?: (teamSize: number | undefined) => void;
+  readonly onCrossplayToggle?: (enabled: boolean) => void;
+  readonly onResetFilters?: () => void;
+}
+
+interface IndicatorProps {
+  readonly label: string;
+  readonly value: string;
+  readonly tone?: 'success' | 'warning' | 'danger' | 'neutral';
+}
+
+const toneToClass = (tone: IndicatorProps['tone']): string => {
+  switch (tone) {
+    case 'success':
+      return 'matchmaking-indicator matchmaking-indicator--success';
+    case 'warning':
+      return 'matchmaking-indicator matchmaking-indicator--warning';
+    case 'danger':
+      return 'matchmaking-indicator matchmaking-indicator--danger';
+    default:
+      return 'matchmaking-indicator matchmaking-indicator--neutral';
+  }
+};
+
+const Indicator: React.FC<IndicatorProps> = ({ label, value, tone = 'neutral' }) => (
+  <div className={toneToClass(tone)}>
+    <span className="matchmaking-indicator__label">{label}</span>
+    <span className="matchmaking-indicator__value">{value}</span>
+  </div>
+);
+
+const humanizeWait = (waitInSeconds?: number): string => {
+  if (waitInSeconds === undefined || Number.isNaN(waitInSeconds)) {
+    return 'n/d';
+  }
+  if (waitInSeconds < 60) {
+    return `${Math.round(waitInSeconds)}s`;
+  }
+  const minutes = Math.floor(waitInSeconds / 60);
+  const seconds = Math.round(waitInSeconds % 60);
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+};
+
+const computeQueueTone = (players?: number): IndicatorProps['tone'] => {
+  if (players === undefined || Number.isNaN(players)) {
+    return 'neutral';
+  }
+  if (players >= 2000) {
+    return 'success';
+  }
+  if (players >= 800) {
+    return 'warning';
+  }
+  return 'danger';
+};
+
+const computeActiveFilterCount = (props: MatchmakingControlsProps): number => {
+  let count = 0;
+  if (props.selectedRegion) count += 1;
+  if (props.selectedMode) count += 1;
+  if (props.selectedTeamSize !== undefined) count += 1;
+  if (props.crossplayEnabled !== undefined) count += 1;
+  const { skillBracket } = props;
+  if (skillBracket?.min !== undefined || skillBracket?.max !== undefined) {
+    count += 1;
+  }
+  return count;
+};
+
+const toValue = (value: number | undefined, fallback: number): number =>
+  typeof value === 'number' && !Number.isNaN(value) ? value : fallback;
+
+export const MatchmakingControls: React.FC<MatchmakingControlsProps> = (props) => {
+  const {
+    regions,
+    gameModes,
+    selectedRegion,
+    selectedMode,
+    skillBracket,
+    teamSizeOptions = [],
+    selectedTeamSize,
+    crossplayEnabled,
+    isFiltered,
+    isFetching,
+    activePlayers,
+    averageWaitTime,
+    onRegionChange,
+    onModeChange,
+    onSkillBracketChange,
+    onTeamSizeChange,
+    onCrossplayToggle,
+    onResetFilters,
+  } = props;
+
+  const lowerBound = toValue(skillBracket?.lowerBound, 0);
+  const upperBound = toValue(skillBracket?.upperBound, 5000);
+  const minValue = Math.max(lowerBound, toValue(skillBracket?.min, lowerBound));
+  const maxValue = Math.min(upperBound, toValue(skillBracket?.max, upperBound));
+
+  const filterCount = computeActiveFilterCount(props);
+
+  const queueTone = computeQueueTone(activePlayers);
+  const waitTone: IndicatorProps['tone'] = averageWaitTime && averageWaitTime > 90 ? 'warning' : 'success';
+
+  const handleSkillChange = (next: Partial<{ min: number; max: number }>) => {
+    if (!onSkillBracketChange) return;
+    const nextBracket = {
+      min: next.min ?? (skillBracket?.min ?? lowerBound),
+      max: next.max ?? (skillBracket?.max ?? upperBound),
+    };
+    onSkillBracketChange(nextBracket);
+  };
+
+  return (
+    <section className="matchmaking-controls" aria-busy={isFetching}>
+      <header className="matchmaking-controls__header">
+        <h2>Matchmaking</h2>
+        <div className="matchmaking-controls__status">
+          <Indicator label="Giocatori attivi" value={activePlayers ? activePlayers.toLocaleString() : 'n/d'} tone={queueTone} />
+          <Indicator label="Tempo medio coda" value={humanizeWait(averageWaitTime)} tone={waitTone} />
+          <Indicator
+            label="Filtri attivi"
+            value={filterCount.toString()}
+            tone={filterCount > 0 ? 'success' : 'neutral'}
+          />
+        </div>
+      </header>
+
+      <div className="matchmaking-controls__grid">
+        <label className="matchmaking-controls__field">
+          <span className="matchmaking-controls__field-label">Regione</span>
+          <select
+            value={selectedRegion ?? ''}
+            onChange={(event) => onRegionChange?.(event.target.value || '')}
+            aria-label="Filtro regione"
+          >
+            <option value="">Tutte le regioni</option>
+            {regions.map((region) => (
+              <option key={region} value={region}>
+                {region}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="matchmaking-controls__field">
+          <span className="matchmaking-controls__field-label">Modalità</span>
+          <select
+            value={selectedMode ?? ''}
+            onChange={(event) => onModeChange?.(event.target.value || '')}
+            aria-label="Filtro modalità"
+          >
+            <option value="">Tutte le modalità</option>
+            {gameModes.map((mode) => (
+              <option key={mode} value={mode}>
+                {mode}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {teamSizeOptions.length > 0 && (
+          <label className="matchmaking-controls__field">
+            <span className="matchmaking-controls__field-label">Dimensione squadra</span>
+            <select
+              value={selectedTeamSize?.toString() ?? ''}
+              onChange={(event) =>
+                onTeamSizeChange?.(event.target.value ? Number.parseInt(event.target.value, 10) : undefined)
+              }
+              aria-label="Filtro dimensione squadra"
+            >
+              <option value="">Qualsiasi</option>
+              {teamSizeOptions.map((size) => (
+                <option key={size} value={size}>
+                  {size}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        <fieldset className="matchmaking-controls__field matchmaking-controls__field--range">
+          <legend className="matchmaking-controls__field-label">Fascia abilità</legend>
+          <div className="matchmaking-controls__range-inputs">
+            <label>
+              <span>Min</span>
+              <input
+                type="range"
+                min={lowerBound}
+                max={maxValue}
+                value={minValue}
+                onChange={(event) => handleSkillChange({ min: Number(event.target.value) })}
+              />
+              <output aria-live="polite">{minValue}</output>
+            </label>
+            <label>
+              <span>Max</span>
+              <input
+                type="range"
+                min={minValue}
+                max={upperBound}
+                value={maxValue}
+                onChange={(event) => handleSkillChange({ max: Number(event.target.value) })}
+              />
+              <output aria-live="polite">{maxValue}</output>
+            </label>
+          </div>
+        </fieldset>
+
+        <label className="matchmaking-controls__toggle">
+          <span className="matchmaking-controls__field-label">Cross-play</span>
+          <input
+            type="checkbox"
+            checked={Boolean(crossplayEnabled)}
+            onChange={(event) => onCrossplayToggle?.(event.target.checked)}
+          />
+        </label>
+      </div>
+
+      <footer className="matchmaking-controls__footer">
+        <button type="button" onClick={() => onResetFilters?.()} disabled={!isFiltered}>
+          Reimposta filtri
+        </button>
+        {isFetching && <span className="matchmaking-controls__loading">Aggiornamento dati…</span>}
+      </footer>
+    </section>
+  );
+};
+
+export default MatchmakingControls;

--- a/src/api/matchmaking.ts
+++ b/src/api/matchmaking.ts
@@ -1,0 +1,156 @@
+export interface SkillBracket {
+  readonly min?: number;
+  readonly max?: number;
+}
+
+export interface MatchmakingFilter {
+  readonly region?: string;
+  readonly mode?: string;
+  readonly teamSize?: number;
+  readonly crossplay?: boolean;
+  readonly skillBracket?: SkillBracket;
+}
+
+export interface MatchmakingSummary {
+  readonly id: string;
+  readonly region: string;
+  readonly mode: string;
+  readonly playersInQueue: number;
+  readonly averageWaitTime: number;
+  readonly updatedAt: string;
+}
+
+export interface MatchmakingClientOptions {
+  readonly baseUrl?: string;
+  readonly cacheTtlMs?: number;
+  readonly fetch?: typeof fetch;
+  readonly now?: () => number;
+}
+
+interface CacheEntry {
+  expiresAt: number;
+  payload: MatchmakingSummary[];
+}
+
+export type FlattenedFilters = Record<string, string | number | boolean>;
+
+export const MATCHMAKING_ENDPOINT = '/api/matchmaking';
+
+export const DEFAULT_CACHE_TTL_MS = 30_000;
+
+const serializeBoolean = (value: boolean): string => (value ? 'true' : 'false');
+
+export function flattenFilters(filters: MatchmakingFilter = {}): FlattenedFilters {
+  const normalized: FlattenedFilters = {};
+  if (filters.region) {
+    normalized.region = filters.region;
+  }
+  if (filters.mode) {
+    normalized.mode = filters.mode;
+  }
+  if (filters.teamSize !== undefined) {
+    normalized.teamSize = filters.teamSize;
+  }
+  if (filters.crossplay !== undefined) {
+    normalized.crossplay = serializeBoolean(filters.crossplay);
+  }
+  const bracket = filters.skillBracket;
+  if (bracket?.min !== undefined) {
+    normalized.skillMin = bracket.min;
+  }
+  if (bracket?.max !== undefined) {
+    normalized.skillMax = bracket.max;
+  }
+  return normalized;
+}
+
+const buildQueryString = (filters: MatchmakingFilter): string => {
+  const params = new URLSearchParams();
+  Object.entries(flattenFilters(filters)).forEach(([key, value]) => {
+    params.append(key, String(value));
+  });
+  const query = params.toString();
+  return query ? `?${query}` : '';
+};
+
+const isMatchmakingSummaryArray = (value: unknown): value is MatchmakingSummary[] => {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        entry &&
+        typeof entry === 'object' &&
+        typeof (entry as MatchmakingSummary).id === 'string' &&
+        typeof (entry as MatchmakingSummary).region === 'string' &&
+        typeof (entry as MatchmakingSummary).mode === 'string' &&
+        typeof (entry as MatchmakingSummary).playersInQueue === 'number' &&
+        typeof (entry as MatchmakingSummary).averageWaitTime === 'number' &&
+        typeof (entry as MatchmakingSummary).updatedAt === 'string',
+    )
+  );
+};
+
+export class MatchmakingClient {
+  private readonly baseUrl: string;
+  private readonly cacheTtlMs: number;
+  private readonly fetcher: typeof fetch;
+  private readonly now: () => number;
+  private readonly cache = new Map<string, CacheEntry>();
+
+  constructor(options: MatchmakingClientOptions = {}) {
+    this.baseUrl = options.baseUrl ?? MATCHMAKING_ENDPOINT;
+    this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    this.fetcher = options.fetch ?? (globalThis.fetch?.bind(globalThis) as typeof fetch);
+    if (!this.fetcher) {
+      throw new Error("MatchmakingClient richiede un'implementazione fetch disponibile.");
+    }
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  private getCacheKey(filters: MatchmakingFilter): string {
+    return JSON.stringify(flattenFilters(filters));
+  }
+
+  clearCache(filters?: MatchmakingFilter): void {
+    if (!filters) {
+      this.cache.clear();
+      return;
+    }
+    this.cache.delete(this.getCacheKey(filters));
+  }
+
+  async fetchSummaries(filters: MatchmakingFilter = {}): Promise<MatchmakingSummary[]> {
+    const key = this.getCacheKey(filters);
+    const currentTime = this.now();
+    const cached = this.cache.get(key);
+
+    if (cached && cached.expiresAt > currentTime) {
+      return cached.payload;
+    }
+
+    const url = `${this.baseUrl}${buildQueryString(filters)}`;
+    const response = await this.fetcher(url, {
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Richiesta matchmaking fallita con status ${response.status}`);
+    }
+
+    const payload = await response.json();
+    if (!isMatchmakingSummaryArray(payload)) {
+      throw new Error('Risposta matchmaking non valida.');
+    }
+
+    const immutablePayload = payload.map((entry) => ({ ...entry }));
+
+    this.cache.set(key, {
+      expiresAt: currentTime + this.cacheTtlMs,
+      payload: immutablePayload,
+    });
+
+    return immutablePayload;
+  }
+}
+
+export default MatchmakingClient;

--- a/tests/matchmaking/filters.spec.ts
+++ b/tests/matchmaking/filters.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it } from 'node:test';
+import assert from 'assert';
+import { MatchmakingClient, type MatchmakingFilter } from '../../src/api/matchmaking';
+import {
+  createMatchmakingAnalytics,
+  MATCHMAKING_FILTER_APPLIED,
+  MATCHMAKING_FILTER_RESET,
+} from '../../analytics/matchmaking';
+
+describe('Matchmaking — combinazione filtri', () => {
+  it('costruisce la query combinata e utilizza la cache per richieste identiche', async () => {
+    let currentTime = 1000;
+    const capturedUrls: string[] = [];
+    const responsePayload = [
+      {
+        id: 'match-001',
+        region: 'EU',
+        mode: 'ranked',
+        playersInQueue: 1540,
+        averageWaitTime: 67,
+        updatedAt: new Date().toISOString(),
+      },
+    ];
+
+    const fetchStub: typeof fetch = async (input) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : (typeof input === 'object' && input && 'url' in input
+              ? String((input as { url: string }).url)
+              : String(input));
+      capturedUrls.push(url);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => responsePayload,
+      } as unknown as Response;
+    };
+
+    const client = new MatchmakingClient({
+      fetch: fetchStub,
+      cacheTtlMs: 5_000,
+      now: () => currentTime,
+    });
+
+    const filters: MatchmakingFilter = {
+      region: 'EU',
+      mode: 'ranked',
+      teamSize: 3,
+      crossplay: false,
+      skillBracket: { min: 1200, max: 1800 },
+    };
+
+    const first = await client.fetchSummaries(filters);
+    assert.strictEqual(first.length, 1, 'il payload deve essere restituito');
+    assert.strictEqual(capturedUrls.length, 1, 'la prima richiesta deve raggiungere la rete');
+    assert.match(
+      capturedUrls[0],
+      /region=EU/,
+      'la query deve contenere il filtro regione',
+    );
+    assert.match(capturedUrls[0], /mode=ranked/, 'la query deve contenere il filtro modalità');
+    assert.match(capturedUrls[0], /teamSize=3/, 'la query deve includere la dimensione squadra');
+    assert.match(capturedUrls[0], /crossplay=false/, 'la query deve includere cross-play');
+    assert.match(capturedUrls[0], /skillMin=1200/, 'la query deve includere il minimo skill');
+    assert.match(capturedUrls[0], /skillMax=1800/, 'la query deve includere il massimo skill');
+
+    const second = await client.fetchSummaries(filters);
+    assert.strictEqual(second.length, 1, 'la cache deve restituire gli stessi risultati');
+    assert.strictEqual(capturedUrls.length, 1, 'la cache deve evitare richieste duplicate');
+
+    currentTime += 10_000;
+    const third = await client.fetchSummaries(filters);
+    assert.strictEqual(third.length, 1, 'anche dopo la scadenza deve tornare dati validi');
+    assert.strictEqual(capturedUrls.length, 2, 'dopo la scadenza deve essere effettuata una nuova richiesta');
+  });
+
+  it('registra eventi analytics per filtri combinati e reset', () => {
+    const recorded: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    const analytics = createMatchmakingAnalytics({
+      track(eventName, payload) {
+        recorded.push({ event: eventName, payload: payload ?? {} });
+      },
+    });
+
+    analytics.recordFilterApplied({
+      filters: {
+        region: 'NA',
+        mode: 'casual',
+        crossplay: true,
+        teamSize: 2,
+        skillBracket: { min: 800, max: 1500 },
+      },
+      resultCount: 12,
+      source: 'sidebar',
+    });
+
+    analytics.recordFilterReset({ source: 'sidebar' });
+
+    assert.strictEqual(recorded.length, 2, 'devono essere registrati due eventi');
+    assert.strictEqual(recorded[0].event, MATCHMAKING_FILTER_APPLIED);
+    assert.deepStrictEqual(recorded[0].payload.filters, {
+      region: 'NA',
+      mode: 'casual',
+      crossplay: 'true',
+      teamSize: 2,
+      skillMin: 800,
+      skillMax: 1500,
+    });
+    assert.strictEqual(recorded[0].payload.resultCount, 12);
+    assert.strictEqual(recorded[0].payload.source, 'sidebar');
+
+    assert.strictEqual(recorded[1].event, MATCHMAKING_FILTER_RESET);
+    assert.strictEqual(recorded[1].payload.source, 'sidebar');
+  });
+});


### PR DESCRIPTION
## Summary
- add a matchmaking controls component with dropdowns, sliders, and live indicators
- implement a filtered matchmaking API client with in-memory caching helpers
- add analytics helpers and coverage for combined filter behaviour

## Testing
- tools/ts/node_modules/.bin/tsx --test tests/matchmaking/filters.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_6904d662dad48332862070e6f06e80aa