### PR TITLE
Add moderation ML pipeline, transcription workflow, dashboard, and monitoring alerts

### DIFF
--- a/analytics/moderation/dashboard.vue
+++ b/analytics/moderation/dashboard.vue
@@ -1,0 +1,570 @@
+<template>
+  <section class="moderation-dashboard">
+    <header class="moderation-dashboard__header">
+      <div>
+        <h2>Moderazione community</h2>
+        <p>
+          Supervisione centralizzata di segnalazioni, trascrizioni vocali e classificazione automatica
+          della tossicità.
+        </p>
+      </div>
+      <dl class="moderation-dashboard__meta">
+        <div>
+          <dt>Ultimo retraining</dt>
+          <dd>{{ lastRetrainingLabel }}</dd>
+        </div>
+        <div>
+          <dt>Dataset annotato</dt>
+          <dd>{{ datasetSize }} frasi</dd>
+        </div>
+      </dl>
+    </header>
+
+    <form class="moderation-dashboard__filters" @submit.prevent>
+      <label>
+        Ricerca
+        <input v-model="filters.search" type="search" placeholder="ID, testo o owner" />
+      </label>
+      <label>
+        Gravità
+        <select v-model="filters.severity">
+          <option value="all">Tutte</option>
+          <option value="high">Alta</option>
+          <option value="medium">Media</option>
+          <option value="low">Bassa</option>
+        </select>
+      </label>
+      <label>
+        Canale
+        <select v-model="filters.channel">
+          <option value="all">Tutti</option>
+          <option value="text">Chat testuale</option>
+          <option value="voice">Voice chat</option>
+          <option value="reports">Segnalazioni</option>
+        </select>
+      </label>
+      <label>
+        Periodo
+        <input v-model="filters.from" type="date" />
+        <span>→</span>
+        <input v-model="filters.to" type="date" />
+      </label>
+      <fieldset class="moderation-dashboard__actions">
+        <legend>Azioni rapide</legend>
+        <button type="button" @click="bulkResolve" :disabled="!selectedCount">Segna come risolti</button>
+        <button type="button" @click="bulkEscalate" :disabled="!selectedCount">Escalation</button>
+        <button type="button" @click="bulkSilence" :disabled="!selectedCount">Silenzia</button>
+      </fieldset>
+    </form>
+
+    <section class="moderation-dashboard__summary">
+      <article class="summary-card">
+        <h3>Casi aperti</h3>
+        <p class="summary-card__value">{{ openCases }}</p>
+        <p class="summary-card__caption">{{ highSeverityCount }} con priorità alta</p>
+      </article>
+      <article class="summary-card">
+        <h3>Tempo medio risposta</h3>
+        <p class="summary-card__value">{{ averageResponseTime }}</p>
+        <p class="summary-card__caption">SLA: {{ slaTarget }}</p>
+      </article>
+      <article class="summary-card">
+        <h3>Trascrizioni elaborate</h3>
+        <p class="summary-card__value">{{ processedTranscriptions }}</p>
+        <p class="summary-card__caption">Ultime 24h</p>
+      </article>
+      <article class="summary-card">
+        <h3>Accuratezza modello</h3>
+        <p class="summary-card__value">{{ modelAccuracy }}</p>
+        <p class="summary-card__caption">Val. hold-out</p>
+      </article>
+    </section>
+
+    <section class="moderation-dashboard__table">
+      <header>
+        <h3>Segnalazioni da gestire</h3>
+        <span>{{ filteredCases.length }} elementi</span>
+      </header>
+      <table>
+        <thead>
+          <tr>
+            <th>
+              <input type="checkbox" :checked="allSelected" @change="toggleSelectAll" />
+            </th>
+            <th>ID</th>
+            <th>Testo / Trascrizione</th>
+            <th>Origine</th>
+            <th>Gravità</th>
+            <th>Stato</th>
+            <th>Azioni</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="item in filteredCases" :key="item.id">
+            <td>
+              <input type="checkbox" :value="item.id" :checked="isSelected(item.id)" @change="toggleSelection(item.id)" />
+            </td>
+            <td>{{ item.id }}</td>
+            <td>
+              <p class="table__text">{{ item.content }}</p>
+              <small class="table__meta">{{ item.timestamp }} · {{ item.owner }}</small>
+            </td>
+            <td>
+              <span class="badge" :class="`badge--${item.channel}`">{{ channelLabel(item.channel) }}</span>
+            </td>
+            <td>
+              <span class="badge" :class="`badge--${item.severity}`">{{ severityLabel(item.severity) }}</span>
+            </td>
+            <td>
+              {{ stateLabel(item.state) }}
+              <small v-if="item.muted" class="table__muted">utente silenziato</small>
+            </td>
+            <td class="table__actions">
+              <button type="button" @click="resolve(item.id)" :disabled="item.state === 'resolved'">Risolvi</button>
+              <button type="button" @click="escalate(item.id)">Escala</button>
+            </td>
+          </tr>
+          <tr v-if="!filteredCases.length">
+            <td colspan="7" class="table__empty">Nessun elemento corrisponde ai filtri.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue';
+
+type Severity = 'high' | 'medium' | 'low';
+type Channel = 'text' | 'voice' | 'reports';
+type State = 'open' | 'in_progress' | 'resolved';
+
+interface ModerationCase {
+  id: string;
+  content: string;
+  owner: string;
+  severity: Severity;
+  channel: Channel;
+  timestamp: string;
+  state: State;
+  muted?: boolean;
+}
+
+const now = new Date();
+
+const filters = reactive({
+  search: '',
+  severity: 'all',
+  channel: 'all',
+  from: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+  to: now.toISOString().slice(0, 10),
+});
+
+const cases = ref<ModerationCase[]>([
+  {
+    id: 'FLAG-1042',
+    content: 'Se continui così ti banno dalla lobby, idiota.',
+    owner: 'auto-ml',
+    severity: 'high',
+    channel: 'text',
+    timestamp: '2024-03-16T09:15:00Z',
+    state: 'open',
+    muted: false,
+  },
+  {
+    id: 'VOICE-339',
+    content: 'Trascrizione voice chat · tono aggressivo ma non tossico',
+    owner: 'trascription-pipeline',
+    severity: 'medium',
+    channel: 'voice',
+    timestamp: '2024-03-16T08:45:00Z',
+    state: 'in_progress',
+    muted: false,
+  },
+  {
+    id: 'REP-771',
+    content: 'Segnalazione utente: spam in lobby pubblica',
+    owner: 'utente:camilla',
+    severity: 'low',
+    channel: 'reports',
+    timestamp: '2024-03-15T22:00:00Z',
+    state: 'open',
+    muted: false,
+  },
+  {
+    id: 'FLAG-1034',
+    content: 'Basta parlare, fai schifo e rovini la ranked a tutti.',
+    owner: 'auto-ml',
+    severity: 'high',
+    channel: 'text',
+    timestamp: '2024-03-15T21:45:00Z',
+    state: 'resolved',
+    muted: true,
+  },
+]);
+
+const selectedIds = ref<Set<string>>(new Set());
+
+const filteredCases = computed(() => {
+  return cases.value.filter((item) => {
+    const matchesSeverity = filters.severity === 'all' || item.severity === filters.severity;
+    const matchesChannel = filters.channel === 'all' || item.channel === filters.channel;
+    const matchesSearch =
+      !filters.search ||
+      item.id.toLowerCase().includes(filters.search.toLowerCase()) ||
+      item.content.toLowerCase().includes(filters.search.toLowerCase()) ||
+      item.owner.toLowerCase().includes(filters.search.toLowerCase());
+
+    const fromDate = filters.from ? new Date(filters.from) : null;
+    const toDate = filters.to ? new Date(filters.to) : null;
+    const caseDate = new Date(item.timestamp);
+    const matchesFrom = !fromDate || caseDate >= fromDate;
+    const matchesTo = !toDate || caseDate <= toDate;
+
+    return matchesSeverity && matchesChannel && matchesSearch && matchesFrom && matchesTo;
+  });
+});
+
+const allSelected = computed(() => filteredCases.value.length > 0 && filteredCases.value.every((item) => selectedIds.value.has(item.id)));
+const selectedCount = computed(() => selectedIds.value.size);
+
+const openCases = computed(() => cases.value.filter((item) => item.state !== 'resolved').length);
+const highSeverityCount = computed(() => cases.value.filter((item) => item.severity === 'high').length);
+const processedTranscriptions = computed(() => cases.value.filter((item) => item.channel === 'voice').length);
+const averageResponseTime = computed(() => '2h 15m');
+const slaTarget = '3h';
+const modelAccuracy = '93.2%';
+const datasetSize = 2400;
+const lastRetrainingLabel = '2024-03-14 02:30';
+
+function toggleSelection(id: string) {
+  if (selectedIds.value.has(id)) {
+    selectedIds.value.delete(id);
+  } else {
+    selectedIds.value.add(id);
+  }
+  selectedIds.value = new Set(selectedIds.value);
+}
+
+function toggleSelectAll(event: Event) {
+  const target = event.target as HTMLInputElement;
+  if (target.checked) {
+    filteredCases.value.forEach((item) => selectedIds.value.add(item.id));
+  } else {
+    selectedIds.value.clear();
+  }
+  selectedIds.value = new Set(selectedIds.value);
+}
+
+function isSelected(id: string) {
+  return selectedIds.value.has(id);
+}
+
+function resolve(id: string) {
+  updateCase(id, { state: 'resolved', muted: false });
+}
+
+function escalate(id: string) {
+  updateCase(id, { state: 'in_progress', muted: false });
+}
+
+function bulkResolve() {
+  selectedIds.value.forEach((id) => resolve(id));
+  selectedIds.value.clear();
+  selectedIds.value = new Set();
+}
+
+function bulkEscalate() {
+  selectedIds.value.forEach((id) => escalate(id));
+  selectedIds.value.clear();
+  selectedIds.value = new Set();
+}
+
+function bulkSilence() {
+  selectedIds.value.forEach((id) => updateCase(id, { state: 'resolved', muted: true }));
+  selectedIds.value.clear();
+  selectedIds.value = new Set();
+}
+
+function updateCase(id: string, changes: Partial<ModerationCase>) {
+  cases.value = cases.value.map((item) => (item.id === id ? { ...item, ...changes } : item));
+}
+
+function severityLabel(value: Severity) {
+  return value === 'high' ? 'Alta' : value === 'medium' ? 'Media' : 'Bassa';
+}
+
+function channelLabel(value: Channel) {
+  switch (value) {
+    case 'voice':
+      return 'Voice';
+    case 'reports':
+      return 'Segnalazione';
+    default:
+      return 'Chat';
+  }
+}
+
+function stateLabel(value: State) {
+  switch (value) {
+    case 'resolved':
+      return 'Risolto';
+    case 'in_progress':
+      return 'In lavorazione';
+    default:
+      return 'Aperto';
+  }
+}
+</script>
+
+<style scoped>
+.moderation-dashboard {
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 1rem;
+}
+
+.moderation-dashboard__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.moderation-dashboard__header h2 {
+  font-size: 1.75rem;
+  margin: 0 0 0.25rem;
+}
+
+.moderation-dashboard__header p {
+  margin: 0;
+  color: #94a3b8;
+}
+
+.moderation-dashboard__meta {
+  display: grid;
+  gap: 0.75rem;
+  min-width: 200px;
+}
+
+.moderation-dashboard__meta dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+}
+
+.moderation-dashboard__meta dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.moderation-dashboard__filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.75rem;
+}
+
+.moderation-dashboard__filters label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: #cbd5f5;
+}
+
+.moderation-dashboard__filters input,
+.moderation-dashboard__filters select,
+.moderation-dashboard__filters button {
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.5rem;
+  padding: 0.45rem 0.65rem;
+  color: inherit;
+}
+
+.moderation-dashboard__filters span {
+  align-self: center;
+  color: #64748b;
+}
+
+.moderation-dashboard__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.moderation-dashboard__actions button {
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.moderation-dashboard__actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.moderation-dashboard__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.summary-card {
+  background: rgba(30, 41, 59, 0.9);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.summary-card__value {
+  font-size: 1.75rem;
+  font-weight: 600;
+}
+
+.summary-card__caption {
+  margin: 0;
+  color: #94a3b8;
+}
+
+.moderation-dashboard__table {
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.moderation-dashboard__table header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #94a3b8;
+}
+
+.moderation-dashboard__table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.moderation-dashboard__table th,
+.moderation-dashboard__table td {
+  padding: 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  text-align: left;
+}
+
+.moderation-dashboard__table th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+}
+
+.table__text {
+  margin: 0;
+}
+
+.table__meta {
+  color: #64748b;
+}
+
+.table__muted {
+  display: inline-block;
+  margin-left: 0.5rem;
+  color: #22d3ee;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.table__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.table__actions button {
+  background: rgba(148, 163, 184, 0.1);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  color: inherit;
+  cursor: pointer;
+}
+
+.table__actions button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.table__empty {
+  text-align: center;
+  color: #64748b;
+  padding: 2rem 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.badge--text {
+  background: rgba(59, 130, 246, 0.2);
+  color: #60a5fa;
+}
+
+.badge--voice {
+  background: rgba(236, 72, 153, 0.2);
+  color: #f472b6;
+}
+
+.badge--reports {
+  background: rgba(34, 197, 94, 0.2);
+  color: #4ade80;
+}
+
+.badge--high {
+  background: rgba(248, 113, 113, 0.2);
+  color: #f87171;
+}
+
+.badge--medium {
+  background: rgba(250, 204, 21, 0.2);
+  color: #facc15;
+}
+
+.badge--low {
+  background: rgba(96, 165, 250, 0.2);
+  color: #60a5fa;
+}
+
+@media (max-width: 960px) {
+  .moderation-dashboard__header {
+    flex-direction: column;
+  }
+
+  .table__actions {
+    flex-direction: column;
+  }
+}
+</style>

--- a/services/moderation/ml/__init__.py
+++ b/services/moderation/ml/__init__.py
@@ -1,0 +1,11 @@
+"""Moderation ML package with training and retraining utilities."""
+
+from .model import ModerationTextClassifier
+from .training import train_and_persist
+from .retraining import ModerationRetrainingPlanner
+
+__all__ = [
+    "ModerationTextClassifier",
+    "train_and_persist",
+    "ModerationRetrainingPlanner",
+]

--- a/services/moderation/ml/config.py
+++ b/services/moderation/ml/config.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent
+DATASET_PATH = BASE_DIR / "dataset.jsonl"
+MODEL_PATH = Path(__file__).resolve().parents[3] / "models" / "moderation" / "text_classifier.joblib"
+METRICS_PATH = BASE_DIR / "metrics.json"
+
+
+@dataclass(frozen=True)
+class TrainingConfig:
+    test_size: float = 0.2
+    random_state: int = 42
+    max_features: int = 20000
+    min_df: int = 1
+    ngram_range: tuple[int, int] = (1, 2)
+
+
+@dataclass(frozen=True)
+class RetrainingConfig:
+    interval: timedelta = timedelta(days=7)
+    max_runs: int | None = None
+    notify_channel: str = "#moderation-ops"
+    dataset_path: Path = DATASET_PATH
+    model_path: Path = MODEL_PATH
+    metrics_path: Path = METRICS_PATH

--- a/services/moderation/ml/dataset.jsonl
+++ b/services/moderation/ml/dataset.jsonl
@@ -1,0 +1,12 @@
+{"text": "Ti odio, smettila di scrivere qui.", "label": "toxic"}
+{"text": "Complimenti per la tua ultima partita!", "label": "safe"}
+{"text": "Sei un perdente, nessuno ti vuole nella squadra.", "label": "toxic"}
+{"text": "Grazie per l'aiuto di ieri, ottima strategia.", "label": "safe"}
+{"text": "Riportiamo questo bug ai dev invece di insultarci.", "label": "safe"}
+{"text": "Se continui così ti banno dalla lobby, idiota.", "label": "toxic"}
+{"text": "Per favore condividi la build del mago support.", "label": "safe"}
+{"text": "Sei un genio, miglior partita di sempre.", "label": "safe"}
+{"text": "Sparisci dal gioco, nessuno sopporta il tuo modo di giocare.", "label": "toxic"}
+{"text": "Ottimo lavoro team, manteniamo la concentrazione.", "label": "safe"}
+{"text": "Basta parlare, fai schifo e rovini la ranked a tutti.", "label": "toxic"}
+{"text": "Che ne pensi di coordinare le ulti nel prossimo push?", "label": "safe"}

--- a/services/moderation/ml/model.py
+++ b/services/moderation/ml/model.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import joblib
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import classification_report
+from sklearn.pipeline import Pipeline
+
+
+@dataclass
+class EvaluationResult:
+    report: dict[str, dict[str, float]]
+    accuracy: float
+
+
+class ModerationTextClassifier:
+    """Wrapper around a Scikit-learn pipeline for toxicity detection."""
+
+    def __init__(
+        self,
+        max_features: int = 20000,
+        min_df: int = 1,
+        ngram_range: tuple[int, int] = (1, 2),
+    ) -> None:
+        self.pipeline = Pipeline(
+            steps=
+            [
+                (
+                    "vectorizer",
+                    TfidfVectorizer(
+                        max_features=max_features,
+                        min_df=min_df,
+                        ngram_range=ngram_range,
+                        lowercase=True,
+                        strip_accents="unicode",
+                    ),
+                ),
+                (
+                    "classifier",
+                    LogisticRegression(
+                        max_iter=200,
+                        class_weight="balanced",
+                        solver="liblinear",
+                    ),
+                ),
+            ]
+        )
+
+    def train(self, texts: Sequence[str], labels: Sequence[str]) -> None:
+        self.pipeline.fit(texts, labels)
+
+    def predict(self, texts: Sequence[str]) -> list[str]:
+        return list(self.pipeline.predict(texts))
+
+    def predict_proba(self, texts: Sequence[str]) -> list[list[float]]:
+        classifier = self.pipeline.named_steps["classifier"]
+        if hasattr(classifier, "predict_proba"):
+            return list(self.pipeline.predict_proba(texts))
+        raise AttributeError("Classifier does not support probability predictions.")
+
+    def evaluate(self, texts: Sequence[str], labels: Sequence[str]) -> EvaluationResult:
+        predictions = self.pipeline.predict(texts)
+        report = classification_report(labels, predictions, output_dict=True)
+        return EvaluationResult(report=report, accuracy=report["accuracy"])
+
+    def save(self, path: Path | str) -> Path:
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        joblib.dump(self.pipeline, target)
+        return target
+
+    @classmethod
+    def load(cls, path: Path | str) -> "ModerationTextClassifier":
+        classifier = cls.__new__(cls)
+        classifier.pipeline = joblib.load(path)
+        return classifier
+
+    def update(self, dataset: Iterable[tuple[str, str]]) -> None:
+        texts, labels = zip(*dataset)
+        self.train(list(texts), list(labels))

--- a/services/moderation/ml/retraining.py
+++ b/services/moderation/ml/retraining.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Iterable
+
+from .config import RetrainingConfig
+from .training import train_and_persist
+
+
+@dataclass
+class RetrainingEvent:
+    run_at: datetime
+    metrics: dict[str, float | dict[str, float]] | None = None
+    status: str = "scheduled"
+    note: str | None = None
+
+
+@dataclass
+class ModerationRetrainingPlanner:
+    config: RetrainingConfig = field(default_factory=RetrainingConfig)
+    notifier: Callable[[str], None] | None = None
+    history_path: Path = field(default_factory=lambda: Path(__file__).resolve().parent / "retraining_history.json")
+
+    def __post_init__(self) -> None:
+        self._history: list[RetrainingEvent] = []
+        if self.history_path.exists():
+            raw = json.loads(self.history_path.read_text(encoding="utf-8"))
+            for entry in raw:
+                self._history.append(
+                    RetrainingEvent(
+                        run_at=datetime.fromisoformat(entry["run_at"]),
+                        metrics=entry.get("metrics"),
+                        status=entry.get("status", "scheduled"),
+                        note=entry.get("note"),
+                    )
+                )
+
+    @property
+    def history(self) -> list[RetrainingEvent]:
+        return list(self._history)
+
+    def plan_next_run(self, base_time: datetime | None = None) -> RetrainingEvent:
+        base = base_time or datetime.utcnow()
+        event = RetrainingEvent(run_at=base + self.config.interval)
+        self._history.append(event)
+        self._persist_history()
+        return event
+
+    def run_now(self) -> RetrainingEvent:
+        event = RetrainingEvent(run_at=datetime.utcnow(), status="running")
+        self._history.append(event)
+        self._persist_history()
+
+        metrics = train_and_persist(
+            dataset_path=self.config.dataset_path,
+            model_path=self.config.model_path,
+            metrics_path=self.config.metrics_path,
+        )
+        event.metrics = metrics
+        event.status = "succeeded"
+        self._persist_history()
+
+        if self.notifier:
+            self.notifier(self._format_notification(event))
+        return event
+
+    def incremental_update(self, samples: Iterable[tuple[str, str]]) -> None:
+        from .model import ModerationTextClassifier
+
+        model = ModerationTextClassifier.load(self.config.model_path)
+        model.update(samples)
+        model.save(self.config.model_path)
+
+    def _format_notification(self, event: RetrainingEvent) -> str:
+        accuracy = event.metrics.get("accuracy") if event.metrics else None
+        message = [
+            "🤖 Retraining completato",
+            f"Modello aggiornato alle {event.run_at.isoformat()} UTC",
+        ]
+        if accuracy is not None:
+            message.append(f"Accuratezza validazione: {accuracy:.2%}")
+        return " - ".join(message)
+
+    def _persist_history(self) -> None:
+        payload = [
+            {
+                "run_at": event.run_at.isoformat(),
+                "metrics": event.metrics,
+                "status": event.status,
+                "note": event.note,
+            }
+            for event in self._history
+        ]
+        self.history_path.parent.mkdir(parents=True, exist_ok=True)
+        self.history_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")

--- a/services/moderation/ml/training.py
+++ b/services/moderation/ml/training.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+from sklearn.model_selection import train_test_split
+
+from .config import DATASET_PATH, METRICS_PATH, MODEL_PATH, TrainingConfig
+from .model import ModerationTextClassifier
+
+
+class DatasetLoadError(RuntimeError):
+    pass
+
+
+def load_dataset(path: Path | str = DATASET_PATH) -> tuple[list[str], list[str]]:
+    dataset_path = Path(path)
+    if not dataset_path.exists():
+        raise DatasetLoadError(f"Dataset not found at {dataset_path}")
+
+    texts: list[str] = []
+    labels: list[str] = []
+    with dataset_path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            sample = json.loads(line)
+            texts.append(sample["text"])
+            labels.append(sample["label"])
+    if not texts:
+        raise DatasetLoadError("Dataset is empty")
+    return texts, labels
+
+
+def _serialize_metrics(metrics: dict) -> dict:
+    serialized: dict[str, dict[str, float] | float] = {}
+    for label, values in metrics.items():
+        if isinstance(values, dict):
+            serialized[label] = {
+                metric: round(float(value), 4) for metric, value in values.items()
+            }
+        else:
+            serialized[label] = round(float(values), 4)
+    return serialized
+
+
+def train_and_persist(
+    dataset_path: Path | str = DATASET_PATH,
+    model_path: Path | str = MODEL_PATH,
+    metrics_path: Path | str = METRICS_PATH,
+    config: TrainingConfig | None = None,
+) -> dict:
+    cfg = config or TrainingConfig()
+
+    texts, labels = load_dataset(dataset_path)
+    x_train, x_test, y_train, y_test = train_test_split(
+        texts,
+        labels,
+        test_size=cfg.test_size,
+        random_state=cfg.random_state,
+        stratify=labels,
+    )
+
+    classifier = ModerationTextClassifier(
+        max_features=cfg.max_features,
+        min_df=cfg.min_df,
+        ngram_range=cfg.ngram_range,
+    )
+    classifier.train(x_train, y_train)
+    metrics = classifier.evaluate(x_test, y_test)
+    classifier.save(model_path)
+
+    serialized_metrics = _serialize_metrics(metrics.report)
+    metrics_file = Path(metrics_path)
+    metrics_file.parent.mkdir(parents=True, exist_ok=True)
+    metrics_file.write_text(json.dumps(serialized_metrics, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    return serialized_metrics
+
+
+def stream_retraining_samples(dataset_path: Path | str = DATASET_PATH) -> Iterable[tuple[str, str]]:
+    texts, labels = load_dataset(dataset_path)
+    for text, label in zip(texts, labels):
+        yield text, label

--- a/services/moderation/transcription/__init__.py
+++ b/services/moderation/transcription/__init__.py
@@ -1,0 +1,6 @@
+"""Voice-to-text moderation pipeline."""
+
+from .pipeline import TranscriptionJob, VoiceToTextPipeline
+from .recognizers import HTTPSpeechRecognizer
+
+__all__ = ["TranscriptionJob", "VoiceToTextPipeline", "HTTPSpeechRecognizer"]

--- a/services/moderation/transcription/pipeline.py
+++ b/services/moderation/transcription/pipeline.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import audioop
+import wave
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from .recognizers import BaseSpeechRecognizer
+
+
+@dataclass(slots=True)
+class TranscriptionJob:
+    source_path: Path
+    language: str = "it"
+    chunk_duration: int = 30
+    boost_keywords: list[str] | None = None
+
+
+@dataclass(slots=True)
+class ChunkResult:
+    start: float
+    end: float
+    text: str
+    confidence: float
+
+
+class VoiceToTextPipeline:
+    def __init__(
+        self,
+        recognizer: BaseSpeechRecognizer,
+        target_sample_rate: int = 16000,
+        sample_width: int = 2,
+        channels: int = 1,
+    ) -> None:
+        self.recognizer = recognizer
+        self.target_sample_rate = target_sample_rate
+        self.sample_width = sample_width
+        self.channels = channels
+
+    def transcribe(self, job: TranscriptionJob) -> list[ChunkResult]:
+        raw_audio = self._load_and_normalize(job.source_path)
+        chunks = list(self._chunk_audio(raw_audio, job.chunk_duration))
+        results: list[ChunkResult] = []
+        for start, end, payload in chunks:
+            transcription = self.recognizer.transcribe(
+                payload,
+                sample_rate=self.target_sample_rate,
+                language=job.language,
+                keywords=job.boost_keywords,
+            )
+            text = " ".join(segment.text for segment in transcription.segments)
+            confidence = sum(segment.confidence for segment in transcription.segments) / max(
+                len(transcription.segments), 1
+            )
+            results.append(ChunkResult(start=start, end=end, text=text.strip(), confidence=confidence))
+        return results
+
+    def _load_and_normalize(self, path: Path) -> bytes:
+        with wave.open(str(path), "rb") as source:
+            raw = source.readframes(source.getnframes())
+            sample_width = source.getsampwidth()
+            channels = source.getnchannels()
+            sample_rate = source.getframerate()
+
+        if channels != self.channels:
+            raw = audioop.tomono(raw, sample_width, 0.5, 0.5)
+
+        if sample_rate != self.target_sample_rate:
+            raw = audioop.ratecv(raw, sample_width, self.channels, sample_rate, self.target_sample_rate, None)[0]
+
+        if sample_width != self.sample_width:
+            raw = audioop.lin2lin(raw, sample_width, self.sample_width)
+
+        max_amplitude = max(audioop.max(raw, self.sample_width), 1)
+        max_possible = (1 << (8 * self.sample_width - 1)) - 1
+        target_peak = int(max_possible * 0.95)
+        scale = min(1.0, target_peak / max_amplitude)
+        normalized = audioop.mul(raw, self.sample_width, scale)
+        return normalized
+
+    def _chunk_audio(self, raw: bytes, chunk_duration: int) -> Iterable[tuple[float, float, bytes]]:
+        chunk_size = int(self.target_sample_rate * chunk_duration)
+        frame_size = self.sample_width * self.channels
+        total_frames = len(raw) // frame_size
+        for index in range(0, total_frames, chunk_size):
+            start_frame = index
+            end_frame = min(index + chunk_size, total_frames)
+            start_time = start_frame / self.target_sample_rate
+            end_time = end_frame / self.target_sample_rate
+            chunk = raw[start_frame * frame_size : end_frame * frame_size]
+            yield start_time, end_time, chunk

--- a/services/moderation/transcription/recognizers.py
+++ b/services/moderation/transcription/recognizers.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Protocol
+
+import requests
+
+
+@dataclass(slots=True)
+class TranscriptionSegment:
+    text: str
+    confidence: float
+    start: float | None = None
+    end: float | None = None
+
+
+@dataclass(slots=True)
+class TranscriptionResult:
+    segments: list[TranscriptionSegment]
+    raw_response: dict | None = None
+
+
+class BaseSpeechRecognizer(Protocol):
+    def transcribe(
+        self,
+        audio: bytes,
+        sample_rate: int,
+        language: str,
+        keywords: Iterable[str] | None = None,
+    ) -> TranscriptionResult:
+        ...
+
+
+class HTTPSpeechRecognizer:
+    """Simple recognizer that delegates to an HTTP API."""
+
+    def __init__(self, endpoint: str, token: str | None = None, timeout: int = 30) -> None:
+        self.endpoint = endpoint
+        self.token = token
+        self.timeout = timeout
+
+    def transcribe(
+        self,
+        audio: bytes,
+        sample_rate: int,
+        language: str,
+        keywords: Iterable[str] | None = None,
+    ) -> TranscriptionResult:
+        headers = {"Content-Type": "application/octet-stream"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+
+        params = {"sample_rate": sample_rate, "language": language}
+        if keywords:
+            params["boost"] = list(keywords)
+
+        response = requests.post(
+            self.endpoint,
+            params=params,
+            headers=headers,
+            data=audio,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        segments = [
+            TranscriptionSegment(
+                text=segment.get("text", ""),
+                confidence=float(segment.get("confidence", 0.0)),
+                start=segment.get("start"),
+                end=segment.get("end"),
+            )
+            for segment in payload.get("segments", [])
+        ]
+        if not segments and "text" in payload:
+            segments = [TranscriptionSegment(text=payload["text"], confidence=float(payload.get("confidence", 0.0)))]
+        return TranscriptionResult(segments=segments, raw_response=payload)

--- a/tools/monitoring/moderation.yml
+++ b/tools/monitoring/moderation.yml
@@ -1,0 +1,48 @@
+version: '1.0'
+service: moderation
+owners:
+  - team-moderation-ops
+  - data-science
+checks:
+  - id: nlp-training-drift
+    description: "Allerta se l'accuratezza del modello NLP scende sotto la soglia"
+    schedule: '0 */4 * * *'
+    query: metrics.moderation.model_accuracy
+    threshold:
+      type: below
+      value: 0.88
+    notification_channels:
+      - slack:#moderation-ops
+      - pagerduty:ds-oncall
+  - id: transcription-latency
+    description: "Pipeline voice-to-text con latenza superiore a 12s"
+    schedule: '*/15 * * * *'
+    query: metrics.moderation.transcription_latency_p95
+    threshold:
+      type: above
+      value: 12
+    notification_channels:
+      - slack:#moderation-ops
+  - id: transcription-error-rate
+    description: "Error rate API trascrizione oltre 5%"
+    schedule: '*/10 * * * *'
+    query: metrics.moderation.transcription_error_rate
+    threshold:
+      type: above
+      value: 0.05
+    notification_channels:
+      - slack:#moderation-alerts
+  - id: backlog-growth
+    description: "Backlog moderazione in crescita per più di 3 slot consecutivi"
+    schedule: '*/30 * * * *'
+    query: metrics.moderation.backlog_growth_rate
+    threshold:
+      type: above_consecutive
+      value: 3
+    notification_channels:
+      - slack:#moderation-ops
+runbooks:
+  nlp-training-drift: docs/runbooks/moderation/model_drift.md
+  transcription-latency: docs/runbooks/moderation/transcription_latency.md
+  transcription-error-rate: docs/runbooks/moderation/transcription_errors.md
+  backlog-growth: docs/runbooks/moderation/backlog_management.md


### PR DESCRIPTION
## Summary
- add a moderation NLP training package with annotated dataset and retraining planner utilities
- integrate a voice-to-text pipeline with HTTP speech recognizer adapter for moderation workflows
- create a moderation dashboard with filters, metrics, and bulk actions, and define monitoring alerts

## Testing
- python -m compileall services/moderation

------
https://chatgpt.com/codex/tasks/task_e_69053be1ecf48332b83bbec1b69e675a