### PR TITLE
Add dynamic event editor tooling and telemetry coverage

### DIFF
--- a/analytics/events.ts
+++ b/analytics/events.ts
@@ -1,0 +1,155 @@
+import type { AnalyticsAdapter } from './matchmaking';
+
+export const EVENT_JOIN = 'events.join';
+export const EVENT_COMPLETE = 'events.complete';
+export const EVENT_PURCHASE = 'events.purchase';
+
+export interface EventJoinPayload {
+  eventId: string;
+  playerId: string;
+  partySize?: number;
+  joinMethod?: string;
+  phaseId?: string;
+  timestamp?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface EventCompletePayload {
+  eventId: string;
+  playerId: string;
+  result: 'victory' | 'defeat' | 'abandon' | 'timeout';
+  durationMs?: number;
+  rewards?: string[];
+  phaseId?: string;
+  timestamp?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface EventPurchasePayload {
+  eventId: string;
+  playerId: string;
+  sku: string;
+  currency: string;
+  amount: number;
+  quantity?: number;
+  source?: string;
+  timestamp?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface EventsAnalytics {
+  recordJoin(payload: EventJoinPayload): void;
+  recordCompletion(payload: EventCompletePayload): void;
+  recordPurchase(payload: EventPurchasePayload): void;
+}
+
+const sanitizeMetadata = (metadata?: Record<string, unknown>): Record<string, unknown> | undefined => {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return undefined;
+  }
+  return { ...metadata };
+};
+
+const sanitizeStringList = (values?: string[]): string[] | undefined => {
+  if (!Array.isArray(values)) {
+    return undefined;
+  }
+  return values.map((value) => String(value));
+};
+
+const normalizeTimestamp = (timestamp?: string): string | undefined => {
+  if (!timestamp) {
+    return undefined;
+  }
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+  return parsed.toISOString();
+};
+
+const normalizePartySize = (partySize?: number): number | undefined => {
+  if (typeof partySize !== 'number' || !Number.isFinite(partySize)) {
+    return undefined;
+  }
+  const rounded = Math.max(1, Math.round(partySize));
+  return rounded;
+};
+
+const normalizeAmount = (amount: number): number | undefined => {
+  if (typeof amount !== 'number' || !Number.isFinite(amount)) {
+    return undefined;
+  }
+  return Math.round(amount * 100) / 100;
+};
+
+const compact = <T extends Record<string, unknown>>(payload: T): T => {
+  return Object.entries(payload).reduce((acc, [key, value]) => {
+    if (value !== undefined && value !== null) {
+      (acc as Record<string, unknown>)[key] = value;
+    }
+    return acc;
+  }, {} as Record<string, unknown>) as T;
+};
+
+export function createEventsAnalytics(adapter: AnalyticsAdapter): EventsAnalytics {
+  const track = (eventName: string, payload: Record<string, unknown>): void => {
+    adapter.track(eventName, payload);
+  };
+
+  return {
+    recordJoin(payload: EventJoinPayload): void {
+      track(
+        EVENT_JOIN,
+        compact({
+          eventId: String(payload.eventId),
+          playerId: String(payload.playerId),
+          partySize: normalizePartySize(payload.partySize),
+          joinMethod: payload.joinMethod ? String(payload.joinMethod) : undefined,
+          phaseId: payload.phaseId ? String(payload.phaseId) : undefined,
+          timestamp: normalizeTimestamp(payload.timestamp) ?? new Date().toISOString(),
+          metadata: sanitizeMetadata(payload.metadata),
+        }),
+      );
+    },
+    recordCompletion(payload: EventCompletePayload): void {
+      track(
+        EVENT_COMPLETE,
+        compact({
+          eventId: String(payload.eventId),
+          playerId: String(payload.playerId),
+          result: String(payload.result),
+          durationMs:
+            typeof payload.durationMs === 'number' && Number.isFinite(payload.durationMs)
+              ? payload.durationMs
+              : undefined,
+          rewards: sanitizeStringList(payload.rewards),
+          phaseId: payload.phaseId ? String(payload.phaseId) : undefined,
+          timestamp: normalizeTimestamp(payload.timestamp) ?? new Date().toISOString(),
+          metadata: sanitizeMetadata(payload.metadata),
+        }),
+      );
+    },
+    recordPurchase(payload: EventPurchasePayload): void {
+      track(
+        EVENT_PURCHASE,
+        compact({
+          eventId: String(payload.eventId),
+          playerId: String(payload.playerId),
+          sku: String(payload.sku),
+          currency: String(payload.currency).toUpperCase(),
+          amount: normalizeAmount(payload.amount),
+          quantity:
+            typeof payload.quantity === 'number' && Number.isFinite(payload.quantity)
+              ? Math.max(1, Math.round(payload.quantity))
+              : 1,
+          source: payload.source ? String(payload.source) : undefined,
+          timestamp: normalizeTimestamp(payload.timestamp) ?? new Date().toISOString(),
+          metadata: sanitizeMetadata(payload.metadata),
+        }),
+      );
+    },
+  };
+}
+
+export default createEventsAnalytics;

--- a/docs/ideas/idea-intake.css
+++ b/docs/ideas/idea-intake.css
@@ -336,12 +336,15 @@
   white-space: pre-wrap;
 }
 
-#idea-widget .linkish {
+#idea-widget .linkish,
+#idea-widget .feedback-link {
   color: var(--color-accent-400);
 }
 
 #idea-widget .linkish:hover,
-#idea-widget .linkish:focus-visible {
+#idea-widget .linkish:focus-visible,
+#idea-widget .feedback-link:hover,
+#idea-widget .feedback-link:focus-visible {
   text-decoration: underline;
 }
 

--- a/docs/public/embed.js
+++ b/docs/public/embed.js
@@ -70,7 +70,7 @@ ius:8px; padding:0.45rem 0.6rem; font:inherit; }
       .feedback-card .status { font-size:0.85rem; min-height:1.2rem; }
       .feedback-card .status.err { color:#8b1a1a; }
       .feedback-card .status.ok { color:#1a7f3b; }
-      .feedback-card .linkish { color:#3046c5; text-decoration:underline; }
+      .feedback-card .feedback-link { color:#3046c5; text-decoration:underline; }
     `;
     document.head.appendChild(style);
   }
@@ -478,13 +478,13 @@ ius:8px; padding:0.45rem 0.6rem; font:inherit; }
 
     const introParts = [];
     if (templateUrl) {
-      const link = el('a', { href: templateUrl, target: '_blank', rel: 'noreferrer', class: 'linkish' }, 'template completo');
+      const link = el('a', { href: templateUrl, target: '_blank', rel: 'noreferrer', class: 'feedback-link' }, 'template completo');
       introParts.push('Aiutaci a migliorare il flusso (feedback rapido qui sotto o apri il ', link, ').');
     } else {
       introParts.push('Aiutaci a migliorare il flusso: lascia un commento rapido qui sotto.');
     }
     if (!hasApi && slackChannel) {
-      const slackAnchor = el('a', { href: slackLink, target: '_blank', rel: 'noreferrer', class: 'linkish' }, slackChannel);
+      const slackAnchor = el('a', { href: slackLink, target: '_blank', rel: 'noreferrer', class: 'feedback-link' }, slackChannel);
       introParts.push(' Puoi anche aprire ', slackAnchor, ' per discutere follow-up o allegare materiali.');
     }
     wrapper.appendChild(el('p', { class: 'note small' }, introParts));
@@ -553,7 +553,7 @@ ius:8px; padding:0.45rem 0.6rem; font:inherit; }
     } else if (slackLink) {
       const fallback = el('p', { class: 'note small' }, [
         'API non configurata: usa ',
-        el('a', { href: slackLink, target: '_blank', rel: 'noreferrer', class: 'linkish' }, slackChannel),
+        el('a', { href: slackLink, target: '_blank', rel: 'noreferrer', class: 'feedback-link' }, slackChannel),
         ' per condividere il feedback (allega log o screenshot rilevanti).'
       ]);
       wrapper.appendChild(fallback);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test:web": "npm --prefix tools/ts run test:web --",
     "build": "npm --prefix tools/ts run build --",
     "test": "npm run test:api && npm --prefix tools/ts run test -- && npm --prefix webapp run test",
-    "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 tools/ts/node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 tools/ts/node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && tools/ts/node_modules/.bin/tsx tests/scripts/tune_items.test.ts",
+    "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 tools/ts/node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 tools/ts/node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && tools/ts/node_modules/.bin/tsx tests/scripts/tune_items.test.ts && tools/ts/node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts",
     "start:api": "node server/index.js",
     "build:idea-taxonomy": "node scripts/build-idea-taxonomy.js",
     "drive:generate-approved": "node tools/drive/generate-approved-assets.mjs",

--- a/services/eventsScheduler/index.js
+++ b/services/eventsScheduler/index.js
@@ -1,0 +1,377 @@
+const ISO_HAS_OFFSET = /(?:Z|[+-]\d\d:?\d\d)$/i;
+
+function isValidTimeZone(timeZone) {
+  try {
+    if (!timeZone) {
+      return false;
+    }
+    new Intl.DateTimeFormat('en-US', { timeZone }).format();
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+function slugify(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || undefined;
+}
+
+function normalizeNumber(value, fallback = 0) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return fallback;
+}
+
+function getTimezoneOffsetMinutes(timeZone, date = new Date()) {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+
+  const parts = dtf.formatToParts(date).reduce((acc, part) => {
+    acc[part.type] = part.value;
+    return acc;
+  }, {});
+
+  const asUtc = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    Number(parts.hour),
+    Number(parts.minute),
+    Number(parts.second),
+  );
+
+  return (asUtc - date.getTime()) / 60000;
+}
+
+function formatOffset(minutes) {
+  const sign = minutes >= 0 ? '+' : '-';
+  const abs = Math.abs(minutes);
+  const hours = String(Math.trunc(abs / 60)).padStart(2, '0');
+  const mins = String(Math.trunc(abs % 60)).padStart(2, '0');
+  return `${sign}${hours}:${mins}`;
+}
+
+function formatOffsetIso(date, timeZone) {
+  const dtf = new Intl.DateTimeFormat('sv-SE', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  const parts = dtf.formatToParts(date).reduce((acc, part) => {
+    acc[part.type] = part.value;
+    return acc;
+  }, {});
+  const offsetMinutes = getTimezoneOffsetMinutes(timeZone, date);
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}${formatOffset(
+    offsetMinutes,
+  )}`;
+}
+
+function parseInTimeZone(value, timeZone) {
+  if (!isValidTimeZone(timeZone)) {
+    return new Date(Number.NaN);
+  }
+  const [datePart, timePart = '00:00:00'] = String(value).split('T');
+  const [year, month, day] = datePart.split('-').map((part) => Number.parseInt(part, 10));
+  const [hour = '00', minute = '00', second = '00'] = timePart.split(':');
+  const [secondPart, milliPart = '0'] = second.split('.');
+  const utc = Date.UTC(
+    year,
+    (month || 1) - 1,
+    day || 1,
+    Number.parseInt(hour, 10) || 0,
+    Number.parseInt(minute, 10) || 0,
+    Number.parseInt(secondPart, 10) || 0,
+    Number.parseInt(milliPart, 10) || 0,
+  );
+  const offset = getTimezoneOffsetMinutes(timeZone, new Date(utc));
+  return new Date(utc - offset * 60000);
+}
+
+function parseDateInput(value, timeZone) {
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return new Date(value);
+  }
+  if (typeof value === 'string') {
+    if (ISO_HAS_OFFSET.test(value)) {
+      const parsed = new Date(value);
+      if (!Number.isNaN(parsed.getTime())) {
+        return parsed;
+      }
+    }
+    if (timeZone) {
+      const parsedTz = parseInTimeZone(value, timeZone);
+      if (parsedTz && !Number.isNaN(parsedTz.getTime())) {
+        return parsedTz;
+      }
+    }
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function cloneDefinition(definition) {
+  return JSON.parse(JSON.stringify(definition ?? {}));
+}
+
+function buildPhase(phase, eventStart, defaultTimezone, index = 0) {
+  if (!phase || typeof phase !== 'object') {
+    return null;
+  }
+  const timezone = phase.timezone || defaultTimezone;
+  if (!isValidTimeZone(timezone)) {
+    return null;
+  }
+  const offsetMinutes = normalizeNumber(phase.offsetMinutes, index === 0 ? 0 : index * 5);
+  const start = phase.start
+    ? parseDateInput(phase.start, timezone)
+    : new Date(eventStart.getTime() + offsetMinutes * 60000);
+  if (!start || Number.isNaN(start.getTime())) {
+    return null;
+  }
+  const durationMinutes = normalizeNumber(phase.durationMinutes, 0);
+  const end = phase.end
+    ? parseDateInput(phase.end, timezone)
+    : new Date(start.getTime() + durationMinutes * 60000);
+  if (!end || Number.isNaN(end.getTime())) {
+    return null;
+  }
+  const safeDuration = Math.max(0, Math.round((end.getTime() - start.getTime()) / 60000));
+  return {
+    id: String(phase.id ?? phase.key ?? `phase-${index + 1}`),
+    label: String(phase.label ?? `Fase ${index + 1}`),
+    offsetMinutes: Math.max(0, Math.round((start.getTime() - eventStart.getTime()) / 60000)),
+    durationMinutes: safeDuration,
+    start,
+    end,
+    isoStart: start.toISOString(),
+    isoEnd: end.toISOString(),
+    localStart: formatOffsetIso(start, timezone),
+    localEnd: formatOffsetIso(end, timezone),
+    timezone,
+  };
+}
+
+function normalizeEvent(definition, defaultTimezone, source, index = 0) {
+  if (!definition || typeof definition !== 'object') {
+    return null;
+  }
+  const timezone = definition.timezone || defaultTimezone;
+  if (!isValidTimeZone(timezone)) {
+    return null;
+  }
+  const start = parseDateInput(definition.start, timezone);
+  if (!start || Number.isNaN(start.getTime())) {
+    return null;
+  }
+  const hasEnd = definition.end !== undefined && definition.end !== null;
+  let end = hasEnd ? parseDateInput(definition.end, timezone) : null;
+  const durationMinutes = normalizeNumber(definition.durationMinutes, NaN);
+  if ((!end || Number.isNaN(end.getTime())) && Number.isFinite(durationMinutes)) {
+    end = new Date(start.getTime() + Math.max(0, durationMinutes) * 60000);
+  }
+  if (!end || Number.isNaN(end.getTime()) || end.getTime() <= start.getTime()) {
+    return null;
+  }
+  const effectiveDurationMinutes = Math.round((end.getTime() - start.getTime()) / 60000);
+  const phases = Array.isArray(definition.phases)
+    ? definition.phases
+        .map((phase, phaseIndex) => buildPhase(phase, start, timezone, phaseIndex))
+        .filter(Boolean)
+        .sort((a, b) => a.start.getTime() - b.start.getTime())
+    : [];
+
+  const tags = Array.isArray(definition.tags) ? definition.tags.map((tag) => String(tag)) : undefined;
+  const metadata = definition.metadata && typeof definition.metadata === 'object' ? { ...definition.metadata } : undefined;
+
+  const title = definition.title || definition.name || `Evento ${index + 1}`;
+  const id = String(definition.id ?? slugify(title) ?? `event-${index + 1}`);
+
+  return {
+    id,
+    title: String(title),
+    timezone,
+    start,
+    end,
+    isoStart: start.toISOString(),
+    isoEnd: end.toISOString(),
+    localStart: formatOffsetIso(start, timezone),
+    localEnd: formatOffsetIso(end, timezone),
+    durationMinutes: effectiveDurationMinutes,
+    metadata,
+    tags,
+    phases,
+    source,
+  };
+}
+
+function serializeEvent(event) {
+  return {
+    id: event.id,
+    title: event.title,
+    timezone: event.timezone,
+    isoStart: event.isoStart,
+    isoEnd: event.isoEnd,
+    localStart: event.localStart,
+    localEnd: event.localEnd,
+    durationMinutes: event.durationMinutes,
+    metadata: event.metadata ? { ...event.metadata } : undefined,
+    tags: event.tags ? [...event.tags] : undefined,
+    phases: event.phases.map((phase) => ({
+      id: phase.id,
+      label: phase.label,
+      offsetMinutes: phase.offsetMinutes,
+      durationMinutes: phase.durationMinutes,
+      isoStart: phase.isoStart,
+      isoEnd: phase.isoEnd,
+      localStart: phase.localStart,
+      localEnd: phase.localEnd,
+      timezone: phase.timezone,
+    })),
+    source: event.source,
+  };
+}
+
+function normalizeEvents(definitions, timezone, source, allowUtcFallback = false) {
+  return definitions
+    .map((definition, index) => {
+      const timezoneValid = isValidTimeZone(timezone);
+      const candidateTimezone =
+        definition?.timezone || (timezoneValid ? timezone : allowUtcFallback ? 'UTC' : timezone);
+      return normalizeEvent(definition, candidateTimezone, source, index);
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.start.getTime() - b.start.getTime());
+}
+
+export function createEventsScheduler(options = {}) {
+  let timezone =
+    typeof options.timezone === 'string' && options.timezone.trim() ? options.timezone.trim() : 'UTC';
+  let timezoneValid = isValidTimeZone(timezone);
+  let now = typeof options.now === 'function' ? options.now : () => new Date();
+  let baseDefinitions = Array.isArray(options.events) ? options.events.map(cloneDefinition) : [];
+  let fallbackDefinitions = Array.isArray(options.manualFallback)
+    ? options.manualFallback.map(cloneDefinition)
+    : [];
+
+  let events = normalizeEvents(baseDefinitions, timezone, 'primary', false);
+  let fallbackEvents = normalizeEvents(fallbackDefinitions, timezone, 'manualFallback', true);
+
+  const usingFallback = () =>
+    (!timezoneValid && fallbackEvents.length > 0) || (events.length === 0 && fallbackEvents.length > 0);
+  const dataset = () => (usingFallback() ? fallbackEvents : events);
+
+  function refresh() {
+    events = normalizeEvents(baseDefinitions, timezone, 'primary', false);
+    fallbackEvents = normalizeEvents(fallbackDefinitions, timezone, 'manualFallback', true);
+    timezoneValid = isValidTimeZone(timezone);
+  }
+
+  function resolveDate(value) {
+    const parsed = parseDateInput(value, timezone);
+    return parsed && !Number.isNaN(parsed.getTime()) ? parsed : null;
+  }
+
+  return {
+    load(definitions = []) {
+      baseDefinitions = Array.isArray(definitions) ? definitions.map(cloneDefinition) : [];
+      refresh();
+      return this;
+    },
+    setManualFallback(definitions = []) {
+      fallbackDefinitions = Array.isArray(definitions) ? definitions.map(cloneDefinition) : [];
+      refresh();
+      return this;
+    },
+    setTimezone(value) {
+      timezone = value && value.toString().trim() ? value.toString().trim() : 'UTC';
+      timezoneValid = isValidTimeZone(timezone);
+      refresh();
+      return this;
+    },
+    getTimezone() {
+      return timezone;
+    },
+    getTimeline({ from, to, includePast = true } = {}) {
+      const fromDate = from ? resolveDate(from) : null;
+      const toDate = to ? resolveDate(to) : null;
+      let result = dataset();
+      if (fromDate) {
+        result = result.filter((event) => event.end.getTime() >= fromDate.getTime());
+      }
+      if (toDate) {
+        result = result.filter((event) => event.start.getTime() <= toDate.getTime());
+      }
+      if (!includePast) {
+        const nowDate = now();
+        result = result.filter((event) => event.end.getTime() >= nowDate.getTime());
+      }
+      return result.map(serializeEvent);
+    },
+    getActiveEvents(reference) {
+      const ref = reference ? resolveDate(reference) : now();
+      if (!ref || Number.isNaN(ref.getTime())) {
+        return [];
+      }
+      return dataset()
+        .filter((event) => event.start.getTime() <= ref.getTime() && ref.getTime() < event.end.getTime())
+        .map(serializeEvent);
+    },
+    getNextEvent(reference) {
+      const ref = reference ? resolveDate(reference) : now();
+      if (!ref || Number.isNaN(ref.getTime())) {
+        return null;
+      }
+      const next = dataset()
+        .filter((event) => event.start.getTime() > ref.getTime())
+        .sort((a, b) => a.start.getTime() - b.start.getTime())[0];
+      return next ? serializeEvent(next) : null;
+    },
+    isUsingFallback() {
+      return usingFallback();
+    },
+    toJSON() {
+      return {
+        timezone,
+        events: events.map(serializeEvent),
+        manualFallback: fallbackEvents.map(serializeEvent),
+      };
+    },
+  };
+}
+
+export function buildEventTimeline(events, options) {
+  return createEventsScheduler(options).load(events).getTimeline();
+}
+
+export default createEventsScheduler;

--- a/services/eventsScheduler/package.json
+++ b/services/eventsScheduler/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "events-scheduler",
+  "type": "module"
+}

--- a/tests/events/dynamicEvents.e2e.ts
+++ b/tests/events/dynamicEvents.e2e.ts
@@ -1,0 +1,168 @@
+import { describe, it } from 'node:test';
+import assert from 'assert';
+import { createEventsScheduler } from '../../services/eventsScheduler/index.js';
+import {
+  createEventsAnalytics,
+  EVENT_JOIN,
+  EVENT_COMPLETE,
+  EVENT_PURCHASE,
+} from '../../analytics/events';
+
+describe('Dynamic events — scheduler e telemetria', () => {
+  it('gestisce timeline multi-fuso e registra telemetria end-to-end', () => {
+    const now = () => new Date('2024-02-10T08:00:00Z');
+
+    const scheduler = createEventsScheduler({
+      timezone: 'Europe/Rome',
+      now,
+      manualFallback: [
+        {
+          id: 'fallback-briefing',
+          title: 'Briefing di emergenza',
+          start: '2024-02-10T08:30',
+          durationMinutes: 45,
+          timezone: 'UTC',
+          metadata: { description: 'Contingency plan attivo.' },
+        },
+      ],
+    });
+
+    const events = [
+      {
+        id: 'raid-alba',
+        title: 'Raid Alba Nebula',
+        start: '2024-02-10T10:00',
+        durationMinutes: 120,
+        metadata: {
+          description: 'Invasione coordinata sui bastioni orbitali.',
+          rewards: ['Sigillo Zenith', '7500 crediti'],
+        },
+        tags: ['raid', 'premium'],
+        phases: [
+          { id: 'setup', label: 'Preparazione', offsetMinutes: 0, durationMinutes: 30 },
+          { id: 'assault', label: 'Assalto', offsetMinutes: 30, durationMinutes: 60 },
+          { id: 'recover', label: 'Recupero', offsetMinutes: 90, durationMinutes: 30 },
+        ],
+      },
+      {
+        id: 'raid-crepuscolo',
+        title: 'Raid Crepuscolo',
+        start: '2024-02-10T18:30',
+        durationMinutes: 90,
+        timezone: 'Europe/London',
+        phases: [
+          { id: 'intel', label: 'Intelligence', offsetMinutes: 0, durationMinutes: 20 },
+          { id: 'breach', label: 'Breach', offsetMinutes: 20, durationMinutes: 40 },
+        ],
+      },
+    ];
+
+    scheduler.load(events);
+
+    const timeline = scheduler.getTimeline();
+    assert.strictEqual(timeline.length, 2, 'La timeline deve includere due eventi programmati');
+    assert.strictEqual(timeline[0].id, 'raid-alba');
+    assert.strictEqual(
+      timeline[0].isoStart,
+      '2024-02-10T09:00:00.000Z',
+      'L\'inizio deve essere convertito in UTC rispettando il fuso orario globale',
+    );
+    assert.strictEqual(timeline[0].phases?.length, 3, 'Devono essere presenti tre fasi');
+    assert.strictEqual(
+      timeline[0].phases?.[1].isoStart,
+      '2024-02-10T09:30:00.000Z',
+      'La fase di assalto deve essere calcolata con offset corretto',
+    );
+    assert.strictEqual(timeline[1].isoStart, '2024-02-10T18:30:00.000Z');
+    assert.strictEqual(timeline[1].timezone, 'Europe/London');
+
+    const active = scheduler.getActiveEvents('2024-02-10T09:45:00Z');
+    assert.strictEqual(active.length, 1, 'Un evento deve essere attivo alle 09:45Z');
+    assert.strictEqual(active[0].id, 'raid-alba');
+
+    const next = scheduler.getNextEvent('2024-02-10T12:30:00Z');
+    assert.ok(next, 'Deve esistere un evento successivo');
+    assert.strictEqual(next?.id, 'raid-crepuscolo');
+
+    scheduler.setTimezone('Invalid/Timezone');
+    const fallbackTimeline = scheduler.getTimeline();
+    assert.strictEqual(scheduler.isUsingFallback(), true, 'Con fuso invalido deve attivarsi il fallback');
+    assert.strictEqual(fallbackTimeline.length, 1, 'Il fallback deve contenere un evento');
+    assert.strictEqual(fallbackTimeline[0].id, 'fallback-briefing');
+    assert.strictEqual(
+      fallbackTimeline[0].isoStart,
+      '2024-02-10T08:30:00.000Z',
+      'Il fallback deve rispettare il proprio fuso orario',
+    );
+
+    scheduler.setTimezone('Europe/Rome');
+    scheduler.load(events);
+
+    const recorded: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    const analytics = createEventsAnalytics({
+      track(eventName, payload) {
+        recorded.push({ event: eventName, payload: payload ?? {} });
+      },
+    });
+
+    const raidAlba = scheduler.getActiveEvents('2024-02-10T09:45:00Z')[0];
+    const raidPhase = raidAlba.phases?.find((phase) => phase.id === 'assault');
+
+    analytics.recordJoin({
+      eventId: raidAlba.id,
+      playerId: 'scout-09',
+      partySize: 3,
+      joinMethod: 'matchmaking',
+      phaseId: raidPhase?.id,
+      timestamp: '2024-02-10T09:45:00Z',
+    });
+
+    analytics.recordCompletion({
+      eventId: raidAlba.id,
+      playerId: 'scout-09',
+      result: 'victory',
+      durationMs: 7_200_000,
+      rewards: ['Sigillo Zenith'],
+      timestamp: '2024-02-10T11:05:00Z',
+    });
+
+    analytics.recordPurchase({
+      eventId: raidAlba.id,
+      playerId: 'scout-09',
+      sku: 'bundle_xp_boost',
+      currency: 'eur',
+      amount: 4.989,
+      quantity: 2,
+      source: 'timeline',
+      timestamp: '2024-02-10T09:50:00Z',
+    });
+
+    assert.strictEqual(recorded.length, 3, 'Devono essere registrati tre eventi');
+
+    const join = recorded[0];
+    assert.strictEqual(join.event, EVENT_JOIN);
+    assert.strictEqual(join.payload.eventId, 'raid-alba');
+    assert.strictEqual(join.payload.playerId, 'scout-09');
+    assert.strictEqual(join.payload.partySize, 3);
+    assert.strictEqual(join.payload.joinMethod, 'matchmaking');
+    assert.strictEqual(join.payload.phaseId, 'assault');
+    assert.strictEqual(join.payload.timestamp, new Date('2024-02-10T09:45:00Z').toISOString());
+
+    const completion = recorded[1];
+    assert.strictEqual(completion.event, EVENT_COMPLETE);
+    assert.strictEqual(completion.payload.result, 'victory');
+    assert.strictEqual(completion.payload.durationMs, 7_200_000);
+    assert.deepStrictEqual(completion.payload.rewards, ['Sigillo Zenith']);
+
+    const purchase = recorded[2];
+    assert.strictEqual(purchase.event, EVENT_PURCHASE);
+    assert.strictEqual(purchase.payload.currency, 'EUR');
+    assert.strictEqual(purchase.payload.amount, 4.99);
+    assert.strictEqual(purchase.payload.quantity, 2);
+
+    const exported = scheduler.toJSON();
+    assert.strictEqual(exported.events.length, 2, 'La serializzazione deve mantenere gli eventi');
+    assert.strictEqual(exported.manualFallback.length, 1, 'La serializzazione deve includere il fallback');
+    assert.strictEqual(exported.timezone, 'Europe/Rome');
+  });
+});

--- a/webapp/admin/events/index.html
+++ b/webapp/admin/events/index.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Editor eventi dinamici</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Editor eventi dinamici</h1>
+      <p>
+        Configura eventi live per le missioni, personalizza le fasi e verifica la timeline
+        risultante con gestione del fuso orario e fallback manuale.
+      </p>
+    </header>
+    <main class="layout">
+      <section class="panel panel--form">
+        <div class="panel__header">
+          <h2>Configurazione evento</h2>
+          <p>Aggiungi o modifica un evento dinamico e definisci le sue fasi principali.</p>
+        </div>
+        <form data-event-form class="event-form">
+          <div class="form-grid">
+            <label class="form-field">
+              <span>Titolo</span>
+              <input name="title" type="text" placeholder="Assalto alle Torri" required />
+            </label>
+            <label class="form-field">
+              <span>ID</span>
+              <input name="eventId" type="text" placeholder="raid-assalto" />
+            </label>
+            <label class="form-field">
+              <span>Inizio</span>
+              <input name="start" type="datetime-local" required />
+            </label>
+            <label class="form-field">
+              <span>Durata (min)</span>
+              <input name="duration" type="number" min="15" step="5" value="90" required />
+            </label>
+            <label class="form-field">
+              <span>Fuso orario evento</span>
+              <input
+                name="timezone"
+                type="text"
+                list="timezone-list"
+                placeholder="Europe/Rome"
+              />
+            </label>
+            <label class="form-field">
+              <span>Tag</span>
+              <input name="tags" type="text" placeholder="raid, premium" />
+            </label>
+          </div>
+          <label class="form-field form-field--wide">
+            <span>Descrizione</span>
+            <textarea
+              name="description"
+              rows="3"
+              placeholder="Raid cooperativo a ondate con ricompense uniche"
+            ></textarea>
+          </label>
+          <label class="form-field form-field--wide">
+            <span>Ricompense (separate da virgola)</span>
+            <input name="rewards" type="text" placeholder="Gladio Astro, 5000 credito" />
+          </label>
+          <section class="phase-section">
+            <div class="phase-section__header">
+              <h3>Fasi evento</h3>
+              <button type="button" data-add-phase class="ghost-button">Aggiungi fase</button>
+            </div>
+            <p class="phase-section__hint">
+              Usa le fasi per coordinare attività, notifiche e spawn. Offsets e durate sono
+              espressi in minuti rispetto all'inizio dell'evento.
+            </p>
+            <div class="phase-list" data-phase-list></div>
+          </section>
+          <div class="form-actions">
+            <button type="submit" class="primary">Salva evento</button>
+            <button type="button" data-reset-form class="ghost-button">Pulisci form</button>
+          </div>
+        </form>
+      </section>
+      <section class="panel panel--timeline">
+        <div class="panel__header">
+          <h2>Timeline dinamica</h2>
+          <p>La timeline aggiorna automaticamente la sequenza degli eventi configurati.</p>
+        </div>
+        <div class="timeline-toolbar">
+          <label class="form-field">
+            <span>Fuso orario globale</span>
+            <input
+              type="text"
+              data-scheduler-timezone
+              list="timezone-list"
+              placeholder="UTC"
+            />
+          </label>
+          <button type="button" data-export-json class="ghost-button">Esporta JSON</button>
+        </div>
+        <div class="timeline-preview" data-timeline></div>
+      </section>
+      <section class="panel panel--list">
+        <div class="panel__header">
+          <h2>Eventi programmati</h2>
+          <p>Gestisci gli eventi attivi nella timeline. Modifica o rimuovi quelli non più utili.</p>
+        </div>
+        <div class="events-list" data-events-list></div>
+      </section>
+      <section class="panel panel--fallback">
+        <div class="panel__header">
+          <h2>Fallback manuale</h2>
+          <p>
+            Definisci eventi di backup usati quando il fuso orario principale non è valido o non ci
+            sono eventi attivi.
+          </p>
+        </div>
+        <form data-fallback-form class="fallback-form">
+          <div class="form-grid">
+            <label class="form-field">
+              <span>Titolo</span>
+              <input name="fallbackTitle" type="text" placeholder="Emergenza Nebula" required />
+            </label>
+            <label class="form-field">
+              <span>ID</span>
+              <input name="fallbackId" type="text" placeholder="fallback-emergenza" />
+            </label>
+            <label class="form-field">
+              <span>Inizio</span>
+              <input name="fallbackStart" type="datetime-local" required />
+            </label>
+            <label class="form-field">
+              <span>Durata (min)</span>
+              <input name="fallbackDuration" type="number" min="15" step="5" value="60" required />
+            </label>
+            <label class="form-field">
+              <span>Fuso orario</span>
+              <input
+                name="fallbackTimezone"
+                type="text"
+                list="timezone-list"
+                placeholder="UTC"
+              />
+            </label>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="primary">Aggiungi fallback</button>
+            <button type="button" data-clear-fallback class="ghost-button">Svuota fallback</button>
+          </div>
+        </form>
+        <div class="events-list" data-fallback-list></div>
+      </section>
+    </main>
+    <template id="phase-row-template">
+      <div class="phase-row">
+        <label>
+          <span>Nome fase</span>
+          <input type="text" data-phase-label placeholder="Preparazione" />
+        </label>
+        <label>
+          <span>Offset (min)</span>
+          <input type="number" min="0" step="5" data-phase-offset value="0" />
+        </label>
+        <label>
+          <span>Durata (min)</span>
+          <input type="number" min="5" step="5" data-phase-duration value="15" />
+        </label>
+        <button type="button" class="ghost-button" data-remove-phase>Rimuovi</button>
+      </div>
+    </template>
+    <datalist id="timezone-list">
+      <option value="UTC"></option>
+      <option value="Europe/Rome"></option>
+      <option value="Europe/London"></option>
+      <option value="America/New_York"></option>
+      <option value="America/Los_Angeles"></option>
+      <option value="America/Sao_Paulo"></option>
+      <option value="Asia/Tokyo"></option>
+      <option value="Asia/Singapore"></option>
+      <option value="Australia/Sydney"></option>
+    </datalist>
+    <footer class="app-footer">
+      <p>
+        La timeline utilizza lo scheduler condiviso con i servizi backend per garantire
+        allineamento tra anteprima e logica di pubblicazione eventi.
+      </p>
+    </footer>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/webapp/admin/events/main.js
+++ b/webapp/admin/events/main.js
@@ -1,0 +1,399 @@
+import { createEventsScheduler } from '../../../services/eventsScheduler/index.js';
+import { createTimelinePreview } from './timelinePreview.js';
+
+const scheduler = createEventsScheduler({ timezone: 'UTC' });
+const timeline = createTimelinePreview(document.querySelector('[data-timeline]'));
+
+const state = {
+  events: [],
+  manualFallback: [],
+  editingId: null,
+};
+
+const eventForm = document.querySelector('[data-event-form]');
+const phaseList = document.querySelector('[data-phase-list]');
+const addPhaseButton = document.querySelector('[data-add-phase]');
+const resetButton = document.querySelector('[data-reset-form]');
+const eventsList = document.querySelector('[data-events-list]');
+const fallbackForm = document.querySelector('[data-fallback-form]');
+const fallbackList = document.querySelector('[data-fallback-list]');
+const fallbackClearButton = document.querySelector('[data-clear-fallback]');
+const timezoneInput = document.querySelector('[data-scheduler-timezone]');
+const exportButton = document.querySelector('[data-export-json]');
+
+function slugify(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function parseNumber(value, fallback = 0) {
+  const parsed = Number.parseFloat(value);
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+  return fallback;
+}
+
+function generateEventId(event) {
+  if (event.id && event.id.trim()) {
+    return event.id.trim();
+  }
+  const fromTitle = slugify(event.title);
+  if (fromTitle) {
+    return fromTitle;
+  }
+  return `event-${Date.now()}`;
+}
+
+function createPhaseRow(phase = {}) {
+  const template = document.getElementById('phase-row-template');
+  const fragment = template.content.cloneNode(true);
+  const row = fragment.querySelector('.phase-row');
+  const labelInput = fragment.querySelector('[data-phase-label]');
+  const offsetInput = fragment.querySelector('[data-phase-offset]');
+  const durationInput = fragment.querySelector('[data-phase-duration]');
+  const removeButton = fragment.querySelector('[data-remove-phase]');
+
+  const phaseId = phase.id || `phase-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+  row.dataset.phaseId = phaseId;
+  labelInput.value = phase.label || '';
+  offsetInput.value = phase.offsetMinutes ?? 0;
+  durationInput.value = phase.durationMinutes ?? 15;
+
+  removeButton.addEventListener('click', () => {
+    row.remove();
+    refreshPreview();
+  });
+
+  return row;
+}
+
+function resetPhaseList(phases = []) {
+  phaseList.innerHTML = '';
+  if (!phases.length) {
+    phases = [
+      { label: 'Preparazione', offsetMinutes: 0, durationMinutes: 15 },
+      { label: 'Climax', offsetMinutes: 30, durationMinutes: 30 },
+    ];
+  }
+  phases.forEach((phase) => {
+    phaseList.append(createPhaseRow(phase));
+  });
+}
+
+function readPhases() {
+  return Array.from(phaseList.querySelectorAll('.phase-row'))
+    .map((row, index) => {
+      const labelInput = row.querySelector('[data-phase-label]');
+      const offsetInput = row.querySelector('[data-phase-offset]');
+      const durationInput = row.querySelector('[data-phase-duration]');
+      const label = labelInput.value.trim() || `Fase ${index + 1}`;
+      const offsetMinutes = Math.max(0, Math.round(parseNumber(offsetInput.value, index * 10)));
+      const durationMinutes = Math.max(5, Math.round(parseNumber(durationInput.value, 10)));
+      return {
+        id: row.dataset.phaseId || `phase-${index + 1}`,
+        label,
+        offsetMinutes,
+        durationMinutes,
+      };
+    })
+    .filter((phase) => Boolean(phase));
+}
+
+function formToEvent() {
+  const data = new FormData(eventForm);
+  const description = data.get('description')?.toString().trim();
+  const rewards = data
+    .get('rewards')
+    ?.toString()
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const tags = data
+    .get('tags')
+    ?.toString()
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  const event = {
+    id: data.get('eventId')?.toString().trim() || undefined,
+    title: data.get('title')?.toString().trim() || 'Evento senza titolo',
+    start: data.get('start')?.toString(),
+    durationMinutes: Math.max(15, Math.round(parseNumber(data.get('duration'), 60))),
+    timezone: data.get('timezone')?.toString().trim() || undefined,
+    metadata: {},
+  };
+
+  const phases = readPhases();
+  if (phases.length) {
+    event.phases = phases;
+  }
+  if (description) {
+    event.metadata.description = description;
+  }
+  if (rewards?.length) {
+    event.metadata.rewards = rewards;
+  }
+  if (tags?.length) {
+    event.tags = tags;
+  }
+  if (event.metadata && Object.keys(event.metadata).length === 0) {
+    delete event.metadata;
+  }
+
+  return event;
+}
+
+function fillForm(event) {
+  eventForm.querySelector('[name="title"]').value = event.title || '';
+  eventForm.querySelector('[name="eventId"]').value = event.id || '';
+  eventForm.querySelector('[name="start"]').value = event.start || '';
+  eventForm.querySelector('[name="duration"]').value = event.durationMinutes ?? 60;
+  eventForm.querySelector('[name="timezone"]').value = event.timezone || '';
+  eventForm.querySelector('[name="description"]').value = event.metadata?.description || '';
+  eventForm.querySelector('[name="rewards"]').value = Array.isArray(event.metadata?.rewards)
+    ? event.metadata.rewards.join(', ')
+    : event.metadata?.rewards || '';
+  eventForm.querySelector('[name="tags"]').value = Array.isArray(event.tags)
+    ? event.tags.join(', ')
+    : event.tags || '';
+  resetPhaseList(event.phases || []);
+  state.editingId = event.id;
+}
+
+function resetForm() {
+  eventForm.reset();
+  state.editingId = null;
+  resetPhaseList();
+}
+
+function renderEventsList() {
+  eventsList.innerHTML = '';
+  if (!state.events.length) {
+    const empty = document.createElement('p');
+    empty.className = 'events-list__meta';
+    empty.textContent = 'Nessun evento programmato. Salva dal form per aggiungerlo alla timeline.';
+    eventsList.append(empty);
+    return;
+  }
+
+  state.events
+    .slice()
+    .sort((a, b) => (a.start || '').localeCompare(b.start || ''))
+    .forEach((event) => {
+      const item = document.createElement('article');
+      item.className = 'events-list__item';
+
+      const header = document.createElement('div');
+      header.className = 'events-list__header';
+
+      const title = document.createElement('h3');
+      title.className = 'events-list__title';
+      title.textContent = event.title;
+      header.append(title);
+
+      const actions = document.createElement('div');
+      actions.className = 'events-list__actions';
+
+      const editButton = document.createElement('button');
+      editButton.type = 'button';
+      editButton.className = 'ghost-button';
+      editButton.textContent = 'Modifica';
+      editButton.addEventListener('click', () => {
+        fillForm(event);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      });
+      actions.append(editButton);
+
+      const removeButton = document.createElement('button');
+      removeButton.type = 'button';
+      removeButton.className = 'ghost-button';
+      removeButton.textContent = 'Rimuovi';
+      removeButton.addEventListener('click', () => {
+        state.events = state.events.filter((existing) => existing.id !== event.id);
+        refreshPreview();
+        renderEventsList();
+      });
+      actions.append(removeButton);
+
+      header.append(actions);
+      item.append(header);
+
+      const meta = document.createElement('p');
+      meta.className = 'events-list__meta';
+      meta.textContent = `${event.start || '—'} · ${event.durationMinutes} min · ${
+        event.timezone || 'timezone ereditato'
+      }`;
+      item.append(meta);
+
+      if (event.phases?.length) {
+        const phasesInfo = document.createElement('p');
+        phasesInfo.className = 'events-list__meta';
+        phasesInfo.textContent = `${event.phases.length} fasi configurate.`;
+        item.append(phasesInfo);
+      }
+
+      eventsList.append(item);
+    });
+}
+
+function renderFallbackList() {
+  fallbackList.innerHTML = '';
+  if (!state.manualFallback.length) {
+    const empty = document.createElement('p');
+    empty.className = 'events-list__meta';
+    empty.textContent = 'Nessun fallback impostato.';
+    fallbackList.append(empty);
+    return;
+  }
+
+  state.manualFallback.forEach((event) => {
+    const item = document.createElement('article');
+    item.className = 'events-list__item';
+
+    const header = document.createElement('div');
+    header.className = 'events-list__header';
+
+    const title = document.createElement('h3');
+    title.className = 'events-list__title';
+    title.textContent = event.title;
+    header.append(title);
+
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.className = 'ghost-button';
+    removeButton.textContent = 'Rimuovi';
+    removeButton.addEventListener('click', () => {
+      state.manualFallback = state.manualFallback.filter((existing) => existing.id !== event.id);
+      refreshPreview();
+      renderFallbackList();
+    });
+
+    const meta = document.createElement('p');
+    meta.className = 'events-list__meta';
+    meta.textContent = `${event.start || '—'} · ${event.durationMinutes} min · ${
+      event.timezone || 'UTC'
+    }`;
+
+    header.append(removeButton);
+    item.append(header);
+    item.append(meta);
+
+    fallbackList.append(item);
+  });
+}
+
+function refreshPreview() {
+  const timezone = timezoneInput.value?.trim() || 'UTC';
+  scheduler.setTimezone(timezone);
+  scheduler.load(state.events);
+  scheduler.setManualFallback(state.manualFallback);
+  const timelineData = scheduler.getTimeline();
+  timeline.render(timelineData, {
+    usingFallback: scheduler.isUsingFallback(),
+    timezone: scheduler.getTimezone(),
+  });
+}
+
+function handleEventSubmit(event) {
+  event.preventDefault();
+  const payload = formToEvent();
+  payload.id = generateEventId(payload);
+
+  if (!payload.start) {
+    alert('Specifica un orario di inizio valido per l\'evento.');
+    return;
+  }
+
+  const existingIndex = state.events.findIndex((item) => item.id === payload.id);
+  if (existingIndex >= 0) {
+    state.events[existingIndex] = { ...state.events[existingIndex], ...payload };
+  } else {
+    state.events.push(payload);
+  }
+
+  resetForm();
+  renderEventsList();
+  refreshPreview();
+}
+
+function handleFallbackSubmit(event) {
+  event.preventDefault();
+  const data = new FormData(fallbackForm);
+  const fallback = {
+    id: data.get('fallbackId')?.toString().trim() || undefined,
+    title: data.get('fallbackTitle')?.toString().trim() || 'Fallback',
+    start: data.get('fallbackStart')?.toString(),
+    durationMinutes: Math.max(15, Math.round(parseNumber(data.get('fallbackDuration'), 60))),
+    timezone: data.get('fallbackTimezone')?.toString().trim() || undefined,
+  };
+
+  fallback.id = fallback.id || `${slugify(fallback.title)}-fallback`;
+
+  if (!fallback.start) {
+    alert('Imposta una data di inizio valida per il fallback.');
+    return;
+  }
+
+  const existingIndex = state.manualFallback.findIndex((item) => item.id === fallback.id);
+  if (existingIndex >= 0) {
+    state.manualFallback[existingIndex] = { ...state.manualFallback[existingIndex], ...fallback };
+  } else {
+    state.manualFallback.push(fallback);
+  }
+
+  fallbackForm.reset();
+  renderFallbackList();
+  refreshPreview();
+}
+
+function handleClearFallback() {
+  state.manualFallback = [];
+  renderFallbackList();
+  refreshPreview();
+}
+
+function handleExport() {
+  const payload = scheduler.toJSON();
+  const json = JSON.stringify(payload, null, 2);
+
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard
+      .writeText(json)
+      .then(() => {
+        alert('Configurazione copiata negli appunti.');
+      })
+      .catch(() => {
+        window.open()?.document.write(`<pre>${json.replace(/</g, '&lt;')}</pre>`);
+      });
+  } else {
+    window.open()?.document.write(`<pre>${json.replace(/</g, '&lt;')}</pre>`);
+  }
+}
+
+addPhaseButton?.addEventListener('click', () => {
+  phaseList.append(createPhaseRow());
+});
+
+resetButton?.addEventListener('click', () => {
+  resetForm();
+});
+
+eventForm?.addEventListener('submit', handleEventSubmit);
+fallbackForm?.addEventListener('submit', handleFallbackSubmit);
+fallbackClearButton?.addEventListener('click', handleClearFallback);
+timezoneInput?.addEventListener('change', refreshPreview);
+exportButton?.addEventListener('click', handleExport);
+
+if (timezoneInput && !timezoneInput.value) {
+  timezoneInput.value = scheduler.getTimezone();
+}
+
+resetPhaseList();
+renderEventsList();
+renderFallbackList();
+refreshPreview();

--- a/webapp/admin/events/styles.css
+++ b/webapp/admin/events/styles.css
@@ -1,0 +1,399 @@
+:root {
+  color-scheme: light dark;
+  --surface: rgba(255, 255, 255, 0.82);
+  --surface-alt: rgba(245, 247, 250, 0.88);
+  --border: rgba(30, 35, 55, 0.15);
+  --border-strong: rgba(30, 35, 55, 0.3);
+  --accent: #7a5cff;
+  --accent-strong: #5939ff;
+  --muted: rgba(30, 35, 55, 0.6);
+  --text: #0b1020;
+  --shadow: 0 12px 30px rgba(10, 20, 60, 0.1);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(122, 92, 255, 0.15), transparent 45%),
+    linear-gradient(135deg, #f6f8ff 0%, #eef2ff 40%, #fbfdff 100%);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header,
+.app-footer {
+  padding: 2.5rem 3rem 1rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.app-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2.5rem;
+  letter-spacing: -0.02em;
+}
+
+.app-header p,
+.app-footer p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 720px;
+  line-height: 1.5;
+}
+
+.layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+  padding: 0 3rem 3rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.panel {
+  background: var(--surface);
+  backdrop-filter: blur(12px);
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.panel__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.panel__header p {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.form-field span {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.form-field input,
+.form-field textarea,
+.timeline-toolbar input {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.65rem 0.85rem;
+  font-size: 1rem;
+  background: var(--surface-alt);
+  color: var(--text);
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-field input:focus,
+.form-field textarea:focus,
+.timeline-toolbar input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(122, 92, 255, 0.15);
+}
+
+.form-field--wide {
+  grid-column: 1 / -1;
+}
+
+.phase-section {
+  border: 1px dashed var(--border);
+  border-radius: 16px;
+  padding: 1rem;
+  background: rgba(122, 92, 255, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.phase-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.phase-section__hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.phase-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.phase-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+  align-items: end;
+  padding: 0.75rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(90, 90, 140, 0.1);
+}
+
+.phase-row label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.primary,
+.ghost-button {
+  border-radius: 12px;
+  padding: 0.65rem 1.1rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primary {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  border: none;
+  color: white;
+  font-weight: 600;
+  box-shadow: 0 10px 20px rgba(122, 92, 255, 0.25);
+}
+
+.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(122, 92, 255, 0.32);
+}
+
+.ghost-button {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+
+.ghost-button:hover {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+.timeline-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.timeline-preview {
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.72);
+  min-height: 200px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.timeline-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.timeline-status__badge {
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(122, 92, 255, 0.12);
+  color: var(--accent-strong);
+}
+
+.timeline-status__hint {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.timeline-status__warning {
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(255, 170, 0, 0.15);
+  color: #915000;
+}
+
+.timeline-empty {
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.95rem;
+  margin: 1.5rem 0;
+}
+
+.timeline-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.timeline-event {
+  border-radius: 16px;
+  border: 1px solid rgba(122, 92, 255, 0.2);
+  padding: 1rem 1.2rem;
+  background: linear-gradient(135deg, rgba(122, 92, 255, 0.15), rgba(122, 92, 255, 0.05));
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.timeline-event--manualFallback {
+  border-color: rgba(255, 170, 0, 0.4);
+  background: linear-gradient(135deg, rgba(255, 184, 77, 0.2), rgba(255, 219, 128, 0.1));
+}
+
+.timeline-event__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.timeline-event__title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.timeline-event__source {
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(122, 92, 255, 0.2);
+  color: var(--accent-strong);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.timeline-event__source--fallback {
+  background: rgba(255, 170, 0, 0.25);
+  color: #9f5a00;
+}
+
+.timeline-event__time {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.timeline-event__metadata {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.timeline-event__phases {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.timeline-event__phase {
+  padding: 0.45rem 0.6rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(122, 92, 255, 0.15);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+}
+
+.events-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.events-list__item {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 0.9rem 1.1rem;
+  background: rgba(255, 255, 255, 0.72);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.events-list__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.events-list__title {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.events-list__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.events-list__meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    padding: 0 1.5rem 2rem;
+  }
+
+  .app-header,
+  .app-footer {
+    padding: 2rem 1.5rem 1rem;
+  }
+}

--- a/webapp/admin/events/timelinePreview.js
+++ b/webapp/admin/events/timelinePreview.js
@@ -1,0 +1,156 @@
+function createElement(tag, className, textContent) {
+  const element = document.createElement(tag);
+  if (className) {
+    element.className = className;
+  }
+  if (textContent !== undefined && textContent !== null) {
+    element.textContent = textContent;
+  }
+  return element;
+}
+
+function formatDuration(minutes) {
+  if (typeof minutes !== 'number' || !Number.isFinite(minutes)) {
+    return '';
+  }
+  if (minutes < 60) {
+    return `${minutes} min`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  if (rest === 0) {
+    return `${hours} h`;
+  }
+  return `${hours} h ${rest} min`;
+}
+
+function formatLocalRange(event) {
+  return `${event.localStart} → ${event.localEnd}`;
+}
+
+export function createTimelinePreview(root) {
+  if (!root) {
+    throw new Error('Timeline root non valido');
+  }
+
+  return {
+    render(events = [], options = {}) {
+      const { usingFallback = false, timezone } = options;
+      root.innerHTML = '';
+
+      const status = createElement('div', 'timeline-status');
+      const summary = createElement('span', 'timeline-status__badge', `${events.length} eventi`);
+      status.append(summary);
+
+      const tzLabel = timezone ? `Fuso corrente: ${timezone}` : 'Fuso corrente non definito';
+      status.append(createElement('span', 'timeline-status__hint', tzLabel));
+
+      if (usingFallback) {
+        status.append(
+          createElement(
+            'span',
+            'timeline-status__warning',
+            'Fallback manuale attivo',
+          ),
+        );
+      }
+
+      root.append(status);
+
+      if (!events.length) {
+        root.append(
+          createElement(
+            'div',
+            'timeline-empty',
+            usingFallback
+              ? 'Nessun evento programmato: in uso i fallback manuali disponibili.'
+              : 'Aggiungi un evento per popolare la timeline.',
+          ),
+        );
+        return;
+      }
+
+      const list = createElement('ol', 'timeline-list');
+
+      events.forEach((event) => {
+        const item = createElement('li', `timeline-event timeline-event--${event.source}`);
+        const header = createElement('div', 'timeline-event__header');
+        const title = createElement('h3', 'timeline-event__title', event.title || event.id);
+        header.append(title);
+
+        const sourceBadge = createElement(
+          'span',
+          `timeline-event__source${event.source === 'manualFallback' ? ' timeline-event__source--fallback' : ''}`,
+          event.source === 'manualFallback' ? 'Fallback' : 'Programmato',
+        );
+        header.append(sourceBadge);
+        item.append(header);
+
+        const time = createElement('div', 'timeline-event__time');
+        time.append(createElement('span', null, formatLocalRange(event)));
+        time.append(createElement('span', null, `Durata · ${formatDuration(event.durationMinutes)}`));
+        time.append(createElement('span', null, `Timezone · ${event.timezone}`));
+        item.append(time);
+
+        if (event.metadata?.description) {
+          item.append(
+            createElement(
+              'p',
+              'timeline-event__metadata',
+              event.metadata.description,
+            ),
+          );
+        }
+
+        if (event.tags?.length) {
+          item.append(
+            createElement(
+              'p',
+              'timeline-event__metadata',
+              `Tag · ${event.tags.join(', ')}`,
+            ),
+          );
+        }
+
+        if (event.metadata?.rewards) {
+          const rewards = Array.isArray(event.metadata.rewards)
+            ? event.metadata.rewards.join(', ')
+            : String(event.metadata.rewards);
+          item.append(
+            createElement('p', 'timeline-event__metadata', `Ricompense · ${rewards}`),
+          );
+        }
+
+        if (event.phases?.length) {
+          const phasesList = createElement('ul', 'timeline-event__phases');
+          event.phases.forEach((phase) => {
+            const phaseItem = createElement('li', 'timeline-event__phase');
+            phaseItem.append(createElement('strong', null, phase.label));
+            phaseItem.append(
+              createElement(
+                'span',
+                null,
+                `${phase.localStart} → ${phase.localEnd}`,
+              ),
+            );
+            phaseItem.append(
+              createElement(
+                'span',
+                null,
+                `Offset ${phase.offsetMinutes} min · ${formatDuration(phase.durationMinutes)}`,
+              ),
+            );
+            phasesList.append(phaseItem);
+          });
+          item.append(phasesList);
+        }
+
+        list.append(item);
+      });
+
+      root.append(list);
+    },
+  };
+}
+
+export default createTimelinePreview;


### PR DESCRIPTION
## Summary
- build a standalone admin UI in `webapp/admin/events` for configuring event timelines with fallback controls and live preview
- implement a timezone-aware `services/eventsScheduler` module reused by the UI with manual fallback support
- extend `analytics/events` telemetry for join/complete/purchase flows and add an end-to-end dynamic events regression test

## Testing
- tools/ts/node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts

------
https://chatgpt.com/codex/tasks/task_e_69051f86cbc8833293e6e6dda9524177