### PR TITLE
Fix drop-off baseline in campaign progress funnel

### DIFF
--- a/scripts/etl/campaign_progress.py
+++ b/scripts/etl/campaign_progress.py
@@ -193,7 +193,7 @@ def build_campaign_progress(records: Iterable[CampaignRecord]) -> Dict[str, Any]
         leads = int(stage["leads"])
         conversions = int(stage["conversions"])
         previous = funnel[index - 1] if index > 0 else None
-        drop_off_base = (previous["conversions"] if previous else leads) or (previous["leads"] if previous else leads)
+        drop_off_base = previous["leads"] if previous else leads
         drop_off_rate = 0.0
         if previous and drop_off_base:
             drop_off_rate = max(0.0, 1 - leads / drop_off_base)


### PR DESCRIPTION
## Summary
- compute funnel drop-off using the previous stage's lead count instead of conversions
- ensure drop-off rates reflect attrition between campaign stages accurately

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69051cb3b4fc83328c049ff5b1d96da7