### PR TITLE
Add route metadata navigation guards and demo mode UI

### DIFF
--- a/tests/webapp/__snapshots__/NebulaAtlasView.spec.ts.snap
+++ b/tests/webapp/__snapshots__/NebulaAtlasView.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`NebulaAtlasView > renderizza indicatori live e snapshot coerente 1`] = `
 "<section data-v-43e6e8ac="" class="nebula-atlas-view">
+  <!--v-if-->
   <section data-v-43e6e8ac="" class="stub-progress" header="[object Object]" cards="[object Object]" timeline-entries="[object Object]" evolution-matrix="[object Object]" share="[object Object]" telemetry-status="[object Object]">progress</section>
   <section data-v-43e6e8ac="" class="nebula-atlas-view__live" aria-live="polite">
     <header data-v-43e6e8ac="" class="nebula-atlas-view__live-header">
@@ -11,8 +12,68 @@ exports[`NebulaAtlasView > renderizza indicatori live e snapshot coerente 1`] = 
       </div>
       <div data-v-43e6e8ac="" class="nebula-atlas-view__status"><span data-v-43e6e8ac="" class="nebula-atlas-view__badge" data-tone="warning">Sync 30 min fa</span><small data-v-43e6e8ac="">Ultimo sync: 2024-05-18T10:45:00Z</small></div>
     </header>
-    <div data-v-43e6e8ac="" class="nebula-atlas-view__error" role="status"></div>
-    <footer data-v-43e6e8ac="" class="nebula-atlas-view__footer"><span data-v-43e6e8ac=""></span><button data-v-43e6e8ac="" type="button" class="nebula-atlas-view__refresh">Aggiorna ora</button></footer>
+    <div data-v-43e6e8ac="" class="nebula-atlas-view__grid">
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__metrics">
+        <article data-v-43e6e8ac="" class="nebula-atlas-view__metric" data-tone="neutral">
+          <h4 data-v-43e6e8ac="">Eventi totali</h4><strong data-v-43e6e8ac="">6</strong>
+        </article>
+        <article data-v-43e6e8ac="" class="nebula-atlas-view__metric" data-tone="warning">
+          <h4 data-v-43e6e8ac="">Eventi aperti</h4><strong data-v-43e6e8ac="">2</strong>
+        </article>
+        <article data-v-43e6e8ac="" class="nebula-atlas-view__metric" data-tone="critical">
+          <h4 data-v-43e6e8ac="">Priorità alta</h4><strong data-v-43e6e8ac="">1</strong>
+        </article>
+        <article data-v-43e6e8ac="" class="nebula-atlas-view__metric" data-tone="success">
+          <h4 data-v-43e6e8ac="">Acknowledged</h4><strong data-v-43e6e8ac="">4</strong>
+        </article>
+      </div>
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__readiness">
+        <h4 data-v-43e6e8ac="">Readiness branchi</h4>
+        <ul data-v-43e6e8ac="">
+          <li data-v-43e6e8ac="" data-tone="success" data-mode="live">
+            <div data-v-43e6e8ac="" class="nebula-atlas-view__chip-label"><span data-v-43e6e8ac="">Pronte</span>
+              <!--v-if-->
+            </div><strong data-v-43e6e8ac="">3</strong>
+          </li>
+          <li data-v-43e6e8ac="" data-tone="warning" data-mode="live">
+            <div data-v-43e6e8ac="" class="nebula-atlas-view__chip-label"><span data-v-43e6e8ac="">In attesa</span>
+              <!--v-if-->
+            </div><strong data-v-43e6e8ac="">1</strong>
+          </li>
+          <li data-v-43e6e8ac="" data-tone="neutral" data-mode="live">
+            <div data-v-43e6e8ac="" class="nebula-atlas-view__chip-label"><span data-v-43e6e8ac="">Neutrali</span>
+              <!--v-if-->
+            </div><strong data-v-43e6e8ac="">1</strong>
+          </li>
+          <li data-v-43e6e8ac="" data-tone="critical" data-mode="live">
+            <div data-v-43e6e8ac="" class="nebula-atlas-view__chip-label"><span data-v-43e6e8ac="">Bloccate</span>
+              <!--v-if-->
+            </div><strong data-v-43e6e8ac="">0</strong>
+          </li>
+        </ul>
+      </div>
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__chart" aria-label="Copertura QA">
+        <header data-v-43e6e8ac="">
+          <h4 data-v-43e6e8ac="">Copertura QA media</h4><span data-v-43e6e8ac="">78%</span>
+        </header>
+        <div data-v-43e6e8ac="" class="sparkline-stub" color="#61d5ff" variant="live">60,70,80</div>
+      </div>
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__chart" aria-label="Incidenti telemetria">
+        <header data-v-43e6e8ac="">
+          <h4 data-v-43e6e8ac="">Incidenti ultimi 7 giorni</h4><span data-v-43e6e8ac="">4</span>
+        </header>
+        <div data-v-43e6e8ac="" class="sparkline-stub" color="#ff6982" variant="live">1,2,1</div>
+      </div>
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__chart" aria-label="High priority">
+        <header data-v-43e6e8ac="">
+          <h4 data-v-43e6e8ac="">High priority</h4><span data-v-43e6e8ac="">1</span>
+        </header>
+        <div data-v-43e6e8ac="" class="sparkline-stub" color="#f4c060" variant="live">0,1,0</div>
+      </div>
+    </div>
+    <footer data-v-43e6e8ac="" class="nebula-atlas-view__footer"><span data-v-43e6e8ac="">Sync 30 min fa</span>
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__controls"><button data-v-43e6e8ac="" type="button" class="nebula-atlas-view__refresh">Aggiorna ora</button><button data-v-43e6e8ac="" type="button" class="nebula-atlas-view__refresh">Carica mock</button></div>
+    </footer>
   </section>
 </section>"
 `;

--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -13,6 +13,11 @@
           {{ link.label }}
         </RouterLink>
       </nav>
+      <AppBreadcrumbs
+        :items="breadcrumbItems"
+        :description="pageDescription"
+        :demo="isDemoMode"
+      />
     </header>
 
     <main class="app-shell__main">
@@ -27,7 +32,11 @@
 import { computed } from 'vue';
 import { RouterLink, RouterView, useRoute } from 'vue-router';
 
+import AppBreadcrumbs from './components/layout/AppBreadcrumbs.vue';
+import { useNavigationMeta } from './state/navigationMeta.js';
+
 const route = useRoute();
+const { breadcrumbs: breadcrumbItems, description: pageDescription, demo: isDemoMode } = useNavigationMeta();
 
 const mainLinks = computed(() => {
   const currentName = route.name;

--- a/webapp/src/components/layout/AppBreadcrumbs.vue
+++ b/webapp/src/components/layout/AppBreadcrumbs.vue
@@ -1,0 +1,138 @@
+<template>
+  <section v-if="hasContent" class="app-breadcrumbs" aria-label="Contestualizzazione pagina">
+    <nav v-if="items.length" class="app-breadcrumbs__nav" aria-label="Percorso applicazione">
+      <ol class="app-breadcrumbs__list">
+        <li v-for="item in items" :key="item.key" class="app-breadcrumbs__item" :data-current="item.current">
+          <RouterLink
+            v-if="!item.current"
+            :to="item.to"
+            class="app-breadcrumbs__link"
+          >
+            <span>{{ item.label }}</span>
+          </RouterLink>
+          <span v-else class="app-breadcrumbs__current">{{ item.label }}</span>
+        </li>
+      </ol>
+    </nav>
+
+    <div class="app-breadcrumbs__meta">
+      <p v-if="description" class="app-breadcrumbs__description">{{ description }}</p>
+      <span v-if="demo" class="app-breadcrumbs__badge">Modalità demo</span>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { RouterLink } from 'vue-router';
+
+const props = defineProps({
+  items: {
+    type: Array,
+    default: () => [],
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+  demo: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const items = computed(() =>
+  props.items.map((item, index) => ({
+    key: item.key ?? `${item.label}-${index}`,
+    label: item.label,
+    to: item.to,
+    current: Boolean(item.current),
+  })),
+);
+
+const description = computed(() => props.description);
+const demo = computed(() => props.demo);
+const hasContent = computed(() => items.value.length > 0 || Boolean(description.value) || demo.value);
+</script>
+
+<style scoped>
+.app-breadcrumbs {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 1rem;
+  background: rgba(17, 25, 44, 0.4);
+  border: 1px solid rgba(99, 153, 255, 0.3);
+  color: rgba(209, 224, 255, 0.92);
+}
+
+.app-breadcrumbs__nav {
+  overflow: auto;
+}
+
+.app-breadcrumbs__list {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.app-breadcrumbs__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.app-breadcrumbs__item::after {
+  content: '/';
+  opacity: 0.35;
+}
+
+.app-breadcrumbs__item[data-current='true']::after {
+  display: none;
+}
+
+.app-breadcrumbs__link {
+  color: rgba(209, 224, 255, 0.85);
+  text-decoration: none;
+  transition: color 0.18s ease;
+}
+
+.app-breadcrumbs__link:hover {
+  color: #f8fbff;
+}
+
+.app-breadcrumbs__current {
+  color: #f8fbff;
+  font-weight: 600;
+}
+
+.app-breadcrumbs__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.app-breadcrumbs__description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(209, 224, 255, 0.75);
+}
+
+.app-breadcrumbs__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(255, 204, 102, 0.2);
+  color: #ffdd8a;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+</style>

--- a/webapp/src/modules/useNebulaProgressModule.ts
+++ b/webapp/src/modules/useNebulaProgressModule.ts
@@ -305,6 +305,17 @@ export function useNebulaProgressModule(
     }
   }
 
+  async function activateDemoTelemetry() {
+    try {
+      await loadTelemetryMock();
+      return;
+    } catch (mockError) {
+      const mapped = toError(mockError);
+      error.value = mapped;
+      throw mapped;
+    }
+  }
+
   function startPolling() {
     if (pollIntervalMs <= 0 || typeof setInterval !== 'function') {
       return;
@@ -643,5 +654,6 @@ export function useNebulaProgressModule(
     error,
     lastUpdated,
     refresh: () => loadAtlas(),
+    activateDemoTelemetry,
   };
 }

--- a/webapp/src/router/index.js
+++ b/webapp/src/router/index.js
@@ -1,54 +1,140 @@
 import { createRouter, createWebHistory } from 'vue-router';
-import FlowShellView from '../views/FlowShellView.vue';
-import NebulaAtlasView from '../views/NebulaAtlasView.vue';
-import AtlasLayoutView from '../views/atlas/AtlasLayoutView.vue';
-import AtlasPokedexView from '../views/atlas/AtlasPokedexView.vue';
-import AtlasWorldBuilderView from '../views/atlas/AtlasWorldBuilderView.vue';
-import AtlasEncounterLabView from '../views/atlas/AtlasEncounterLabView.vue';
+import { updateNavigationMeta } from '../state/navigationMeta.js';
 
-const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
-  routes: [
-    {
-      path: '/',
-      name: 'workflow',
-      component: FlowShellView,
-    },
-    {
-      path: '/nebula-atlas',
-      name: 'nebula-atlas',
-      component: NebulaAtlasView,
-    },
-    {
-      path: '/atlas',
-      component: AtlasLayoutView,
-      children: [
-        {
-          path: '',
-          redirect: { name: 'atlas-pokedex' },
+const APP_TITLE = 'Evo-Tactics Mission Console';
+
+function buildBreadcrumbs(to, router) {
+  return to.matched
+    .filter((record) => record.meta && record.meta.breadcrumb !== false)
+    .map((record, index, array) => {
+      const breadcrumbMeta = record.meta?.breadcrumb || {};
+      const label = breadcrumbMeta.label || record.meta?.title || record.name || record.path || '—';
+      const target =
+        breadcrumbMeta.to ||
+        (record.name
+          ? { name: record.name, params: to.params, query: to.query }
+          : { path: record.path });
+      const resolved = target ? router.resolve(target) : null;
+      return {
+        key: record.name || record.path || String(index),
+        label,
+        to: target,
+        href: resolved ? resolved.href : null,
+        current: index === array.length - 1,
+        demo: Boolean(record.meta?.demo),
+      };
+    });
+}
+
+export function createAppRouter({ base, history } = {}) {
+  const resolvedHistory = history || createWebHistory(base ?? import.meta.env.BASE_URL);
+
+  const router = createRouter({
+    history: resolvedHistory,
+    routes: [
+      {
+        path: '/',
+        name: 'workflow',
+        component: () => import('../views/FlowShellView.vue'),
+        meta: {
+          title: 'Workflow Orchestrator',
+          description: 'Coordina i passaggi del generatore Nebula e monitora lo stato delle pipeline.',
+          breadcrumb: { label: 'Workflow Orchestrator' },
+          demo: false,
         },
-        {
-          path: 'pokedex',
-          name: 'atlas-pokedex',
-          component: AtlasPokedexView,
+      },
+      {
+        path: '/nebula-atlas',
+        name: 'nebula-atlas',
+        component: () => import('../views/NebulaAtlasView.vue'),
+        meta: {
+          title: 'Nebula Atlas Overview',
+          description: 'Monitoraggio dataset e telemetria Nebula con fallback in modalità demo.',
+          breadcrumb: { label: 'Nebula Atlas Overview' },
+          demo: true,
         },
-        {
-          path: 'world-builder',
-          name: 'atlas-world-builder',
-          component: AtlasWorldBuilderView,
+      },
+      {
+        path: '/atlas',
+        component: () => import('../views/atlas/AtlasLayoutView.vue'),
+        props: (route) => ({
+          isDemo: Boolean(route.meta?.demo),
+          isOffline: Boolean(route.meta?.offline),
+        }),
+        meta: {
+          title: 'Nebula Atlas',
+          description: 'Esplora il dataset Nebula Atlas e le sue sottosezioni operative.',
+          breadcrumb: { label: 'Nebula Atlas', to: { name: 'nebula-atlas' } },
+          demo: true,
+          offline: true,
         },
-        {
-          path: 'encounter-lab',
-          name: 'atlas-encounter-lab',
-          component: AtlasEncounterLabView,
+        children: [
+          {
+            path: '',
+            redirect: { name: 'atlas-pokedex' },
+          },
+          {
+            path: 'pokedex',
+            name: 'atlas-pokedex',
+            component: () => import('../views/atlas/AtlasPokedexView.vue'),
+            meta: {
+              title: 'Atlas · Pokédex Nebula',
+              description: 'Catalogo delle specie Nebula pronte per la convalida.',
+              breadcrumb: { label: 'Pokédex Nebula' },
+              demo: true,
+            },
+          },
+          {
+            path: 'world-builder',
+            name: 'atlas-world-builder',
+            component: () => import('../views/atlas/AtlasWorldBuilderView.vue'),
+            meta: {
+              title: 'Atlas · World Builder',
+              description: 'Setup dei biomi e dei builder per la generazione di mondi.',
+              breadcrumb: { label: 'World Builder' },
+              demo: true,
+            },
+          },
+          {
+            path: 'encounter-lab',
+            name: 'atlas-encounter-lab',
+            component: () => import('../views/atlas/AtlasEncounterLabView.vue'),
+            meta: {
+              title: 'Atlas · Encounter Lab',
+              description: 'Laboratorio per combinare incontri e pattern di missione.',
+              breadcrumb: { label: 'Encounter Lab' },
+              demo: true,
+            },
+          },
+        ],
+      },
+      {
+        path: '/:pathMatch(.*)*',
+        redirect: { name: 'workflow' },
+        meta: {
+          breadcrumb: false,
         },
-      ],
-    },
-    {
-      path: '/:pathMatch(.*)*',
-      redirect: { name: 'workflow' },
-    },
-  ],
-});
+      },
+    ],
+  });
+
+  router.afterEach((to) => {
+    const meta = to.meta || {};
+    const resolvedTitle = meta.title ? `${meta.title} · ${APP_TITLE}` : APP_TITLE;
+    if (typeof document !== 'undefined' && typeof document.title === 'string') {
+      document.title = resolvedTitle;
+    }
+    updateNavigationMeta({
+      title: meta.title || APP_TITLE,
+      description: meta.description || '',
+      demo: Boolean(meta.demo),
+      breadcrumbs: buildBreadcrumbs(to, router),
+    });
+  });
+
+  return router;
+}
+
+const router = createAppRouter();
 
 export default router;

--- a/webapp/src/state/navigationMeta.js
+++ b/webapp/src/state/navigationMeta.js
@@ -1,0 +1,32 @@
+import { computed, reactive, readonly } from 'vue';
+
+const state = reactive({
+  title: 'Evo-Tactics Mission Console',
+  description: '',
+  demo: false,
+  breadcrumbs: [],
+});
+
+export function updateNavigationMeta(payload) {
+  state.title = payload?.title || 'Evo-Tactics Mission Console';
+  state.description = payload?.description || '';
+  state.demo = Boolean(payload?.demo);
+  state.breadcrumbs = Array.isArray(payload?.breadcrumbs) ? payload.breadcrumbs : [];
+}
+
+export function useNavigationMeta() {
+  return {
+    navigation: readonly(state),
+    title: computed(() => state.title),
+    description: computed(() => state.description),
+    demo: computed(() => state.demo),
+    breadcrumbs: computed(() => state.breadcrumbs),
+  };
+}
+
+export function resetNavigationMeta() {
+  state.title = 'Evo-Tactics Mission Console';
+  state.description = '';
+  state.demo = false;
+  state.breadcrumbs = [];
+}

--- a/webapp/src/views/atlas/AtlasLayoutView.vue
+++ b/webapp/src/views/atlas/AtlasLayoutView.vue
@@ -27,6 +27,10 @@
       </aside>
     </header>
 
+    <p v-if="statusLabel" class="atlas-layout__status" :data-offline="isOffline">
+      {{ statusLabel }}
+    </p>
+
     <AtlasCollectionProgress :metrics="dataset.metrics" :dataset="dataset" :highlights="dataset.highlights" />
 
     <nav class="atlas-layout__nav" aria-label="Sottosezioni atlas">
@@ -52,6 +56,17 @@ import { computed } from 'vue';
 import { RouterLink, RouterView, useRoute } from 'vue-router';
 import { atlasDataset, atlasTotals } from '../../state/atlasDataset.js';
 import AtlasCollectionProgress from '../../components/atlas/AtlasCollectionProgress.vue';
+
+const props = defineProps({
+  isDemo: {
+    type: Boolean,
+    default: false,
+  },
+  isOffline: {
+    type: Boolean,
+    default: false,
+  },
+});
 
 const dataset = atlasDataset;
 const totals = atlasTotals;
@@ -81,6 +96,16 @@ const links = computed(() => {
       active: name === 'atlas-encounter-lab',
     },
   ];
+});
+
+const statusLabel = computed(() => {
+  if (!props.isDemo && !props.isOffline) {
+    return '';
+  }
+  if (props.isOffline) {
+    return 'Modalità demo · dataset offline sincronizzato da fallback';
+  }
+  return 'Modalità demo attiva per le sezioni Atlas';
 });
 
 function forwardNotification(payload) {
@@ -165,6 +190,21 @@ function forwardNotification(payload) {
 .atlas-layout__curator {
   font-size: 0.85rem;
   color: rgba(15, 23, 42, 0.6);
+}
+
+.atlas-layout__status {
+  margin: -1rem 0 0;
+  padding: 0.85rem 1.25rem;
+  border-radius: 0.85rem;
+  background: rgba(59, 130, 246, 0.12);
+  color: rgba(15, 23, 42, 0.85);
+  font-weight: 600;
+  border: 1px dashed rgba(59, 130, 246, 0.3);
+}
+
+.atlas-layout__status[data-offline='true'] {
+  background: rgba(244, 114, 182, 0.12);
+  border-color: rgba(244, 114, 182, 0.4);
 }
 
 .atlas-layout__nav {

--- a/webapp/tests/NebulaAtlasView.spec.ts
+++ b/webapp/tests/NebulaAtlasView.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { computed, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import NebulaAtlasView from '../src/views/NebulaAtlasView.vue';
+
+const refreshMock = vi.fn();
+const activateMock = vi.fn();
+
+vi.mock('../src/modules/useNebulaProgressModule', () => ({
+  useNebulaProgressModule: () => ({
+    header: computed(() => ({
+      datasetId: 'atlas-demo',
+      title: 'Nebula Atlas Demo',
+      summary: 'Dataset statico per QA',
+      releaseWindow: 'Q4 · 2035',
+      curator: 'Team Nebula',
+    })),
+    cards: computed(() => []),
+    timelineEntries: computed(() => []),
+    evolutionMatrix: computed(() => []),
+    share: computed(() => ({})),
+    telemetrySummary: computed(() => ({
+      total: 128,
+      open: 4,
+      acknowledged: 92,
+      highPriority: 2,
+      lastEventAt: null,
+      lastEventLabel: 'Sync mock 15m fa',
+      updatedAt: '2035-04-01T12:00:00Z',
+      mode: 'mock',
+      isDemo: true,
+      sourceLabel: 'Telemetria offline · demo',
+    })),
+    telemetryStreams: computed(() => ({
+      coverage: [60, 72, 88],
+      incidents: [2, 1, 0],
+      highPriority: [1, 1, 0],
+    })),
+    telemetryDistribution: computed(() => ({
+      success: 8,
+      warning: 2,
+      neutral: 1,
+      critical: 0,
+    })),
+    telemetryCoverageAverage: computed(() => 82),
+    telemetryStatus: computed(() => ({
+      mode: 'mock',
+      offline: true,
+      variant: 'demo',
+      label: 'Telemetria offline · demo',
+    })),
+    loading: computed(() => false),
+    error: computed(() => null),
+    lastUpdated: ref('2035-04-01T12:00:00Z'),
+    refresh: refreshMock,
+    activateDemoTelemetry: activateMock,
+  }),
+}));
+
+describe('NebulaAtlasView', () => {
+  beforeEach(() => {
+    refreshMock.mockClear();
+    activateMock.mockClear();
+  });
+
+  function mountView() {
+    return mount(NebulaAtlasView, {
+      global: {
+        stubs: {
+          NebulaProgressModule: {
+            template: '<div data-test="progress-stub"></div>',
+          },
+          SparklineChart: {
+            template: '<div class="sparkline-chart"></div>',
+          },
+        },
+      },
+    });
+  }
+
+  it('mostra il banner demo e genera uno snapshot stabile', () => {
+    const wrapper = mountView();
+    expect(wrapper.find('.nebula-atlas-view__banner').exists()).toBe(true);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('espone i controlli manuali di sincronizzazione', async () => {
+    const wrapper = mountView();
+    const buttons = wrapper.findAll('button');
+    expect(buttons.length).toBeGreaterThan(0);
+
+    for (const button of buttons) {
+      await button.trigger('click');
+    }
+
+    expect(refreshMock).toHaveBeenCalledTimes(2);
+    expect(activateMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/webapp/tests/__snapshots__/NebulaAtlasView.spec.ts.snap
+++ b/webapp/tests/__snapshots__/NebulaAtlasView.spec.ts.snap
@@ -1,0 +1,78 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`NebulaAtlasView > mostra il banner demo e genera uno snapshot stabile 1`] = `
+"<section data-v-43e6e8ac="" class="nebula-atlas-view">
+  <aside data-v-43e6e8ac="" class="nebula-atlas-view__banner" role="status">
+    <div data-v-43e6e8ac="">
+      <h2 data-v-43e6e8ac="">Modalità demo attiva</h2>
+      <p data-v-43e6e8ac=""> Il dataset statico Nebula Atlas Demo è disponibile offline mentre la telemetria live è temporaneamente sospesa. I grafici mostrano una sincronizzazione mock per mantenere la console operativa. </p>
+      <p data-v-43e6e8ac="" class="nebula-atlas-view__banner-meta"> Origine dati: <strong data-v-43e6e8ac="">Telemetria offline · demo</strong></p>
+    </div>
+    <div data-v-43e6e8ac="" class="nebula-atlas-view__banner-actions"><button data-v-43e6e8ac="" type="button" class="nebula-atlas-view__banner-button"> Riprova sincronizzazione </button><button data-v-43e6e8ac="" type="button" class="nebula-atlas-view__banner-button"> Forza telemetria demo </button></div>
+  </aside>
+  <div data-v-43e6e8ac="" data-test="progress-stub" header="[object Object]" cards="[object Object]" timeline-entries="[object Object]" evolution-matrix="[object Object]" share="[object Object]" telemetry-status="[object Object]"></div>
+  <section data-v-43e6e8ac="" class="nebula-atlas-view__live" aria-live="polite">
+    <header data-v-43e6e8ac="" class="nebula-atlas-view__live-header">
+      <div data-v-43e6e8ac="">
+        <h3 data-v-43e6e8ac="">Telemetria live</h3>
+        <p data-v-43e6e8ac="">Indicatori dal generatore Nebula combinati con il dataset atlas.</p>
+      </div>
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__status"><span data-v-43e6e8ac="" class="nebula-atlas-view__badge" data-tone="offline">Telemetria offline · demo</span><small data-v-43e6e8ac="">Ultimo sync: 2035-04-01T12:00:00Z · Telemetria offline · demo</small></div>
+    </header>
+    <div data-v-43e6e8ac="" class="nebula-atlas-view__grid">
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__metrics">
+        <article data-v-43e6e8ac="" class="nebula-atlas-view__metric" data-tone="neutral">
+          <h4 data-v-43e6e8ac="">Eventi totali</h4><strong data-v-43e6e8ac="">128</strong>
+        </article>
+        <article data-v-43e6e8ac="" class="nebula-atlas-view__metric" data-tone="warning">
+          <h4 data-v-43e6e8ac="">Eventi aperti</h4><strong data-v-43e6e8ac="">4</strong>
+        </article>
+        <article data-v-43e6e8ac="" class="nebula-atlas-view__metric" data-tone="critical">
+          <h4 data-v-43e6e8ac="">Priorità alta</h4><strong data-v-43e6e8ac="">2</strong>
+        </article>
+        <article data-v-43e6e8ac="" class="nebula-atlas-view__metric" data-tone="success">
+          <h4 data-v-43e6e8ac="">Acknowledged</h4><strong data-v-43e6e8ac="">92</strong>
+        </article>
+      </div>
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__readiness">
+        <h4 data-v-43e6e8ac="">Readiness branchi</h4>
+        <ul data-v-43e6e8ac="">
+          <li data-v-43e6e8ac="" data-tone="success" data-mode="demo">
+            <div data-v-43e6e8ac="" class="nebula-atlas-view__chip-label"><span data-v-43e6e8ac="">Pronte</span><small data-v-43e6e8ac="">Offline demo</small></div><strong data-v-43e6e8ac="">8</strong>
+          </li>
+          <li data-v-43e6e8ac="" data-tone="warning" data-mode="demo">
+            <div data-v-43e6e8ac="" class="nebula-atlas-view__chip-label"><span data-v-43e6e8ac="">In attesa</span><small data-v-43e6e8ac="">Offline demo</small></div><strong data-v-43e6e8ac="">2</strong>
+          </li>
+          <li data-v-43e6e8ac="" data-tone="neutral" data-mode="demo">
+            <div data-v-43e6e8ac="" class="nebula-atlas-view__chip-label"><span data-v-43e6e8ac="">Neutrali</span><small data-v-43e6e8ac="">Offline demo</small></div><strong data-v-43e6e8ac="">1</strong>
+          </li>
+          <li data-v-43e6e8ac="" data-tone="critical" data-mode="demo">
+            <div data-v-43e6e8ac="" class="nebula-atlas-view__chip-label"><span data-v-43e6e8ac="">Bloccate</span><small data-v-43e6e8ac="">Offline demo</small></div><strong data-v-43e6e8ac="">0</strong>
+          </li>
+        </ul>
+      </div>
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__chart" aria-label="Copertura QA">
+        <header data-v-43e6e8ac="">
+          <h4 data-v-43e6e8ac="">Copertura QA media</h4><span data-v-43e6e8ac="">82%</span>
+        </header>
+        <div data-v-43e6e8ac="" class="sparkline-chart" points="60,72,88" color="#61d5ff" variant="demo"></div>
+      </div>
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__chart" aria-label="Incidenti telemetria">
+        <header data-v-43e6e8ac="">
+          <h4 data-v-43e6e8ac="">Incidenti ultimi 7 giorni</h4><span data-v-43e6e8ac="">3</span>
+        </header>
+        <div data-v-43e6e8ac="" class="sparkline-chart" points="2,1,0" color="#ff6982" variant="demo"></div>
+      </div>
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__chart" aria-label="High priority">
+        <header data-v-43e6e8ac="">
+          <h4 data-v-43e6e8ac="">High priority</h4><span data-v-43e6e8ac="">2</span>
+        </header>
+        <div data-v-43e6e8ac="" class="sparkline-chart" points="1,1,0" color="#f4c060" variant="demo"></div>
+      </div>
+    </div>
+    <footer data-v-43e6e8ac="" class="nebula-atlas-view__footer"><span data-v-43e6e8ac="">Sync mock 15m fa</span>
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__controls"><button data-v-43e6e8ac="" type="button" class="nebula-atlas-view__refresh">Aggiorna ora</button><button data-v-43e6e8ac="" type="button" class="nebula-atlas-view__refresh">Carica mock</button></div>
+    </footer>
+  </section>
+</section>"
+`;

--- a/webapp/tests/router/AppRouter.spec.ts
+++ b/webapp/tests/router/AppRouter.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { nextTick } from 'vue';
+import { createMemoryHistory } from 'vue-router';
+
+import { createAppRouter } from '../../src/router/index.js';
+import { resetNavigationMeta, useNavigationMeta } from '../../src/state/navigationMeta.js';
+
+describe('App router metadata', () => {
+  beforeEach(() => {
+    resetNavigationMeta();
+    document.title = 'Test Suite';
+  });
+
+  it('rispetta il BASE_URL personalizzato nella risoluzione dei link', () => {
+    const router = createAppRouter({ history: createMemoryHistory('/console/') });
+    const resolved = router.resolve({ name: 'atlas-world-builder' });
+    expect(resolved.href).toBe('/console/atlas/world-builder');
+  });
+
+  it('aggiorna document title e breadcrumb condivisi', async () => {
+    const router = createAppRouter({ history: createMemoryHistory('/console/') });
+    const { title, description, demo, breadcrumbs } = useNavigationMeta();
+
+    await router.push({ name: 'atlas-encounter-lab' });
+    await router.isReady();
+    await nextTick();
+
+    expect(document.title).toContain('Atlas · Encounter Lab');
+    expect(title.value).toBe('Atlas · Encounter Lab');
+    expect(description.value).toContain('incontri');
+    expect(demo.value).toBe(true);
+    const labels = breadcrumbs.value.map((entry) => entry.label);
+    expect(labels).toContain('Nebula Atlas');
+    expect(labels.at(-1)).toBe('Encounter Lab');
+  });
+});


### PR DESCRIPTION
## Summary
- add route metadata and navigation guard updates with a shared breadcrumb store and header component
- lazy-load atlas routes, surface demo/offline status in the layout, and enhance the Nebula atlas view with demo banner and controls
- expose demo telemetry activation and cover router base-url handling plus new UI snapshots in tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6904fdf0ada88332bdc802b4e4cae13f