### PR TITLE
Add telemetry-based item tuning CLI

### DIFF
--- a/data/telemetry/items.json
+++ b/data/telemetry/items.json
@@ -1,0 +1,55 @@
+{
+  "metadata": {
+    "season": "v0.9-playtest-05",
+    "generated_at": "2025-11-12T09:45:00Z",
+    "source": "playtest_telemetry_batch_512"
+  },
+  "rules": {
+    "defaults": {
+      "tolerance": 0.02,
+      "weight": 1
+    },
+    "metrics": {
+      "win_rate": { "tolerance": 0.015, "weight": 2.5 },
+      "pick_rate": { "tolerance": 0.01, "weight": 1.2 },
+      "avg_damage": { "tolerance": 12, "weight": 0.8 }
+    }
+  },
+  "items": [
+    {
+      "id": "ember_wand",
+      "name": "Ember Wand",
+      "role": "caster",
+      "rarity": "rare",
+      "notes": "Burst mage loadout underperforming in late game.",
+      "metrics": {
+        "win_rate": { "current": 0.46, "target": 0.52 },
+        "pick_rate": { "current": 0.11, "target": 0.14 },
+        "avg_damage": { "current": 118, "target": 140 }
+      }
+    },
+    {
+      "id": "glacial_aegis",
+      "name": "Glacial Aegis",
+      "role": "tank",
+      "rarity": "epic",
+      "metrics": {
+        "win_rate": { "current": 0.57, "target": 0.52 },
+        "pick_rate": { "current": 0.21, "target": 0.18 },
+        "avg_damage": { "current": 84, "target": 80 }
+      }
+    },
+    {
+      "id": "verdant_surge",
+      "name": "Verdant Surge",
+      "role": "support",
+      "rarity": "uncommon",
+      "notes": "Healing numbers inflated by duo queue stacking.",
+      "metrics": {
+        "win_rate": { "current": 0.51, "target": 0.5 },
+        "pick_rate": { "current": 0.19, "target": 0.17 },
+        "avg_damage": { "current": 63, "target": 60 }
+      }
+    }
+  ]
+}

--- a/logs/balance_proposals/items-2025-10-31T18-03-49.720Z-baseline.yaml
+++ b/logs/balance_proposals/items-2025-10-31T18-03-49.720Z-baseline.yaml
@@ -1,0 +1,156 @@
+summary:
+  generated_at: '2025-10-31T18:03:49.697Z'
+  dataset_generated_at: '2025-11-12T09:45:00Z'
+  season: v0.9-playtest-05
+  source_snapshot: playtest_telemetry_batch_512
+  items_considered: 3
+  total_score: 31.53
+  average_score: 10.51
+  defaults:
+    tolerance: 0.02
+    weight: 1
+  alerts:
+    - id: ember_wand
+      name: Ember Wand
+      peak_severity: critical
+      total_score: 15.07
+      suggested_direction: buff
+    - id: glacial_aegis
+      name: Glacial Aegis
+      peak_severity: critical
+      total_score: 12.2
+      suggested_direction: nerf
+    - id: verdant_surge
+      name: Verdant Surge
+      peak_severity: major
+      total_score: 4.2667
+      suggested_direction: nerf
+items:
+  - id: ember_wand
+    name: Ember Wand
+    role: caster
+    rarity: rare
+    notes: Burst mage loadout underperforming in late game.
+    summary:
+      peak_severity: critical
+      total_score: 15.07
+      suggested_direction: buff
+    metrics:
+      avg_damage:
+        current: 118
+        target: 140
+        delta: 22
+        delta_ratio: 0.1571
+        tolerance: 12
+        severity: moderate
+        action: buff
+        weight: 0.8
+        score: 1.4667
+        recommendation: Incrementare avg damage di 22 (2200%).
+      pick_rate:
+        current: 0.11
+        target: 0.14
+        delta: 0.03
+        delta_ratio: 0.2143
+        tolerance: 0.01
+        severity: critical
+        action: buff
+        weight: 1.2
+        score: 3.6
+        recommendation: Incrementare pick rate di 0.03 (3%).
+      win_rate:
+        current: 0.46
+        target: 0.52
+        delta: 0.06
+        delta_ratio: 0.1154
+        tolerance: 0.015
+        severity: critical
+        action: buff
+        weight: 2.5
+        score: 10
+        recommendation: Incrementare win rate di 0.06 (6%).
+  - id: glacial_aegis
+    name: Glacial Aegis
+    role: tank
+    rarity: epic
+    summary:
+      peak_severity: critical
+      total_score: 12.2
+      suggested_direction: nerf
+    metrics:
+      avg_damage:
+        current: 84
+        target: 80
+        delta: -4
+        delta_ratio: -0.05
+        tolerance: 12
+        severity: trivial
+        action: hold
+        weight: 0.8
+        score: 0.2667
+        recommendation: 'Monitorare: scostamento entro la soglia.'
+      pick_rate:
+        current: 0.21
+        target: 0.18
+        delta: -0.03
+        delta_ratio: -0.1667
+        tolerance: 0.01
+        severity: critical
+        action: nerf
+        weight: 1.2
+        score: 3.6
+        recommendation: Ridurre pick rate di 0.03 (-3%).
+      win_rate:
+        current: 0.57
+        target: 0.52
+        delta: -0.05
+        delta_ratio: -0.0962
+        tolerance: 0.015
+        severity: critical
+        action: nerf
+        weight: 2.5
+        score: 8.3333
+        recommendation: Ridurre win rate di 0.05 (-5%).
+  - id: verdant_surge
+    name: Verdant Surge
+    role: support
+    rarity: uncommon
+    notes: Healing numbers inflated by duo queue stacking.
+    summary:
+      peak_severity: major
+      total_score: 4.2667
+      suggested_direction: nerf
+    metrics:
+      avg_damage:
+        current: 63
+        target: 60
+        delta: -3
+        delta_ratio: -0.05
+        tolerance: 12
+        severity: trivial
+        action: hold
+        weight: 0.8
+        score: 0.2
+        recommendation: 'Monitorare: scostamento entro la soglia.'
+      pick_rate:
+        current: 0.19
+        target: 0.17
+        delta: -0.02
+        delta_ratio: -0.1176
+        tolerance: 0.01
+        severity: major
+        action: nerf
+        weight: 1.2
+        score: 2.4
+        recommendation: Ridurre pick rate di 0.02 (-2%).
+      win_rate:
+        current: 0.51
+        target: 0.5
+        delta: -0.01
+        delta_ratio: -0.02
+        tolerance: 0.015
+        severity: minor
+        action: nerf
+        weight: 2.5
+        score: 1.6667
+        recommendation: Ridurre win rate di 0.01 (-1%).

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test:web": "npm --prefix tools/ts run test:web --",
     "build": "npm --prefix tools/ts run build --",
     "test": "npm run test:api && npm --prefix tools/ts run test -- && npm --prefix webapp run test",
-    "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 tools/ts/node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 tools/ts/node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts",
+    "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 tools/ts/node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 tools/ts/node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && tools/ts/node_modules/.bin/tsx tests/scripts/tune_items.test.ts",
     "start:api": "node server/index.js",
     "build:idea-taxonomy": "node scripts/build-idea-taxonomy.js",
     "drive:generate-approved": "node tools/drive/generate-approved-assets.mjs",

--- a/scripts/balance/tune_items.js
+++ b/scripts/balance/tune_items.js
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const DEFAULT_DATASET = path.join(ROOT, 'data', 'telemetry', 'items.json');
+const DEFAULT_OUTPUT_DIR = path.join(ROOT, 'logs', 'balance_proposals');
+const FILE_PREFIX = 'items-';
+const FILE_EXTENSION = '.yaml';
+const SEVERITY_ORDER = ['trivial', 'minor', 'moderate', 'major', 'critical'];
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const options = {
+    items: DEFAULT_DATASET,
+    output: DEFAULT_OUTPUT_DIR,
+    tag: '',
+    dryRun: false,
+    check: false,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const value = args[i];
+    if (value === '--items' || value === '-i') {
+      options.items = resolvePath(args[++i], DEFAULT_DATASET);
+    } else if (value === '--output' || value === '-o') {
+      options.output = resolvePath(args[++i], DEFAULT_OUTPUT_DIR);
+    } else if (value === '--tag' || value === '-t') {
+      options.tag = String(args[++i] || '').trim();
+    } else if (value === '--dry-run') {
+      options.dryRun = true;
+    } else if (value === '--check') {
+      options.check = true;
+    } else if (value === '--help' || value === '-h') {
+      printUsage();
+      process.exit(0);
+    } else {
+      throw new Error(`Argomento sconosciuto: ${value}`);
+    }
+  }
+
+  return options;
+}
+
+function resolvePath(input, fallback) {
+  if (!input) {
+    return fallback;
+  }
+  if (path.isAbsolute(input)) {
+    return input;
+  }
+  return path.resolve(process.cwd(), input);
+}
+
+function printUsage() {
+  console.log(`Utilizzo: node scripts/balance/tune_items.js [opzioni]\n\n` +
+    `Opzioni:\n` +
+    `  --items,  -i   Percorso al dataset JSON (default: data/telemetry/items.json)\n` +
+    `  --output, -o   Directory di destinazione (default: logs/balance_proposals)\n` +
+    `  --tag,    -t   Suffisso facoltativo per il nome del file\n` +
+    `  --dry-run      Stampa il risultato su STDOUT senza scrivere file\n` +
+    `  --check        Confronta l'output con l'ultimo file generato\n` +
+    `  --help,   -h   Mostra questo messaggio`);
+}
+
+function readJson(filePath) {
+  try {
+    const src = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(src);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      throw new Error(`Dataset non trovato: ${filePath}`);
+    }
+    throw new Error(`Impossibile leggere ${filePath}: ${error.message}`);
+  }
+}
+
+function ensureDirectory(targetDir) {
+  fs.mkdirSync(targetDir, { recursive: true });
+}
+
+function toNumber(value) {
+  if (value == null || value === '') {
+    return null;
+  }
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function roundNumber(value) {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+  const abs = Math.abs(value);
+  const digits = abs >= 100 ? 1 : abs >= 10 ? 2 : 4;
+  return Number(value.toFixed(digits));
+}
+
+function getRules(dataset) {
+  const rules = dataset.rules || {};
+  const defaults = rules.defaults || {};
+  return {
+    defaults: {
+      tolerance: toNumber(defaults.tolerance) || 0.02,
+      weight: toNumber(defaults.weight) || 1,
+    },
+    metrics: Object.entries(rules.metrics || {}).reduce((acc, [metric, config]) => {
+      const tolerance = toNumber(config && config.tolerance);
+      const weight = toNumber(config && config.weight);
+      acc[metric] = {
+        tolerance: tolerance || null,
+        weight: weight || null,
+      };
+      return acc;
+    }, {}),
+  };
+}
+
+function metricTolerance(metric, rules) {
+  const entry = rules.metrics[metric] || {};
+  return entry.tolerance || rules.defaults.tolerance;
+}
+
+function metricWeight(metric, rules) {
+  const entry = rules.metrics[metric] || {};
+  return entry.weight || rules.defaults.weight;
+}
+
+function severityFromDelta(absDelta, tolerance) {
+  if (!Number.isFinite(absDelta) || !Number.isFinite(tolerance) || tolerance <= 0) {
+    return 'trivial';
+  }
+  const normalized = absDelta / tolerance;
+  const epsilon = Number.EPSILON * 10;
+  if (normalized + epsilon >= 3) return 'critical';
+  if (normalized + epsilon >= 2) return 'major';
+  if (normalized + epsilon >= 1) return 'moderate';
+  if (normalized + epsilon >= 0.5) return 'minor';
+  return 'trivial';
+}
+
+function compareSeverity(a, b) {
+  return SEVERITY_ORDER.indexOf(a) - SEVERITY_ORDER.indexOf(b);
+}
+
+function actionFromDelta(delta, severity) {
+  if (!Number.isFinite(delta) || severity === 'trivial' || delta === 0) {
+    return 'hold';
+  }
+  return delta > 0 ? 'buff' : 'nerf';
+}
+
+function formatPercent(value) {
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  return `${roundNumber(value * 100)}%`;
+}
+
+function recommendation(metric, delta, severity) {
+  if (severity === 'trivial' || !Number.isFinite(delta)) {
+    return 'Monitorare: scostamento entro la soglia.';
+  }
+  const direction = delta > 0 ? 'Incrementare' : 'Ridurre';
+  const magnitude = Math.abs(delta);
+  const prettyMetric = metric.replace(/_/g, ' ');
+  const relative = formatPercent(delta);
+  const formattedDelta = roundNumber(magnitude);
+  if (relative) {
+    return `${direction} ${prettyMetric} di ${formattedDelta} (${relative}).`;
+  }
+  return `${direction} ${prettyMetric} di ${formattedDelta}.`;
+}
+
+function sanitizeItemDetails(item) {
+  const result = {};
+  if (item.id) result.id = String(item.id);
+  if (item.name) result.name = String(item.name);
+  if (item.role) result.role = String(item.role);
+  if (item.rarity) result.rarity = String(item.rarity);
+  if (item.notes) result.notes = String(item.notes);
+  return result;
+}
+
+function buildProposal(dataset, { timestamp } = {}) {
+  const rules = getRules(dataset);
+  const items = Array.isArray(dataset.items) ? dataset.items : [];
+  const now = timestamp ? new Date(timestamp) : new Date();
+
+  let totalScore = 0;
+  const enriched = [];
+  for (const item of items) {
+    const metrics = item.metrics || {};
+    const resultMetrics = {};
+    let highestSeverity = 'trivial';
+    let itemScore = 0;
+    let suggestedDirection = 'hold';
+
+    for (const [metric, values] of Object.entries(metrics)) {
+      const current = toNumber(values && values.current);
+      const target = toNumber(values && values.target);
+      if (!Number.isFinite(current) || !Number.isFinite(target)) {
+        continue;
+      }
+      const delta = target - current;
+      const absDelta = Math.abs(delta);
+      const tolerance = metricTolerance(metric, rules);
+      const weight = metricWeight(metric, rules);
+      const severity = severityFromDelta(absDelta, tolerance);
+      if (compareSeverity(severity, highestSeverity) > 0) {
+        highestSeverity = severity;
+      }
+      const action = actionFromDelta(delta, severity);
+      if (action !== 'hold') {
+        suggestedDirection = action;
+      }
+      const score = Number.isFinite(tolerance) && tolerance > 0 ? (absDelta / tolerance) * weight : absDelta * weight;
+      itemScore += score;
+      totalScore += score;
+      resultMetrics[metric] = {
+        current: roundNumber(current),
+        target: roundNumber(target),
+        delta: roundNumber(delta),
+        delta_ratio: Number.isFinite(target) && target !== 0 ? roundNumber(delta / target) : null,
+        tolerance: roundNumber(tolerance),
+        severity,
+        action,
+        weight: roundNumber(weight),
+        score: roundNumber(score),
+        recommendation: recommendation(metric, delta, severity),
+      };
+    }
+
+    if (Object.keys(resultMetrics).length === 0) {
+      continue;
+    }
+
+    const details = sanitizeItemDetails(item);
+    details.summary = {
+      peak_severity: highestSeverity,
+      total_score: roundNumber(itemScore),
+      suggested_direction: suggestedDirection,
+    };
+    details.metrics = Object.keys(resultMetrics)
+      .sort((a, b) => a.localeCompare(b))
+      .reduce((acc, key) => {
+        const metricDetails = resultMetrics[key];
+        if (metricDetails.delta_ratio === null) {
+          delete metricDetails.delta_ratio;
+        }
+        acc[key] = metricDetails;
+        return acc;
+      }, {});
+
+    enriched.push(details);
+  }
+
+  enriched.sort((a, b) => {
+    const scoreB = Number.isFinite(b.summary?.total_score) ? b.summary.total_score : 0;
+    const scoreA = Number.isFinite(a.summary?.total_score) ? a.summary.total_score : 0;
+    if (scoreB === scoreA) {
+      return (a.id || '').localeCompare(b.id || '');
+    }
+    return scoreB - scoreA;
+  });
+
+  const alerts = enriched
+    .filter((item) => compareSeverity(item.summary?.peak_severity || 'trivial', 'moderate') >= 0)
+    .map((item) => ({
+      id: item.id,
+      name: item.name,
+      peak_severity: item.summary?.peak_severity,
+      total_score: item.summary?.total_score,
+      suggested_direction: item.summary?.suggested_direction,
+    }));
+
+  const metadata = dataset.metadata || {};
+  const summary = {
+    generated_at: now.toISOString(),
+    dataset_generated_at: metadata.generated_at || null,
+    season: metadata.season || null,
+    source_snapshot: metadata.source || null,
+    items_considered: enriched.length,
+    total_score: roundNumber(totalScore),
+    average_score: enriched.length ? roundNumber(totalScore / enriched.length) : 0,
+    defaults: {
+      tolerance: roundNumber(rules.defaults.tolerance),
+      weight: roundNumber(rules.defaults.weight),
+    },
+  };
+  if (alerts.length > 0) {
+    summary.alerts = alerts;
+  }
+
+  return {
+    summary,
+    items: enriched,
+  };
+}
+
+function generateFileName(tag = '') {
+  const timestamp = new Date().toISOString().replace(/[:]/g, '-');
+  const suffix = tag ? `-${tag.replace(/[^a-z0-9_-]+/gi, '').toLowerCase()}` : '';
+  return `${FILE_PREFIX}${timestamp}${suffix}${FILE_EXTENSION}`;
+}
+
+function findLatestProposal(dirPath) {
+  if (!fs.existsSync(dirPath)) {
+    return null;
+  }
+  const files = fs.readdirSync(dirPath).filter((name) => name.startsWith(FILE_PREFIX) && name.endsWith(FILE_EXTENSION));
+  if (files.length === 0) {
+    return null;
+  }
+  files.sort();
+  return path.join(dirPath, files[files.length - 1]);
+}
+
+function normalizeForComparison(proposal) {
+  const clone = JSON.parse(JSON.stringify(proposal || {}));
+  if (clone.summary) {
+    delete clone.summary.generated_at;
+  }
+  if (Array.isArray(clone.items)) {
+    clone.items = clone.items
+      .map((item) => {
+        const normalized = { ...item };
+        if (normalized.metrics) {
+          const ordered = Object.keys(normalized.metrics)
+            .sort((a, b) => a.localeCompare(b))
+            .reduce((acc, key) => {
+              acc[key] = normalized.metrics[key];
+              return acc;
+            }, {});
+          normalized.metrics = ordered;
+        }
+        return normalized;
+      })
+      .sort((a, b) => (a.id || '').localeCompare(b.id || ''));
+  }
+  return clone;
+}
+
+function main() {
+  let options;
+  try {
+    options = parseArgs(process.argv);
+  } catch (error) {
+    console.error(error.message);
+    printUsage();
+    process.exit(1);
+    return;
+  }
+
+  let dataset;
+  try {
+    dataset = readJson(options.items);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+    return;
+  }
+
+  const proposal = buildProposal(dataset);
+  const yamlContent = yaml.dump(proposal, {
+    lineWidth: 120,
+    noRefs: true,
+    sortKeys: false,
+  });
+
+  if (options.dryRun) {
+    process.stdout.write(yamlContent);
+    return;
+  }
+
+  ensureDirectory(options.output);
+
+  if (options.check) {
+    const latest = findLatestProposal(options.output);
+    if (!latest) {
+      console.error('Nessuna proposta trovata: generare un file prima di eseguire --check.');
+      process.exit(1);
+      return;
+    }
+    let existing;
+    try {
+      existing = yaml.load(fs.readFileSync(latest, 'utf8')) || {};
+    } catch (error) {
+      console.error(`Impossibile leggere ${latest}: ${error.message}`);
+      process.exit(1);
+      return;
+    }
+
+    const expected = normalizeForComparison(proposal);
+    const current = normalizeForComparison(existing);
+    if (JSON.stringify(expected) !== JSON.stringify(current)) {
+      console.error('La proposta esistente non è aggiornata con i dati correnti.');
+      console.error(`Ultimo file: ${path.relative(ROOT, latest)}`);
+      console.error('Suggerimento: rieseguire lo script senza --check per aggiornare i delta.');
+      process.exit(1);
+      return;
+    }
+
+    console.log(`Proposta aggiornata: ${path.relative(ROOT, latest)}`);
+    return;
+  }
+
+  const fileName = generateFileName(options.tag);
+  const targetPath = path.join(options.output, fileName);
+  fs.writeFileSync(targetPath, yamlContent);
+  console.log(`Proposta di bilanciamento salvata in ${path.relative(ROOT, targetPath)}`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  buildProposal,
+  parseArgs,
+  severityFromDelta,
+  actionFromDelta,
+  normalizeForComparison,
+};

--- a/tests/scripts/tune_items.test.ts
+++ b/tests/scripts/tune_items.test.ts
@@ -1,0 +1,175 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { load as loadYaml } from 'js-yaml';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..', '..');
+const CLI = path.join(ROOT, 'scripts', 'balance', 'tune_items.js');
+
+function createTempDir(prefix: string) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  return dir;
+}
+
+function removeDir(dir: string) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function writeDataset(targetDir: string, dataset: any) {
+  const datasetPath = path.join(targetDir, 'items.json');
+  fs.writeFileSync(datasetPath, JSON.stringify(dataset, null, 2));
+  return datasetPath;
+}
+
+test('CLI genera proposte YAML con delta e punteggi ordinati', async (t) => {
+  const tempDir = createTempDir('tune-items-');
+  t.after(() => removeDir(tempDir));
+
+  const outputDir = path.join(tempDir, 'output');
+  fs.mkdirSync(outputDir);
+
+  const dataset = {
+    metadata: {
+      season: 'playtest-alpha',
+      generated_at: '2025-10-01T09:00:00Z',
+      source: 'test-suite',
+    },
+    rules: {
+      defaults: { tolerance: 0.02, weight: 1 },
+      metrics: {
+        win_rate: { tolerance: 0.015, weight: 2 },
+        pick_rate: { tolerance: 0.02, weight: 1 },
+      },
+    },
+    items: [
+      {
+        id: 'alpha_blade',
+        name: 'Alpha Blade',
+        role: 'assassin',
+        rarity: 'rare',
+        notes: 'Soffre nelle fasi iniziali del match.',
+        metrics: {
+          win_rate: { current: 0.44, target: 0.5 },
+          pick_rate: { current: 0.18, target: 0.2 },
+        },
+      },
+      {
+        id: 'beta_shield',
+        name: 'Beta Shield',
+        role: 'tank',
+        rarity: 'epic',
+        metrics: {
+          win_rate: { current: 0.54, target: 0.5 },
+          pick_rate: { current: 0.22, target: 0.2 },
+        },
+      },
+    ],
+  };
+
+  const datasetPath = writeDataset(tempDir, dataset);
+  execFileSync('node', [CLI, '--items', datasetPath, '--output', outputDir, '--tag', 'spec']);
+
+  const files = fs.readdirSync(outputDir).filter((file) => file.endsWith('.yaml'));
+  assert.equal(files.length, 1, 'deve essere generato un singolo file YAML');
+
+  const proposalPath = path.join(outputDir, files[0]);
+  const proposal = loadYaml(fs.readFileSync(proposalPath, 'utf8')) as any;
+
+  assert.equal(proposal.summary.items_considered, 2);
+  assert.ok(Array.isArray(proposal.summary.alerts), 'deve includere un riepilogo alert');
+  assert.equal(proposal.summary.alerts.length >= 1, true);
+
+  assert.equal(proposal.items[0].id, 'alpha_blade');
+  assert.equal(proposal.items[0].summary.peak_severity, 'critical');
+  assert.equal(proposal.items[0].metrics.win_rate.action, 'buff');
+  assert.equal(proposal.items[0].metrics.win_rate.severity, 'critical');
+  assert.equal(proposal.items[0].metrics.win_rate.score > proposal.items[1].metrics.win_rate.score, true);
+  assert.equal(proposal.items[1].metrics.win_rate.action, 'nerf');
+  assert.equal(proposal.items[1].metrics.pick_rate.severity, 'moderate');
+  assert.match(
+    proposal.items[1].metrics.pick_rate.recommendation,
+    /Ridurre pick rate di/,
+  );
+});
+
+test('modalità dry-run stampa YAML su STDOUT senza creare file', async (t) => {
+  const tempDir = createTempDir('tune-items-dry-');
+  t.after(() => removeDir(tempDir));
+
+  const outputDir = path.join(tempDir, 'out');
+  fs.mkdirSync(outputDir);
+
+  const dataset = {
+    items: [
+      {
+        id: 'gamma_staff',
+        metrics: {
+          win_rate: { current: 0.5, target: 0.53 },
+        },
+      },
+    ],
+  };
+
+  const datasetPath = writeDataset(tempDir, dataset);
+  const stdout = execFileSync('node', [CLI, '--items', datasetPath, '--output', outputDir, '--dry-run'], {
+    encoding: 'utf8',
+  });
+
+  assert.ok(stdout.includes('summary:'), 'dry-run deve produrre YAML');
+  const generated = fs.readdirSync(outputDir).filter((file) => file.endsWith('.yaml'));
+  assert.equal(generated.length, 0, 'dry-run non deve scrivere file');
+});
+
+test('modalità check confronta i delta con il file più recente', async (t) => {
+  const tempDir = createTempDir('tune-items-check-');
+  t.after(() => removeDir(tempDir));
+
+  const outputDir = path.join(tempDir, 'out');
+  fs.mkdirSync(outputDir);
+
+  const baseDataset = {
+    items: [
+      {
+        id: 'delta_bow',
+        metrics: {
+          win_rate: { current: 0.48, target: 0.5 },
+        },
+      },
+    ],
+  };
+
+  const datasetPath = writeDataset(tempDir, baseDataset);
+  execFileSync('node', [CLI, '--items', datasetPath, '--output', outputDir]);
+
+  const checkOk = spawnSync('node', [CLI, '--items', datasetPath, '--output', outputDir, '--check'], {
+    encoding: 'utf8',
+  });
+  assert.equal(checkOk.status, 0, checkOk.stderr);
+
+  const updatedDataset = {
+    items: [
+      {
+        id: 'delta_bow',
+        metrics: {
+          win_rate: { current: 0.52, target: 0.5 },
+        },
+      },
+    ],
+  };
+  fs.writeFileSync(datasetPath, JSON.stringify(updatedDataset, null, 2));
+
+  const checkFail = spawnSync('node', [CLI, '--items', datasetPath, '--output', outputDir, '--check'], {
+    encoding: 'utf8',
+  });
+  assert.notEqual(checkFail.status, 0, 'il controllo deve fallire se i delta cambiano');
+  assert.ok(
+    (checkFail.stderr || '').includes('non è aggiornata'),
+    'il messaggio di errore deve spiegare lo scostamento',
+  );
+});

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Pre-commit hook per verificare che le proposte di bilanciamento degli item siano aggiornate.
+# Installa lo script copiandolo in .git/hooks/pre-commit e rendendolo eseguibile:
+#   mkdir -p .git/hooks
+#   cp tools/hooks/pre-commit .git/hooks/pre-commit
+#   chmod +x .git/hooks/pre-commit
+# È possibile saltare il controllo impostando la variabile SKIP_TUNE_ITEMS=1.
+
+set -euo pipefail
+
+if [[ "${SKIP_TUNE_ITEMS:-0}" == "1" ]]; then
+  echo "[pre-commit] controllo tune_items saltato (SKIP_TUNE_ITEMS=1)."
+  exit 0
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+CLI="$ROOT/scripts/balance/tune_items.js"
+DATASET="$ROOT/data/telemetry/items.json"
+OUTPUT="$ROOT/logs/balance_proposals"
+
+if [[ ! -f "$CLI" ]]; then
+  echo "[pre-commit] CLI mancante: $CLI" >&2
+  exit 1
+fi
+
+echo "[pre-commit] Verifica proposte di bilanciamento degli item..."
+node "$CLI" --check --items "$DATASET" --output "$OUTPUT"


### PR DESCRIPTION
## Summary
- add a telemetry-driven `tune_items` CLI that computes metric deltas, generates YAML proposals, and supports dry-run/check flows
- provide the default telemetry dataset, baseline proposal artifact, and a documented pre-commit hook for keeping outputs fresh
- cover the CLI with node:test scenarios and register the new suite inside the root `test:api` npm script

## Testing
- tools/ts/node_modules/.bin/tsx tests/scripts/tune_items.test.ts

------
https://chatgpt.com/codex/tasks/task_e_6904f8a067e883328818039c3079c532