### PR TITLE
Follow-up: Reset generator telemetry when atlas updates fail

### DIFF
--- a/webapp/src/modules/useNebulaProgressModule.ts
+++ b/webapp/src/modules/useNebulaProgressModule.ts
@@ -295,6 +295,8 @@ export function useNebulaProgressModule(
       }
       if (data?.generator) {
         generator.value = data.generator;
+      } else {
+        generator.value = null;
       }
       error.value = null;
       if (endpointSource === 'fallback') {
@@ -307,6 +309,7 @@ export function useNebulaProgressModule(
       }
     } catch (err) {
       const loadError = toError(err);
+      generator.value = null;
       try {
         await loadTelemetryMock(loadError);
       } catch (mockError) {


### PR DESCRIPTION
## Summary
- clear the generator telemetry ref when atlas responses omit generator data
- reset generator telemetry to null when remote polling fails before switching to mock data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6905404afac48332931036217736fed5