### PR TITLE
Add campaign progress dashboard and ETL job

### DIFF
--- a/analytics/dashboards/campaignProgress.vue
+++ b/analytics/dashboards/campaignProgress.vue
@@ -1,0 +1,595 @@
+<template>
+  <section class="campaign-progress">
+    <header class="campaign-progress__header">
+      <div>
+        <h2>Progressione campagna</h2>
+        <p>
+          Monitoraggio continuo del funnel di conversione e della reattività dei canali operativi
+          per la campagna in corso.
+        </p>
+      </div>
+      <dl class="campaign-progress__meta">
+        <div>
+          <dt>Ultimo aggiornamento</dt>
+          <dd>{{ formatTimestamp(summary.lastUpdated) }}</dd>
+        </div>
+        <div>
+          <dt>Campagne attive</dt>
+          <dd>{{ summary.activeCampaigns }}</dd>
+        </div>
+      </dl>
+    </header>
+
+    <section class="campaign-progress__summary">
+      <article class="campaign-progress__card">
+        <h3>Lead totali</h3>
+        <p class="campaign-progress__value">{{ formatNumber(summary.totalLeads) }}</p>
+        <p class="campaign-progress__caption">Totale opportunità raccolte nel periodo</p>
+      </article>
+      <article class="campaign-progress__card">
+        <h3>Tasso di conversione</h3>
+        <p class="campaign-progress__value">{{ formatPercent(summary.conversionRate) }}</p>
+        <p class="campaign-progress__caption">
+          Target: {{ formatPercent(summary.targetConversionRate) }} · {{ conversionDeltaLabel }}
+        </p>
+      </article>
+      <article class="campaign-progress__card">
+        <h3>Momentum medio</h3>
+        <p class="campaign-progress__value">{{ formatPercent(averageMomentum) }}</p>
+        <p class="campaign-progress__caption">Var. media giornaliera sul funnel</p>
+      </article>
+      <article class="campaign-progress__card">
+        <h3>Segmento top</h3>
+        <p class="campaign-progress__value">{{ topPerformer?.title ?? '—' }}</p>
+        <p class="campaign-progress__caption">Owner: {{ topPerformer?.owner ?? '—' }}</p>
+      </article>
+    </section>
+
+    <div class="campaign-progress__layout">
+      <section class="campaign-progress__panel campaign-progress__panel--funnel">
+        <header class="campaign-progress__panel-header">
+          <div>
+            <h3>Funnel di conversione</h3>
+            <p>Analisi dei passaggi dalla scoperta alla fidelizzazione.</p>
+          </div>
+          <span class="campaign-progress__panel-meta">{{ normalizedFunnel.length }} stadi</span>
+        </header>
+        <ol class="funnel">
+          <li v-for="(stage, index) in normalizedFunnel" :key="stage.id" class="funnel__stage">
+            <div class="funnel__bar" :style="{ '--width': stage.width + '%', '--index': index }">
+              <strong>{{ stage.label }}</strong>
+              <span class="funnel__metric">{{ formatNumber(stage.leads) }} lead</span>
+              <span class="funnel__metric">{{ formatPercent(stage.conversionRate) }} conv.</span>
+            </div>
+            <footer class="funnel__footer">
+              <span>Drop-off: {{ formatPercent(stage.dropOffRate) }}</span>
+              <span :class="{ 'funnel__delta--up': stage.delta >= 0, 'funnel__delta--down': stage.delta < 0 }">
+                {{ stage.delta >= 0 ? '▲' : '▼' }} {{ formatPercent(Math.abs(stage.delta)) }}
+              </span>
+            </footer>
+          </li>
+          <li v-if="!normalizedFunnel.length" class="funnel__empty">Nessun dato disponibile.</li>
+        </ol>
+      </section>
+
+      <section class="campaign-progress__panel campaign-progress__panel--heatmap">
+        <header class="campaign-progress__panel-header">
+          <div>
+            <h3>Heatmap canali</h3>
+            <p>Intensità settimanale dei touchpoint attivati per segmento.</p>
+          </div>
+          <span class="campaign-progress__panel-meta">{{ heatmapMatrix.periods.length }} periodi</span>
+        </header>
+        <div class="heatmap">
+          <table>
+            <thead>
+              <tr>
+                <th>Segmento</th>
+                <th v-for="period in heatmapMatrix.periods" :key="period">{{ period }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="row in heatmapMatrix.rows" :key="row.channel">
+                <th scope="row">{{ row.channel }}</th>
+                <td
+                  v-for="cell in row.cells"
+                  :key="cell.period"
+                  :style="{ '--intensity': cell.intensity.toFixed(2) }"
+                >
+                  <span class="heatmap__value">{{ formatPercent(cell.value) }}</span>
+                  <small>{{ formatNumber(cell.leads) }} lead</small>
+                </td>
+              </tr>
+              <tr v-if="!heatmapMatrix.rows.length" class="heatmap__empty">
+                <td :colspan="heatmapMatrix.periods.length + 1">Nessun canale monitorato.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section v-if="highlights.length" class="campaign-progress__panel campaign-progress__panel--highlights">
+        <header class="campaign-progress__panel-header">
+          <div>
+            <h3>Focus e follow-up</h3>
+            <p>Azioni prioritarie con ownership definita.</p>
+          </div>
+          <span class="campaign-progress__panel-meta">{{ highlights.length }} elementi</span>
+        </header>
+        <ul class="highlights">
+          <li v-for="item in highlights" :key="item.id" class="highlights__item">
+            <h4>{{ item.title }}</h4>
+            <p>{{ item.description }}</p>
+            <footer>
+              <span class="highlights__owner">Owner: {{ item.owner }}</span>
+              <span class="highlights__eta" v-if="item.eta">ETA: {{ item.eta }}</span>
+            </footer>
+          </li>
+        </ul>
+      </section>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+interface CampaignSummary {
+  activeCampaigns: number;
+  totalLeads: number;
+  conversionRate: number;
+  targetConversionRate: number;
+  lastUpdated: string;
+}
+
+interface FunnelStageInput {
+  id: string;
+  label: string;
+  leads: number;
+  conversions: number;
+  delta?: number;
+}
+
+interface HeatmapInput {
+  periods: string[];
+  channels: string[];
+  values: number[][];
+  leads?: number[][];
+}
+
+interface HighlightItem {
+  id: string;
+  title: string;
+  description: string;
+  owner: string;
+  eta?: string;
+  momentum?: number;
+}
+
+const props = withDefaults(
+  defineProps<{
+    summary: CampaignSummary;
+    funnel: FunnelStageInput[];
+    heatmap: HeatmapInput;
+    highlights?: HighlightItem[];
+  }>(),
+  {
+    highlights: () => [],
+  },
+);
+
+const normalizedFunnel = computed(() => {
+  const maxLeads = Math.max(0, ...props.funnel.map((stage) => stage.leads));
+  return props.funnel.map((stage, index) => {
+    const previous = index > 0 ? props.funnel[index - 1] : undefined;
+    const dropOffBase = previous ? previous.conversions || previous.leads : 0;
+    const dropOffRate = previous && dropOffBase
+      ? Math.max(0, 1 - stage.leads / dropOffBase)
+      : 0;
+    const conversionRate = stage.leads > 0 ? stage.conversions / stage.leads : 0;
+    const delta = stage.delta ?? 0;
+    return {
+      ...stage,
+      width: maxLeads > 0 ? Math.max(12, (stage.leads / maxLeads) * 100) : 12,
+      dropOffRate,
+      conversionRate,
+      delta,
+    };
+  });
+});
+
+const averageMomentum = computed(() => {
+  if (!props.highlights.length) {
+    return 0;
+  }
+  const values = props.highlights
+    .map((item) => item.momentum)
+    .filter((value): value is number => typeof value === 'number');
+  if (!values.length) {
+    return 0;
+  }
+  const total = values.reduce((acc, value) => acc + value, 0);
+  return total / values.length;
+});
+
+const heatmapMatrix = computed(() => {
+  const { periods, channels, values, leads } = props.heatmap;
+  const flattened = values.flat();
+  const maxValue = flattened.length ? Math.max(...flattened) : 0;
+  const minValue = flattened.length ? Math.min(...flattened) : 0;
+  return {
+    periods,
+    rows: channels.map((channel, rowIndex) => ({
+      channel,
+      cells: periods.map((period, columnIndex) => {
+        const value = values[rowIndex]?.[columnIndex] ?? 0;
+        const leadValue = leads?.[rowIndex]?.[columnIndex] ?? 0;
+        const intensity = maxValue === minValue ? 0.5 : (value - minValue) / (maxValue - minValue);
+        return {
+          period,
+          value,
+          leads: leadValue,
+          intensity,
+        };
+      }),
+    })),
+  };
+});
+
+const conversionDeltaLabel = computed(() => {
+  const delta = props.summary.conversionRate - props.summary.targetConversionRate;
+  const direction = delta >= 0 ? 'sopra target' : 'sotto target';
+  return `${formatPercent(Math.abs(delta))} ${direction}`;
+});
+
+const highlights = computed(() => props.highlights);
+
+const topPerformer = computed(() => {
+  if (!highlights.value.length) {
+    return undefined;
+  }
+  return [...highlights.value].sort((a, b) => (b.momentum ?? 0) - (a.momentum ?? 0))[0];
+});
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatNumber(value: number): string {
+  return value.toLocaleString('it-IT');
+}
+
+function formatTimestamp(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleString('it-IT', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+</script>
+
+<style scoped>
+.campaign-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: var(--campaign-surface, #0b101a);
+  color: var(--campaign-foreground, #f5f7fb);
+  padding: 2rem;
+  border-radius: 1.5rem;
+  box-shadow: 0 24px 48px rgba(4, 8, 20, 0.35);
+}
+
+.campaign-progress__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  align-items: flex-start;
+}
+
+.campaign-progress__header h2 {
+  margin: 0;
+  font-size: 1.75rem;
+  letter-spacing: 0.02em;
+}
+
+.campaign-progress__header p {
+  margin: 0.5rem 0 0;
+  max-width: 32rem;
+  color: rgba(245, 247, 251, 0.75);
+}
+
+.campaign-progress__meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, max-content));
+  gap: 0.75rem 2.5rem;
+  margin: 0;
+}
+
+.campaign-progress__meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.campaign-progress__meta dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(245, 247, 251, 0.6);
+}
+
+.campaign-progress__meta dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.campaign-progress__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: 1rem;
+}
+
+.campaign-progress__card {
+  background: rgba(18, 25, 40, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.campaign-progress__card h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(245, 247, 251, 0.68);
+}
+
+.campaign-progress__value {
+  margin: 0;
+  font-size: 1.8rem;
+  font-weight: 600;
+}
+
+.campaign-progress__caption {
+  margin: 0;
+  color: rgba(245, 247, 251, 0.65);
+}
+
+.campaign-progress__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 2.3fr);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.campaign-progress__panel {
+  background: rgba(16, 22, 34, 0.88);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.campaign-progress__panel--highlights {
+  grid-column: span 2;
+}
+
+.campaign-progress__panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.campaign-progress__panel-header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.campaign-progress__panel-header p {
+  margin: 0.35rem 0 0;
+  color: rgba(245, 247, 251, 0.65);
+}
+
+.campaign-progress__panel-meta {
+  font-size: 0.8rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(77, 161, 255, 0.18);
+  color: #74b6ff;
+  align-self: center;
+}
+
+.funnel {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.funnel__stage {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.funnel__bar {
+  --base-color: rgba(82, 156, 255, 0.3);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, max-content));
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  position: relative;
+  background: linear-gradient(
+    135deg,
+    rgba(82, 156, 255, 0.28),
+    rgba(82, 156, 255, 0.08)
+  );
+  border: 1px solid rgba(82, 156, 255, 0.25);
+  overflow: hidden;
+}
+
+.funnel__bar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform-origin: left;
+  transform: scaleX(calc(var(--width) / 100));
+  background: radial-gradient(circle at top left, rgba(82, 156, 255, 0.65), rgba(82, 156, 255, 0.2));
+  opacity: 0.85;
+  border-radius: inherit;
+  z-index: 0;
+}
+
+.funnel__bar > * {
+  position: relative;
+  z-index: 1;
+}
+
+.funnel__bar strong {
+  font-size: 1.05rem;
+}
+
+.funnel__metric {
+  font-weight: 600;
+}
+
+.funnel__footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: rgba(245, 247, 251, 0.75);
+}
+
+.funnel__delta--up {
+  color: #78ffcc;
+}
+
+.funnel__delta--down {
+  color: #ff7a85;
+}
+
+.funnel__empty {
+  text-align: center;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(245, 247, 251, 0.6);
+}
+
+.heatmap table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0.35rem;
+}
+
+.heatmap th,
+.heatmap td {
+  padding: 0.75rem;
+  text-align: center;
+  border-radius: 0.75rem;
+}
+
+.heatmap thead th {
+  font-size: 0.85rem;
+  color: rgba(245, 247, 251, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.heatmap tbody th {
+  text-align: left;
+  font-weight: 600;
+}
+
+.heatmap td {
+  background: rgba(98, 105, 140, calc(0.25 + var(--intensity) * 0.65));
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  color: #f5f7fb;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.heatmap__value {
+  font-weight: 600;
+}
+
+.heatmap__empty td {
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(245, 247, 251, 0.6);
+}
+
+.highlights {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
+
+.highlights__item {
+  background: rgba(22, 30, 46, 0.85);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.highlights__item h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.highlights__item p {
+  margin: 0;
+  color: rgba(245, 247, 251, 0.7);
+}
+
+.highlights__item footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: rgba(245, 247, 251, 0.6);
+}
+
+@media (max-width: 1180px) {
+  .campaign-progress__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .campaign-progress__panel--highlights {
+    grid-column: auto;
+  }
+
+  .campaign-progress__header {
+    flex-direction: column;
+  }
+
+  .campaign-progress__meta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+</style>

--- a/config/access.yaml
+++ b/config/access.yaml
@@ -1,0 +1,23 @@
+roles:
+  analytics.viewer:
+    description: Accesso in sola lettura alle dashboard analytics.
+    grants:
+      - view: dashboards/campaign-progress
+  analytics.operator:
+    description: Gestione pipeline ETL analytics.
+    inherits:
+      - analytics.viewer
+    grants:
+      - execute: etl/campaign-progress
+
+views:
+  dashboards/campaign-progress:
+    description: Vista Campaign Progress con funnel e heatmap.
+    requiredRoles:
+      - analytics.viewer
+
+jobs:
+  etl/campaign-progress:
+    description: Pipeline ETL per sincronizzare il dataset Campaign Progress.
+    requiredRoles:
+      - analytics.operator

--- a/scripts/etl/campaign_progress.py
+++ b/scripts/etl/campaign_progress.py
@@ -1,0 +1,337 @@
+"""Pipeline ETL per la dashboard Campaign Progress."""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+DATE_INPUT_FORMATS = ("%Y-%m-%d", "%d/%m/%Y", "%Y%m%d")
+DEFAULT_OUTPUT_PATH = Path("data/derived/analytics/campaign_progress.json")
+STAGE_ORDER = (
+    "awareness",
+    "consideration",
+    "evaluation",
+    "activation",
+    "retention",
+)
+
+
+class CampaignProgressError(RuntimeError):
+    """Errore generico dell'ETL campaign progress."""
+
+
+@dataclass(frozen=True)
+class CampaignRecord:
+    """Record normalizzato per la pipeline campaign progress."""
+
+    campaign: str
+    stage: str
+    channel: str
+    period: str
+    leads: int
+    conversions: int
+    report_date: date
+    momentum: float = 0.0
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, Any]) -> "CampaignRecord":
+        try:
+            campaign = str(mapping["campaign"]).strip()
+        except KeyError as exc:  # pragma: no cover - sicurezza input
+            raise CampaignProgressError("Record privo del campo 'campaign'") from exc
+        if not campaign:
+            raise CampaignProgressError("Il campo 'campaign' non può essere vuoto")
+
+        try:
+            stage = str(mapping["stage"]).strip()
+        except KeyError as exc:  # pragma: no cover - sicurezza input
+            raise CampaignProgressError("Record privo del campo 'stage'") from exc
+        if not stage:
+            raise CampaignProgressError("Il campo 'stage' non può essere vuoto")
+
+        try:
+            channel = str(mapping["channel"]).strip()
+        except KeyError as exc:  # pragma: no cover - sicurezza input
+            raise CampaignProgressError("Record privo del campo 'channel'") from exc
+        if not channel:
+            raise CampaignProgressError("Il campo 'channel' non può essere vuoto")
+
+        period = str(mapping.get("period", "")) or "N/D"
+
+        leads = _ensure_int(mapping, "leads")
+        conversions = _ensure_int(mapping, "conversions")
+
+        if conversions > leads:
+            raise CampaignProgressError(
+                f"Le conversioni ({conversions}) non possono superare le lead ({leads})"
+            )
+
+        report_date_raw = mapping.get("report_date") or mapping.get("date")
+        if report_date_raw is None:
+            raise CampaignProgressError("Record privo della data di report")
+        report_date = _parse_date(report_date_raw)
+
+        momentum_raw = mapping.get("momentum", 0)
+        try:
+            momentum = float(momentum_raw)
+        except (TypeError, ValueError):
+            raise CampaignProgressError(f"Momentum non numerico: {momentum_raw!r}") from None
+
+        return cls(
+            campaign=campaign,
+            stage=stage,
+            channel=channel,
+            period=period,
+            leads=leads,
+            conversions=conversions,
+            report_date=report_date,
+            momentum=momentum,
+        )
+
+
+def _ensure_int(mapping: Mapping[str, Any], field: str) -> int:
+    try:
+        value = int(mapping[field])
+    except KeyError as exc:  # pragma: no cover - sicurezza input
+        raise CampaignProgressError(f"Record privo del campo '{field}'") from exc
+    except (TypeError, ValueError) as exc:
+        raise CampaignProgressError(f"Valore non numerico per '{field}': {mapping[field]!r}") from exc
+    if value < 0:
+        raise CampaignProgressError(f"Il campo '{field}' non può essere negativo: {value}")
+    return value
+
+
+def _parse_date(raw: Any) -> date:
+    if isinstance(raw, date):
+        return raw
+    if isinstance(raw, datetime):
+        return raw.date()
+    if not isinstance(raw, str):  # pragma: no cover - sicurezza input
+        raise CampaignProgressError(f"Formato data non supportato: {raw!r}")
+    raw = raw.strip()
+    for fmt in DATE_INPUT_FORMATS:
+        try:
+            return datetime.strptime(raw, fmt).date()
+        except ValueError:
+            continue
+    raise CampaignProgressError(f"Formato data non riconosciuto: {raw!r}")
+
+
+def load_campaign_records(path: Path) -> List[CampaignRecord]:
+    """Carica i record da un file CSV o JSON."""
+
+    if not path.exists():
+        raise CampaignProgressError(f"Dataset inesistente: {path}")
+
+    if path.suffix.lower() == ".csv":
+        with path.open("r", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            return [CampaignRecord.from_mapping(row) for row in reader]
+
+    if path.suffix.lower() == ".json":
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        if isinstance(payload, Mapping):
+            records = payload.get("records")
+            if records is None:
+                raise CampaignProgressError("JSON privo della chiave 'records'")
+        elif isinstance(payload, list):
+            records = payload
+        else:
+            raise CampaignProgressError("Struttura JSON non supportata")
+        return [CampaignRecord.from_mapping(item) for item in records]
+
+    raise CampaignProgressError(f"Estensione file non supportata: {path.suffix}")
+
+
+def build_campaign_progress(records: Iterable[CampaignRecord]) -> Dict[str, Any]:
+    """Aggrega i record in un payload per la dashboard."""
+
+    record_list = list(records)
+    if not record_list:
+        raise CampaignProgressError("Nessun record disponibile per generare il report")
+
+    stages: Dict[str, Dict[str, float]] = {}
+    channels: Dict[str, Dict[str, float]] = {}
+    campaigns = {record.campaign for record in record_list}
+
+    for record in record_list:
+        stage_key = record.stage.lower()
+        stage_bucket = stages.setdefault(
+            stage_key,
+            {
+                "id": stage_key,
+                "label": record.stage,
+                "leads": 0,
+                "conversions": 0,
+                "momentum": 0.0,
+            },
+        )
+        stage_bucket["leads"] += record.leads
+        stage_bucket["conversions"] += record.conversions
+        stage_bucket["momentum"] += record.momentum
+
+        channel_bucket = channels.setdefault(record.channel, {})
+        period_payload = channel_bucket.setdefault(record.period, {"leads": 0, "conversions": 0})
+        period_payload["leads"] += record.leads
+        period_payload["conversions"] += record.conversions
+
+    sorted_stages = sorted(
+        stages.values(),
+        key=lambda item: (
+            STAGE_ORDER.index(item["id"]) if item["id"] in STAGE_ORDER else len(STAGE_ORDER),
+            item["label"],
+        ),
+    )
+
+    funnel: List[Dict[str, Any]] = []
+    for index, stage in enumerate(sorted_stages):
+        leads = int(stage["leads"])
+        conversions = int(stage["conversions"])
+        previous = funnel[index - 1] if index > 0 else None
+        drop_off_base = (previous["conversions"] if previous else leads) or (previous["leads"] if previous else leads)
+        drop_off_rate = 0.0
+        if previous and drop_off_base:
+            drop_off_rate = max(0.0, 1 - leads / drop_off_base)
+        conversion_rate = conversions / leads if leads else 0.0
+        stage_momentum = stage["momentum"]
+        funnel.append(
+            {
+                "id": stage["id"],
+                "label": stage["label"],
+                "leads": leads,
+                "conversions": conversions,
+                "conversionRate": round(conversion_rate, 4),
+                "dropOffRate": round(drop_off_rate, 4),
+                "delta": round(stage_momentum, 4),
+            }
+        )
+
+    periods = sorted({period for bucket in channels.values() for period in bucket})
+    channel_rows: List[Dict[str, Any]] = []
+    for channel_name, bucket in sorted(channels.items()):
+        channel_rows.append(
+            {
+                "channel": channel_name,
+                "values": [
+                    _compute_rate(bucket.get(period, {"leads": 0, "conversions": 0})) for period in periods
+                ],
+                "leads": [
+                    int(bucket.get(period, {"leads": 0})["leads"]) for period in periods
+                ],
+            }
+        )
+
+    total_leads = sum(record.leads for record in record_list)
+    total_conversions = sum(record.conversions for record in record_list)
+    conversion_rate = total_conversions / total_leads if total_leads else 0.0
+    avg_momentum = (
+        sum(stage["delta"] for stage in funnel) / len(funnel)
+        if funnel
+        else 0.0
+    )
+    last_report = max(record.report_date for record in record_list)
+
+    highlights = _build_highlights(record_list)
+
+    return {
+        "generatedAt": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "summary": {
+            "activeCampaigns": len(campaigns),
+            "totalLeads": total_leads,
+            "totalConversions": total_conversions,
+            "conversionRate": round(conversion_rate, 4),
+            "targetConversionRate": round(conversion_rate - avg_momentum, 4),
+            "lastUpdated": last_report.isoformat(),
+        },
+        "funnel": funnel,
+        "heatmap": {
+            "periods": periods,
+            "channels": [row["channel"] for row in channel_rows],
+            "values": [row["values"] for row in channel_rows],
+            "leads": [row["leads"] for row in channel_rows],
+        },
+        "highlights": highlights,
+    }
+
+
+def _build_highlights(records: Iterable[CampaignRecord]) -> List[Dict[str, Any]]:
+    grouped: Dict[str, Dict[str, Any]] = {}
+    for record in records:
+        key = f"{record.campaign}:{record.stage}"
+        payload = grouped.setdefault(
+            key,
+            {
+                "id": key,
+                "title": record.campaign,
+                "owner": record.channel,
+                "description": f"Stage {record.stage} — period {record.period}",
+                "momentum": 0.0,
+                "leadTotal": 0,
+                "conversionTotal": 0,
+            },
+        )
+        payload["momentum"] += record.momentum
+        payload["leadTotal"] += record.leads
+        payload["conversionTotal"] += record.conversions
+    highlights = []
+    for payload in grouped.values():
+        conversion_rate = (
+            payload["conversionTotal"] / payload["leadTotal"]
+            if payload["leadTotal"]
+            else 0.0
+        )
+        highlights.append(
+            {
+                "id": payload["id"],
+                "title": payload["title"],
+                "description": payload["description"],
+                "owner": payload["owner"],
+                "eta": None,
+                "momentum": round(payload["momentum"], 4),
+                "conversionRate": round(conversion_rate, 4),
+            }
+        )
+    return sorted(highlights, key=lambda item: item["momentum"], reverse=True)
+
+
+def _compute_rate(payload: Mapping[str, float]) -> float:
+    leads = float(payload.get("leads", 0) or 0)
+    conversions = float(payload.get("conversions", 0) or 0)
+    if leads <= 0:
+        return 0.0
+    return round(conversions / leads, 4)
+
+
+def write_snapshot(payload: Mapping[str, Any], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Genera il dataset campaign progress consolidato")
+    parser.add_argument("input", type=Path, help="Percorso del dataset (CSV o JSON)")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help=f"Percorso di scrittura (default: {DEFAULT_OUTPUT_PATH})",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    records = load_campaign_records(args.input)
+    payload = build_campaign_progress(records)
+    write_snapshot(payload, args.output)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point CLI
+    raise SystemExit(main())

--- a/tests/analytics/__snapshots__/campaignProgress.test.ts.snap
+++ b/tests/analytics/__snapshots__/campaignProgress.test.ts.snap
@@ -1,0 +1,156 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CampaignProgress dashboard > renderizza layout funnel e heatmap coerente 1`] = `
+"<section data-v-adbb7110="" class="campaign-progress">
+  <header data-v-adbb7110="" class="campaign-progress__header">
+    <div data-v-adbb7110="">
+      <h2 data-v-adbb7110="">Progressione campagna</h2>
+      <p data-v-adbb7110=""> Monitoraggio continuo del funnel di conversione e della reattività dei canali operativi per la campagna in corso. </p>
+    </div>
+    <dl data-v-adbb7110="" class="campaign-progress__meta">
+      <div data-v-adbb7110="">
+        <dt data-v-adbb7110="">Ultimo aggiornamento</dt>
+        <dd data-v-adbb7110="">05 ott 2024, 10:30</dd>
+      </div>
+      <div data-v-adbb7110="">
+        <dt data-v-adbb7110="">Campagne attive</dt>
+        <dd data-v-adbb7110="">3</dd>
+      </div>
+    </dl>
+  </header>
+  <section data-v-adbb7110="" class="campaign-progress__summary">
+    <article data-v-adbb7110="" class="campaign-progress__card">
+      <h3 data-v-adbb7110="">Lead totali</h3>
+      <p data-v-adbb7110="" class="campaign-progress__value">12.840</p>
+      <p data-v-adbb7110="" class="campaign-progress__caption">Totale opportunità raccolte nel periodo</p>
+    </article>
+    <article data-v-adbb7110="" class="campaign-progress__card">
+      <h3 data-v-adbb7110="">Tasso di conversione</h3>
+      <p data-v-adbb7110="" class="campaign-progress__value">24.7%</p>
+      <p data-v-adbb7110="" class="campaign-progress__caption"> Target: 22.8% · 1.9% sopra target</p>
+    </article>
+    <article data-v-adbb7110="" class="campaign-progress__card">
+      <h3 data-v-adbb7110="">Momentum medio</h3>
+      <p data-v-adbb7110="" class="campaign-progress__value">5.0%</p>
+      <p data-v-adbb7110="" class="campaign-progress__caption">Var. media giornaliera sul funnel</p>
+    </article>
+    <article data-v-adbb7110="" class="campaign-progress__card">
+      <h3 data-v-adbb7110="">Segmento top</h3>
+      <p data-v-adbb7110="" class="campaign-progress__value">Campaign Alpha</p>
+      <p data-v-adbb7110="" class="campaign-progress__caption">Owner: Email</p>
+    </article>
+  </section>
+  <div data-v-adbb7110="" class="campaign-progress__layout">
+    <section data-v-adbb7110="" class="campaign-progress__panel campaign-progress__panel--funnel">
+      <header data-v-adbb7110="" class="campaign-progress__panel-header">
+        <div data-v-adbb7110="">
+          <h3 data-v-adbb7110="">Funnel di conversione</h3>
+          <p data-v-adbb7110="">Analisi dei passaggi dalla scoperta alla fidelizzazione.</p>
+        </div><span data-v-adbb7110="" class="campaign-progress__panel-meta">5 stadi</span>
+      </header>
+      <ol data-v-adbb7110="" class="funnel">
+        <li data-v-adbb7110="" class="funnel__stage">
+          <div data-v-adbb7110="" class="funnel__bar" style="--width: 100%; --index: 0;"><strong data-v-adbb7110="">Awareness</strong><span data-v-adbb7110="" class="funnel__metric">12.840 lead</span><span data-v-adbb7110="" class="funnel__metric">53.3% conv.</span></div>
+          <footer data-v-adbb7110="" class="funnel__footer"><span data-v-adbb7110="">Drop-off: 0.0%</span><span data-v-adbb7110="" class="funnel__delta--up">▲ 8.0%</span></footer>
+        </li>
+        <li data-v-adbb7110="" class="funnel__stage">
+          <div data-v-adbb7110="" class="funnel__bar" style="--width: 53.271028037383175%; --index: 1;"><strong data-v-adbb7110="">Considerazione</strong><span data-v-adbb7110="" class="funnel__metric">6840 lead</span><span data-v-adbb7110="" class="funnel__metric">51.5% conv.</span></div>
+          <footer data-v-adbb7110="" class="funnel__footer"><span data-v-adbb7110="">Drop-off: 0.0%</span><span data-v-adbb7110="" class="funnel__delta--up">▲ 4.0%</span></footer>
+        </li>
+        <li data-v-adbb7110="" class="funnel__stage">
+          <div data-v-adbb7110="" class="funnel__bar" style="--width: 27.41433021806853%; --index: 2;"><strong data-v-adbb7110="">Valutazione</strong><span data-v-adbb7110="" class="funnel__metric">3520 lead</span><span data-v-adbb7110="" class="funnel__metric">52.8% conv.</span></div>
+          <footer data-v-adbb7110="" class="funnel__footer"><span data-v-adbb7110="">Drop-off: 0.0%</span><span data-v-adbb7110="" class="funnel__delta--up">▲ 2.0%</span></footer>
+        </li>
+        <li data-v-adbb7110="" class="funnel__stage">
+          <div data-v-adbb7110="" class="funnel__bar" style="--width: 14.485981308411214%; --index: 3;"><strong data-v-adbb7110="">Attivazione</strong><span data-v-adbb7110="" class="funnel__metric">1860 lead</span><span data-v-adbb7110="" class="funnel__metric">52.7% conv.</span></div>
+          <footer data-v-adbb7110="" class="funnel__footer"><span data-v-adbb7110="">Drop-off: 0.0%</span><span data-v-adbb7110="" class="funnel__delta--down">▼ 1.0%</span></footer>
+        </li>
+        <li data-v-adbb7110="" class="funnel__stage">
+          <div data-v-adbb7110="" class="funnel__bar" style="--width: 12%; --index: 4;"><strong data-v-adbb7110="">Fidelizzazione</strong><span data-v-adbb7110="" class="funnel__metric">980 lead</span><span data-v-adbb7110="" class="funnel__metric">62.2% conv.</span></div>
+          <footer data-v-adbb7110="" class="funnel__footer"><span data-v-adbb7110="">Drop-off: 0.0%</span><span data-v-adbb7110="" class="funnel__delta--up">▲ 3.0%</span></footer>
+        </li>
+        <!--v-if-->
+      </ol>
+    </section>
+    <section data-v-adbb7110="" class="campaign-progress__panel campaign-progress__panel--heatmap">
+      <header data-v-adbb7110="" class="campaign-progress__panel-header">
+        <div data-v-adbb7110="">
+          <h3 data-v-adbb7110="">Heatmap canali</h3>
+          <p data-v-adbb7110="">Intensità settimanale dei touchpoint attivati per segmento.</p>
+        </div><span data-v-adbb7110="" class="campaign-progress__panel-meta">4 periodi</span>
+      </header>
+      <div data-v-adbb7110="" class="heatmap">
+        <table data-v-adbb7110="">
+          <thead data-v-adbb7110="">
+            <tr data-v-adbb7110="">
+              <th data-v-adbb7110="">Segmento</th>
+              <th data-v-adbb7110="">Settimana 1</th>
+              <th data-v-adbb7110="">Settimana 2</th>
+              <th data-v-adbb7110="">Settimana 3</th>
+              <th data-v-adbb7110="">Settimana 4</th>
+            </tr>
+          </thead>
+          <tbody data-v-adbb7110="">
+            <tr data-v-adbb7110="">
+              <th data-v-adbb7110="" scope="row">Email</th>
+              <td data-v-adbb7110="" style="--intensity: 0.23;"><span data-v-adbb7110="" class="heatmap__value">41.0%</span><small data-v-adbb7110="">520 lead</small></td>
+              <td data-v-adbb7110="" style="--intensity: 0.37;"><span data-v-adbb7110="" class="heatmap__value">46.0%</span><small data-v-adbb7110="">610 lead</small></td>
+              <td data-v-adbb7110="" style="--intensity: 0.51;"><span data-v-adbb7110="" class="heatmap__value">51.0%</span><small data-v-adbb7110="">690 lead</small></td>
+              <td data-v-adbb7110="" style="--intensity: 0.71;"><span data-v-adbb7110="" class="heatmap__value">58.0%</span><small data-v-adbb7110="">810 lead</small></td>
+            </tr>
+            <tr data-v-adbb7110="">
+              <th data-v-adbb7110="" scope="row">Social</th>
+              <td data-v-adbb7110="" style="--intensity: 0.14;"><span data-v-adbb7110="" class="heatmap__value">38.0%</span><small data-v-adbb7110="">480 lead</small></td>
+              <td data-v-adbb7110="" style="--intensity: 0.31;"><span data-v-adbb7110="" class="heatmap__value">44.0%</span><small data-v-adbb7110="">560 lead</small></td>
+              <td data-v-adbb7110="" style="--intensity: 0.43;"><span data-v-adbb7110="" class="heatmap__value">48.0%</span><small data-v-adbb7110="">640 lead</small></td>
+              <td data-v-adbb7110="" style="--intensity: 0.63;"><span data-v-adbb7110="" class="heatmap__value">55.0%</span><small data-v-adbb7110="">720 lead</small></td>
+            </tr>
+            <tr data-v-adbb7110="">
+              <th data-v-adbb7110="" scope="row">In-Game</th>
+              <td data-v-adbb7110="" style="--intensity: 0.54;"><span data-v-adbb7110="" class="heatmap__value">52.0%</span><small data-v-adbb7110="">690 lead</small></td>
+              <td data-v-adbb7110="" style="--intensity: 0.69;"><span data-v-adbb7110="" class="heatmap__value">57.0%</span><small data-v-adbb7110="">740 lead</small></td>
+              <td data-v-adbb7110="" style="--intensity: 0.80;"><span data-v-adbb7110="" class="heatmap__value">61.0%</span><small data-v-adbb7110="">810 lead</small></td>
+              <td data-v-adbb7110="" style="--intensity: 1.00;"><span data-v-adbb7110="" class="heatmap__value">68.0%</span><small data-v-adbb7110="">920 lead</small></td>
+            </tr>
+            <tr data-v-adbb7110="">
+              <th data-v-adbb7110="" scope="row">LiveOps</th>
+              <td data-v-adbb7110="" style="--intensity: 0.00;"><span data-v-adbb7110="" class="heatmap__value">33.0%</span><small data-v-adbb7110="">320 lead</small></td>
+              <td data-v-adbb7110="" style="--intensity: 0.17;"><span data-v-adbb7110="" class="heatmap__value">39.0%</span><small data-v-adbb7110="">380 lead</small></td>
+              <td data-v-adbb7110="" style="--intensity: 0.31;"><span data-v-adbb7110="" class="heatmap__value">44.0%</span><small data-v-adbb7110="">450 lead</small></td>
+              <td data-v-adbb7110="" style="--intensity: 0.46;"><span data-v-adbb7110="" class="heatmap__value">49.0%</span><small data-v-adbb7110="">500 lead</small></td>
+            </tr>
+            <!--v-if-->
+          </tbody>
+        </table>
+      </div>
+    </section>
+    <section data-v-adbb7110="" class="campaign-progress__panel campaign-progress__panel--highlights">
+      <header data-v-adbb7110="" class="campaign-progress__panel-header">
+        <div data-v-adbb7110="">
+          <h3 data-v-adbb7110="">Focus e follow-up</h3>
+          <p data-v-adbb7110="">Azioni prioritarie con ownership definita.</p>
+        </div><span data-v-adbb7110="" class="campaign-progress__panel-meta">3 elementi</span>
+      </header>
+      <ul data-v-adbb7110="" class="highlights">
+        <li data-v-adbb7110="" class="highlights__item">
+          <h4 data-v-adbb7110="">Campaign Alpha</h4>
+          <p data-v-adbb7110="">Stage awareness — period Settimana 4</p>
+          <footer data-v-adbb7110=""><span data-v-adbb7110="" class="highlights__owner">Owner: Email</span><span data-v-adbb7110="" class="highlights__eta">ETA: Sprint 42</span></footer>
+        </li>
+        <li data-v-adbb7110="" class="highlights__item">
+          <h4 data-v-adbb7110="">Campaign Beta</h4>
+          <p data-v-adbb7110="">Stage evaluation — period Settimana 3</p>
+          <footer data-v-adbb7110=""><span data-v-adbb7110="" class="highlights__owner">Owner: In-Game</span><span data-v-adbb7110="" class="highlights__eta">ETA: Sprint 43</span></footer>
+        </li>
+        <li data-v-adbb7110="" class="highlights__item">
+          <h4 data-v-adbb7110="">Campaign Gamma</h4>
+          <p data-v-adbb7110="">Stage activation — period Settimana 2</p>
+          <footer data-v-adbb7110=""><span data-v-adbb7110="" class="highlights__owner">Owner: LiveOps</span>
+            <!--v-if-->
+          </footer>
+        </li>
+      </ul>
+    </section>
+  </div>
+</section>"
+`;

--- a/tests/analytics/campaignProgress.test.ts
+++ b/tests/analytics/campaignProgress.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import CampaignProgress from '../../analytics/dashboards/campaignProgress.vue';
+
+describe('CampaignProgress dashboard', () => {
+  it('renderizza layout funnel e heatmap coerente', () => {
+    const wrapper = mount(CampaignProgress, {
+      props: {
+        summary: {
+          activeCampaigns: 3,
+          totalLeads: 12840,
+          conversionRate: 0.247,
+          targetConversionRate: 0.228,
+          lastUpdated: '2024-10-05T10:30:00Z',
+        },
+        funnel: [
+          { id: 'awareness', label: 'Awareness', leads: 12840, conversions: 6840, delta: 0.08 },
+          { id: 'consideration', label: 'Considerazione', leads: 6840, conversions: 3520, delta: 0.04 },
+          { id: 'evaluation', label: 'Valutazione', leads: 3520, conversions: 1860, delta: 0.02 },
+          { id: 'activation', label: 'Attivazione', leads: 1860, conversions: 980, delta: -0.01 },
+          { id: 'retention', label: 'Fidelizzazione', leads: 980, conversions: 610, delta: 0.03 },
+        ],
+        heatmap: {
+          periods: ['Settimana 1', 'Settimana 2', 'Settimana 3', 'Settimana 4'],
+          channels: ['Email', 'Social', 'In-Game', 'LiveOps'],
+          values: [
+            [0.41, 0.46, 0.51, 0.58],
+            [0.38, 0.44, 0.48, 0.55],
+            [0.52, 0.57, 0.61, 0.68],
+            [0.33, 0.39, 0.44, 0.49],
+          ],
+          leads: [
+            [520, 610, 690, 810],
+            [480, 560, 640, 720],
+            [690, 740, 810, 920],
+            [320, 380, 450, 500],
+          ],
+        },
+        highlights: [
+          {
+            id: 'campaign-alpha:awareness',
+            title: 'Campaign Alpha',
+            description: 'Stage awareness — period Settimana 4',
+            owner: 'Email',
+            eta: 'Sprint 42',
+            momentum: 0.12,
+          },
+          {
+            id: 'campaign-beta:evaluation',
+            title: 'Campaign Beta',
+            description: 'Stage evaluation — period Settimana 3',
+            owner: 'In-Game',
+            eta: 'Sprint 43',
+            momentum: 0.06,
+          },
+          {
+            id: 'campaign-gamma:activation',
+            title: 'Campaign Gamma',
+            description: 'Stage activation — period Settimana 2',
+            owner: 'LiveOps',
+            momentum: -0.03,
+          },
+        ],
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+});

--- a/webapp/vitest.config.ts
+++ b/webapp/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    include: ['tests/**/*.spec.ts', '../tests/webapp/**/*.spec.ts'],
+    include: ['tests/**/*.spec.ts', '../tests/webapp/**/*.spec.ts', '../tests/analytics/**/*.test.ts'],
     root: __dirname,
   },
 });


### PR DESCRIPTION
## Summary
- add a Campaign Progress dashboard layout with funnel, heatmap and highlights
- configure the campaign_progress ETL pipeline and wire access control for the new view
- cover the dashboard with a Vitest snapshot and include it in the webapp test suite

## Testing
- npm --prefix webapp run test -- --run --update

------
https://chatgpt.com/codex/tasks/task_e_6904d947bca883328f0e4dbd4d1010fe