### PR TITLE
Add offline telemetry fallback for Nebula module

### DIFF
--- a/tests/webapp/NebulaAtlasView.spec.ts
+++ b/tests/webapp/NebulaAtlasView.spec.ts
@@ -60,6 +60,7 @@ describe('NebulaAtlasView', () => {
     const originalFetch = global.fetch;
     const fetchStub = createFetchStub();
     global.fetch = fetchStub;
+    const dateSpy = vi.spyOn(Date, 'now').mockReturnValue(new Date('2024-05-18T11:00:00Z').getTime());
 
     try {
       const wrapper = mount(NebulaAtlasView, {
@@ -85,6 +86,7 @@ describe('NebulaAtlasView', () => {
       expect(fetchStub).toHaveBeenCalled();
     } finally {
       global.fetch = originalFetch;
+      dateSpy.mockRestore();
     }
   });
 });

--- a/tests/webapp/__snapshots__/NebulaAtlasView.spec.ts.snap
+++ b/tests/webapp/__snapshots__/NebulaAtlasView.spec.ts.snap
@@ -2,14 +2,14 @@
 
 exports[`NebulaAtlasView > renderizza indicatori live e snapshot coerente 1`] = `
 "<section data-v-43e6e8ac="" class="nebula-atlas-view">
-  <section data-v-43e6e8ac="" class="stub-progress" header="[object Object]" cards="[object Object]" timeline-entries="[object Object]" evolution-matrix="[object Object]" share="[object Object]">progress</section>
+  <section data-v-43e6e8ac="" class="stub-progress" header="[object Object]" cards="[object Object]" timeline-entries="[object Object]" evolution-matrix="[object Object]" share="[object Object]" telemetry-status="[object Object]">progress</section>
   <section data-v-43e6e8ac="" class="nebula-atlas-view__live" aria-live="polite">
     <header data-v-43e6e8ac="" class="nebula-atlas-view__live-header">
       <div data-v-43e6e8ac="">
         <h3 data-v-43e6e8ac="">Telemetria live</h3>
         <p data-v-43e6e8ac="">Indicatori dal generatore Nebula combinati con il dataset atlas.</p>
       </div>
-      <div data-v-43e6e8ac="" class="nebula-atlas-view__status"><span data-v-43e6e8ac="" class="nebula-atlas-view__badge">Aggiornamento…</span><small data-v-43e6e8ac="">Ultimo sync: —</small></div>
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__status"><span data-v-43e6e8ac="" class="nebula-atlas-view__badge" data-tone="warning">Sync 30 min fa</span><small data-v-43e6e8ac="">Ultimo sync: 2024-05-18T10:45:00Z</small></div>
     </header>
     <div data-v-43e6e8ac="" class="nebula-atlas-view__error" role="status"></div>
     <footer data-v-43e6e8ac="" class="nebula-atlas-view__footer"><span data-v-43e6e8ac=""></span><button data-v-43e6e8ac="" type="button" class="nebula-atlas-view__refresh">Aggiorna ora</button></footer>

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -11,3 +11,10 @@ La dashboard viene distribuita con Vite e supporta il deploy su hosting statico.
 Il file di fallback di default (`demo/flow-shell-snapshot.json`) è incluso in `webapp/public/demo/`, quindi viene copiato automaticamente in fase di build e servito in base al valore di `import.meta.env.BASE_URL`. Quando `base` è relativo (ad esempio `vite build --base=./`), il loader prova per prima cosa il fallback locale e registra nei log il passaggio allo snapshot statico prima di contattare l'endpoint remoto. Lo stesso meccanismo è disponibile per gli altri servizi (generazione, anteprime, validatori, quality release, trait diagnostics, modulo Nebula) con i JSON presenti sotto `webapp/public/api-mock/`. È possibile sostituire i file oppure puntare a percorsi personalizzati tramite le opzioni dei singoli store/servizi.
 
 Per deploy statici è sufficiente mantenere `base: './'` in `vite.config.ts` (o passare `--base=./` al comando di build) così che tutti gli asset, inclusi quelli nella cartella `public/`, vengano risolti in maniera relativa.
+
+## Telemetria Nebula offline
+
+Il modulo Nebula ora include un payload di telemetria mock (`public/nebula/telemetry.json`) che viene caricato automaticamente
+quando la fetch remota fallisce. In questo scenario l'interfaccia mostra badge "offline/demo" su sparkline, readiness chips e
+progress bar evolutive per distinguere i dati mock dai dati live. L'intervallo di polling può essere personalizzato passando
+`pollIntervalMs` a `useNebulaProgressModule`; per impostazione predefinita il modulo effettua un aggiornamento ogni 15 secondi.

--- a/webapp/public/nebula/telemetry.json
+++ b/webapp/public/nebula/telemetry.json
@@ -1,0 +1,36 @@
+{
+  "summary": {
+    "totalEvents": 42,
+    "openEvents": 1,
+    "acknowledgedEvents": 38,
+    "highPriorityEvents": 3,
+    "lastEventAt": "2024-05-18T09:45:00Z"
+  },
+  "coverage": {
+    "average": 78,
+    "history": [62, 68, 73, 78],
+    "distribution": {
+      "success": 3,
+      "warning": 2,
+      "neutral": 1,
+      "critical": 0
+    }
+  },
+  "incidents": {
+    "timeline": [
+      { "date": "2024-05-12", "total": 2, "highPriority": 1 },
+      { "date": "2024-05-13", "total": 1, "highPriority": 0 },
+      { "date": "2024-05-14", "total": 0, "highPriority": 0 },
+      { "date": "2024-05-15", "total": 3, "highPriority": 1 },
+      { "date": "2024-05-16", "total": 1, "highPriority": 0 },
+      { "date": "2024-05-17", "total": 2, "highPriority": 1 },
+      { "date": "2024-05-18", "total": 1, "highPriority": 0 }
+    ]
+  },
+  "updatedAt": "2024-05-18T10:15:00Z",
+  "sample": [
+    { "id": "nebula-alpha", "label": "Sync QA freeze completato", "severity": "info" },
+    { "id": "mist-reclaimer", "label": "Validazione metabolica demo", "severity": "success" },
+    { "id": "veil-harbinger", "label": "Scenario narrativo in mock", "severity": "warning" }
+  ]
+}

--- a/webapp/src/components/flow/NebulaProgressModule.vue
+++ b/webapp/src/components/flow/NebulaProgressModule.vue
@@ -35,20 +35,38 @@
 
     <div class="nebula-progress__grid">
       <NebulaProgressTimeline :entries="timelineEntries" />
-      <section class="nebula-progress__telemetry">
+      <section class="nebula-progress__telemetry" :data-mode="telemetryStatus.offline ? 'demo' : 'live'">
         <header>
           <h3>Progress bar evolutiva</h3>
           <p>Telemetria &amp; readiness sincronizzate con orchestrator.</p>
+          <span
+            v-if="telemetryStatus.offline"
+            class="nebula-progress__badge nebula-progress__badge--demo"
+            data-tone="offline"
+          >
+            {{ telemetryStatus.label }}
+          </span>
         </header>
         <ul>
-          <li v-for="entry in evolutionMatrix" :key="entry.id">
+          <li v-for="entry in evolutionMatrix" :key="entry.id" :data-mode="entry.telemetryMode === 'live' ? 'live' : 'demo'">
             <header class="nebula-progress__telemetry-header">
               <span class="nebula-progress__species">{{ entry.name }}</span>
               <span class="nebula-progress__badge" :data-tone="entry.readinessTone">
                 {{ entry.stage }} · {{ entry.readiness }}
               </span>
+              <span
+                v-if="entry.telemetryMode !== 'live'"
+                class="nebula-progress__badge nebula-progress__badge--demo"
+                data-tone="offline"
+              >
+                Demo
+              </span>
             </header>
-            <SparklineChart :points="entry.telemetryHistory" :color="sparklineColor(entry.readinessTone)" />
+            <SparklineChart
+              :points="entry.telemetryHistory"
+              :color="sparklineColor(entry.readinessTone)"
+              :variant="entry.telemetryMode !== 'live' ? 'demo' : 'live'"
+            />
             <div class="nebula-progress__evolution">
               <div class="nebula-progress__evolution-fill" :style="{ width: `${entry.telemetryCoverage}%` }"></div>
               <span class="nebula-progress__evolution-label">{{ entry.telemetryLabel }}</span>
@@ -95,6 +113,10 @@ const props = defineProps({
   share: {
     type: Object,
     required: true,
+  },
+  telemetryStatus: {
+    type: Object,
+    default: () => ({ mode: 'live', offline: false, label: 'Telemetry live', variant: 'live' }),
   },
 });
 
@@ -306,6 +328,11 @@ function sparklineColor(tone) {
   gap: 1rem;
 }
 
+.nebula-progress__telemetry[data-mode='demo'] {
+  border-color: rgba(244, 192, 96, 0.4);
+  background: rgba(10, 15, 22, 0.55);
+}
+
 .nebula-progress__telemetry header h3 {
   margin: 0;
   text-transform: uppercase;
@@ -334,6 +361,12 @@ function sparklineColor(tone) {
   flex-wrap: wrap;
 }
 
+.nebula-progress__telemetry li[data-mode='demo'] {
+  border: 1px dashed rgba(244, 192, 96, 0.35);
+  border-radius: 14px;
+  padding: 1rem;
+}
+
 .nebula-progress__species {
   font-size: 1.05rem;
   font-weight: 600;
@@ -347,6 +380,17 @@ function sparklineColor(tone) {
   text-transform: uppercase;
   background: rgba(255, 255, 255, 0.08);
   border: 1px solid transparent;
+}
+
+.nebula-progress__badge[data-tone='offline'] {
+  border-color: rgba(244, 192, 96, 0.5);
+  color: rgba(255, 232, 198, 0.95);
+  background: rgba(244, 192, 96, 0.12);
+}
+
+.nebula-progress__badge--demo {
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
 }
 
 .nebula-progress__badge[data-tone='success'] {

--- a/webapp/src/components/shared/SparklineChart.vue
+++ b/webapp/src/components/shared/SparklineChart.vue
@@ -1,7 +1,7 @@
 <template>
   <svg
     v-if="points.length"
-    class="sparkline"
+    :class="['sparkline', variantClass]"
     :viewBox="`0 0 ${viewBoxWidth} ${viewBoxHeight}`"
     role="img"
     aria-label="Andamento metriche"
@@ -15,6 +15,7 @@
       :stroke-width="strokeWidth"
       stroke-linecap="round"
       stroke-linejoin="round"
+      :stroke-dasharray="variant === 'demo' ? '6 6' : undefined"
     />
     <circle
       v-if="lastPoint"
@@ -25,7 +26,7 @@
       :fill="color"
     />
   </svg>
-  <div v-else class="sparkline sparkline--empty" aria-hidden="true"></div>
+  <div v-else :class="['sparkline', 'sparkline--empty', variantClass]" aria-hidden="true"></div>
 </template>
 
 <script setup>
@@ -44,9 +45,15 @@ const props = defineProps({
     type: Number,
     default: 2,
   },
+  variant: {
+    type: String,
+    default: 'live',
+  },
 });
 
 const viewBoxHeight = 40;
+
+const variantClass = computed(() => (props.variant === 'demo' ? 'sparkline--demo' : ''));
 
 const validPoints = computed(() =>
   (props.points || [])
@@ -99,5 +106,14 @@ const lastPoint = computed(() => {
 .sparkline__pivot {
   stroke: rgba(5, 8, 13, 0.8);
   stroke-width: 1.25;
+}
+
+.sparkline--demo .sparkline__line {
+  filter: drop-shadow(0 0 4px rgba(244, 192, 96, 0.35));
+}
+
+.sparkline--demo .sparkline__pivot {
+  stroke: rgba(5, 8, 13, 0.6);
+  opacity: 0.85;
 }
 </style>


### PR DESCRIPTION
## Summary
- add a mock telemetry payload for Nebula and document the offline data behaviour
- extend the Nebula progress module to load the mock on failures and expose telemetry status metadata
- refresh UI components and tests to show offline/demo badges and styling when telemetry is not live

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6904dbd26ccc833291353388da68971c