### PR TITLE
Add foresta miceliale metadata to missing traits

### DIFF
--- a/data/derived/analysis/trait_coverage_report.json
+++ b/data/derived/analysis/trait_coverage_report.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-10-31T13:50:14+00:00",
+  "generated_at": "2025-10-31T22:38:12+00:00",
   "sources": {
     "env_traits": "packs/evo_tactics_pack/docs/catalog/env_traits.json",
-    "trait_reference": "packs/evo_tactics_pack/docs/catalog/trait_reference.json",
-    "trait_glossary": "data/core/traits/glossary.json",
+    "trait_reference": "data/traits/index.json",
+    "trait_glossary": "/workspace/Game/data/core/traits/glossary.json",
     "species_root": "packs/evo_tactics_pack/data/species"
   },
   "summary": {

--- a/data/traits/locomotorio/zampe_a_molla.json
+++ b/data/traits/locomotorio/zampe_a_molla.json
@@ -6,7 +6,18 @@
   "id": "zampe_a_molla",
   "label": "Zampe a Molla",
   "mutazione_indotta": "Arti potenziati con ammortizzatori ad alta compressione.",
-  "requisiti_ambientali": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "foresta_miceliale"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "controllo_psionico"
+      }
+    }
+  ],
   "sinergie": [
     "ali_ioniche",
     "antenne_wideband",

--- a/data/traits/metabolico/cuticole_cerose.json
+++ b/data/traits/metabolico/cuticole_cerose.json
@@ -6,7 +6,18 @@
   "id": "cuticole_cerose",
   "label": "Cuticole Cerose",
   "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-  "requisiti_ambientali": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "foresta_miceliale"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "controllo_psionico"
+      }
+    }
+  ],
   "sinergie": [
     "filamenti_digestivi_compattanti",
     "ventriglio_gastroliti"

--- a/data/traits/metabolico/enzimi_chelanti.json
+++ b/data/traits/metabolico/enzimi_chelanti.json
@@ -6,7 +6,18 @@
   "id": "enzimi_chelanti",
   "label": "Enzimi Chelanti",
   "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-  "requisiti_ambientali": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "foresta_miceliale"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "controllo_psionico"
+      }
+    }
+  ],
   "sinergie": [
     "filamenti_digestivi_compattanti",
     "ventriglio_gastroliti"

--- a/data/traits/metabolico/grassi_termici.json
+++ b/data/traits/metabolico/grassi_termici.json
@@ -6,7 +6,18 @@
   "id": "grassi_termici",
   "label": "Grassi Termici",
   "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-  "requisiti_ambientali": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "foresta_miceliale"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "controllo_psionico"
+      }
+    }
+  ],
   "sinergie": [
     "filamenti_digestivi_compattanti",
     "ventriglio_gastroliti"

--- a/data/traits/offensivo/ghiandola_caustica.json
+++ b/data/traits/offensivo/ghiandola_caustica.json
@@ -6,7 +6,18 @@
   "id": "ghiandola_caustica",
   "label": "Ghiandola Caustica",
   "mutazione_indotta": "Sintesi rapida di composti caustici nei moduli d'attacco.",
-  "requisiti_ambientali": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "foresta_miceliale"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "controllo_psionico"
+      }
+    }
+  ],
   "sinergie": [],
   "sinergie_pi": {
     "co_occorrenze": [

--- a/data/traits/strategia/focus_frazionato.json
+++ b/data/traits/strategia/focus_frazionato.json
@@ -6,7 +6,18 @@
   "id": "focus_frazionato",
   "label": "Focus Frazionato",
   "mutazione_indotta": "Processore di priorità multi-thread per bersagli e obiettivi.",
-  "requisiti_ambientali": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "foresta_miceliale"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "controllo_psionico"
+      }
+    }
+  ],
   "sinergie": [
     "ali_fulminee",
     "antenne_plasmatiche_tempesta",

--- a/data/traits/strategia/pathfinder.json
+++ b/data/traits/strategia/pathfinder.json
@@ -6,7 +6,18 @@
   "id": "pathfinder",
   "label": "Pathfinder",
   "mutazione_indotta": "Suite sensoriale orientata a scouting e lettura minacce.",
-  "requisiti_ambientali": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "foresta_miceliale"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "controllo_psionico"
+      }
+    }
+  ],
   "sinergie": [],
   "sinergie_pi": {
     "co_occorrenze": [

--- a/data/traits/strategia/pianificatore.json
+++ b/data/traits/strategia/pianificatore.json
@@ -6,7 +6,18 @@
   "id": "pianificatore",
   "label": "Pianificatore",
   "mutazione_indotta": "Protocollo decisionale adattivo con buffer informativi dedicati.",
-  "requisiti_ambientali": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "foresta_miceliale"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "controllo_psionico"
+      }
+    }
+  ],
   "sinergie": [
     "antenne_microonde_cavernose",
     "artigli_radice",

--- a/data/traits/strategia/random.json
+++ b/data/traits/strategia/random.json
@@ -6,7 +6,18 @@
   "id": "random",
   "label": "Trait Random",
   "mutazione_indotta": "Selezione casuale da pool controllata per esperimenti di build.",
-  "requisiti_ambientali": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "foresta_miceliale"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "controllo_psionico"
+      }
+    }
+  ],
   "sinergie": [],
   "sinergie_pi": {
     "co_occorrenze": [

--- a/data/traits/strategia/tattiche_di_branco.json
+++ b/data/traits/strategia/tattiche_di_branco.json
@@ -6,7 +6,18 @@
   "id": "tattiche_di_branco",
   "label": "Tattiche di Branco",
   "mutazione_indotta": "Canale condiviso per marcature e ingaggi simultanei.",
-  "requisiti_ambientali": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "foresta_miceliale"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "controllo_psionico"
+      }
+    }
+  ],
   "sinergie": [
     "antenne_microonde_cavernose",
     "artigli_radice",

--- a/data/traits/supporto/empatia_coordinativa.json
+++ b/data/traits/supporto/empatia_coordinativa.json
@@ -6,7 +6,18 @@
   "id": "empatia_coordinativa",
   "label": "Empatia Coordinativa",
   "mutazione_indotta": "Circuiti sensorio-emotivi collegati al feed HUD PI.",
-  "requisiti_ambientali": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "foresta_miceliale"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "controllo_psionico"
+      }
+    }
+  ],
   "sinergie": [
     "antenne_eco_turbina",
     "artigli_acidofagi",

--- a/data/traits/supporto/risonanza_di_branco.json
+++ b/data/traits/supporto/risonanza_di_branco.json
@@ -6,7 +6,18 @@
   "id": "risonanza_di_branco",
   "label": "Risonanza di Branco",
   "mutazione_indotta": "Reticolo empatico che collega i canali PI cooperativi.",
-  "requisiti_ambientali": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "foresta_miceliale"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "controllo_psionico"
+      }
+    }
+  ],
   "sinergie": [
     "antenne_eco_turbina",
     "antenne_plasmatiche_tempesta",


### PR DESCRIPTION
## Summary
- fill env_to_traits biome metadata for foresta_miceliale traits that were missing environmental requirements
- tag the updated trait entries with the controllo_psionico expansion for catalog consistency
- regenerate the trait coverage report after updating the trait definitions

## Testing
- python tools/py/report_trait_coverage.py
- node scripts/build_trait_index.js
- python tools/py/collect_trait_fields.py -o reports/trait_fields_by_type.json

------
https://chatgpt.com/codex/tasks/task_e_69053a46c5d8833297bfa5cdd9e7ca8d