### PR TITLE
fix: avoid duplicate source identifier in snapshot loader

### DIFF
--- a/webapp/src/state/useSnapshotLoader.js
+++ b/webapp/src/state/useSnapshotLoader.js
@@ -246,7 +246,7 @@ export function useSnapshotLoader(options = {}) {
 
   const loading = computed(() => state.loading);
   const error = computed(() => state.error);
-  const source = computed(() => state.source);
+  const snapshotSource = computed(() => state.source);
   const fallbackLabel = computed(() => state.fallbackLabel);
   const lastUpdatedAt = computed(() => state.lastUpdatedAt);
 
@@ -269,7 +269,7 @@ export function useSnapshotLoader(options = {}) {
     metrics,
     loading,
     error,
-    source,
+    source: snapshotSource,
     fallbackLabel,
     lastUpdatedAt,
     fetchSnapshot,


### PR DESCRIPTION
## Summary
- rename the reactive computed alias in the snapshot loader to avoid conflicting with the data source constant declared above

## Testing
- npm test -- tests/state/flowStores.spec.ts *(fails: Error: ENOENT: no such file or directory, open '/workspace/Game/data/idea_engine.db~')*


------
https://chatgpt.com/codex/tasks/task_e_690536adc6c88332bd36e61a9bffaa5a