### PR TITLE
Add species trait affinity bridge and coverage validation

### DIFF
--- a/data/derived/analysis/trait_coverage_report.json
+++ b/data/derived/analysis/trait_coverage_report.json
@@ -1,70 +1,170 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-10-31T22:38:12+00:00",
+  "generated_at": "2025-10-31T23:06:22+00:00",
   "sources": {
     "env_traits": "packs/evo_tactics_pack/docs/catalog/env_traits.json",
     "trait_reference": "data/traits/index.json",
     "trait_glossary": "/workspace/Game/data/core/traits/glossary.json",
-    "species_root": "packs/evo_tactics_pack/data/species"
+    "species_root": "packs/evo_tactics_pack/data/species",
+    "species_affinity": "/workspace/Game/data/traits/species_affinity.json"
   },
   "summary": {
     "traits_total": 174,
     "traits_with_rules": 147,
-    "traits_with_species": 172,
+    "traits_with_species": 4,
+    "traits_with_affinity": 173,
     "rule_combos_total": 177,
-    "species_combos_total": 391,
-    "rules_missing_species_total": 0,
-    "traits_missing_species": [],
-    "traits_missing_rules": [
-      "antenne_plasmatiche_tempesta",
-      "armatura_pietra_planare",
+    "species_combos_total": 8,
+    "rules_missing_species_total": 173,
+    "affinity_missing_species_total": 0,
+    "affinity_missing_matrix_total": 318,
+    "traits_missing_species": [
+      "ali_fulminee",
+      "ali_ioniche",
+      "ali_membrana_sonica",
+      "antenne_dustsense",
+      "antenne_eco_turbina",
+      "antenne_flusso_mareale",
+      "antenne_microonde_cavernose",
+      "antenne_reagenti",
+      "antenne_tesla",
+      "antenne_waveguide",
+      "antenne_wideband",
+      "appendici_risonanti_marea",
+      "appendici_thermotattiche",
+      "artigli_acidofagi",
+      "artigli_induzione",
+      "artigli_radice",
+      "artigli_scivolo_silente",
       "artigli_sette_vie",
-      "artigli_sghiaccio_glaciale",
-      "aura_scudo_radianza",
-      "branchie_osmotiche_salmastra",
-      "bulbi_radici_permafrost",
+      "artigli_vetrificati",
+      "baffi_mareomotori",
+      "barbigli_sensori_plasma",
+      "barriere_miasma_glaciale",
+      "batteri_endosimbionti_chemio",
+      "batteri_termofili_endosimbiosi",
+      "biochip_memoria",
+      "biofilm_glow",
+      "biofilm_iperarido",
+      "branchie_dual_mode",
+      "branchie_eoliche",
+      "branchie_metalloidi",
+      "branchie_microfiltri",
+      "branchie_solfatiche",
+      "branchie_turbina",
+      "camere_anticorrosione",
+      "camere_mirage",
+      "camere_nutrienti_vent",
+      "capillari_criogenici",
+      "capillari_fluoridici",
+      "capillari_fotovoltaici",
+      "capsule_paracadute",
       "carapace_fase_variabile",
-      "carapace_luminiscente_abissale",
-      "cartilagine_flessotermica_venti",
-      "cavita_risonanti_tundra",
-      "chioma_parassita_canopica",
-      "circolazione_bifasica_palude",
+      "carapace_segmenti_logici",
+      "carapaci_ferruginosi",
+      "cartilagini_biofibre",
+      "cartilagini_desertiche",
+      "cartilagini_flessoacustiche",
+      "cartilagini_pseudometalliche",
+      "cervelletto_equilibrio_statico",
+      "chemiorecettori_bromuro",
+      "circolazione_bifasica",
+      "circolazione_cooling_loop",
+      "circolazione_doppia",
+      "circolazione_supercritica",
+      "ciste_riduttive",
+      "ciste_salmastre",
+      "cisti_iperbariche",
+      "coda_balanciere",
+      "coda_contrappeso",
+      "coda_coppia_retroattiva",
       "coda_frusta_cinetica",
+      "coda_stabilizzatrice_filo",
+      "coda_stabilizzatrice_geiser",
+      "coda_stabilizzatrice_vortex",
+      "colonne_vibromagnetiche",
+      "coralli_partner",
       "criostasi_adattiva",
+      "cromofori_alert_acido",
+      "cuore_multicamera_bassa_pressione",
+      "cuscinetti_elettrostatici",
       "cute_resistente_sali",
-      "cuticole_cerose",
+      "cuticole_neutralizzanti",
+      "denti_chelatanti",
+      "denti_ossidoferro",
+      "denti_silice_termici",
+      "denti_tuning_fork",
+      "echi_risonanti",
       "eco_interno_riflesso",
       "empatia_coordinativa",
-      "enzimi_chelanti",
+      "enzimi_antifase_termica",
+      "enzimi_antipredatori_algali",
+      "enzimi_chelatori_rapidi",
+      "enzimi_metanoossidanti",
+      "epidermide_dielettrica",
+      "epitelio_fosforescente",
       "filamenti_digestivi_compattanti",
-      "frusta_fiammeggiante",
-      "grassi_termici",
-      "lamelle_termoforetiche",
+      "filamenti_magnetotrofi",
+      "filamenti_superconduttivi",
+      "filamenti_termoconduzione",
+      "filtri_planctonici",
+      "flagelli_ancoranti",
+      "focus_frazionato",
+      "foliage_fotocatodico",
+      "foliaggio_spugna",
+      "ghiaccio_piezoelettrico",
+      "ghiandola_caustica",
+      "ghiandole_cambio_salino",
+      "ghiandole_condensa_ozono",
+      "ghiandole_eco_mappanti",
+      "ghiandole_fango_calde",
+      "ghiandole_fango_coesivo",
+      "ghiandole_grafene",
+      "ghiandole_inchiostro_luce",
+      "ghiandole_iodoattive",
+      "ghiandole_minerali",
+      "ghiandole_nebbia_acida",
+      "ghiandole_nebbia_ionica",
+      "ghiandole_resina_conduttiva",
+      "ghiandole_ventosa",
+      "giunti_antitorsione",
+      "gusci_criovetro",
+      "gusci_magnesio",
+      "lamelle_shear",
+      "lamelle_sincroniche",
+      "lamine_filtranti_aeree",
+      "lamine_scudo_silice",
+      "linfa_tampone",
+      "lingua_cristallina",
       "lingua_tattile_trama",
-      "mantello_meteoritico",
-      "membrane_eliofiltranti",
+      "luminescenza_aurorale",
+      "luminescenza_hydrotermica",
+      "mantelli_geotermici",
+      "membrane_captura_rugiada",
+      "membrane_planata_vectored",
+      "membrane_pneumatofori",
+      "midollo_antivibrazione",
       "mimetismo_cromatico_passivo",
-      "mucillagine_simbionte_mangrovie",
-      "nodi_micorrizici_oracolari",
+      "mucose_aderenza_sonica",
+      "mucose_barofile",
       "nucleo_ovomotore_rotante",
       "occhi_infrarosso_composti",
-      "piume_solari_fotovoltaiche",
-      "polmoni_cristallini_alta_quota",
+      "olfatto_risonanza_magnetica",
+      "pathfinder",
+      "pianificatore",
       "respiro_a_scoppio",
       "risonanza_di_branco",
-      "sacche_spore_stratosferiche",
+      "sacche_galleggianti_ascensoriali",
       "sangue_piroforico",
       "scheletro_idro_regolante",
       "secrezione_rallentante_palmi",
-      "sensori_geomagnetici",
-      "sinapsi_coraline_polifoniche",
       "sonno_emisferico_alternato",
       "spore_psichiche_silenziate",
-      "squame_rifrangenti_deserto",
-      "vello_condensatore_nebbie",
-      "ventriglio_gastroliti",
-      "zoccoli_risonanti_steppe"
-    ]
+      "struttura_elastica_amorfa",
+      "tattiche_di_branco",
+      "ventriglio_gastroliti"
+    ],
+    "traits_missing_rules": []
   },
   "traits": {
     "ali_fulminee": {
@@ -83,29 +183,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          },
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
       }
     },
     "ali_ioniche": {
@@ -124,29 +225,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "canopia_ionica",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          },
-          {
-            "biome": "canopia_ionica",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "canopia-ionica-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
       }
     },
     "ali_membrana_sonica": {
@@ -165,29 +267,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
       }
     },
     "antenne_dustsense": {
@@ -206,29 +309,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
       }
     },
     "antenne_eco_turbina": {
@@ -247,29 +351,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
       }
     },
     "antenne_flusso_mareale": {
@@ -288,29 +393,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "laguna_bioreattiva",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "laguna-bioreattiva-trait-keeper"
-            ]
-          },
-          {
-            "biome": "laguna_bioreattiva",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "laguna-bioreattiva-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
       }
     },
     "antenne_microonde_cavernose": {
@@ -329,29 +435,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
       }
     },
     "antenne_plasmatiche_tempesta": {
@@ -364,25 +471,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "cicloni_psionici",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "cicloni-psionici-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "cicloni_psionici",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "cicloni-psionici-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "cicloni-psionici-trait-keeper"
         ]
       }
     },
@@ -402,29 +508,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "foresta_acida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "foresta_acida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "foresta_acida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "foresta-acida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
       }
     },
     "antenne_tesla": {
@@ -443,29 +550,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "canopia_ionica",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          },
-          {
-            "biome": "canopia_ionica",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "canopia-ionica-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
       }
     },
     "antenne_waveguide": {
@@ -484,29 +592,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "reef_luminescente",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          },
-          {
-            "biome": "reef_luminescente",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "reef-luminescente-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
       }
     },
     "antenne_wideband": {
@@ -525,29 +634,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "steppe_algoritmiche",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "steppe-algoritmiche-trait-keeper"
-            ]
-          },
-          {
-            "biome": "steppe_algoritmiche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "steppe-algoritmiche-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
       }
     },
     "appendici_risonanti_marea": {
@@ -566,29 +676,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "laguna_bioreattiva",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "laguna-bioreattiva-trait-keeper"
-            ]
-          },
-          {
-            "biome": "laguna_bioreattiva",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "laguna-bioreattiva-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
       }
     },
     "appendici_thermotattiche": {
@@ -607,29 +718,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
       }
     },
     "armatura_pietra_planare": {
@@ -642,37 +754,31 @@
         "coverage": []
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "balor-fission"
-            ]
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "scavenger_corazzato",
-            "count": 1,
-            "examples": [
-              "golem-runico"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede"
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "scavenger_corazzato"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "balor-fission",
+          "bulette-fase",
+          "golem-runico",
+          "treant-portale"
+        ]
+      },
+      "affinity": {
+        "total_species": 4,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 4
+        },
+        "top_species": [
+          "golem-runico",
+          "balor-fission",
+          "bulette-fase",
+          "treant-portale"
         ]
       }
     },
@@ -692,29 +798,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "foresta_acida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "foresta_acida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "foresta_acida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "foresta-acida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
       }
     },
     "artigli_induzione": {
@@ -733,29 +840,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "canopia_ionica",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          },
-          {
-            "biome": "canopia_ionica",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "canopia-ionica-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
       }
     },
     "artigli_radice": {
@@ -774,29 +882,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
       }
     },
     "artigli_scivolo_silente": {
@@ -815,29 +924,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
       }
     },
     "artigli_sette_vie": {
@@ -866,61 +976,54 @@
         ]
       },
       "species": {
-        "total": 9,
-        "coverage": [
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [
           {
             "biome": "caverna_risonante",
-            "morphotype": null,
-            "count": 2,
-            "examples": [
-              "caverna-risonante-trait-keeper",
-              "resonant-claw-hunter"
-            ]
-          },
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 2,
-            "examples": [
-              "caverna-risonante-trait-keeper",
-              "resonant-claw-hunter"
-            ]
+            "morphotype": null
           },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 2,
-            "examples": [
-              "dune-stalker",
-              "magneto-ridge-hunter"
-            ]
+            "morphotype": "cursoriale_quadrupede"
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "cryo-lynx"
-            ]
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 2,
-            "examples": [
-              "balor-fission",
-              "marilith-vault"
-            ]
-          }
-        ]
-      },
-      "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "rovine_planari",
             "morphotype": "cursoriale_quadrupede"
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "balor-fission",
+          "caverna-risonante-trait-keeper",
+          "couatl-aurora",
+          "cryo-lynx",
+          "dune-stalker",
+          "magneto-ridge-hunter",
+          "marilith-vault",
+          "otyugh-sentinella",
+          "resonant-claw-hunter"
+        ]
+      },
+      "affinity": {
+        "total_species": 9,
+        "roles_breakdown": {
+          "core": 2,
+          "optional": 9
+        },
+        "top_species": [
+          "dune-stalker",
+          "magneto-ridge-hunter",
+          "balor-fission",
+          "caverna-risonante-trait-keeper",
+          "couatl-aurora",
+          "cryo-lynx",
+          "marilith-vault",
+          "otyugh-sentinella",
+          "resonant-claw-hunter"
         ]
       }
     },
@@ -934,25 +1037,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "calotte_glaciali",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "calotte-glaciali-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "calotte_glaciali",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "calotte-glaciali-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "calotte-glaciali-trait-keeper"
         ]
       }
     },
@@ -972,29 +1074,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
       }
     },
     "aura_scudo_radianza": {
@@ -1007,25 +1110,25 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "rovine_planari",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "archon-solare"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "rovine_planari",
-            "morphotype": "volatore_planatore"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "archon-solare"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 1
+        },
+        "top_species": [
+          "archon-solare"
         ]
       }
     },
@@ -1045,29 +1148,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
       }
     },
     "barbigli_sensori_plasma": {
@@ -1086,29 +1190,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          },
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
       }
     },
     "barriere_miasma_glaciale": {
@@ -1127,29 +1232,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
       }
     },
     "batteri_endosimbionti_chemio": {
@@ -1168,29 +1274,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
       }
     },
     "batteri_termofili_endosimbiosi": {
@@ -1209,29 +1316,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
       }
     },
     "biochip_memoria": {
@@ -1250,29 +1358,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "steppe_algoritmiche",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "steppe-algoritmiche-trait-keeper"
-            ]
-          },
-          {
-            "biome": "steppe_algoritmiche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "steppe-algoritmiche-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
       }
     },
     "biofilm_glow": {
@@ -1291,29 +1400,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "reef_luminescente",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          },
-          {
-            "biome": "reef_luminescente",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "reef-luminescente-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
       }
     },
     "biofilm_iperarido": {
@@ -1332,29 +1442,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
       }
     },
     "branchie_dual_mode": {
@@ -1373,29 +1484,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "laguna_bioreattiva",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "laguna-bioreattiva-trait-keeper"
-            ]
-          },
-          {
-            "biome": "laguna_bioreattiva",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "laguna-bioreattiva-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
       }
     },
     "branchie_eoliche": {
@@ -1414,29 +1526,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          },
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
       }
     },
     "branchie_metalloidi": {
@@ -1455,29 +1568,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
       }
     },
     "branchie_microfiltri": {
@@ -1496,29 +1610,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "reef_luminescente",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          },
-          {
-            "biome": "reef_luminescente",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "reef-luminescente-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
       }
     },
     "branchie_osmotiche_salmastra": {
@@ -1531,25 +1646,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "delta_salmastri",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "delta-salmastri-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "delta_salmastri",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "delta-salmastri-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "delta-salmastri-trait-keeper"
         ]
       }
     },
@@ -1569,29 +1683,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
       }
     },
     "branchie_turbina": {
@@ -1610,29 +1725,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
       }
     },
     "bulbi_radici_permafrost": {
@@ -1645,25 +1761,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "permafrost_psionico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "permafrost-psionico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "permafrost_psionico",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "permafrost-psionico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "permafrost-psionico-trait-keeper"
         ]
       }
     },
@@ -1683,29 +1798,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "foresta_acida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "foresta_acida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "foresta_acida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "foresta-acida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
       }
     },
     "camere_mirage": {
@@ -1724,29 +1840,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
       }
     },
     "camere_nutrienti_vent": {
@@ -1765,29 +1882,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
       }
     },
     "capillari_criogenici": {
@@ -1806,29 +1924,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
       }
     },
     "capillari_fluoridici": {
@@ -1847,29 +1966,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "foresta_acida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "foresta_acida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "foresta_acida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "foresta-acida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
       }
     },
     "capillari_fotovoltaici": {
@@ -1888,29 +2008,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "canopia_ionica",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          },
-          {
-            "biome": "canopia_ionica",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "canopia-ionica-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
       }
     },
     "capsule_paracadute": {
@@ -1929,29 +2050,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          },
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
       }
     },
     "carapace_fase_variabile": {
@@ -1970,69 +2092,45 @@
         ]
       },
       "species": {
-        "total": 5,
-        "coverage": [
-          {
-            "biome": "canopia_psionica_leggera",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopia-psionica-leggera-trait-keeper"
-            ]
-          },
-          {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "falde-magnetiche-psioniche-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "cryo-lynx"
-            ]
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "balor-fission"
-            ]
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "scavenger_corazzato",
-            "count": 1,
-            "examples": [
-              "golem-runico"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
+        "missing_in_species": [
           {
-            "biome": "canopia_psionica_leggera",
+            "biome": "mezzanotte_orbitale",
             "morphotype": "cursoriale_quadrupede"
-          },
-          {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": "cursoriale_quadrupede"
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede"
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "scavenger_corazzato"
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "balor-fission",
+          "bulette-fase",
+          "canopia-psionica-leggera-trait-keeper",
+          "cryo-lynx",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "golem-runico",
+          "nano-rust-bloom",
+          "otyugh-sentinella",
+          "sand-burrower"
+        ]
+      },
+      "affinity": {
+        "total_species": 9,
+        "roles_breakdown": {
+          "optional": 9
+        },
+        "top_species": [
+          "balor-fission",
+          "bulette-fase",
+          "canopia-psionica-leggera-trait-keeper",
+          "cryo-lynx",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "golem-runico",
+          "nano-rust-bloom",
+          "otyugh-sentinella",
+          "sand-burrower"
         ]
       }
     },
@@ -2046,25 +2144,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "abisso_luminescente",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "abisso-luminescente-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "abisso_luminescente",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "abisso-luminescente-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-luminescente-trait-keeper"
         ]
       }
     },
@@ -2084,29 +2181,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "steppe_algoritmiche",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "steppe-algoritmiche-trait-keeper"
-            ]
-          },
-          {
-            "biome": "steppe_algoritmiche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "steppe-algoritmiche-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
       }
     },
     "carapaci_ferruginosi": {
@@ -2125,29 +2223,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
       }
     },
     "cartilagine_flessotermica_venti": {
@@ -2160,25 +2259,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "gole_ventose",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "gole-ventose-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "gole_ventose",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "gole-ventose-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "gole-ventose-trait-keeper"
         ]
       }
     },
@@ -2198,29 +2296,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "reef_luminescente",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          },
-          {
-            "biome": "reef_luminescente",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "reef-luminescente-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
       }
     },
     "cartilagini_desertiche": {
@@ -2239,29 +2338,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
       }
     },
     "cartilagini_flessoacustiche": {
@@ -2280,29 +2380,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
       }
     },
     "cartilagini_pseudometalliche": {
@@ -2321,29 +2422,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
       }
     },
     "cavita_risonanti_tundra": {
@@ -2356,25 +2458,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "tundra_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "tundra-risonante-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "tundra_risonante",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "tundra-risonante-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "tundra-risonante-trait-keeper"
         ]
       }
     },
@@ -2394,29 +2495,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "canopia_ionica",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          },
-          {
-            "biome": "canopia_ionica",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "canopia-ionica-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
       }
     },
     "chemiorecettori_bromuro": {
@@ -2435,29 +2537,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
       }
     },
     "chioma_parassita_canopica": {
@@ -2470,25 +2573,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "canopie_sospese",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopie-sospese-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "canopie_sospese",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "canopie-sospese-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopie-sospese-trait-keeper"
         ]
       }
     },
@@ -2508,29 +2610,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
       }
     },
     "circolazione_bifasica_palude": {
@@ -2543,25 +2646,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "paludi_gas_luminescenti",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "paludi-gas-luminescenti-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "paludi_gas_luminescenti",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "paludi-gas-luminescenti-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "paludi-gas-luminescenti-trait-keeper"
         ]
       }
     },
@@ -2581,29 +2683,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "steppe_algoritmiche",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "steppe-algoritmiche-trait-keeper"
-            ]
-          },
-          {
-            "biome": "steppe_algoritmiche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "steppe-algoritmiche-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
       }
     },
     "circolazione_doppia": {
@@ -2622,29 +2725,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
       }
     },
     "circolazione_supercritica": {
@@ -2663,29 +2767,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
       }
     },
     "ciste_riduttive": {
@@ -2704,29 +2809,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "laguna_bioreattiva",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "laguna-bioreattiva-trait-keeper"
-            ]
-          },
-          {
-            "biome": "laguna_bioreattiva",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "laguna-bioreattiva-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
       }
     },
     "ciste_salmastre": {
@@ -2745,29 +2851,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
       }
     },
     "cisti_iperbariche": {
@@ -2786,29 +2893,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
       }
     },
     "coda_balanciere": {
@@ -2827,29 +2935,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
       }
     },
     "coda_contrappeso": {
@@ -2868,29 +2977,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
       }
     },
     "coda_coppia_retroattiva": {
@@ -2909,29 +3019,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "steppe_algoritmiche",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "steppe-algoritmiche-trait-keeper"
-            ]
-          },
-          {
-            "biome": "steppe_algoritmiche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "steppe-algoritmiche-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
       }
     },
     "coda_frusta_cinetica": {
@@ -2950,60 +3061,42 @@
         ]
       },
       "species": {
-        "total": 7,
-        "coverage": [
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 3,
-            "examples": [
-              "dune-stalker",
-              "magneto-ridge-hunter",
-              "slag-veil-ambusher"
-            ]
-          },
-          {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "falde-magnetiche-psioniche-trait-keeper"
-            ]
-          },
-          {
-            "biome": "orbita_psionica_inversa",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "orbita-psionica-inversa-trait-keeper"
-            ]
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 2,
-            "examples": [
-              "bulette-fase",
-              "marilith-vault"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
+        "missing_in_species": [
           {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": "cursoriale_quadrupede"
-          },
-          {
-            "biome": "orbita_psionica_inversa",
-            "morphotype": "cursoriale_quadrupede"
-          },
-          {
-            "biome": "rovine_planari",
+            "biome": "dorsale_termale_tropicale",
             "morphotype": "cursoriale_quadrupede"
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "bulette-fase",
+          "dune-stalker",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "magneto-ridge-hunter",
+          "marilith-vault",
+          "orbita-psionica-inversa-trait-keeper",
+          "slag-veil-ambusher"
+        ]
+      },
+      "affinity": {
+        "total_species": 7,
+        "roles_breakdown": {
+          "core": 3,
+          "optional": 7
+        },
+        "top_species": [
+          "dune-stalker",
+          "magneto-ridge-hunter",
+          "slag-veil-ambusher",
+          "bulette-fase",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "marilith-vault",
+          "orbita-psionica-inversa-trait-keeper"
         ]
       }
     },
@@ -3023,29 +3116,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "canopia_ionica",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          },
-          {
-            "biome": "canopia_ionica",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "canopia-ionica-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
       }
     },
     "coda_stabilizzatrice_geiser": {
@@ -3064,29 +3158,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
       }
     },
     "coda_stabilizzatrice_vortex": {
@@ -3105,29 +3200,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          },
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
       }
     },
     "colonne_vibromagnetiche": {
@@ -3146,29 +3242,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
       }
     },
     "coralli_partner": {
@@ -3187,29 +3284,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "reef_luminescente",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          },
-          {
-            "biome": "reef_luminescente",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "reef-luminescente-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
       }
     },
     "criostasi_adattiva": {
@@ -3228,45 +3326,35 @@
         ]
       },
       "species": {
-        "total": 3,
-        "coverage": [
-          {
-            "biome": "canopia_psionica_leggera",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopia-psionica-leggera-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "aurora-gull"
-            ]
-          },
-          {
-            "biome": "orbita_psionica_inversa",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "orbita-psionica-inversa-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
+        "missing_in_species": [
           {
-            "biome": "canopia_psionica_leggera",
-            "morphotype": "cursoriale_quadrupede"
-          },
-          {
-            "biome": "orbita_psionica_inversa",
-            "morphotype": "cursoriale_quadrupede"
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore"
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "aurora-gull",
+          "canopia-psionica-leggera-trait-keeper",
+          "orbita-psionica-inversa-trait-keeper",
+          "orbital-ascendant"
+        ]
+      },
+      "affinity": {
+        "total_species": 4,
+        "roles_breakdown": {
+          "optional": 4
+        },
+        "top_species": [
+          "aurora-gull",
+          "canopia-psionica-leggera-trait-keeper",
+          "orbita-psionica-inversa-trait-keeper",
+          "orbital-ascendant"
         ]
       }
     },
@@ -3286,29 +3374,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "foresta_acida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "foresta_acida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "foresta_acida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "foresta-acida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
       }
     },
     "cuore_multicamera_bassa_pressione": {
@@ -3327,29 +3416,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          },
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
       }
     },
     "cuscinetti_elettrostatici": {
@@ -3368,29 +3458,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
       }
     },
     "cute_resistente_sali": {
@@ -3414,7 +3505,7 @@
         ]
       },
       "species": {
-        "total": 5,
+        "total": 2,
         "coverage": [
           {
             "biome": null,
@@ -3431,40 +3522,33 @@
             "examples": [
               "global-trait-keeper"
             ]
-          },
-          {
-            "biome": "badlands",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "badlands-trait-keeper"
-            ]
-          },
-          {
-            "biome": "badlands",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "badlands-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "evento-tempesta-ferrosa"
-            ]
           }
         ]
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
+        "missing_in_species": [
           {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "volatore_planatore"
+            "biome": "badlands",
+            "morphotype": null
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "badlands-trait-keeper",
+          "evento-tempesta-ferrosa"
+        ]
+      },
+      "affinity": {
+        "total_species": 3,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 3
+        },
+        "top_species": [
+          "evento-tempesta-ferrosa",
+          "badlands-trait-keeper",
+          "global-trait-keeper"
         ]
       }
     },
@@ -3484,7 +3568,7 @@
         ]
       },
       "species": {
-        "total": 8,
+        "total": 2,
         "coverage": [
           {
             "biome": null,
@@ -3501,73 +3585,35 @@
             "examples": [
               "global-trait-keeper"
             ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "thermo-raptor"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "ingegnere_radicante",
-            "count": 1,
-            "examples": [
-              "cactus-weaver"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "scavenger_corazzato",
-            "count": 1,
-            "examples": [
-              "silica-bloom"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "volatore_planatore",
-            "count": 2,
-            "examples": [
-              "evento-ondata-termica",
-              "noctule-termico"
-            ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "evento-brinastorm"
-            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede"
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "ingegnere_radicante"
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "scavenger_corazzato"
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "volatore_planatore"
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "cactus-weaver",
+          "evento-brinastorm",
+          "evento-ondata-termica",
+          "noctule-termico",
+          "silica-bloom",
+          "thermo-raptor"
+        ]
+      },
+      "affinity": {
+        "total_species": 7,
+        "roles_breakdown": {
+          "optional": 7
+        },
+        "top_species": [
+          "cactus-weaver",
+          "evento-brinastorm",
+          "evento-ondata-termica",
+          "global-trait-keeper",
+          "noctule-termico",
+          "silica-bloom",
+          "thermo-raptor"
         ]
       }
     },
@@ -3587,29 +3633,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "foresta_acida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "foresta_acida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "foresta_acida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "foresta-acida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
       }
     },
     "denti_chelatanti": {
@@ -3628,29 +3675,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "foresta_acida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "foresta_acida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "foresta_acida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "foresta-acida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
       }
     },
     "denti_ossidoferro": {
@@ -3669,29 +3717,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
       }
     },
     "denti_silice_termici": {
@@ -3710,29 +3759,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
       }
     },
     "denti_tuning_fork": {
@@ -3751,29 +3801,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
       }
     },
     "echi_risonanti": {
@@ -3792,29 +3843,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
       }
     },
     "eco_interno_riflesso": {
@@ -3838,55 +3890,46 @@
         ]
       },
       "species": {
-        "total": 6,
-        "coverage": [
-          {
-            "biome": "canopia_psionica_leggera",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopia-psionica-leggera-trait-keeper"
-            ]
-          },
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "echo-wing"
-            ]
-          },
-          {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "falde-magnetiche-psioniche-trait-keeper"
-            ]
+            "morphotype": "volatore_planatore"
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore",
-            "count": 3,
-            "examples": [
-              "aurora-bridge-runner",
-              "aurora-gull",
-              "zephyr-spore-courier"
-            ]
+            "morphotype": "volatore_planatore"
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "aurora-bridge-runner",
+          "aurora-gull",
+          "canopia-psionica-leggera-trait-keeper",
+          "echo-wing",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "orbital-ascendant",
+          "zephyr-spore-courier"
         ]
       },
-      "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "canopia_psionica_leggera",
-            "morphotype": "cursoriale_quadrupede"
-          },
-          {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": "cursoriale_quadrupede"
-          }
+      "affinity": {
+        "total_species": 7,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 7
+        },
+        "top_species": [
+          "echo-wing",
+          "aurora-bridge-runner",
+          "aurora-gull",
+          "canopia-psionica-leggera-trait-keeper",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "orbital-ascendant",
+          "zephyr-spore-courier"
         ]
       }
     },
@@ -3906,57 +3949,43 @@
         ]
       },
       "species": {
-        "total": 8,
-        "coverage": [
-          {
-            "biome": "foresta_miceliale",
-            "morphotype": null,
-            "count": 3,
-            "examples": [
-              "glowcap-weaver",
-              "lupus-temperatus",
-              "myco-spire-warden"
-            ]
-          },
-          {
-            "biome": "foresta_miceliale",
-            "morphotype": "scavenger_corazzato",
-            "count": 2,
-            "examples": [
-              "glowcap-weaver",
-              "myco-spire-warden"
-            ]
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "rakshasa-corte"
-            ]
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "volatore_planatore",
-            "count": 2,
-            "examples": [
-              "archon-solare",
-              "couatl-aurora"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
+        "missing_in_species": [
           {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede"
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "volatore_planatore"
+            "biome": "foresta_miceliale",
+            "morphotype": null
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "archon-solare",
+          "balor-fission",
+          "couatl-aurora",
+          "glowcap-weaver",
+          "lupus-temperatus",
+          "marilith-vault",
+          "myco-spire-warden",
+          "rakshasa-corte"
+        ]
+      },
+      "affinity": {
+        "total_species": 8,
+        "roles_breakdown": {
+          "optional": 8
+        },
+        "top_species": [
+          "archon-solare",
+          "balor-fission",
+          "couatl-aurora",
+          "glowcap-weaver",
+          "lupus-temperatus",
+          "marilith-vault",
+          "myco-spire-warden",
+          "rakshasa-corte"
         ]
       }
     },
@@ -3976,29 +4005,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
       }
     },
     "enzimi_antipredatori_algali": {
@@ -4017,29 +4047,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "reef_luminescente",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          },
-          {
-            "biome": "reef_luminescente",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "reef-luminescente-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
       }
     },
     "enzimi_chelanti": {
@@ -4058,7 +4089,7 @@
         ]
       },
       "species": {
-        "total": 3,
+        "total": 2,
         "coverage": [
           {
             "biome": null,
@@ -4075,24 +4106,26 @@
             "examples": [
               "global-trait-keeper"
             ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "evento-tempesta-ferrosa"
-            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "volatore_planatore"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "evento-tempesta-ferrosa"
+        ]
+      },
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 2
+        },
+        "top_species": [
+          "evento-tempesta-ferrosa",
+          "global-trait-keeper"
         ]
       }
     },
@@ -4112,29 +4145,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "foresta_acida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "foresta_acida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "foresta_acida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "foresta-acida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
       }
     },
     "enzimi_metanoossidanti": {
@@ -4153,29 +4187,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
       }
     },
     "epidermide_dielettrica": {
@@ -4194,29 +4229,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          },
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
       }
     },
     "epitelio_fosforescente": {
@@ -4235,29 +4271,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "reef_luminescente",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          },
-          {
-            "biome": "reef_luminescente",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "reef-luminescente-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
       }
     },
     "filamenti_digestivi_compattanti": {
@@ -4291,85 +4328,56 @@
         ]
       },
       "species": {
-        "total": 12,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "scavenger_corazzato",
-            "count": 2,
-            "examples": [
-              "nano-rust-bloom",
-              "rust-scavenger"
-            ]
+            "morphotype": "scavenger_corazzato"
           },
           {
             "biome": "falde_magnetiche_psioniche",
-            "morphotype": null,
-            "count": 2,
-            "examples": [
-              "falde-magnetiche-psioniche-trait-keeper",
-              "magnet-fathom-surveyor"
-            ]
-          },
-          {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "falde-magnetiche-psioniche-trait-keeper"
-            ]
-          },
-          {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": "scavenger_corazzato",
-            "count": 1,
-            "examples": [
-              "magnet-fathom-surveyor"
-            ]
+            "morphotype": null
           },
           {
             "biome": "foresta_miceliale",
-            "morphotype": null,
-            "count": 2,
-            "examples": [
-              "glowcap-weaver",
-              "myco-spire-warden"
-            ]
-          },
-          {
-            "biome": "foresta_miceliale",
-            "morphotype": "scavenger_corazzato",
-            "count": 2,
-            "examples": [
-              "glowcap-weaver",
-              "myco-spire-warden"
-            ]
+            "morphotype": null
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "scavenger_corazzato",
-            "count": 1,
-            "examples": [
-              "thaw-rot"
-            ]
+            "morphotype": "scavenger_corazzato"
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "glowcap-weaver",
+          "magnet-fathom-surveyor",
+          "myco-spire-warden",
+          "nano-rust-bloom",
+          "rust-scavenger",
+          "thaw-rot"
         ]
       },
-      "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede"
-          }
+      "affinity": {
+        "total_species": 8,
+        "roles_breakdown": {
+          "core": 3,
+          "optional": 8
+        },
+        "top_species": [
+          "magnet-fathom-surveyor",
+          "nano-rust-bloom",
+          "rust-scavenger",
+          "caverna-risonante-trait-keeper",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "glowcap-weaver",
+          "myco-spire-warden",
+          "thaw-rot"
         ]
       }
     },
@@ -4389,29 +4397,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
       }
     },
     "filamenti_superconduttivi": {
@@ -4430,29 +4439,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
       }
     },
     "filamenti_termoconduzione": {
@@ -4471,29 +4481,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
       }
     },
     "filtri_planctonici": {
@@ -4512,29 +4523,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "laguna_bioreattiva",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "laguna-bioreattiva-trait-keeper"
-            ]
-          },
-          {
-            "biome": "laguna_bioreattiva",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "laguna-bioreattiva-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
       }
     },
     "flagelli_ancoranti": {
@@ -4553,29 +4565,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "laguna_bioreattiva",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "laguna-bioreattiva-trait-keeper"
-            ]
-          },
-          {
-            "biome": "laguna_bioreattiva",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "laguna-bioreattiva-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
       }
     },
     "focus_frazionato": {
@@ -4604,53 +4617,54 @@
         ]
       },
       "species": {
-        "total": 5,
-        "coverage": [
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [
           {
             "biome": "canopia_psionica_leggera",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "psionic-canopy-scout"
-            ]
-          },
-          {
-            "biome": "canopia_psionica_leggera",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "psionic-canopy-scout"
-            ]
+            "morphotype": null
           },
           {
             "biome": "foresta_miceliale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "sentinella-radice"
-            ]
+            "morphotype": null
           },
           {
             "biome": "orbita_psionica_inversa",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "orbital-ascendant"
-            ]
-          },
-          {
-            "biome": "orbita_psionica_inversa",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "orbital-ascendant"
-            ]
+            "morphotype": null
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "archon-solare",
+          "balor-fission",
+          "banshee-risonante",
+          "couatl-aurora",
+          "marilith-vault",
+          "orbital-ascendant",
+          "psionic-canopy-scout",
+          "sentinella-radice"
         ]
       },
-      "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+      "affinity": {
+        "total_species": 8,
+        "roles_breakdown": {
+          "core": 3,
+          "optional": 3,
+          "synergy": 4
+        },
+        "top_species": [
+          "orbital-ascendant",
+          "psionic-canopy-scout",
+          "marilith-vault",
+          "archon-solare",
+          "balor-fission",
+          "banshee-risonante",
+          "couatl-aurora",
+          "sentinella-radice"
+        ]
       }
     },
     "foliage_fotocatodico": {
@@ -4669,29 +4683,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "foresta_acida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "foresta_acida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "foresta_acida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "foresta-acida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
       }
     },
     "foliaggio_spugna": {
@@ -4710,29 +4725,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
       }
     },
     "frusta_fiammeggiante": {
@@ -4745,25 +4761,27 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "balor-fission"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "balor-fission",
+          "marilith-vault"
+        ]
+      },
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 2,
+          "optional": 1
+        },
+        "top_species": [
+          "balor-fission",
+          "marilith-vault"
         ]
       }
     },
@@ -4783,29 +4801,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
       }
     },
     "ghiandola_caustica": {
@@ -4824,21 +4843,32 @@
         ]
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "foresta_miceliale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "blight-micotico"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "blight-micotico",
+          "slag-veil-ambusher"
+        ]
+      },
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "optional": 2
+        },
+        "top_species": [
+          "blight-micotico",
+          "slag-veil-ambusher"
+        ]
       }
     },
     "ghiandole_cambio_salino": {
@@ -4857,29 +4887,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "laguna_bioreattiva",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "laguna-bioreattiva-trait-keeper"
-            ]
-          },
-          {
-            "biome": "laguna_bioreattiva",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "laguna-bioreattiva-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
       }
     },
     "ghiandole_condensa_ozono": {
@@ -4898,29 +4929,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          },
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
       }
     },
     "ghiandole_eco_mappanti": {
@@ -4939,29 +4971,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
       }
     },
     "ghiandole_fango_calde": {
@@ -4980,29 +5013,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
       }
     },
     "ghiandole_fango_coesivo": {
@@ -5021,29 +5055,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
       }
     },
     "ghiandole_grafene": {
@@ -5062,29 +5097,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "steppe_algoritmiche",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "steppe-algoritmiche-trait-keeper"
-            ]
-          },
-          {
-            "biome": "steppe_algoritmiche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "steppe-algoritmiche-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
       }
     },
     "ghiandole_inchiostro_luce": {
@@ -5103,29 +5139,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "reef_luminescente",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          },
-          {
-            "biome": "reef_luminescente",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "reef-luminescente-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "reef-luminescente-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
       }
     },
     "ghiandole_iodoattive": {
@@ -5144,29 +5181,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
       }
     },
     "ghiandole_minerali": {
@@ -5185,29 +5223,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
       }
     },
     "ghiandole_nebbia_acida": {
@@ -5226,29 +5265,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "foresta_acida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "foresta_acida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "foresta_acida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "foresta-acida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
       }
     },
     "ghiandole_nebbia_ionica": {
@@ -5267,29 +5307,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "canopia_ionica",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          },
-          {
-            "biome": "canopia_ionica",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "canopia-ionica-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
       }
     },
     "ghiandole_resina_conduttiva": {
@@ -5308,29 +5349,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "canopia_ionica",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          },
-          {
-            "biome": "canopia_ionica",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "canopia-ionica-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
       }
     },
     "ghiandole_ventosa": {
@@ -5349,29 +5391,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
       }
     },
     "giunti_antitorsione": {
@@ -5390,29 +5433,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
       }
     },
     "grassi_termici": {
@@ -5431,7 +5475,7 @@
         ]
       },
       "species": {
-        "total": 8,
+        "total": 2,
         "coverage": [
           {
             "biome": null,
@@ -5448,73 +5492,35 @@
             "examples": [
               "global-trait-keeper"
             ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "thermo-raptor"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "ingegnere_radicante",
-            "count": 1,
-            "examples": [
-              "cactus-weaver"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "scavenger_corazzato",
-            "count": 1,
-            "examples": [
-              "silica-bloom"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "volatore_planatore",
-            "count": 2,
-            "examples": [
-              "evento-ondata-termica",
-              "noctule-termico"
-            ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "evento-brinastorm"
-            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede"
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "ingegnere_radicante"
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "scavenger_corazzato"
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "volatore_planatore"
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "cactus-weaver",
+          "evento-brinastorm",
+          "evento-ondata-termica",
+          "noctule-termico",
+          "silica-bloom",
+          "thermo-raptor"
+        ]
+      },
+      "affinity": {
+        "total_species": 7,
+        "roles_breakdown": {
+          "optional": 7
+        },
+        "top_species": [
+          "cactus-weaver",
+          "evento-brinastorm",
+          "evento-ondata-termica",
+          "global-trait-keeper",
+          "noctule-termico",
+          "silica-bloom",
+          "thermo-raptor"
         ]
       }
     },
@@ -5534,29 +5540,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
       }
     },
     "gusci_magnesio": {
@@ -5575,29 +5582,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
       }
     },
     "lamelle_shear": {
@@ -5616,29 +5624,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          },
-          {
-            "biome": "stratosfera_tempestosa",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "stratosfera-tempestosa-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
       }
     },
     "lamelle_sincroniche": {
@@ -5657,29 +5666,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "steppe_algoritmiche",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "steppe-algoritmiche-trait-keeper"
-            ]
-          },
-          {
-            "biome": "steppe_algoritmiche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "steppe-algoritmiche-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
       }
     },
     "lamelle_termoforetiche": {
@@ -5692,37 +5702,32 @@
         "coverage": []
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "bulette-fase"
-            ]
-          },
-          {
-            "biome": "sorgenti_geotermiche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "sorgenti-geotermiche-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede"
-          },
-          {
-            "biome": "sorgenti_geotermiche",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "bulette-fase",
+          "couatl-aurora",
+          "magnet-fathom-surveyor",
+          "otyugh-sentinella",
+          "sorgenti-geotermiche-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 5,
+        "roles_breakdown": {
+          "optional": 5
+        },
+        "top_species": [
+          "bulette-fase",
+          "couatl-aurora",
+          "magnet-fathom-surveyor",
+          "otyugh-sentinella",
+          "sorgenti-geotermiche-trait-keeper"
         ]
       }
     },
@@ -5742,29 +5747,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
       }
     },
     "lamine_scudo_silice": {
@@ -5783,29 +5789,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
       }
     },
     "linfa_tampone": {
@@ -5824,29 +5831,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "foresta_acida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "foresta_acida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "foresta-acida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "foresta_acida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "foresta-acida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
       }
     },
     "lingua_cristallina": {
@@ -5865,29 +5873,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
       }
     },
     "lingua_tattile_trama": {
@@ -5906,33 +5915,35 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
-          {
-            "biome": "foresta_miceliale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "blight-micotico"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
+        "missing_in_species": [
           {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede"
+            "biome": "foresta_miceliale",
+            "morphotype": null
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "blight-micotico",
+          "caverna-risonante-trait-keeper",
+          "echo-wing",
+          "ferrocolonia-magnetotattica"
+        ]
+      },
+      "affinity": {
+        "total_species": 4,
+        "roles_breakdown": {
+          "optional": 4
+        },
+        "top_species": [
+          "blight-micotico",
+          "caverna-risonante-trait-keeper",
+          "echo-wing",
+          "ferrocolonia-magnetotattica"
         ]
       }
     },
@@ -5952,29 +5963,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
       }
     },
     "luminescenza_hydrotermica": {
@@ -5993,29 +6005,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
       }
     },
     "mantelli_geotermici": {
@@ -6034,29 +6047,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caldera_glaciale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caldera-glaciale-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
       }
     },
     "mantello_meteoritico": {
@@ -6069,25 +6083,27 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "balor-fission"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "balor-fission",
+          "marilith-vault"
+        ]
+      },
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 2,
+          "optional": 1
+        },
+        "top_species": [
+          "balor-fission",
+          "marilith-vault"
         ]
       }
     },
@@ -6107,29 +6123,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          },
-          {
-            "biome": "pianura_salina_iperarida",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "pianura-salina-iperarida-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
       }
     },
     "membrane_eliofiltranti": {
@@ -6142,25 +6159,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "laghi_alcalini",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "laghi-alcalini-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "laghi_alcalini",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "laghi-alcalini-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laghi-alcalini-trait-keeper"
         ]
       }
     },
@@ -6180,29 +6196,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "canopia_ionica",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          },
-          {
-            "biome": "canopia_ionica",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopia-ionica-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "canopia-ionica-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
       }
     },
     "membrane_pneumatofori": {
@@ -6221,29 +6238,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mangrovieto_cinetico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "mangrovieto-cinetico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
       }
     },
     "midollo_antivibrazione": {
@@ -6262,29 +6280,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
       }
     },
     "mimetismo_cromatico_passivo": {
@@ -6313,67 +6332,48 @@
         ]
       },
       "species": {
-        "total": 8,
-        "coverage": [
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [
           {
             "biome": "canopia_psionica_leggera",
-            "morphotype": null,
-            "count": 2,
-            "examples": [
-              "canopia-psionica-leggera-trait-keeper",
-              "psionic-canopy-scout"
-            ]
-          },
-          {
-            "biome": "canopia_psionica_leggera",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopia-psionica-leggera-trait-keeper"
-            ]
-          },
-          {
-            "biome": "canopia_psionica_leggera",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "psionic-canopy-scout"
-            ]
+            "morphotype": null
           },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "ingegnere_radicante",
-            "count": 1,
-            "examples": [
-              "ferrocolonia-magnetotattica"
-            ]
-          },
-          {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "falde-magnetiche-psioniche-trait-keeper"
-            ]
+            "morphotype": "ingegnere_radicante"
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore",
-            "count": 2,
-            "examples": [
-              "aurora-bridge-runner",
-              "zephyr-spore-courier"
-            ]
+            "morphotype": "volatore_planatore"
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "aurora-bridge-runner",
+          "canopia-psionica-leggera-trait-keeper",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "ferrocolonia-magnetotattica",
+          "psionic-canopy-scout",
+          "zephyr-spore-courier"
         ]
       },
-      "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": "cursoriale_quadrupede"
-          }
+      "affinity": {
+        "total_species": 6,
+        "roles_breakdown": {
+          "core": 2,
+          "optional": 6
+        },
+        "top_species": [
+          "ferrocolonia-magnetotattica",
+          "psionic-canopy-scout",
+          "aurora-bridge-runner",
+          "canopia-psionica-leggera-trait-keeper",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "zephyr-spore-courier"
         ]
       }
     },
@@ -6387,25 +6387,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "mangrovie_risonanti",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "mangrovie-risonanti-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "mangrovie_risonanti",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "mangrovie-risonanti-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovie-risonanti-trait-keeper"
         ]
       }
     },
@@ -6425,29 +6424,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
       }
     },
     "mucose_barofile": {
@@ -6466,29 +6466,30 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          },
-          {
-            "biome": "abisso_vulcanico",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "abisso-vulcanico-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
       }
     },
     "nodi_micorrizici_oracolari": {
@@ -6501,25 +6502,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "reti_micorriziche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "reti-micorriziche-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "reti_micorriziche",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "reti-micorriziche-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reti-micorriziche-trait-keeper"
         ]
       }
     },
@@ -6549,65 +6549,46 @@
         ]
       },
       "species": {
-        "total": 6,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "sand-burrower"
-            ]
-          },
-          {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "magnet-fathom-surveyor"
-            ]
-          },
-          {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": "scavenger_corazzato",
-            "count": 1,
-            "examples": [
-              "magnet-fathom-surveyor"
-            ]
-          },
-          {
-            "biome": "orbita_psionica_inversa",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "orbital-ascendant"
-            ]
-          },
-          {
-            "biome": "orbita_psionica_inversa",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "orbital-ascendant"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
+        "missing_in_species": [
           {
-            "biome": "caverna_risonante",
+            "biome": "dorsale_termale_tropicale",
             "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper",
+          "magnet-fathom-surveyor",
+          "orbital-ascendant",
+          "rust-scavenger",
+          "sand-burrower"
+        ]
+      },
+      "affinity": {
+        "total_species": 5,
+        "roles_breakdown": {
+          "core": 3,
+          "optional": 5
+        },
+        "top_species": [
+          "magnet-fathom-surveyor",
+          "orbital-ascendant",
+          "sand-burrower",
+          "caverna-risonante-trait-keeper",
+          "rust-scavenger"
         ]
       }
     },
@@ -6627,33 +6608,32 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "echo-wing"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
+        "missing_in_species": [
           {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede"
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "volatore_planatore"
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper",
+          "echo-wing"
+        ]
+      },
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 2
+        },
+        "top_species": [
+          "echo-wing",
+          "caverna-risonante-trait-keeper"
         ]
       }
     },
@@ -6688,79 +6668,59 @@
         ]
       },
       "species": {
-        "total": 10,
-        "coverage": [
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "slag-veil-ambusher"
-            ]
+            "morphotype": "cursoriale_quadrupede"
           },
           {
             "biome": "falde_magnetiche_psioniche",
-            "morphotype": null,
-            "count": 2,
-            "examples": [
-              "falde-magnetiche-psioniche-trait-keeper",
-              "magnet-fathom-surveyor"
-            ]
-          },
-          {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "falde-magnetiche-psioniche-trait-keeper"
-            ]
-          },
-          {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": "scavenger_corazzato",
-            "count": 1,
-            "examples": [
-              "magnet-fathom-surveyor"
-            ]
+            "morphotype": null
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "cryo-lynx"
-            ]
+            "morphotype": "cursoriale_quadrupede"
           },
           {
             "biome": "orbita_psionica_inversa",
-            "morphotype": null,
-            "count": 2,
-            "examples": [
-              "orbita-psionica-inversa-trait-keeper",
-              "orbital-ascendant"
-            ]
-          },
-          {
-            "biome": "orbita_psionica_inversa",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "orbita-psionica-inversa-trait-keeper"
-            ]
-          },
-          {
-            "biome": "orbita_psionica_inversa",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "orbital-ascendant"
-            ]
+            "morphotype": null
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "cryo-lynx",
+          "dune-stalker",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "magnet-fathom-surveyor",
+          "magneto-ridge-hunter",
+          "orbita-psionica-inversa-trait-keeper",
+          "orbital-ascendant",
+          "psionic-canopy-scout",
+          "slag-veil-ambusher"
         ]
       },
-      "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+      "affinity": {
+        "total_species": 9,
+        "roles_breakdown": {
+          "core": 3,
+          "optional": 9
+        },
+        "top_species": [
+          "magnet-fathom-surveyor",
+          "orbital-ascendant",
+          "slag-veil-ambusher",
+          "cryo-lynx",
+          "dune-stalker",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "magneto-ridge-hunter",
+          "orbita-psionica-inversa-trait-keeper",
+          "psionic-canopy-scout"
+        ]
       }
     },
     "pathfinder": {
@@ -6779,21 +6739,30 @@
         ]
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "foresta_miceliale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "sentinella-radice"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "sentinella-radice"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "sentinella-radice"
+        ]
       }
     },
     "pianificatore": {
@@ -6812,21 +6781,30 @@
         ]
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "foresta_miceliale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "sentinella-radice"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "sentinella-radice"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "sentinella-radice"
+        ]
       }
     },
     "piume_solari_fotovoltaiche": {
@@ -6839,25 +6817,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "altipiani_solari",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "altipiani-solari-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "altipiani_solari",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "altipiani-solari-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "altipiani-solari-trait-keeper"
         ]
       }
     },
@@ -6871,25 +6848,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "picchi_cristallini",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "picchi-cristallini-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "picchi_cristallini",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "picchi-cristallini-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "picchi-cristallini-trait-keeper"
         ]
       }
     },
@@ -6908,7 +6884,9 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "respiro_a_scoppio": {
@@ -6932,41 +6910,44 @@
         ]
       },
       "species": {
-        "total": 3,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "scavenger_corazzato",
-            "count": 1,
-            "examples": [
-              "rust-scavenger"
-            ]
+            "morphotype": "scavenger_corazzato"
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "steppe-bison-mini"
-            ]
-          }
-        ]
-      },
-      "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "caverna_risonante",
             "morphotype": "cursoriale_quadrupede"
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper",
+          "dune-stalker",
+          "magneto-ridge-hunter",
+          "rust-scavenger",
+          "slag-veil-ambusher",
+          "steppe-bison-mini"
+        ]
+      },
+      "affinity": {
+        "total_species": 6,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 6
+        },
+        "top_species": [
+          "rust-scavenger",
+          "caverna-risonante-trait-keeper",
+          "dune-stalker",
+          "magneto-ridge-hunter",
+          "slag-veil-ambusher",
+          "steppe-bison-mini"
         ]
       }
     },
@@ -6986,33 +6967,41 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "foresta_miceliale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "lupus-temperatus"
-            ]
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "archon-solare"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
+        "missing_in_species": [
           {
-            "biome": "rovine_planari",
-            "morphotype": "volatore_planatore"
+            "biome": "foresta_miceliale",
+            "morphotype": null
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "archon-solare",
+          "banshee-risonante",
+          "couatl-aurora",
+          "lupus-temperatus",
+          "rakshasa-corte",
+          "treant-portale"
+        ]
+      },
+      "affinity": {
+        "total_species": 6,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 2,
+          "synergy": 4
+        },
+        "top_species": [
+          "archon-solare",
+          "banshee-risonante",
+          "couatl-aurora",
+          "rakshasa-corte",
+          "treant-portale",
+          "lupus-temperatus"
         ]
       }
     },
@@ -7047,80 +7036,57 @@
         ]
       },
       "species": {
-        "total": 11,
-        "coverage": [
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [
           {
             "biome": "canopia_psionica_leggera",
-            "morphotype": null,
-            "count": 2,
-            "examples": [
-              "canopia-psionica-leggera-trait-keeper",
-              "psionic-canopy-scout"
-            ]
-          },
-          {
-            "biome": "canopia_psionica_leggera",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopia-psionica-leggera-trait-keeper"
-            ]
-          },
-          {
-            "biome": "canopia_psionica_leggera",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "psionic-canopy-scout"
-            ]
+            "morphotype": null
           },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "sand-burrower"
-            ]
+            "morphotype": "cursoriale_quadrupede"
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore",
-            "count": 2,
-            "examples": [
-              "aurora-bridge-runner",
-              "zephyr-spore-courier"
-            ]
+            "morphotype": "volatore_planatore"
           },
           {
             "biome": "orbita_psionica_inversa",
-            "morphotype": null,
-            "count": 2,
-            "examples": [
-              "orbita-psionica-inversa-trait-keeper",
-              "orbital-ascendant"
-            ]
-          },
-          {
-            "biome": "orbita_psionica_inversa",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "orbita-psionica-inversa-trait-keeper"
-            ]
-          },
-          {
-            "biome": "orbita_psionica_inversa",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "orbital-ascendant"
-            ]
+            "morphotype": null
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "aurora-bridge-runner",
+          "canopia-psionica-leggera-trait-keeper",
+          "echo-wing",
+          "orbita-psionica-inversa-trait-keeper",
+          "orbital-ascendant",
+          "psionic-canopy-scout",
+          "sand-burrower",
+          "zephyr-spore-courier"
         ]
       },
-      "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+      "affinity": {
+        "total_species": 8,
+        "roles_breakdown": {
+          "core": 3,
+          "optional": 8
+        },
+        "top_species": [
+          "orbital-ascendant",
+          "psionic-canopy-scout",
+          "sand-burrower",
+          "aurora-bridge-runner",
+          "canopia-psionica-leggera-trait-keeper",
+          "echo-wing",
+          "orbita-psionica-inversa-trait-keeper",
+          "zephyr-spore-courier"
+        ]
       }
     },
     "sacche_spore_stratosferiche": {
@@ -7133,25 +7099,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "stratosfera_portante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "stratosfera-portante-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "stratosfera_portante",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "stratosfera-portante-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-portante-trait-keeper"
         ]
       }
     },
@@ -7176,41 +7141,40 @@
         ]
       },
       "species": {
-        "total": 3,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "ingegnere_radicante",
-            "count": 1,
-            "examples": [
-              "ferrocolonia-magnetotattica"
-            ]
+            "morphotype": "ingegnere_radicante"
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "scavenger_corazzato",
-            "count": 1,
-            "examples": [
-              "thaw-rot"
-            ]
+            "morphotype": "scavenger_corazzato"
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper",
+          "ferrocolonia-magnetotattica",
+          "nano-rust-bloom",
+          "thaw-rot"
         ]
       },
-      "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede"
-          }
+      "affinity": {
+        "total_species": 4,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 4
+        },
+        "top_species": [
+          "ferrocolonia-magnetotattica",
+          "caverna-risonante-trait-keeper",
+          "nano-rust-bloom",
+          "thaw-rot"
         ]
       }
     },
@@ -7240,63 +7204,57 @@
         ]
       },
       "species": {
-        "total": 7,
-        "coverage": [
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [
           {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede"
           },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 3,
-            "examples": [
-              "dune-stalker",
-              "magneto-ridge-hunter",
-              "sand-burrower"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "scavenger_corazzato",
-            "count": 1,
-            "examples": [
-              "nano-rust-bloom"
-            ]
+            "morphotype": "scavenger_corazzato"
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "steppe-bison-mini"
-            ]
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "bulette-fase"
-            ]
+            "morphotype": "cursoriale_quadrupede"
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "bulette-fase",
+          "caverna-risonante-trait-keeper",
+          "dune-stalker",
+          "magnet-fathom-surveyor",
+          "magneto-ridge-hunter",
+          "nano-rust-bloom",
+          "rust-scavenger",
+          "sand-burrower",
+          "slag-veil-ambusher",
+          "steppe-bison-mini"
         ]
       },
-      "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede"
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede"
-          }
+      "affinity": {
+        "total_species": 10,
+        "roles_breakdown": {
+          "core": 4,
+          "optional": 9,
+          "synergy": 1
+        },
+        "top_species": [
+          "dune-stalker",
+          "magneto-ridge-hunter",
+          "nano-rust-bloom",
+          "sand-burrower",
+          "slag-veil-ambusher",
+          "bulette-fase",
+          "caverna-risonante-trait-keeper",
+          "magnet-fathom-surveyor",
+          "rust-scavenger",
+          "steppe-bison-mini"
         ]
       }
     },
@@ -7316,33 +7274,32 @@
         ]
       },
       "species": {
-        "total": 2,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "ingegnere_radicante",
-            "count": 1,
-            "examples": [
-              "ferrocolonia-magnetotattica"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
+        "missing_in_species": [
           {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede"
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "ingegnere_radicante"
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper",
+          "ferrocolonia-magnetotattica"
+        ]
+      },
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 2
+        },
+        "top_species": [
+          "ferrocolonia-magnetotattica",
+          "caverna-risonante-trait-keeper"
         ]
       }
     },
@@ -7356,50 +7313,30 @@
         "coverage": []
       },
       "species": {
-        "total": 4,
-        "coverage": [
-          {
-            "biome": "pianure_magnetiche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "pianure-magnetiche-trait-keeper"
-            ]
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 2,
-            "examples": [
-              "bulette-fase",
-              "marilith-vault"
-            ]
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "couatl-aurora"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "pianure_magnetiche",
-            "morphotype": "cursoriale_quadrupede"
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "cursoriale_quadrupede"
-          },
-          {
-            "biome": "rovine_planari",
-            "morphotype": "volatore_planatore"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "bulette-fase",
+          "couatl-aurora",
+          "marilith-vault",
+          "pianure-magnetiche-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 4,
+        "roles_breakdown": {
+          "optional": 4
+        },
+        "top_species": [
+          "bulette-fase",
+          "couatl-aurora",
+          "marilith-vault",
+          "pianure-magnetiche-trait-keeper"
         ]
       }
     },
@@ -7413,25 +7350,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "barriere_coralline_psioniche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "barriere-coralline-psioniche-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "barriere_coralline_psioniche",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "barriere-coralline-psioniche-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "barriere-coralline-psioniche-trait-keeper"
         ]
       }
     },
@@ -7456,41 +7392,38 @@
         ]
       },
       "species": {
-        "total": 3,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "echo-wing"
-            ]
+            "morphotype": "volatore_planatore"
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "aurora-gull"
-            ]
+            "morphotype": "volatore_planatore"
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "aurora-gull",
+          "caverna-risonante-trait-keeper",
+          "echo-wing"
         ]
       },
-      "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede"
-          }
+      "affinity": {
+        "total_species": 3,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 3
+        },
+        "top_species": [
+          "echo-wing",
+          "aurora-gull",
+          "caverna-risonante-trait-keeper"
         ]
       }
     },
@@ -7520,49 +7453,44 @@
         ]
       },
       "species": {
-        "total": 4,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "scavenger_corazzato",
-            "count": 1,
-            "examples": [
-              "nano-rust-bloom"
-            ]
+            "morphotype": "scavenger_corazzato"
           },
           {
             "biome": "foresta_miceliale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "blight-micotico"
-            ]
+            "morphotype": null
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "scavenger_corazzato",
-            "count": 1,
-            "examples": [
-              "thaw-rot"
-            ]
+            "morphotype": "scavenger_corazzato"
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "blight-micotico",
+          "caverna-risonante-trait-keeper",
+          "nano-rust-bloom",
+          "thaw-rot"
         ]
       },
-      "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede"
-          }
+      "affinity": {
+        "total_species": 4,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 4
+        },
+        "top_species": [
+          "nano-rust-bloom",
+          "blight-micotico",
+          "caverna-risonante-trait-keeper",
+          "thaw-rot"
         ]
       }
     },
@@ -7576,25 +7504,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "dune_cristalline",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "dune-cristalline-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "dune_cristalline",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "dune-cristalline-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dune-cristalline-trait-keeper"
         ]
       }
     },
@@ -7629,90 +7556,60 @@
         ]
       },
       "species": {
-        "total": 14,
-        "coverage": [
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [
           {
             "biome": "canopia_psionica_leggera",
-            "morphotype": null,
-            "count": 2,
-            "examples": [
-              "canopia-psionica-leggera-trait-keeper",
-              "psionic-canopy-scout"
-            ]
-          },
-          {
-            "biome": "canopia_psionica_leggera",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "canopia-psionica-leggera-trait-keeper"
-            ]
-          },
-          {
-            "biome": "canopia_psionica_leggera",
-            "morphotype": "volatore_planatore",
-            "count": 1,
-            "examples": [
-              "psionic-canopy-scout"
-            ]
+            "morphotype": null
           },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 2,
-            "examples": [
-              "dune-stalker",
-              "slag-veil-ambusher"
-            ]
+            "morphotype": "cursoriale_quadrupede"
           },
           {
             "biome": "falde_magnetiche_psioniche",
-            "morphotype": null,
-            "count": 2,
-            "examples": [
-              "falde-magnetiche-psioniche-trait-keeper",
-              "magnet-fathom-surveyor"
-            ]
-          },
-          {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "falde-magnetiche-psioniche-trait-keeper"
-            ]
-          },
-          {
-            "biome": "falde_magnetiche_psioniche",
-            "morphotype": "scavenger_corazzato",
-            "count": 1,
-            "examples": [
-              "magnet-fathom-surveyor"
-            ]
+            "morphotype": null
           },
           {
             "biome": "foresta_miceliale",
-            "morphotype": null,
-            "count": 2,
-            "examples": [
-              "glowcap-weaver",
-              "myco-spire-warden"
-            ]
-          },
-          {
-            "biome": "foresta_miceliale",
-            "morphotype": "scavenger_corazzato",
-            "count": 2,
-            "examples": [
-              "glowcap-weaver",
-              "myco-spire-warden"
-            ]
+            "morphotype": null
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "canopia-psionica-leggera-trait-keeper",
+          "dune-stalker",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "glowcap-weaver",
+          "magnet-fathom-surveyor",
+          "magneto-ridge-hunter",
+          "myco-spire-warden",
+          "psionic-canopy-scout",
+          "slag-veil-ambusher"
         ]
       },
-      "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+      "affinity": {
+        "total_species": 9,
+        "roles_breakdown": {
+          "core": 4,
+          "optional": 8,
+          "synergy": 1
+        },
+        "top_species": [
+          "dune-stalker",
+          "magnet-fathom-surveyor",
+          "psionic-canopy-scout",
+          "slag-veil-ambusher",
+          "magneto-ridge-hunter",
+          "canopia-psionica-leggera-trait-keeper",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "glowcap-weaver",
+          "myco-spire-warden"
+        ]
       }
     },
     "tattiche_di_branco": {
@@ -7731,21 +7628,35 @@
         ]
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "foresta_miceliale",
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "lupus-temperatus"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_species": [
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "lupus-temperatus",
+          "magneto-ridge-hunter",
+          "slag-veil-ambusher"
+        ]
+      },
+      "affinity": {
+        "total_species": 3,
+        "roles_breakdown": {
+          "optional": 1,
+          "synergy": 2
+        },
+        "top_species": [
+          "magneto-ridge-hunter",
+          "slag-veil-ambusher",
+          "lupus-temperatus"
+        ]
       }
     },
     "vello_condensatore_nebbie": {
@@ -7758,25 +7669,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "foreste_nubose",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "foreste-nubose-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "foreste_nubose",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "foreste-nubose-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foreste-nubose-trait-keeper"
         ]
       }
     },
@@ -7801,41 +7711,40 @@
         ]
       },
       "species": {
-        "total": 3,
-        "coverage": [
-          {
-            "biome": "caverna_risonante",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "caverna-risonante-trait-keeper"
-            ]
-          },
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "scavenger_corazzato",
-            "count": 1,
-            "examples": [
-              "rust-scavenger"
-            ]
+            "morphotype": "scavenger_corazzato"
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "steppe-bison-mini"
-            ]
-          }
-        ]
-      },
-      "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "caverna_risonante",
             "morphotype": "cursoriale_quadrupede"
           }
+        ],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "caverna-risonante-trait-keeper",
+          "ferrocolonia-magnetotattica",
+          "rust-scavenger",
+          "steppe-bison-mini"
+        ]
+      },
+      "affinity": {
+        "total_species": 4,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 4
+        },
+        "top_species": [
+          "rust-scavenger",
+          "caverna-risonante-trait-keeper",
+          "ferrocolonia-magnetotattica",
+          "steppe-bison-mini"
         ]
       }
     },
@@ -7854,7 +7763,20 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "sand-burrower"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "sand-burrower"
+        ]
       }
     },
     "zoccoli_risonanti_steppe": {
@@ -7867,25 +7789,24 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
-        "coverage": [
-          {
-            "biome": "steppe_risonanti",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 1,
-            "examples": [
-              "steppe-risonanti-trait-keeper"
-            ]
-          }
-        ]
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [
-          {
-            "biome": "steppe_risonanti",
-            "morphotype": "cursoriale_quadrupede"
-          }
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": [
+          "steppe-risonanti-trait-keeper"
+        ]
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-risonanti-trait-keeper"
         ]
       }
     }

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -3,20 +3,13 @@
   "trait_glossary": "data/core/traits/glossary.json",
   "traits": {
     "ali_fulminee": {
-      "label": "Ali Fulminee",
+      "conflitti": [],
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
       "famiglia_tipologia": "Sensoriale/Analitico",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
-      "slot": [],
-      "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
-      },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
-      "conflitti": [],
+      "id": "ali_fulminee",
+      "label": "Ali Fulminee",
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -31,33 +24,42 @@
           }
         }
       ],
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ali_fulminee"
-    },
-    "ali_ioniche": {
-      "label": "Ali Ioniche",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
+        "complementare": "analitico",
+        "core": "sensoriale"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+    },
+    "ali_ioniche": {
       "conflitti": [],
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ali_ioniche",
+      "label": "Ali Ioniche",
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -72,33 +74,42 @@
           }
         }
       ],
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ali_ioniche"
-    },
-    "ali_membrana_sonica": {
-      "label": "Ali Membrana Sonica",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "mobilita",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "tier": "T1",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+    },
+    "ali_membrana_sonica": {
       "conflitti": [],
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ali_membrana_sonica",
+      "label": "Ali Membrana Sonica",
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -113,33 +124,42 @@
           }
         }
       ],
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ali_membrana_sonica"
-    },
-    "antenne_dustsense": {
-      "label": "Antenne Dustsense",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
+        "complementare": "protezione",
+        "core": "difensivo"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "tier": "T1",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+    },
+    "antenne_dustsense": {
       "conflitti": [],
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_dustsense",
+      "label": "Antenne Dustsense",
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -154,33 +174,42 @@
           }
         }
       ],
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "antenne_dustsense"
-    },
-    "antenne_eco_turbina": {
-      "label": "Antenne Eco Turbina",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
+        "complementare": "energia",
+        "core": "metabolico"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "tier": "T1",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+    },
+    "antenne_eco_turbina": {
       "conflitti": [],
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_eco_turbina",
+      "label": "Antenne Eco Turbina",
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -195,33 +224,42 @@
           }
         }
       ],
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "antenne_eco_turbina"
-    },
-    "antenne_flusso_mareale": {
-      "label": "Antenne Flusso Mareale",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "tier": "T1",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+    },
+    "antenne_flusso_mareale": {
       "conflitti": [],
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_flusso_mareale",
+      "label": "Antenne Flusso Mareale",
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -236,33 +274,42 @@
           }
         }
       ],
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "antenne_flusso_mareale"
-    },
-    "antenne_microonde_cavernose": {
-      "label": "Antenne Microonde Cavernose",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
+        "complementare": "assalto",
+        "core": "offensivo"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "tier": "T1",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+    },
+    "antenne_microonde_cavernose": {
       "conflitti": [],
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_microonde_cavernose",
+      "label": "Antenne Microonde Cavernose",
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -277,35 +324,42 @@
           }
         }
       ],
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "antenne_microonde_cavernose"
-    },
-    "antenne_plasmatiche_tempesta": {
-      "label": "Antenne Plasmatiche di Tempesta",
-      "famiglia_tipologia": "Sensoriale/Offensivo",
-      "fattore_mantenimento_energetico": "Alto (Canalizzazione costante di plasma atmosferico)",
-      "tier": "T3",
       "slot": [],
       "slot_profile": {
-        "complementare": "offensivo",
-        "core": "sensoriale"
+        "complementare": "tattico",
+        "core": "strategia"
       },
-      "sinergie": [
-        "carapace_luminiscente_abissale",
-        "focus_frazionato",
-        "risonanza_di_branco",
-        "sinapsi_coraline_polifoniche"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "tier": "T1",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+    },
+    "antenne_plasmatiche_tempesta": {
       "conflitti": [],
+      "debolezza": "Scariche elettriche massicce possono bruciare i recettori e compromettere la coordinazione.",
+      "famiglia_tipologia": "Sensoriale/Offensivo",
+      "fattore_mantenimento_energetico": "Alto (Canalizzazione costante di plasma atmosferico)",
+      "id": "antenne_plasmatiche_tempesta",
+      "label": "Antenne Plasmatiche di Tempesta",
+      "mutazione_indotta": "Flagelli coronati da nodi plasma-sensibili che captano e deviano fulmini.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -319,10 +373,12 @@
           }
         }
       ],
-      "mutazione_indotta": "Flagelli coronati da nodi plasma-sensibili che captano e deviano fulmini.",
-      "uso_funzione": "Canalizza scariche atmosferiche in attacchi direzionati o scudi ionici.",
-      "spinta_selettiva": "Comandare fulmini e navigare in cieli turbolenti durante campagne aeree.",
-      "debolezza": "Scariche elettriche massicce possono bruciare i recettori e compromettere la coordinazione.",
+      "sinergie": [
+        "carapace_luminiscente_abissale",
+        "focus_frazionato",
+        "risonanza_di_branco",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [
           "boardgame:Evolution/Camouflage-Ambush",
@@ -338,23 +394,32 @@
           "tabella:fulmini_empatici"
         ]
       },
-      "id": "antenne_plasmatiche_tempesta"
-    },
-    "antenne_reagenti": {
-      "label": "Antenne Reagenti",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
+        "complementare": "offensivo",
+        "core": "sensoriale"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cicloni-psionici-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Comandare fulmini e navigare in cieli turbolenti durante campagne aeree.",
+      "tier": "T3",
+      "uso_funzione": "Canalizza scariche atmosferiche in attacchi direzionati o scudi ionici."
+    },
+    "antenne_reagenti": {
       "conflitti": [],
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_reagenti",
+      "label": "Antenne Reagenti",
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -369,33 +434,42 @@
           }
         }
       ],
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "antenne_reagenti"
-    },
-    "antenne_tesla": {
-      "label": "Antenne Tesla",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
+        "complementare": "cooperazione",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "tier": "T1",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+    },
+    "antenne_tesla": {
       "conflitti": [],
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_tesla",
+      "label": "Antenne Tesla",
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -410,33 +484,42 @@
           }
         }
       ],
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "antenne_tesla"
-    },
-    "antenne_waveguide": {
-      "label": "Antenne Waveguide",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
+        "complementare": "resilienza",
+        "core": "strutturale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "tier": "T1",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+    },
+    "antenne_waveguide": {
       "conflitti": [],
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_waveguide",
+      "label": "Antenne Waveguide",
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -451,33 +534,42 @@
           }
         }
       ],
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "antenne_waveguide"
-    },
-    "antenne_wideband": {
-      "label": "Antenne Wideband",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
+        "complementare": "analitico",
+        "core": "sensoriale"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+    },
+    "antenne_wideband": {
       "conflitti": [],
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_wideband",
+      "label": "Antenne Wideband",
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -492,33 +584,42 @@
           }
         }
       ],
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "antenne_wideband"
-    },
-    "appendici_risonanti_marea": {
-      "label": "Appendici Risonanti Marea",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "mobilita",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "tier": "T1",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+    },
+    "appendici_risonanti_marea": {
       "conflitti": [],
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "appendici_risonanti_marea",
+      "label": "Appendici Risonanti Marea",
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -533,33 +634,42 @@
           }
         }
       ],
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "appendici_risonanti_marea"
-    },
-    "appendici_thermotattiche": {
-      "label": "Appendici Thermotattiche",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
+        "complementare": "protezione",
+        "core": "difensivo"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "tier": "T1",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+    },
+    "appendici_thermotattiche": {
       "conflitti": [],
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "appendici_thermotattiche",
+      "label": "Appendici Thermotattiche",
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -574,34 +684,44 @@
           }
         }
       ],
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "appendici_thermotattiche"
-    },
-    "armatura_pietra_planare": {
-      "label": "Armatura di Pietra Planare",
-      "famiglia_tipologia": "Difesa/Strutturale",
-      "fattore_mantenimento_energetico": "Basso (Risonanza geodetica stabile)",
-      "tier": "T2",
       "slot": [],
       "slot_profile": {
-        "complementare": "strutturale",
-        "core": "difesa"
+        "complementare": "energia",
+        "core": "metabolico"
       },
-      "sinergie": [
-        "carapace_fase_variabile"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "tier": "T1",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+    },
+    "armatura_pietra_planare": {
       "conflitti": [
         "frusta_fiammeggiante"
       ],
+      "debolezza": "Pesante: riduce mobilità in ambienti non supportati o a bassa gravità.",
+      "famiglia_tipologia": "Difesa/Strutturale",
+      "fattore_mantenimento_energetico": "Basso (Risonanza geodetica stabile)",
+      "id": "armatura_pietra_planare",
+      "label": "Armatura di Pietra Planare",
+      "mutazione_indotta": "Cristallizza il dermascheletro con nodi rune che deviano energia.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [
@@ -618,33 +738,63 @@
           }
         }
       ],
-      "mutazione_indotta": "Cristallizza il dermascheletro con nodi rune che deviano energia.",
-      "uso_funzione": "Offre schermatura massiva e ancoraggio durante le aperture dimensionali.",
-      "spinta_selettiva": "Stabilizzare varchi e proteggere infrastrutture dalle onde d'urto.",
-      "debolezza": "Pesante: riduce mobilità in ambienti non supportati o a bassa gravità.",
+      "sinergie": [
+        "carapace_fase_variabile"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "armatura_pietra_planare"
-    },
-    "artigli_acidofagi": {
-      "label": "Artigli Acidofagi",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
+        "complementare": "strutturale",
+        "core": "difesa"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "golem-runico",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "balor-fission",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "treant-portale",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Stabilizzare varchi e proteggere infrastrutture dalle onde d'urto.",
+      "tier": "T2",
+      "uso_funzione": "Offre schermatura massiva e ancoraggio durante le aperture dimensionali."
+    },
+    "artigli_acidofagi": {
       "conflitti": [],
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "artigli_acidofagi",
+      "label": "Artigli Acidofagi",
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -659,33 +809,42 @@
           }
         }
       ],
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "artigli_acidofagi"
-    },
-    "artigli_induzione": {
-      "label": "Artigli Induzione",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "tier": "T1",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+    },
+    "artigli_induzione": {
       "conflitti": [],
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "artigli_induzione",
+      "label": "Artigli Induzione",
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -700,33 +859,42 @@
           }
         }
       ],
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "artigli_induzione"
-    },
-    "artigli_radice": {
-      "label": "Artigli Radice",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
+        "complementare": "assalto",
+        "core": "offensivo"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "tier": "T1",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+    },
+    "artigli_radice": {
       "conflitti": [],
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "artigli_radice",
+      "label": "Artigli Radice",
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -741,33 +909,42 @@
           }
         }
       ],
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "artigli_radice"
-    },
-    "artigli_scivolo_silente": {
-      "label": "Artigli Scivolo Silente",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
+        "complementare": "tattico",
+        "core": "strategia"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "tier": "T1",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+    },
+    "artigli_scivolo_silente": {
       "conflitti": [],
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "artigli_scivolo_silente",
+      "label": "Artigli Scivolo Silente",
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -782,35 +959,42 @@
           }
         }
       ],
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "artigli_scivolo_silente"
-    },
-    "artigli_sette_vie": {
-      "label": "Artigli a Sette Vie",
-      "famiglia_tipologia": "Locomotorio/Prensile",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "prensile",
-        "core": "locomotorio"
+        "complementare": "cooperazione",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "mimetismo_cromatico_passivo",
-        "struttura_elastica_amorfa",
-        "tattiche_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "tier": "T1",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+    },
+    "artigli_sette_vie": {
       "conflitti": [],
+      "debolezza": "Angoli di presa limitati se la superficie è perfettamente liscia.",
+      "famiglia_tipologia": "Locomotorio/Prensile",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "artigli_sette_vie",
+      "label": "Artigli a Sette Vie",
+      "mutazione_indotta": "Dita lunghe e segmentate con punte a uncino multiplo.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -824,10 +1008,12 @@
           }
         }
       ],
-      "mutazione_indotta": "Dita lunghe e segmentate con punte a uncino multiplo.",
-      "uso_funzione": "Afferrare superfici irregolari o oggetti multipli.",
-      "spinta_selettiva": "Arrampicarsi su pareti rocciose o vegetazione densa.",
-      "debolezza": "Angoli di presa limitati se la superficie è perfettamente liscia.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "mimetismo_cromatico_passivo",
+        "struttura_elastica_amorfa",
+        "tattiche_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [
           "boardgame:Evolution/Aggression-Camouflage",
@@ -843,24 +1029,90 @@
           "tabella:predazione_multicanale"
         ]
       },
-      "id": "artigli_sette_vie"
-    },
-    "artigli_sghiaccio_glaciale": {
-      "label": "Artigli Sghiaccio Glaciale",
-      "famiglia_tipologia": "Locomotorio/Predatorio",
-      "fattore_mantenimento_energetico": "Medio (Raffreddamento endogeno controllato)",
-      "tier": "T2",
       "slot": [],
       "slot_profile": {
-        "complementare": "predatorio",
+        "complementare": "prensile",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "cartilagine_flessotermica_venti",
-        "sonno_emisferico_alternato",
-        "zampe_a_molla"
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "dune-stalker",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "magneto-ridge-hunter",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "balor-fission",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cryo-lynx",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "resonant-claw-hunter",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Arrampicarsi su pareti rocciose o vegetazione densa.",
+      "tier": "T1",
+      "uso_funzione": "Afferrare superfici irregolari o oggetti multipli."
+    },
+    "artigli_sghiaccio_glaciale": {
       "conflitti": [],
+      "debolezza": "In ambienti temperati i tessuti subiscono microfratture e richiedono continue riparazioni.",
+      "famiglia_tipologia": "Locomotorio/Predatorio",
+      "fattore_mantenimento_energetico": "Medio (Raffreddamento endogeno controllato)",
+      "id": "artigli_sghiaccio_glaciale",
+      "label": "Artigli Sghiaccio Glaciale",
+      "mutazione_indotta": "Falangi rivestite da ghiaccio strutturale che si espande creando lame traslucide.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -874,10 +1126,11 @@
           }
         }
       ],
-      "mutazione_indotta": "Falangi rivestite da ghiaccio strutturale che si espande creando lame traslucide.",
-      "uso_funzione": "Scalza e immobilizza i bersagli congelandoli al contatto.",
-      "spinta_selettiva": "Cacciare su superfici gelate e pareti verticali di ghiaccio vivo.",
-      "debolezza": "In ambienti temperati i tessuti subiscono microfratture e richiedono continue riparazioni.",
+      "sinergie": [
+        "cartilagine_flessotermica_venti",
+        "sonno_emisferico_alternato",
+        "zampe_a_molla"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [
           "boardgame:DominantSpecies/Glaciation",
@@ -892,23 +1145,32 @@
           "tabella:presa_criostatica"
         ]
       },
-      "id": "artigli_sghiaccio_glaciale"
-    },
-    "artigli_vetrificati": {
-      "label": "Artigli Vetrificati",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
+        "complementare": "predatorio",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "calotte-glaciali-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Cacciare su superfici gelate e pareti verticali di ghiaccio vivo.",
+      "tier": "T2",
+      "uso_funzione": "Scalza e immobilizza i bersagli congelandoli al contatto."
+    },
+    "artigli_vetrificati": {
       "conflitti": [],
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "artigli_vetrificati",
+      "label": "Artigli Vetrificati",
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -923,35 +1185,44 @@
           }
         }
       ],
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "artigli_vetrificati"
-    },
-    "aura_scudo_radianza": {
-      "label": "Aura Scudo di Radianza",
-      "famiglia_tipologia": "Supporto/Difesa",
-      "fattore_mantenimento_energetico": "Alto (Canalizzazione fotonica continua)",
-      "tier": "T3",
       "slot": [],
       "slot_profile": {
-        "complementare": "difesa",
-        "core": "supporto"
+        "complementare": "resilienza",
+        "core": "strutturale"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "tier": "T1",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+    },
+    "aura_scudo_radianza": {
       "conflitti": [
         "mantello_meteoritico"
       ],
+      "debolezza": "Soffre saturazione se esposta a ombre gravitazionali o zone di antimagia.",
+      "famiglia_tipologia": "Supporto/Difesa",
+      "fattore_mantenimento_energetico": "Alto (Canalizzazione fotonica continua)",
+      "id": "aura_scudo_radianza",
+      "label": "Aura Scudo di Radianza",
+      "mutazione_indotta": "Innesta organi fotoplasmatici che diffondono uno scudo radiante sugli alleati vicini.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [
@@ -968,33 +1239,43 @@
           }
         }
       ],
-      "mutazione_indotta": "Innesta organi fotoplasmatici che diffondono uno scudo radiante sugli alleati vicini.",
-      "uso_funzione": "Proietta schermature luminose sincronizzate con i segnali tattici della squadra.",
-      "spinta_selettiva": "Proteggere gli hub di evacuazione durante tempeste di energia planare.",
-      "debolezza": "Soffre saturazione se esposta a ombre gravitazionali o zone di antimagia.",
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "aura_scudo_radianza"
-    },
-    "baffi_mareomotori": {
-      "label": "Baffi Mareomotori",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
+        "complementare": "difesa",
+        "core": "supporto"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "archon-solare",
+          "weight": 4
+        }
       ],
+      "spinta_selettiva": "Proteggere gli hub di evacuazione durante tempeste di energia planare.",
+      "tier": "T3",
+      "uso_funzione": "Proietta schermature luminose sincronizzate con i segnali tattici della squadra."
+    },
+    "baffi_mareomotori": {
       "conflitti": [],
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "baffi_mareomotori",
+      "label": "Baffi Mareomotori",
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1009,33 +1290,42 @@
           }
         }
       ],
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "baffi_mareomotori"
-    },
-    "barbigli_sensori_plasma": {
-      "label": "Barbigli Sensori Plasma",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
+        "complementare": "analitico",
+        "core": "sensoriale"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+    },
+    "barbigli_sensori_plasma": {
       "conflitti": [],
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "barbigli_sensori_plasma",
+      "label": "Barbigli Sensori Plasma",
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1050,33 +1340,42 @@
           }
         }
       ],
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "barbigli_sensori_plasma"
-    },
-    "barriere_miasma_glaciale": {
-      "label": "Barriere Miasma Glaciale",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "mobilita",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "tier": "T1",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+    },
+    "barriere_miasma_glaciale": {
       "conflitti": [],
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "barriere_miasma_glaciale",
+      "label": "Barriere Miasma Glaciale",
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1091,33 +1390,42 @@
           }
         }
       ],
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "barriere_miasma_glaciale"
-    },
-    "batteri_endosimbionti_chemio": {
-      "label": "Batteri Endosimbionti Chemio",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
+        "complementare": "protezione",
+        "core": "difensivo"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "tier": "T1",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+    },
+    "batteri_endosimbionti_chemio": {
       "conflitti": [],
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "batteri_endosimbionti_chemio",
+      "label": "Batteri Endosimbionti Chemio",
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1132,33 +1440,42 @@
           }
         }
       ],
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "batteri_endosimbionti_chemio"
-    },
-    "batteri_termofili_endosimbiosi": {
-      "label": "Batteri Termofili Endosimbiosi",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
+        "complementare": "energia",
+        "core": "metabolico"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "tier": "T1",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+    },
+    "batteri_termofili_endosimbiosi": {
       "conflitti": [],
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "batteri_termofili_endosimbiosi",
+      "label": "Batteri Termofili Endosimbiosi",
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1173,33 +1490,42 @@
           }
         }
       ],
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "batteri_termofili_endosimbiosi"
-    },
-    "biochip_memoria": {
-      "label": "Biochip Memoria",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "tier": "T1",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+    },
+    "biochip_memoria": {
       "conflitti": [],
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "biochip_memoria",
+      "label": "Biochip Memoria",
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1214,33 +1540,42 @@
           }
         }
       ],
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "biochip_memoria"
-    },
-    "biofilm_glow": {
-      "label": "Biofilm Glow",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
+        "complementare": "assalto",
+        "core": "offensivo"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "tier": "T1",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+    },
+    "biofilm_glow": {
       "conflitti": [],
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "biofilm_glow",
+      "label": "Biofilm Glow",
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1255,33 +1590,42 @@
           }
         }
       ],
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "biofilm_glow"
-    },
-    "biofilm_iperarido": {
-      "label": "Biofilm Iperarido",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
+        "complementare": "tattico",
+        "core": "strategia"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "tier": "T1",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+    },
+    "biofilm_iperarido": {
       "conflitti": [],
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "biofilm_iperarido",
+      "label": "Biofilm Iperarido",
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1296,33 +1640,42 @@
           }
         }
       ],
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "biofilm_iperarido"
-    },
-    "branchie_dual_mode": {
-      "label": "Branchie Dual Mode",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
+        "complementare": "cooperazione",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "tier": "T1",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+    },
+    "branchie_dual_mode": {
       "conflitti": [],
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "branchie_dual_mode",
+      "label": "Branchie Dual Mode",
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1337,33 +1690,42 @@
           }
         }
       ],
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "branchie_dual_mode"
-    },
-    "branchie_eoliche": {
-      "label": "Branchie Eoliche",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
+        "complementare": "resilienza",
+        "core": "strutturale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "tier": "T1",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+    },
+    "branchie_eoliche": {
       "conflitti": [],
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "branchie_eoliche",
+      "label": "Branchie Eoliche",
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1378,33 +1740,42 @@
           }
         }
       ],
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "branchie_eoliche"
-    },
-    "branchie_metalloidi": {
-      "label": "Branchie Metalloidi",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
+        "complementare": "analitico",
+        "core": "sensoriale"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+    },
+    "branchie_metalloidi": {
       "conflitti": [],
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "branchie_metalloidi",
+      "label": "Branchie Metalloidi",
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1419,33 +1790,42 @@
           }
         }
       ],
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "branchie_metalloidi"
-    },
-    "branchie_microfiltri": {
-      "label": "Branchie Microfiltri",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "mobilita",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "tier": "T1",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+    },
+    "branchie_microfiltri": {
       "conflitti": [],
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "branchie_microfiltri",
+      "label": "Branchie Microfiltri",
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1460,35 +1840,44 @@
           }
         }
       ],
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "branchie_microfiltri"
-    },
-    "branchie_osmotiche_salmastra": {
-      "label": "Branchie Osmotiche Salmastre",
-      "famiglia_tipologia": "Respiratorio/Osmoregolazione",
-      "fattore_mantenimento_energetico": "Medio (Pompe ioniche attive)",
-      "tier": "T2",
       "slot": [],
       "slot_profile": {
-        "complementare": "osmoregolazione",
-        "core": "respiratorio"
+        "complementare": "protezione",
+        "core": "difensivo"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "scheletro_idro_regolante"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "tier": "T1",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+    },
+    "branchie_osmotiche_salmastra": {
       "conflitti": [
         "polmoni_cristallini_alta_quota"
       ],
+      "debolezza": "Richiede accesso costante ad acqua salmastra; ambienti d'acqua dolce provocano stress ionico.",
+      "famiglia_tipologia": "Respiratorio/Osmoregolazione",
+      "fattore_mantenimento_energetico": "Medio (Pompe ioniche attive)",
+      "id": "branchie_osmotiche_salmastra",
+      "label": "Branchie Osmotiche Salmastre",
+      "mutazione_indotta": "Lamelle branchiali multilivello con valvole che separano sali e tossine.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1502,10 +1891,10 @@
           }
         }
       ],
-      "mutazione_indotta": "Lamelle branchiali multilivello con valvole che separano sali e tossine.",
-      "uso_funzione": "Bilancia sali e tossine sfruttando microvalvole controllate psionicamente.",
-      "spinta_selettiva": "Colonizzare mangrovie psioniche e barriere di estuario soggette a maree estreme.",
-      "debolezza": "Richiede accesso costante ad acqua salmastra; ambienti d'acqua dolce provocano stress ionico.",
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "scheletro_idro_regolante"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [
           "boardgame:Evolution/Symbiosis",
@@ -1520,23 +1909,32 @@
           "tabella:osmosi_psionica"
         ]
       },
-      "id": "branchie_osmotiche_salmastra"
-    },
-    "branchie_solfatiche": {
-      "label": "Branchie Solfatiche",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
+        "complementare": "osmoregolazione",
+        "core": "respiratorio"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "delta-salmastri-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Colonizzare mangrovie psioniche e barriere di estuario soggette a maree estreme.",
+      "tier": "T2",
+      "uso_funzione": "Bilancia sali e tossine sfruttando microvalvole controllate psionicamente."
+    },
+    "branchie_solfatiche": {
       "conflitti": [],
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "branchie_solfatiche",
+      "label": "Branchie Solfatiche",
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1551,33 +1949,42 @@
           }
         }
       ],
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "branchie_solfatiche"
-    },
-    "branchie_turbina": {
-      "label": "Branchie Turbina",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
+        "complementare": "energia",
+        "core": "metabolico"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "tier": "T1",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+    },
+    "branchie_turbina": {
       "conflitti": [],
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "branchie_turbina",
+      "label": "Branchie Turbina",
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1592,34 +1999,42 @@
           }
         }
       ],
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "branchie_turbina"
-    },
-    "bulbi_radici_permafrost": {
-      "label": "Bulbi Radici del Permafrost",
-      "famiglia_tipologia": "Simbiotico/Nutrizione",
-      "fattore_mantenimento_energetico": "Medio (Accumulo e rilascio lento di nutrienti)",
-      "tier": "T2",
       "slot": [],
       "slot_profile": {
-        "complementare": "nutrizione",
-        "core": "simbiotico"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "sinergie": [
-        "chioma_parassita_canopica",
-        "nodi_micorrizici_oracolari",
-        "vello_condensatore_nebbie"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "tier": "T1",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+    },
+    "bulbi_radici_permafrost": {
       "conflitti": [],
+      "debolezza": "Disgeli improvvisi trasformano i bulbi in masse gelatinose che rallentano i movimenti.",
+      "famiglia_tipologia": "Simbiotico/Nutrizione",
+      "fattore_mantenimento_energetico": "Medio (Accumulo e rilascio lento di nutrienti)",
+      "id": "bulbi_radici_permafrost",
+      "label": "Bulbi Radici del Permafrost",
+      "mutazione_indotta": "Bulbi radicali multipli che immagazzinano energia nelle stagioni fredde per rilasciarla durante le missioni.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1633,10 +2048,11 @@
           }
         }
       ],
-      "mutazione_indotta": "Bulbi radicali multipli che immagazzinano energia nelle stagioni fredde per rilasciarla durante le missioni.",
-      "uso_funzione": "Rilascia energia e calore agli alleati radicati nella stessa rete subglaciale.",
-      "spinta_selettiva": "Sostenere campagne lunghe in climi artici con riserve nutrizionali concentrate.",
-      "debolezza": "Disgeli improvvisi trasformano i bulbi in masse gelatinose che rallentano i movimenti.",
+      "sinergie": [
+        "chioma_parassita_canopica",
+        "nodi_micorrizici_oracolari",
+        "vello_condensatore_nebbie"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [
           "boardgame:DominantSpecies/Fertility",
@@ -1652,23 +2068,32 @@
           "tabella:riserva_empatica"
         ]
       },
-      "id": "bulbi_radici_permafrost"
-    },
-    "camere_anticorrosione": {
-      "label": "Camere Anticorrosione",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
+        "complementare": "nutrizione",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "permafrost-psionico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Sostenere campagne lunghe in climi artici con riserve nutrizionali concentrate.",
+      "tier": "T2",
+      "uso_funzione": "Rilascia energia e calore agli alleati radicati nella stessa rete subglaciale."
+    },
+    "camere_anticorrosione": {
       "conflitti": [],
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "camere_anticorrosione",
+      "label": "Camere Anticorrosione",
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1683,33 +2108,42 @@
           }
         }
       ],
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "camere_anticorrosione"
-    },
-    "camere_mirage": {
-      "label": "Camere Mirage",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
+        "complementare": "assalto",
+        "core": "offensivo"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "tier": "T1",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+    },
+    "camere_mirage": {
       "conflitti": [],
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "camere_mirage",
+      "label": "Camere Mirage",
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1724,33 +2158,42 @@
           }
         }
       ],
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "camere_mirage"
-    },
-    "camere_nutrienti_vent": {
-      "label": "Camere Nutrienti Vent",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
+        "complementare": "tattico",
+        "core": "strategia"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "tier": "T1",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+    },
+    "camere_nutrienti_vent": {
       "conflitti": [],
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "camere_nutrienti_vent",
+      "label": "Camere Nutrienti Vent",
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1765,33 +2208,42 @@
           }
         }
       ],
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "camere_nutrienti_vent"
-    },
-    "capillari_criogenici": {
-      "label": "Capillari Criogenici",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
+        "complementare": "cooperazione",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "tier": "T1",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+    },
+    "capillari_criogenici": {
       "conflitti": [],
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "capillari_criogenici",
+      "label": "Capillari Criogenici",
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1806,33 +2258,42 @@
           }
         }
       ],
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "capillari_criogenici"
-    },
-    "capillari_fluoridici": {
-      "label": "Capillari Fluoridici",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
+        "complementare": "resilienza",
+        "core": "strutturale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "tier": "T1",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+    },
+    "capillari_fluoridici": {
       "conflitti": [],
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "capillari_fluoridici",
+      "label": "Capillari Fluoridici",
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1847,33 +2308,42 @@
           }
         }
       ],
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "capillari_fluoridici"
-    },
-    "capillari_fotovoltaici": {
-      "label": "Capillari Fotovoltaici",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
+        "complementare": "analitico",
+        "core": "sensoriale"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+    },
+    "capillari_fotovoltaici": {
       "conflitti": [],
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "capillari_fotovoltaici",
+      "label": "Capillari Fotovoltaici",
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1888,33 +2358,42 @@
           }
         }
       ],
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "capillari_fotovoltaici"
-    },
-    "capsule_paracadute": {
-      "label": "Capsule Paracadute",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "mobilita",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "tier": "T1",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+    },
+    "capsule_paracadute": {
       "conflitti": [],
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "capsule_paracadute",
+      "label": "Capsule Paracadute",
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1929,51 +2408,44 @@
           }
         }
       ],
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "capsule_paracadute"
-    },
-    "carapace_fase_variabile": {
-      "label": "Carapace a Variazione di Fase",
-      "famiglia_tipologia": "Strutturale/Difensivo",
-      "fattore_mantenimento_energetico": "Alto (Richiede energia per il cambio di fase)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "difensivo",
-        "core": "strutturale"
+        "complementare": "protezione",
+        "core": "difensivo"
       },
-      "sinergie": [
-        "ali_membrana_sonica",
-        "appendici_risonanti_marea",
-        "barriere_miasma_glaciale",
-        "branchie_microfiltri",
-        "capsule_paracadute",
-        "cartilagine_flessotermica_venti",
-        "circolazione_bifasica",
-        "coda_coppia_retroattiva",
-        "cute_resistente_sali",
-        "enzimi_antipredatori_algali",
-        "filtri_planctonici",
-        "ghiandole_fango_coesivo",
-        "giunti_antitorsione",
-        "lingua_cristallina",
-        "mucose_barofile",
-        "sensori_geomagnetici",
-        "armatura_pietra_planare",
-        "mantello_meteoritico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "tier": "T1",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+    },
+    "carapace_fase_variabile": {
       "conflitti": [
         "struttura_elastica_amorfa"
       ],
+      "debolezza": "Debolezza strutturale durante la transizione tra le fasi di durezza.",
+      "famiglia_tipologia": "Strutturale/Difensivo",
+      "fattore_mantenimento_energetico": "Alto (Richiede energia per il cambio di fase)",
+      "id": "carapace_fase_variabile",
+      "label": "Carapace a Variazione di Fase",
+      "mutazione_indotta": "Strutture minerali a legame reversibile o micro-strutture a rigidità controllata.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2000,10 +2472,26 @@
           }
         }
       ],
-      "mutazione_indotta": "Strutture minerali a legame reversibile o micro-strutture a rigidità controllata.",
-      "uso_funzione": "Durezza/densità del guscio modificabile rapidamente.",
-      "spinta_selettiva": "Alternanza tra ambienti con attacchi cinetici pesanti e ambienti che richiedono velocità.",
-      "debolezza": "Debolezza strutturale durante la transizione tra le fasi di durezza.",
+      "sinergie": [
+        "ali_membrana_sonica",
+        "appendici_risonanti_marea",
+        "barriere_miasma_glaciale",
+        "branchie_microfiltri",
+        "capsule_paracadute",
+        "cartilagine_flessotermica_venti",
+        "circolazione_bifasica",
+        "coda_coppia_retroattiva",
+        "cute_resistente_sali",
+        "enzimi_antipredatori_algali",
+        "filtri_planctonici",
+        "ghiandole_fango_coesivo",
+        "giunti_antitorsione",
+        "lingua_cristallina",
+        "mucose_barofile",
+        "sensori_geomagnetici",
+        "armatura_pietra_planare",
+        "mantello_meteoritico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [
           "boardgame:DominantSpecies/Defense",
@@ -2019,26 +2507,90 @@
           "tabella:assetto_fase"
         ]
       },
-      "id": "carapace_fase_variabile"
-    },
-    "carapace_luminiscente_abissale": {
-      "label": "Carapace Luminiscente Abissale",
-      "famiglia_tipologia": "Strutturale/Sensoriale",
-      "fattore_mantenimento_energetico": "Alto (Bioluminescenza controllata)",
-      "tier": "T3",
       "slot": [],
       "slot_profile": {
-        "complementare": "sensoriale",
+        "complementare": "difensivo",
         "core": "strutturale"
       },
-      "sinergie": [
-        "antenne_plasmatiche_tempesta",
-        "risonanza_di_branco",
-        "sinapsi_coraline_polifoniche"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "balor-fission",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cryo-lynx",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "golem-runico",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "nano-rust-bloom",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sand-burrower",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Alternanza tra ambienti con attacchi cinetici pesanti e ambienti che richiedono velocità.",
+      "tier": "T1",
+      "uso_funzione": "Durezza/densità del guscio modificabile rapidamente."
+    },
+    "carapace_luminiscente_abissale": {
       "conflitti": [
         "carapace_fase_variabile"
       ],
+      "debolezza": "Luce intensa di superficie sovraccarica i biofotoni rendendo la corazza fragile.",
+      "famiglia_tipologia": "Strutturale/Sensoriale",
+      "fattore_mantenimento_energetico": "Alto (Bioluminescenza controllata)",
+      "id": "carapace_luminiscente_abissale",
+      "label": "Carapace Luminiscente Abissale",
+      "mutazione_indotta": "Placche chitino-minerali con microrganismi luminescenti che comunicano in pattern.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2052,10 +2604,11 @@
           }
         }
       ],
-      "mutazione_indotta": "Placche chitino-minerali con microrganismi luminescenti che comunicano in pattern.",
-      "uso_funzione": "Emette segnali di branco e devia attacchi grazie a pattern luminosi cangianti.",
-      "spinta_selettiva": "Comunicare e mimetizzarsi nelle profondità prive di luce naturale.",
-      "debolezza": "Luce intensa di superficie sovraccarica i biofotoni rendendo la corazza fragile.",
+      "sinergie": [
+        "antenne_plasmatiche_tempesta",
+        "risonanza_di_branco",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [
           "boardgame:Evolution/WarningCall",
@@ -2071,23 +2624,32 @@
           "tabella:segnali_bioluminosi"
         ]
       },
-      "id": "carapace_luminiscente_abissale"
-    },
-    "carapace_segmenti_logici": {
-      "label": "Carapace Segmenti Logici",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
+        "complementare": "sensoriale",
+        "core": "strutturale"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-luminescente-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Comunicare e mimetizzarsi nelle profondità prive di luce naturale.",
+      "tier": "T3",
+      "uso_funzione": "Emette segnali di branco e devia attacchi grazie a pattern luminosi cangianti."
+    },
+    "carapace_segmenti_logici": {
       "conflitti": [],
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "carapace_segmenti_logici",
+      "label": "Carapace Segmenti Logici",
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2102,33 +2664,42 @@
           }
         }
       ],
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "carapace_segmenti_logici"
-    },
-    "carapaci_ferruginosi": {
-      "label": "Carapaci Ferruginosi",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
+        "complementare": "energia",
+        "core": "metabolico"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "tier": "T1",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+    },
+    "carapaci_ferruginosi": {
       "conflitti": [],
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "carapaci_ferruginosi",
+      "label": "Carapaci Ferruginosi",
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2143,37 +2714,44 @@
           }
         }
       ],
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "carapaci_ferruginosi"
-    },
-    "cartilagine_flessotermica_venti": {
-      "label": "Cartilagine Flessotermica dei Venti",
-      "famiglia_tipologia": "Locomotorio/Adattivo",
-      "fattore_mantenimento_energetico": "Medio (Richiede frequenti riallineamenti fibrosi)",
-      "tier": "T2",
       "slot": [],
       "slot_profile": {
-        "complementare": "adattivo",
-        "core": "locomotorio"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "sinergie": [
-        "artigli_sghiaccio_glaciale",
-        "carapace_fase_variabile",
-        "sacche_galleggianti_ascensoriali",
-        "zoccoli_risonanti_steppe"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "tier": "T1",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+    },
+    "cartilagine_flessotermica_venti": {
       "conflitti": [
         "scheletro_idro_regolante"
       ],
+      "debolezza": "Temperature stabili riducono la reattività della cartilagine rendendo l'organismo lento.",
+      "famiglia_tipologia": "Locomotorio/Adattivo",
+      "fattore_mantenimento_energetico": "Medio (Richiede frequenti riallineamenti fibrosi)",
+      "id": "cartilagine_flessotermica_venti",
+      "label": "Cartilagine Flessotermica dei Venti",
+      "mutazione_indotta": "Giunzioni cartilaginee che cambiano rigidità in risposta a gradienti termici e eolici.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2187,10 +2765,12 @@
           }
         }
       ],
-      "mutazione_indotta": "Giunzioni cartilaginee che cambiano rigidità in risposta a gradienti termici e eolici.",
-      "uso_funzione": "Modula elasticità e rigidità muscolo-scheletrica per manovre evasive rapide.",
-      "spinta_selettiva": "Scalare falesie e planare tra correnti ascensionali turbolente.",
-      "debolezza": "Temperature stabili riducono la reattività della cartilagine rendendo l'organismo lento.",
+      "sinergie": [
+        "artigli_sghiaccio_glaciale",
+        "carapace_fase_variabile",
+        "sacche_galleggianti_ascensoriali",
+        "zoccoli_risonanti_steppe"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [
           "boardgame:DominantSpecies/Wind",
@@ -2205,23 +2785,32 @@
           "tabella:assetto_eolico"
         ]
       },
-      "id": "cartilagine_flessotermica_venti"
-    },
-    "cartilagini_biofibre": {
-      "label": "Cartilagini Biofibre",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
+        "complementare": "adattivo",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "gole-ventose-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Scalare falesie e planare tra correnti ascensionali turbolente.",
+      "tier": "T2",
+      "uso_funzione": "Modula elasticità e rigidità muscolo-scheletrica per manovre evasive rapide."
+    },
+    "cartilagini_biofibre": {
       "conflitti": [],
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cartilagini_biofibre",
+      "label": "Cartilagini Biofibre",
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2236,33 +2825,42 @@
           }
         }
       ],
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "cartilagini_biofibre"
-    },
-    "cartilagini_desertiche": {
-      "label": "Cartilagini Desertiche",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
+        "complementare": "assalto",
+        "core": "offensivo"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "tier": "T1",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+    },
+    "cartilagini_desertiche": {
       "conflitti": [],
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cartilagini_desertiche",
+      "label": "Cartilagini Desertiche",
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2277,33 +2875,42 @@
           }
         }
       ],
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "cartilagini_desertiche"
-    },
-    "cartilagini_flessoacustiche": {
-      "label": "Cartilagini Flessoacustiche",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
+        "complementare": "tattico",
+        "core": "strategia"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "tier": "T1",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+    },
+    "cartilagini_flessoacustiche": {
       "conflitti": [],
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cartilagini_flessoacustiche",
+      "label": "Cartilagini Flessoacustiche",
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2318,33 +2925,42 @@
           }
         }
       ],
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "cartilagini_flessoacustiche"
-    },
-    "cartilagini_pseudometalliche": {
-      "label": "Cartilagini Pseudometalliche",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
+        "complementare": "cooperazione",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "tier": "T1",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+    },
+    "cartilagini_pseudometalliche": {
       "conflitti": [],
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cartilagini_pseudometalliche",
+      "label": "Cartilagini Pseudometalliche",
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2359,35 +2975,42 @@
           }
         }
       ],
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "cartilagini_pseudometalliche"
-    },
-    "cavita_risonanti_tundra": {
-      "label": "Cavità Risonanti della Tundra",
-      "famiglia_tipologia": "Sensoriale/Supporto",
-      "fattore_mantenimento_energetico": "Basso (Camere di risonanza statiche)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "supporto",
-        "core": "sensoriale"
+        "complementare": "resilienza",
+        "core": "strutturale"
       },
-      "sinergie": [
-        "criostasi_adattiva",
-        "eco_interno_riflesso",
-        "empatia_coordinativa",
-        "risonanza_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "tier": "T1",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+    },
+    "cavita_risonanti_tundra": {
       "conflitti": [],
+      "debolezza": "In ambienti temperati l'eco interna produce rumori udibili che rivelano la posizione.",
+      "famiglia_tipologia": "Sensoriale/Supporto",
+      "fattore_mantenimento_energetico": "Basso (Camere di risonanza statiche)",
+      "id": "cavita_risonanti_tundra",
+      "label": "Cavità Risonanti della Tundra",
+      "mutazione_indotta": "Camere toraciche espanse che amplificano vibrazioni subsoniche nel permafrost.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2401,10 +3024,12 @@
           }
         }
       ],
-      "mutazione_indotta": "Camere toraciche espanse che amplificano vibrazioni subsoniche nel permafrost.",
-      "uso_funzione": "Amplifica segnali acustici per comunicazioni a lungo raggio nel gelo.",
-      "spinta_selettiva": "Coordinare branchi in lande aperte dove la visibilità è ridotta da bufere di ghiaccio.",
-      "debolezza": "In ambienti temperati l'eco interna produce rumori udibili che rivelano la posizione.",
+      "sinergie": [
+        "criostasi_adattiva",
+        "eco_interno_riflesso",
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [
           "boardgame:Evolution/Communication",
@@ -2420,23 +3045,32 @@
           "tabella:canti_ipersonici"
         ]
       },
-      "id": "cavita_risonanti_tundra"
-    },
-    "cervelletto_equilibrio_statico": {
-      "label": "Cervelletto Equilibrio Statico",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "analitico",
+        "complementare": "supporto",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "tundra-risonante-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Coordinare branchi in lande aperte dove la visibilità è ridotta da bufere di ghiaccio.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica segnali acustici per comunicazioni a lungo raggio nel gelo."
+    },
+    "cervelletto_equilibrio_statico": {
       "conflitti": [],
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cervelletto_equilibrio_statico",
+      "label": "Cervelletto Equilibrio Statico",
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2451,33 +3085,42 @@
           }
         }
       ],
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "cervelletto_equilibrio_statico"
-    },
-    "chemiorecettori_bromuro": {
-      "label": "Chemiorecettori Bromuro",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
+        "complementare": "analitico",
+        "core": "sensoriale"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+    },
+    "chemiorecettori_bromuro": {
       "conflitti": [],
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "chemiorecettori_bromuro",
+      "label": "Chemiorecettori Bromuro",
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2492,33 +3135,42 @@
           }
         }
       ],
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "chemiorecettori_bromuro"
-    },
-    "chioma_parassita_canopica": {
-      "label": "Chioma Parassita Canopica",
-      "famiglia_tipologia": "Simbiotico/Utility",
-      "fattore_mantenimento_energetico": "Medio (Nutrimento condiviso con l'ospite arboreo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "utility",
-        "core": "simbiotico"
+        "complementare": "mobilita",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "bulbi_radici_permafrost",
-        "nodi_micorrizici_oracolari"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "tier": "T1",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+    },
+    "chioma_parassita_canopica": {
       "conflitti": [],
+      "debolezza": "Se la pianta ospite muore la chioma psionica collassa causando shock sistemico.",
+      "famiglia_tipologia": "Simbiotico/Utility",
+      "fattore_mantenimento_energetico": "Medio (Nutrimento condiviso con l'ospite arboreo)",
+      "id": "chioma_parassita_canopica",
+      "label": "Chioma Parassita Canopica",
+      "mutazione_indotta": "Filamenti vegetali che si intrecciano con la canopia ospite fornendo punti d'ancoraggio e energia.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2532,33 +3184,42 @@
           }
         }
       ],
-      "mutazione_indotta": "Filamenti vegetali che si intrecciano con la canopia ospite fornendo punti d'ancoraggio e energia.",
-      "uso_funzione": "Crea passaggi e nodi energetici condivisi nella canopia per movimenti rapidi.",
-      "spinta_selettiva": "Stabilizzare piattaforme mobili e reti di trasporto tra gli alberi viventi.",
-      "debolezza": "Se la pianta ospite muore la chioma psionica collassa causando shock sistemico.",
+      "sinergie": [
+        "bulbi_radici_permafrost",
+        "nodi_micorrizici_oracolari"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "chioma_parassita_canopica"
-    },
-    "circolazione_bifasica": {
-      "label": "Circolazione Bifasica",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "utility",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopie-sospese-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Stabilizzare piattaforme mobili e reti di trasporto tra gli alberi viventi.",
+      "tier": "T1",
+      "uso_funzione": "Crea passaggi e nodi energetici condivisi nella canopia per movimenti rapidi."
+    },
+    "circolazione_bifasica": {
       "conflitti": [],
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "circolazione_bifasica",
+      "label": "Circolazione Bifasica",
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2573,34 +3234,44 @@
           }
         }
       ],
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "circolazione_bifasica"
-    },
-    "circolazione_bifasica_palude": {
-      "label": "Circolazione Bifasica di Palude",
-      "famiglia_tipologia": "Metabolico/Resilienza",
-      "fattore_mantenimento_energetico": "Medio (Doppio circuito emolinfa/linfa)",
-      "tier": "T2",
       "slot": [],
       "slot_profile": {
-        "complementare": "resilienza",
-        "core": "metabolico"
+        "complementare": "protezione",
+        "core": "difensivo"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "tier": "T1",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+    },
+    "circolazione_bifasica_palude": {
       "conflitti": [
         "sangue_piroforico"
       ],
+      "debolezza": "Zone asciutte e calde causano stagnazione del circuito linfatico portando a tossicosi.",
+      "famiglia_tipologia": "Metabolico/Resilienza",
+      "fattore_mantenimento_energetico": "Medio (Doppio circuito emolinfa/linfa)",
+      "id": "circolazione_bifasica_palude",
+      "label": "Circolazione Bifasica di Palude",
+      "mutazione_indotta": "Cuori gemelli che pompano separatamente emolinfa ossigenata e linfa detossificante.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2614,33 +3285,41 @@
           }
         }
       ],
-      "mutazione_indotta": "Cuori gemelli che pompano separatamente emolinfa ossigenata e linfa detossificante.",
-      "uso_funzione": "Gestisce due circuiti circolatori per filtrare veleni e mantenere prestazioni elevate.",
-      "spinta_selettiva": "Resistere a tossine e anossia tipiche delle paludi psioniche.",
-      "debolezza": "Zone asciutte e calde causano stagnazione del circuito linfatico portando a tossicosi.",
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "circolazione_bifasica_palude"
-    },
-    "circolazione_cooling_loop": {
-      "label": "Circolazione Cooling Loop",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "energia",
+        "complementare": "resilienza",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "paludi-gas-luminescenti-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Resistere a tossine e anossia tipiche delle paludi psioniche.",
+      "tier": "T2",
+      "uso_funzione": "Gestisce due circuiti circolatori per filtrare veleni e mantenere prestazioni elevate."
+    },
+    "circolazione_cooling_loop": {
       "conflitti": [],
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "circolazione_cooling_loop",
+      "label": "Circolazione Cooling Loop",
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2655,33 +3334,42 @@
           }
         }
       ],
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "circolazione_cooling_loop"
-    },
-    "circolazione_doppia": {
-      "label": "Circolazione Doppia",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
+        "complementare": "energia",
+        "core": "metabolico"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "tier": "T1",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+    },
+    "circolazione_doppia": {
       "conflitti": [],
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "circolazione_doppia",
+      "label": "Circolazione Doppia",
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2696,33 +3384,42 @@
           }
         }
       ],
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "circolazione_doppia"
-    },
-    "circolazione_supercritica": {
-      "label": "Circolazione Supercritica",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "tier": "T1",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+    },
+    "circolazione_supercritica": {
       "conflitti": [],
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "circolazione_supercritica",
+      "label": "Circolazione Supercritica",
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2737,33 +3434,42 @@
           }
         }
       ],
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "circolazione_supercritica"
-    },
-    "ciste_riduttive": {
-      "label": "Ciste Riduttive",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
+        "complementare": "assalto",
+        "core": "offensivo"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "tier": "T1",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+    },
+    "ciste_riduttive": {
       "conflitti": [],
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ciste_riduttive",
+      "label": "Ciste Riduttive",
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2778,33 +3484,42 @@
           }
         }
       ],
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ciste_riduttive"
-    },
-    "ciste_salmastre": {
-      "label": "Ciste Salmastre",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
+        "complementare": "tattico",
+        "core": "strategia"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "tier": "T1",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+    },
+    "ciste_salmastre": {
       "conflitti": [],
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ciste_salmastre",
+      "label": "Ciste Salmastre",
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2819,33 +3534,42 @@
           }
         }
       ],
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ciste_salmastre"
-    },
-    "cisti_iperbariche": {
-      "label": "Cisti Iperbariche",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
+        "complementare": "cooperazione",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "tier": "T1",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+    },
+    "cisti_iperbariche": {
       "conflitti": [],
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cisti_iperbariche",
+      "label": "Cisti Iperbariche",
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2860,33 +3584,42 @@
           }
         }
       ],
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "cisti_iperbariche"
-    },
-    "coda_balanciere": {
-      "label": "Coda Balanciere",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
+        "complementare": "resilienza",
+        "core": "strutturale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "tier": "T1",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+    },
+    "coda_balanciere": {
       "conflitti": [],
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "coda_balanciere",
+      "label": "Coda Balanciere",
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2901,33 +3634,42 @@
           }
         }
       ],
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "coda_balanciere"
-    },
-    "coda_contrappeso": {
-      "label": "Coda Contrappeso",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
+        "complementare": "analitico",
+        "core": "sensoriale"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+    },
+    "coda_contrappeso": {
       "conflitti": [],
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "coda_contrappeso",
+      "label": "Coda Contrappeso",
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2942,33 +3684,42 @@
           }
         }
       ],
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "coda_contrappeso"
-    },
-    "coda_coppia_retroattiva": {
-      "label": "Coda Coppia Retroattiva",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "mobilita",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "tier": "T1",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+    },
+    "coda_coppia_retroattiva": {
       "conflitti": [],
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "coda_coppia_retroattiva",
+      "label": "Coda Coppia Retroattiva",
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2983,28 +3734,68 @@
           }
         }
       ],
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "coda_coppia_retroattiva"
-    },
-    "coda_frusta_cinetica": {
-      "label": "Coda a Frusta Cinetica",
-      "famiglia_tipologia": "Locomotorio/Difensivo",
-      "fattore_mantenimento_energetico": "Medio (Mantenimento dell'energia accumulata)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "difensivo",
-        "core": "locomotorio"
+        "complementare": "protezione",
+        "core": "difensivo"
       },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "tier": "T1",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+    },
+    "coda_frusta_cinetica": {
+      "conflitti": [],
+      "debolezza": "Richiede un periodo di inattività o movimento preparatorio per massimizzare il danno.",
+      "famiglia_tipologia": "Locomotorio/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Mantenimento dell'energia accumulata)",
+      "id": "coda_frusta_cinetica",
+      "label": "Coda a Frusta Cinetica",
+      "mutazione_indotta": "Muscolatura della coda densa con tendini e fibre che agiscono come molle.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Corridore T2 per intercettare campi magnetici psionici sulle dorsali.",
+            "tier": "T2"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante T3 calibrata alle camere di gravità invertita e ai flussi orbitali.",
+            "tier": "T3"
+          }
+        }
+      ],
       "sinergie": [
         "ali_ioniche",
         "antenne_flusso_mareale",
@@ -3035,60 +3826,83 @@
         "mantelli_geotermici",
         "mucose_aderenza_sonica"
       ],
-      "conflitti": [],
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "falde_magnetiche_psioniche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Corridore T2 per intercettare campi magnetici psionici sulle dorsali.",
-            "tier": "T2"
-          }
-        },
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "orbita_psionica_inversa"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Variante T3 calibrata alle camere di gravità invertita e ai flussi orbitali.",
-            "tier": "T3"
-          }
-        }
-      ],
-      "mutazione_indotta": "Muscolatura della coda densa con tendini e fibre che agiscono come molle.",
-      "uso_funzione": "Immagazzinare energia da ogni movimento per un colpo finale potente.",
-      "spinta_selettiva": "Necessità di un attacco di \"sfondamento\" dopo movimento preparatorio.",
-      "debolezza": "Richiede un periodo di inattività o movimento preparatorio per massimizzare il danno.",
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "coda_frusta_cinetica"
-    },
-    "coda_stabilizzatrice_filo": {
-      "label": "Coda Stabilizzatrice Filo",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
+        "complementare": "difensivo",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "dune-stalker",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "magneto-ridge-hunter",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "slag-veil-ambusher",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "orbita-psionica-inversa-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Necessità di un attacco di \"sfondamento\" dopo movimento preparatorio.",
+      "tier": "T1",
+      "uso_funzione": "Immagazzinare energia da ogni movimento per un colpo finale potente."
+    },
+    "coda_stabilizzatrice_filo": {
       "conflitti": [],
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "coda_stabilizzatrice_filo",
+      "label": "Coda Stabilizzatrice Filo",
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3103,33 +3917,42 @@
           }
         }
       ],
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "coda_stabilizzatrice_filo"
-    },
-    "coda_stabilizzatrice_geiser": {
-      "label": "Coda Stabilizzatrice Geiser",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
+        "complementare": "energia",
+        "core": "metabolico"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "tier": "T1",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+    },
+    "coda_stabilizzatrice_geiser": {
       "conflitti": [],
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "coda_stabilizzatrice_geiser",
+      "label": "Coda Stabilizzatrice Geiser",
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3144,33 +3967,42 @@
           }
         }
       ],
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "coda_stabilizzatrice_geiser"
-    },
-    "coda_stabilizzatrice_vortex": {
-      "label": "Coda Stabilizzatrice Vortex",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "tier": "T1",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+    },
+    "coda_stabilizzatrice_vortex": {
       "conflitti": [],
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "coda_stabilizzatrice_vortex",
+      "label": "Coda Stabilizzatrice Vortex",
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3185,33 +4017,42 @@
           }
         }
       ],
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "coda_stabilizzatrice_vortex"
-    },
-    "colonne_vibromagnetiche": {
-      "label": "Colonne Vibromagnetiche",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
+        "complementare": "assalto",
+        "core": "offensivo"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "tier": "T1",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+    },
+    "colonne_vibromagnetiche": {
       "conflitti": [],
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "colonne_vibromagnetiche",
+      "label": "Colonne Vibromagnetiche",
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3226,33 +4067,42 @@
           }
         }
       ],
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "colonne_vibromagnetiche"
-    },
-    "coralli_partner": {
-      "label": "Coralli Partner",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
+        "complementare": "tattico",
+        "core": "strategia"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "tier": "T1",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+    },
+    "coralli_partner": {
       "conflitti": [],
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "coralli_partner",
+      "label": "Coralli Partner",
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3267,35 +4117,45 @@
           }
         }
       ],
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "coralli_partner"
-    },
-    "criostasi_adattiva": {
-      "label": "Criostasi",
-      "famiglia_tipologia": "Metabolico/Difensivo",
-      "fattore_mantenimento_energetico": "Alto (Fase di risveglio/inizio) / Basso (Fase Criostasi).",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "difensivo",
-        "core": "metabolico"
+        "complementare": "cooperazione",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "cavita_risonanti_tundra"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "tier": "T1",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+    },
+    "criostasi_adattiva": {
       "conflitti": [
         "sangue_piroforico",
         "sacche_galleggianti_ascensoriali"
       ],
+      "debolezza": "Vulnerabilità estrema agli attacchi chimici (veleni) in fase Criostasi.",
+      "famiglia_tipologia": "Metabolico/Difensivo",
+      "fattore_mantenimento_energetico": "Alto (Fase di risveglio/inizio) / Basso (Fase Criostasi).",
+      "id": "criostasi_adattiva",
+      "label": "Criostasi",
+      "mutazione_indotta": "Sviluppo di enzimi crioprotettivi e tessuto adiposo isolante.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3322,33 +4182,62 @@
           }
         }
       ],
-      "mutazione_indotta": "Sviluppo di enzimi crioprotettivi e tessuto adiposo isolante.",
-      "uso_funzione": "Sopravvivenza a condizioni ambientali estreme.",
-      "spinta_selettiva": "Inverni prolungati o lunghi periodi di scarsità di cibo.",
-      "debolezza": "Vulnerabilità estrema agli attacchi chimici (veleni) in fase Criostasi.",
+      "sinergie": [
+        "cavita_risonanti_tundra"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "criostasi_adattiva"
-    },
-    "cromofori_alert_acido": {
-      "label": "Cromofori Alert Acido",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
+        "complementare": "difensivo",
+        "core": "metabolico"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "aurora-gull",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "orbita-psionica-inversa-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "orbital-ascendant",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Inverni prolungati o lunghi periodi di scarsità di cibo.",
+      "tier": "T1",
+      "uso_funzione": "Sopravvivenza a condizioni ambientali estreme."
+    },
+    "cromofori_alert_acido": {
       "conflitti": [],
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cromofori_alert_acido",
+      "label": "Cromofori Alert Acido",
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3363,33 +4252,42 @@
           }
         }
       ],
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "cromofori_alert_acido"
-    },
-    "cuore_multicamera_bassa_pressione": {
-      "label": "Cuore Multicamera Bassa Pressione",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
+        "complementare": "resilienza",
+        "core": "strutturale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "tier": "T1",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+    },
+    "cuore_multicamera_bassa_pressione": {
       "conflitti": [],
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cuore_multicamera_bassa_pressione",
+      "label": "Cuore Multicamera Bassa Pressione",
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3404,33 +4302,42 @@
           }
         }
       ],
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "cuore_multicamera_bassa_pressione"
-    },
-    "cuscinetti_elettrostatici": {
-      "label": "Cuscinetti Elettrostatici",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
+        "complementare": "analitico",
+        "core": "sensoriale"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+    },
+    "cuscinetti_elettrostatici": {
       "conflitti": [],
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cuscinetti_elettrostatici",
+      "label": "Cuscinetti Elettrostatici",
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3445,33 +4352,42 @@
           }
         }
       ],
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "cuscinetti_elettrostatici"
-    },
-    "cute_resistente_sali": {
-      "label": "Cute Resistente Sali",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Medio (Attivazione situazionale)",
-      "tier": "T2",
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "mobilita",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "tier": "T1",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+    },
+    "cute_resistente_sali": {
       "conflitti": [],
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Attivazione situazionale)",
+      "id": "cute_resistente_sali",
+      "label": "Cute Resistente Sali",
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3486,61 +4402,136 @@
           }
         }
       ],
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "cute_resistente_sali"
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "evento-tempesta-ferrosa",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "badlands-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "tier": "T2",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
     },
     "cuticole_cerose": {
-      "label": "Cuticole Cerose",
+      "conflitti": [],
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "famiglia_tipologia": "Digestivo/Metabolico",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
+      "id": "cuticole_cerose",
+      "label": "Cuticole Cerose",
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "requisiti_ambientali": [],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
       "slot": [],
       "slot_profile": {
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cactus-weaver",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-brinastorm",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-ondata-termica",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "noctule-termico",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "silica-bloom",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thermo-raptor",
+          "weight": 1
+        }
       ],
-      "conflitti": [],
-      "requisiti_ambientali": [],
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "id": "cuticole_cerose"
+      "tier": "T1",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
     },
     "cuticole_neutralizzanti": {
-      "label": "Cuticole Neutralizzanti",
+      "conflitti": [],
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "famiglia_tipologia": "Supporto/Logistico",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "conflitti": [],
+      "id": "cuticole_neutralizzanti",
+      "label": "Cuticole Neutralizzanti",
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3555,33 +4546,42 @@
           }
         }
       ],
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "cuticole_neutralizzanti"
-    },
-    "denti_chelatanti": {
-      "label": "Denti Chelatanti",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "tier": "T1",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+    },
+    "denti_chelatanti": {
       "conflitti": [],
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "denti_chelatanti",
+      "label": "Denti Chelatanti",
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3596,33 +4596,42 @@
           }
         }
       ],
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "denti_chelatanti"
-    },
-    "denti_ossidoferro": {
-      "label": "Denti Ossidoferro",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
+        "complementare": "assalto",
+        "core": "offensivo"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "tier": "T1",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+    },
+    "denti_ossidoferro": {
       "conflitti": [],
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "denti_ossidoferro",
+      "label": "Denti Ossidoferro",
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3637,33 +4646,42 @@
           }
         }
       ],
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "denti_ossidoferro"
-    },
-    "denti_silice_termici": {
-      "label": "Denti Silice Termici",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
+        "complementare": "tattico",
+        "core": "strategia"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "tier": "T1",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+    },
+    "denti_silice_termici": {
       "conflitti": [],
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "denti_silice_termici",
+      "label": "Denti Silice Termici",
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3678,33 +4696,42 @@
           }
         }
       ],
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "denti_silice_termici"
-    },
-    "denti_tuning_fork": {
-      "label": "Denti Tuning Fork",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
+        "complementare": "cooperazione",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "tier": "T1",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+    },
+    "denti_tuning_fork": {
       "conflitti": [],
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "denti_tuning_fork",
+      "label": "Denti Tuning Fork",
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3719,33 +4746,42 @@
           }
         }
       ],
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "denti_tuning_fork"
-    },
-    "echi_risonanti": {
-      "label": "Echi Risonanti",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
+        "complementare": "resilienza",
+        "core": "strutturale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "tier": "T1",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+    },
+    "echi_risonanti": {
       "conflitti": [],
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "echi_risonanti",
+      "label": "Echi Risonanti",
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3760,34 +4796,42 @@
           }
         }
       ],
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "echi_risonanti"
-    },
-    "eco_interno_riflesso": {
-      "label": "Riflesso dell'Eco Interno",
-      "famiglia_tipologia": "Sensoriale/Nervoso",
-      "fattore_mantenimento_energetico": "Medio (Emissioni e ricezione continua)",
-      "tier": "T2",
       "slot": [],
       "slot_profile": {
-        "complementare": "nervoso",
+        "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "cavita_risonanti_tundra",
-        "olfatto_risonanza_magnetica",
-        "sensori_geomagnetici"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+    },
+    "eco_interno_riflesso": {
       "conflitti": [],
+      "debolezza": "Estremamente disorientato da suoni o vibrazioni esterne forti e continue.",
+      "famiglia_tipologia": "Sensoriale/Nervoso",
+      "fattore_mantenimento_energetico": "Medio (Emissioni e ricezione continua)",
+      "id": "eco_interno_riflesso",
+      "label": "Riflesso dell'Eco Interno",
+      "mutazione_indotta": "Organi interni che emettono ultrasuoni e li captano tramite lo scheletro.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3814,30 +4858,87 @@
           }
         }
       ],
-      "mutazione_indotta": "Organi interni che emettono ultrasuoni e li captano tramite lo scheletro.",
-      "uso_funzione": "Utilizzo di onde sonore emesse internamente per mappare l'ambiente.",
-      "spinta_selettiva": "Orientamento in ambienti completamente privi di luce.",
-      "debolezza": "Estremamente disorientato da suoni o vibrazioni esterne forti e continue.",
+      "sinergie": [
+        "cavita_risonanti_tundra",
+        "olfatto_risonanza_magnetica",
+        "sensori_geomagnetici"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "eco_interno_riflesso"
+      "slot": [],
+      "slot_profile": {
+        "complementare": "nervoso",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "echo-wing",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "aurora-bridge-runner",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "aurora-gull",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "orbital-ascendant",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "zephyr-spore-courier",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Orientamento in ambienti completamente privi di luce.",
+      "tier": "T2",
+      "uso_funzione": "Utilizzo di onde sonore emesse internamente per mappare l'ambiente."
     },
     "empatia_coordinativa": {
-      "label": "Empatia Coordinativa",
+      "conflitti": [],
+      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
       "famiglia_tipologia": "Supporto/Empatico",
       "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
-      "tier": "T1",
-      "slot": [
-        "A"
-      ],
-      "slot_profile": {
-        "complementare": "coordinazione",
-        "core": "supporto"
-      },
+      "id": "empatia_coordinativa",
+      "label": "Empatia Coordinativa",
+      "mutazione_indotta": "Circuiti sensorio-emotivi collegati al feed HUD PI.",
+      "requisiti_ambientali": [],
       "sinergie": [
         "antenne_eco_turbina",
         "artigli_acidofagi",
@@ -3855,12 +4956,6 @@
         "luminescenza_hydrotermica",
         "aura_scudo_radianza"
       ],
-      "conflitti": [],
-      "requisiti_ambientali": [],
-      "mutazione_indotta": "Circuiti sensorio-emotivi collegati al feed HUD PI.",
-      "uso_funzione": "Collega cooldown difensivi e cura quando la squadra entra in finestra rischio.",
-      "spinta_selettiva": "Turni lunghi con rischio alto in cui serve mitigare tilt e HP critici.",
-      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
       "sinergie_pi": {
         "co_occorrenze": [
           "job_ability:Warden/Scudo_di_Risonanza"
@@ -3871,23 +4966,83 @@
         ],
         "tabelle_random": []
       },
-      "id": "empatia_coordinativa"
+      "slot": [
+        "A"
+      ],
+      "slot_profile": {
+        "complementare": "coordinazione",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "archon-solare",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "balor-fission",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "glowcap-weaver",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "lupus-temperatus",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "myco-spire-warden",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Turni lunghi con rischio alto in cui serve mitigare tilt e HP critici.",
+      "tier": "T1",
+      "uso_funzione": "Collega cooldown difensivi e cura quando la squadra entra in finestra rischio."
     },
     "enzimi_antifase_termica": {
-      "label": "Enzimi Antifase Termica",
+      "conflitti": [],
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
       "famiglia_tipologia": "Locomotorio/Mobilità",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
-      "slot": [],
-      "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
-      },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
-      "conflitti": [],
+      "id": "enzimi_antifase_termica",
+      "label": "Enzimi Antifase Termica",
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3902,33 +5057,42 @@
           }
         }
       ],
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "enzimi_antifase_termica"
-    },
-    "enzimi_antipredatori_algali": {
-      "label": "Enzimi Antipredatori Algali",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "mobilita",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "tier": "T1",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+    },
+    "enzimi_antipredatori_algali": {
       "conflitti": [],
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "enzimi_antipredatori_algali",
+      "label": "Enzimi Antipredatori Algali",
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3943,61 +5107,87 @@
           }
         }
       ],
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "enzimi_antipredatori_algali"
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "tier": "T1",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
     },
     "enzimi_chelanti": {
-      "label": "Enzimi Chelanti",
+      "conflitti": [],
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "famiglia_tipologia": "Digestivo/Metabolico",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
+      "id": "enzimi_chelanti",
+      "label": "Enzimi Chelanti",
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "requisiti_ambientali": [],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
       "slot": [],
       "slot_profile": {
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "evento-tempesta-ferrosa",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        }
       ],
-      "conflitti": [],
-      "requisiti_ambientali": [],
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "id": "enzimi_chelanti"
+      "tier": "T1",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
     },
     "enzimi_chelatori_rapidi": {
-      "label": "Enzimi Chelatori Rapidi",
+      "conflitti": [],
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "famiglia_tipologia": "Supporto/Logistico",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "conflitti": [],
+      "id": "enzimi_chelatori_rapidi",
+      "label": "Enzimi Chelatori Rapidi",
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4012,33 +5202,42 @@
           }
         }
       ],
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "enzimi_chelatori_rapidi"
-    },
-    "enzimi_metanoossidanti": {
-      "label": "Enzimi Metanoossidanti",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "tier": "T1",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+    },
+    "enzimi_metanoossidanti": {
       "conflitti": [],
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "enzimi_metanoossidanti",
+      "label": "Enzimi Metanoossidanti",
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4053,33 +5252,42 @@
           }
         }
       ],
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "enzimi_metanoossidanti"
-    },
-    "epidermide_dielettrica": {
-      "label": "Epidermide Dielettrica",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
+        "complementare": "assalto",
+        "core": "offensivo"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "tier": "T1",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+    },
+    "epidermide_dielettrica": {
       "conflitti": [],
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "epidermide_dielettrica",
+      "label": "Epidermide Dielettrica",
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4094,33 +5302,42 @@
           }
         }
       ],
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "epidermide_dielettrica"
-    },
-    "epitelio_fosforescente": {
-      "label": "Epitelio Fosforescente",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
+        "complementare": "tattico",
+        "core": "strategia"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "tier": "T1",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+    },
+    "epitelio_fosforescente": {
       "conflitti": [],
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "epitelio_fosforescente",
+      "label": "Epitelio Fosforescente",
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4135,45 +5352,42 @@
           }
         }
       ],
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "epitelio_fosforescente"
-    },
-    "filamenti_digestivi_compattanti": {
-      "label": "Filamento materiali digeriti",
-      "famiglia_tipologia": "Digestivo/Escretorio",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T2",
       "slot": [],
       "slot_profile": {
-        "complementare": "escretorio",
-        "core": "digestivo"
+        "complementare": "cooperazione",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "antenne_dustsense",
-        "appendici_thermotattiche",
-        "batteri_endosimbionti_chemio",
-        "branchie_solfatiche",
-        "carapace_segmenti_logici",
-        "circolazione_cooling_loop",
-        "coda_stabilizzatrice_filo",
-        "cuticole_cerose",
-        "enzimi_chelanti",
-        "flagelli_ancoranti",
-        "ghiandole_grafene",
-        "grassi_termici",
-        "luminescenza_aurorale",
-        "ventriglio_gastroliti"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "tier": "T1",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+    },
+    "filamenti_digestivi_compattanti": {
       "conflitti": [],
+      "debolezza": "Blocco intestinale se la dieta è priva di materiale 'legante'.",
+      "famiglia_tipologia": "Digestivo/Escretorio",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "filamenti_digestivi_compattanti",
+      "label": "Filamento materiali digeriti",
+      "mutazione_indotta": "Muscolatura rettale ipertrofica e organo appendice dedicato.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4200,33 +5414,106 @@
           }
         }
       ],
-      "mutazione_indotta": "Muscolatura rettale ipertrofica e organo appendice dedicato.",
-      "uso_funzione": "Espulsione compatta e ordinata di scorie.",
-      "spinta_selettiva": "Necessità di mantenere la pulizia del territorio/nido.",
-      "debolezza": "Blocco intestinale se la dieta è priva di materiale 'legante'.",
+      "sinergie": [
+        "antenne_dustsense",
+        "appendici_thermotattiche",
+        "batteri_endosimbionti_chemio",
+        "branchie_solfatiche",
+        "carapace_segmenti_logici",
+        "circolazione_cooling_loop",
+        "coda_stabilizzatrice_filo",
+        "cuticole_cerose",
+        "enzimi_chelanti",
+        "flagelli_ancoranti",
+        "ghiandole_grafene",
+        "grassi_termici",
+        "luminescenza_aurorale",
+        "ventriglio_gastroliti"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "filamenti_digestivi_compattanti"
-    },
-    "filamenti_magnetotrofi": {
-      "label": "Filamenti Magnetotrofi",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
+        "complementare": "escretorio",
+        "core": "digestivo"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "magnet-fathom-surveyor",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "nano-rust-bloom",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "rust-scavenger",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "glowcap-weaver",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "myco-spire-warden",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thaw-rot",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Necessità di mantenere la pulizia del territorio/nido.",
+      "tier": "T2",
+      "uso_funzione": "Espulsione compatta e ordinata di scorie."
+    },
+    "filamenti_magnetotrofi": {
       "conflitti": [],
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "filamenti_magnetotrofi",
+      "label": "Filamenti Magnetotrofi",
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4241,33 +5528,42 @@
           }
         }
       ],
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "filamenti_magnetotrofi"
-    },
-    "filamenti_superconduttivi": {
-      "label": "Filamenti Superconduttivi",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
+        "complementare": "resilienza",
+        "core": "strutturale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "tier": "T1",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+    },
+    "filamenti_superconduttivi": {
       "conflitti": [],
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "filamenti_superconduttivi",
+      "label": "Filamenti Superconduttivi",
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4282,33 +5578,42 @@
           }
         }
       ],
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "filamenti_superconduttivi"
-    },
-    "filamenti_termoconduzione": {
-      "label": "Filamenti Termoconduzione",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
+        "complementare": "analitico",
+        "core": "sensoriale"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+    },
+    "filamenti_termoconduzione": {
       "conflitti": [],
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "filamenti_termoconduzione",
+      "label": "Filamenti Termoconduzione",
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4323,33 +5628,42 @@
           }
         }
       ],
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "filamenti_termoconduzione"
-    },
-    "filtri_planctonici": {
-      "label": "Filtri Planctonici",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "mobilita",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "tier": "T1",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+    },
+    "filtri_planctonici": {
       "conflitti": [],
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "filtri_planctonici",
+      "label": "Filtri Planctonici",
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4364,33 +5678,42 @@
           }
         }
       ],
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "filtri_planctonici"
-    },
-    "flagelli_ancoranti": {
-      "label": "Flagelli Ancoranti",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
+        "complementare": "protezione",
+        "core": "difensivo"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "tier": "T1",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+    },
+    "flagelli_ancoranti": {
       "conflitti": [],
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "flagelli_ancoranti",
+      "label": "Flagelli Ancoranti",
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4405,31 +5728,43 @@
           }
         }
       ],
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "flagelli_ancoranti"
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "tier": "T1",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
     },
     "focus_frazionato": {
-      "label": "Focus Frazionato",
+      "conflitti": [],
+      "debolezza": "Rischio di overload mentale se tilt e aggro salgono oltre le soglie HUD.",
       "famiglia_tipologia": "Strategico/Psionico",
       "fattore_mantenimento_energetico": "Medio (Dividere l'attenzione su più canali)",
-      "tier": "T1",
-      "slot": [
-        "A",
-        "C"
-      ],
-      "slot_profile": {
-        "complementare": "psionico",
-        "core": "strategia"
-      },
+      "id": "focus_frazionato",
+      "label": "Focus Frazionato",
+      "mutazione_indotta": "Processore di priorità multi-thread per bersagli e obiettivi.",
+      "requisiti_ambientali": [],
       "sinergie": [
         "ali_fulminee",
         "antenne_plasmatiche_tempesta",
@@ -4448,12 +5783,6 @@
         "midollo_antivibrazione",
         "frusta_fiammeggiante"
       ],
-      "conflitti": [],
-      "requisiti_ambientali": [],
-      "mutazione_indotta": "Processore di priorità multi-thread per bersagli e obiettivi.",
-      "uso_funzione": "Permette di gestire due ingaggi paralleli senza perdere efficienza.",
-      "spinta_selettiva": "Comunicazioni piatte dove occorre coprire minacce su più fronti.",
-      "debolezza": "Rischio di overload mentale se tilt e aggro salgono oltre le soglie HUD.",
       "sinergie_pi": {
         "co_occorrenze": [
           "PE",
@@ -4470,23 +5799,86 @@
         ],
         "tabelle_random": []
       },
-      "id": "focus_frazionato"
+      "slot": [
+        "A",
+        "C"
+      ],
+      "slot_profile": {
+        "complementare": "psionico",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "orbital-ascendant",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "archon-solare",
+          "weight": 2
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "balor-fission",
+          "weight": 2
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 2
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 2
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sentinella-radice",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Comunicazioni piatte dove occorre coprire minacce su più fronti.",
+      "tier": "T1",
+      "uso_funzione": "Permette di gestire due ingaggi paralleli senza perdere efficienza."
     },
     "foliage_fotocatodico": {
-      "label": "Foliage Fotocatodico",
+      "conflitti": [],
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "famiglia_tipologia": "Supporto/Logistico",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "conflitti": [],
+      "id": "foliage_fotocatodico",
+      "label": "Foliage Fotocatodico",
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4501,33 +5893,42 @@
           }
         }
       ],
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "foliage_fotocatodico"
-    },
-    "foliaggio_spugna": {
-      "label": "Foliaggio Spugna",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "tier": "T1",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+    },
+    "foliaggio_spugna": {
       "conflitti": [],
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "foliaggio_spugna",
+      "label": "Foliaggio Spugna",
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4542,35 +5943,44 @@
           }
         }
       ],
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "foliaggio_spugna"
-    },
-    "frusta_fiammeggiante": {
-      "label": "Frusta Fiammeggiante",
-      "famiglia_tipologia": "Offensivo/Controllo",
-      "fattore_mantenimento_energetico": "Medio (Filamenti di plasma vincolato)",
-      "tier": "T2",
       "slot": [],
       "slot_profile": {
-        "complementare": "controllo",
+        "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "mantello_meteoritico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "tier": "T1",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+    },
+    "frusta_fiammeggiante": {
       "conflitti": [
         "armatura_pietra_planare"
       ],
+      "debolezza": "Consumante: richiede costante dissipazione termica per non bruciare la matrice portante.",
+      "famiglia_tipologia": "Offensivo/Controllo",
+      "fattore_mantenimento_energetico": "Medio (Filamenti di plasma vincolato)",
+      "id": "frusta_fiammeggiante",
+      "label": "Frusta Fiammeggiante",
+      "mutazione_indotta": "Genera appendici tentacolari avvolte da plasma infernale controllato.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [
@@ -4587,33 +5997,50 @@
           }
         }
       ],
-      "mutazione_indotta": "Genera appendici tentacolari avvolte da plasma infernale controllato.",
-      "uso_funzione": "Afferra e disarma avversari o sigilla varchi planari con tagli di energia.",
-      "spinta_selettiva": "Creare distanza di sicurezza contro predatori d'élite nelle zone instabili.",
-      "debolezza": "Consumante: richiede costante dissipazione termica per non bruciare la matrice portante.",
+      "sinergie": [
+        "focus_frazionato",
+        "mantello_meteoritico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "frusta_fiammeggiante"
-    },
-    "ghiaccio_piezoelettrico": {
-      "label": "Ghiaccio Piezoelettrico",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
+        "complementare": "controllo",
+        "core": "offensivo"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "balor-fission",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 3
+        }
       ],
+      "spinta_selettiva": "Creare distanza di sicurezza contro predatori d'élite nelle zone instabili.",
+      "tier": "T2",
+      "uso_funzione": "Afferra e disarma avversari o sigilla varchi planari con tagli di energia."
+    },
+    "ghiaccio_piezoelettrico": {
       "conflitti": [],
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiaccio_piezoelettrico",
+      "label": "Ghiaccio Piezoelettrico",
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4628,37 +6055,44 @@
           }
         }
       ],
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ghiaccio_piezoelettrico"
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "tier": "T1",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
     },
     "ghiandola_caustica": {
-      "label": "Ghiandola Caustica",
+      "conflitti": [],
+      "debolezza": "Gestione accurata delle riserve per non calare sotto i budget PE previsto.",
       "famiglia_tipologia": "Offensivo/Chimico",
       "fattore_mantenimento_energetico": "Medio (Produzione reagenti)",
-      "tier": "T1",
-      "slot": [
-        "A"
-      ],
-      "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
-      },
-      "sinergie": [],
-      "conflitti": [],
-      "requisiti_ambientali": [],
+      "id": "ghiandola_caustica",
+      "label": "Ghiandola Caustica",
       "mutazione_indotta": "Sintesi rapida di composti caustici nei moduli d'attacco.",
-      "uso_funzione": "Sblocco early di danni da acido per rompere armature leggere.",
-      "spinta_selettiva": "Squadre che devono rispondere a guardie situazionali al turno 1-2.",
-      "debolezza": "Gestione accurata delle riserve per non calare sotto i budget PE previsto.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
       "sinergie_pi": {
         "co_occorrenze": [
           "PE",
@@ -4670,23 +6104,41 @@
         ],
         "tabelle_random": []
       },
-      "id": "ghiandola_caustica"
+      "slot": [
+        "A"
+      ],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "blight-micotico",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "slag-veil-ambusher",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Squadre che devono rispondere a guardie situazionali al turno 1-2.",
+      "tier": "T1",
+      "uso_funzione": "Sblocco early di danni da acido per rompere armature leggere."
     },
     "ghiandole_cambio_salino": {
-      "label": "Ghiandole Cambio Salino",
+      "conflitti": [],
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
       "famiglia_tipologia": "Simbiotico/Cooperativo",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
-      "slot": [],
-      "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
-      },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
-      "conflitti": [],
+      "id": "ghiandole_cambio_salino",
+      "label": "Ghiandole Cambio Salino",
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4701,33 +6153,42 @@
           }
         }
       ],
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ghiandole_cambio_salino"
-    },
-    "ghiandole_condensa_ozono": {
-      "label": "Ghiandole Condensa Ozono",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
+        "complementare": "cooperazione",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "tier": "T1",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+    },
+    "ghiandole_condensa_ozono": {
       "conflitti": [],
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_condensa_ozono",
+      "label": "Ghiandole Condensa Ozono",
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4742,33 +6203,42 @@
           }
         }
       ],
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ghiandole_condensa_ozono"
-    },
-    "ghiandole_eco_mappanti": {
-      "label": "Ghiandole Eco Mappanti",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
+        "complementare": "resilienza",
+        "core": "strutturale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "tier": "T1",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+    },
+    "ghiandole_eco_mappanti": {
       "conflitti": [],
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_eco_mappanti",
+      "label": "Ghiandole Eco Mappanti",
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4783,33 +6253,42 @@
           }
         }
       ],
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ghiandole_eco_mappanti"
-    },
-    "ghiandole_fango_calde": {
-      "label": "Ghiandole Fango Calde",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
+        "complementare": "analitico",
+        "core": "sensoriale"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+    },
+    "ghiandole_fango_calde": {
       "conflitti": [],
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_fango_calde",
+      "label": "Ghiandole Fango Calde",
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4824,33 +6303,42 @@
           }
         }
       ],
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ghiandole_fango_calde"
-    },
-    "ghiandole_fango_coesivo": {
-      "label": "Ghiandole Fango Coesivo",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "mobilita",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "tier": "T1",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+    },
+    "ghiandole_fango_coesivo": {
       "conflitti": [],
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_fango_coesivo",
+      "label": "Ghiandole Fango Coesivo",
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4865,33 +6353,42 @@
           }
         }
       ],
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ghiandole_fango_coesivo"
-    },
-    "ghiandole_grafene": {
-      "label": "Ghiandole Grafene",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
+        "complementare": "protezione",
+        "core": "difensivo"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "tier": "T1",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+    },
+    "ghiandole_grafene": {
       "conflitti": [],
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_grafene",
+      "label": "Ghiandole Grafene",
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4906,33 +6403,42 @@
           }
         }
       ],
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ghiandole_grafene"
-    },
-    "ghiandole_inchiostro_luce": {
-      "label": "Ghiandole Inchiostro Luce",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
+        "complementare": "energia",
+        "core": "metabolico"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "tier": "T1",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+    },
+    "ghiandole_inchiostro_luce": {
       "conflitti": [],
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_inchiostro_luce",
+      "label": "Ghiandole Inchiostro Luce",
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4947,33 +6453,42 @@
           }
         }
       ],
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ghiandole_inchiostro_luce"
-    },
-    "ghiandole_iodoattive": {
-      "label": "Ghiandole Iodoattive",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "tier": "T1",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+    },
+    "ghiandole_iodoattive": {
       "conflitti": [],
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_iodoattive",
+      "label": "Ghiandole Iodoattive",
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4988,33 +6503,42 @@
           }
         }
       ],
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ghiandole_iodoattive"
-    },
-    "ghiandole_minerali": {
-      "label": "Ghiandole Minerali",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
+        "complementare": "assalto",
+        "core": "offensivo"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "tier": "T1",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+    },
+    "ghiandole_minerali": {
       "conflitti": [],
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_minerali",
+      "label": "Ghiandole Minerali",
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5029,33 +6553,42 @@
           }
         }
       ],
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ghiandole_minerali"
-    },
-    "ghiandole_nebbia_acida": {
-      "label": "Ghiandole Nebbia Acida",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
+        "complementare": "tattico",
+        "core": "strategia"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "tier": "T1",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+    },
+    "ghiandole_nebbia_acida": {
       "conflitti": [],
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_nebbia_acida",
+      "label": "Ghiandole Nebbia Acida",
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5070,33 +6603,42 @@
           }
         }
       ],
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ghiandole_nebbia_acida"
-    },
-    "ghiandole_nebbia_ionica": {
-      "label": "Ghiandole Nebbia Ionica",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
+        "complementare": "cooperazione",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "tier": "T1",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+    },
+    "ghiandole_nebbia_ionica": {
       "conflitti": [],
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_nebbia_ionica",
+      "label": "Ghiandole Nebbia Ionica",
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5111,33 +6653,42 @@
           }
         }
       ],
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ghiandole_nebbia_ionica"
-    },
-    "ghiandole_resina_conduttiva": {
-      "label": "Ghiandole Resina Conduttiva",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
+        "complementare": "resilienza",
+        "core": "strutturale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "tier": "T1",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+    },
+    "ghiandole_resina_conduttiva": {
       "conflitti": [],
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_resina_conduttiva",
+      "label": "Ghiandole Resina Conduttiva",
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5152,33 +6703,42 @@
           }
         }
       ],
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ghiandole_resina_conduttiva"
-    },
-    "ghiandole_ventosa": {
-      "label": "Ghiandole Ventosa",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
+        "complementare": "analitico",
+        "core": "sensoriale"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+    },
+    "ghiandole_ventosa": {
       "conflitti": [],
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_ventosa",
+      "label": "Ghiandole Ventosa",
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5193,33 +6753,42 @@
           }
         }
       ],
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ghiandole_ventosa"
-    },
-    "giunti_antitorsione": {
-      "label": "Giunti Antitorsione",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "mobilita",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "tier": "T1",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+    },
+    "giunti_antitorsione": {
       "conflitti": [],
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "giunti_antitorsione",
+      "label": "Giunti Antitorsione",
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5234,61 +6803,121 @@
           }
         }
       ],
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "giunti_antitorsione"
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "tier": "T1",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
     },
     "grassi_termici": {
-      "label": "Grassi Termici",
+      "conflitti": [],
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "famiglia_tipologia": "Digestivo/Metabolico",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
+      "id": "grassi_termici",
+      "label": "Grassi Termici",
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "requisiti_ambientali": [],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
       "slot": [],
       "slot_profile": {
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cactus-weaver",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-brinastorm",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-ondata-termica",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "noctule-termico",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "silica-bloom",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thermo-raptor",
+          "weight": 1
+        }
       ],
-      "conflitti": [],
-      "requisiti_ambientali": [],
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "id": "grassi_termici"
+      "tier": "T1",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
     },
     "gusci_criovetro": {
-      "label": "Gusci Criovetro",
+      "conflitti": [],
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "famiglia_tipologia": "Supporto/Logistico",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "conflitti": [],
+      "id": "gusci_criovetro",
+      "label": "Gusci Criovetro",
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5303,33 +6932,42 @@
           }
         }
       ],
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "gusci_criovetro"
-    },
-    "gusci_magnesio": {
-      "label": "Gusci Magnesio",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "tier": "T1",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+    },
+    "gusci_magnesio": {
       "conflitti": [],
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "gusci_magnesio",
+      "label": "Gusci Magnesio",
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5344,33 +6982,42 @@
           }
         }
       ],
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "gusci_magnesio"
-    },
-    "lamelle_shear": {
-      "label": "Lamelle Shear",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
+        "complementare": "assalto",
+        "core": "offensivo"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "tier": "T1",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+    },
+    "lamelle_shear": {
       "conflitti": [],
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "lamelle_shear",
+      "label": "Lamelle Shear",
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5385,33 +7032,42 @@
           }
         }
       ],
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "lamelle_shear"
-    },
-    "lamelle_sincroniche": {
-      "label": "Lamelle Sincroniche",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
+        "complementare": "tattico",
+        "core": "strategia"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "tier": "T1",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+    },
+    "lamelle_sincroniche": {
       "conflitti": [],
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "lamelle_sincroniche",
+      "label": "Lamelle Sincroniche",
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5426,34 +7082,44 @@
           }
         }
       ],
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "lamelle_sincroniche"
-    },
-    "lamelle_termoforetiche": {
-      "label": "Lamelle Termoforetiche",
-      "famiglia_tipologia": "Respiratorio/Termoregolazione",
-      "fattore_mantenimento_energetico": "Medio (Flusso continuo di fluidi caldi)",
-      "tier": "T2",
       "slot": [],
       "slot_profile": {
-        "complementare": "termoregolazione",
-        "core": "respiratorio"
+        "complementare": "cooperazione",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "sangue_piroforico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "tier": "T1",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+    },
+    "lamelle_termoforetiche": {
       "conflitti": [
         "criostasi_adattiva"
       ],
+      "debolezza": "Rende instabile la fisiologia in ambienti a gelo improvviso, con rischio di microfratture vascolari.",
+      "famiglia_tipologia": "Respiratorio/Termoregolazione",
+      "fattore_mantenimento_energetico": "Medio (Flusso continuo di fluidi caldi)",
+      "id": "lamelle_termoforetiche",
+      "label": "Lamelle Termoforetiche",
+      "mutazione_indotta": "Canali lamellari mineralizzati che convogliano fluidi caldi tra branchie interne.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5467,33 +7133,69 @@
           }
         }
       ],
-      "mutazione_indotta": "Canali lamellari mineralizzati che convogliano fluidi caldi tra branchie interne.",
-      "uso_funzione": "Regola lo scambio gassoso sfruttando gradienti termici controllati.",
-      "spinta_selettiva": "Sopravvivere a fluidi tossici e temperature estreme nelle fumarole geotermiche.",
-      "debolezza": "Rende instabile la fisiologia in ambienti a gelo improvviso, con rischio di microfratture vascolari.",
+      "sinergie": [
+        "sangue_piroforico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "lamelle_termoforetiche"
-    },
-    "lamine_filtranti_aeree": {
-      "label": "Lamine Filtranti Aeree",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
+        "complementare": "termoregolazione",
+        "core": "respiratorio"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "magnet-fathom-surveyor",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sorgenti-geotermiche-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Sopravvivere a fluidi tossici e temperature estreme nelle fumarole geotermiche.",
+      "tier": "T2",
+      "uso_funzione": "Regola lo scambio gassoso sfruttando gradienti termici controllati."
+    },
+    "lamine_filtranti_aeree": {
       "conflitti": [],
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "lamine_filtranti_aeree",
+      "label": "Lamine Filtranti Aeree",
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5508,33 +7210,42 @@
           }
         }
       ],
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "lamine_filtranti_aeree"
-    },
-    "lamine_scudo_silice": {
-      "label": "Lamine Scudo Silice",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
+        "complementare": "resilienza",
+        "core": "strutturale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "tier": "T1",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+    },
+    "lamine_scudo_silice": {
       "conflitti": [],
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "lamine_scudo_silice",
+      "label": "Lamine Scudo Silice",
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5549,33 +7260,42 @@
           }
         }
       ],
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "lamine_scudo_silice"
-    },
-    "linfa_tampone": {
-      "label": "Linfa Tampone",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
+        "complementare": "analitico",
+        "core": "sensoriale"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+    },
+    "linfa_tampone": {
       "conflitti": [],
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "linfa_tampone",
+      "label": "Linfa Tampone",
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5590,33 +7310,42 @@
           }
         }
       ],
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "linfa_tampone"
-    },
-    "lingua_cristallina": {
-      "label": "Lingua Cristallina",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "mobilita",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "tier": "T1",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+    },
+    "lingua_cristallina": {
       "conflitti": [],
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "lingua_cristallina",
+      "label": "Lingua Cristallina",
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5631,32 +7360,42 @@
           }
         }
       ],
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "lingua_cristallina"
-    },
-    "lingua_tattile_trama": {
-      "label": "Lingua Tattile Trama-Sensibile",
-      "famiglia_tipologia": "Sensoriale/Alimentare",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "alimentare",
-        "core": "sensoriale"
+        "complementare": "protezione",
+        "core": "difensivo"
       },
-      "sinergie": [
-        "olfatto_risonanza_magnetica"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "tier": "T1",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+    },
+    "lingua_tattile_trama": {
       "conflitti": [],
+      "debolezza": "Estrema vulnerabilità della lingua a contaminanti chimici o acidi.",
+      "famiglia_tipologia": "Sensoriale/Alimentare",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "lingua_tattile_trama",
+      "label": "Lingua Tattile Trama-Sensibile",
+      "mutazione_indotta": "Lingua sottile con papille tattili e meccanocettori avanzati.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5670,33 +7409,62 @@
           }
         }
       ],
-      "mutazione_indotta": "Lingua sottile con papille tattili e meccanocettori avanzati.",
-      "uso_funzione": "\"Leggere\" la tessitura delle superfici per vibrazioni o micro-fratture.",
-      "spinta_selettiva": "Individuare movimenti sismici o cibi sepolti.",
-      "debolezza": "Estrema vulnerabilità della lingua a contaminanti chimici o acidi.",
+      "sinergie": [
+        "olfatto_risonanza_magnetica"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "lingua_tattile_trama"
-    },
-    "luminescenza_aurorale": {
-      "label": "Luminescenza Aurorale",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
+        "complementare": "alimentare",
+        "core": "sensoriale"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "blight-micotico",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "echo-wing",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "ferrocolonia-magnetotattica",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Individuare movimenti sismici o cibi sepolti.",
+      "tier": "T1",
+      "uso_funzione": "\"Leggere\" la tessitura delle superfici per vibrazioni o micro-fratture."
+    },
+    "luminescenza_aurorale": {
       "conflitti": [],
+      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "luminescenza_aurorale",
+      "label": "Luminescenza Aurorale",
+      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5711,33 +7479,42 @@
           }
         }
       ],
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "luminescenza_aurorale"
-    },
-    "luminescenza_hydrotermica": {
-      "label": "Luminescenza Hydrotermica",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
+        "complementare": "energia",
+        "core": "metabolico"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "tier": "T1",
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+    },
+    "luminescenza_hydrotermica": {
       "conflitti": [],
+      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "luminescenza_hydrotermica",
+      "label": "Luminescenza Hydrotermica",
+      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5752,33 +7529,42 @@
           }
         }
       ],
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "luminescenza_hydrotermica"
-    },
-    "mantelli_geotermici": {
-      "label": "Mantelli Geotermici",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "tier": "T1",
+      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+    },
+    "mantelli_geotermici": {
       "conflitti": [],
+      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "mantelli_geotermici",
+      "label": "Mantelli Geotermici",
+      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5793,35 +7579,44 @@
           }
         }
       ],
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "mantelli_geotermici"
-    },
-    "mantello_meteoritico": {
-      "label": "Mantello Meteoritico",
-      "famiglia_tipologia": "Difesa/Termoregolazione",
-      "fattore_mantenimento_energetico": "Alto (Rivestimento ablativo rigenerante)",
-      "tier": "T3",
       "slot": [],
       "slot_profile": {
-        "complementare": "termico",
-        "core": "difesa"
+        "complementare": "assalto",
+        "core": "offensivo"
       },
-      "sinergie": [
-        "frusta_fiammeggiante",
-        "carapace_fase_variabile"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
+      "tier": "T1",
+      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+    },
+    "mantello_meteoritico": {
       "conflitti": [
         "aura_scudo_radianza"
       ],
+      "debolezza": "Vulnerabile a scariche di freddo gravitazionale che irrigidiscono il mantello.",
+      "famiglia_tipologia": "Difesa/Termoregolazione",
+      "fattore_mantenimento_energetico": "Alto (Rivestimento ablativo rigenerante)",
+      "id": "mantello_meteoritico",
+      "label": "Mantello Meteoritico",
+      "mutazione_indotta": "Deposita strati sovrapposti di materiale meteorico che vaporizzano l'impatto e rilasciano radianza.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [
@@ -5838,33 +7633,50 @@
           }
         }
       ],
-      "mutazione_indotta": "Deposita strati sovrapposti di materiale meteorico che vaporizzano l'impatto e rilasciano radianza.",
-      "uso_funzione": "Assorbe colpi energetici estremi e converte il surplus in impulsi offensivi.",
-      "spinta_selettiva": "Sopravvivere a bombardamenti planari e piogge di meteore dimensionali.",
-      "debolezza": "Vulnerabile a scariche di freddo gravitazionale che irrigidiscono il mantello.",
+      "sinergie": [
+        "frusta_fiammeggiante",
+        "carapace_fase_variabile"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "mantello_meteoritico"
-    },
-    "membrane_captura_rugiada": {
-      "label": "Membrane Captura Rugiada",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
+        "complementare": "termico",
+        "core": "difesa"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "balor-fission",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 3
+        }
       ],
+      "spinta_selettiva": "Sopravvivere a bombardamenti planari e piogge di meteore dimensionali.",
+      "tier": "T3",
+      "uso_funzione": "Assorbe colpi energetici estremi e converte il surplus in impulsi offensivi."
+    },
+    "membrane_captura_rugiada": {
       "conflitti": [],
+      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "membrane_captura_rugiada",
+      "label": "Membrane Captura Rugiada",
+      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5879,33 +7691,42 @@
           }
         }
       ],
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "membrane_captura_rugiada"
-    },
-    "membrane_eliofiltranti": {
-      "label": "Membrane Eliofiltranti",
-      "famiglia_tipologia": "Respiratorio/Protezione",
-      "fattore_mantenimento_energetico": "Basso (Auto-riparazione lenta)",
-      "tier": "T2",
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "respiratorio"
+        "complementare": "tattico",
+        "core": "strategia"
       },
-      "sinergie": [
-        "piume_solari_fotovoltaiche",
-        "polmoni_cristallini_alta_quota"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "tier": "T1",
+      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+    },
+    "membrane_eliofiltranti": {
       "conflitti": [],
+      "debolezza": "Atmosfere acide degradano rapidamente il film eliofiltrante.",
+      "famiglia_tipologia": "Respiratorio/Protezione",
+      "fattore_mantenimento_energetico": "Basso (Auto-riparazione lenta)",
+      "id": "membrane_eliofiltranti",
+      "label": "Membrane Eliofiltranti",
+      "mutazione_indotta": "Strati di mucopolisaccaridi trasparenti che filtrano radiazioni e microrganismi sospesi.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5919,33 +7740,42 @@
           }
         }
       ],
-      "mutazione_indotta": "Strati di mucopolisaccaridi trasparenti che filtrano radiazioni e microrganismi sospesi.",
-      "uso_funzione": "Filtra l'aria e i flussi luminosi rendendoli sicuri per tessuti delicati.",
-      "spinta_selettiva": "Proteggersi da radiazioni e agenti patogeni in altopiani ipersalini.",
-      "debolezza": "Atmosfere acide degradano rapidamente il film eliofiltrante.",
+      "sinergie": [
+        "piume_solari_fotovoltaiche",
+        "polmoni_cristallini_alta_quota"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "membrane_eliofiltranti"
-    },
-    "membrane_planata_vectored": {
-      "label": "Membrane Planata Vectored",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
+        "complementare": "protezione",
+        "core": "respiratorio"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laghi-alcalini-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Proteggersi da radiazioni e agenti patogeni in altopiani ipersalini.",
+      "tier": "T2",
+      "uso_funzione": "Filtra l'aria e i flussi luminosi rendendoli sicuri per tessuti delicati."
+    },
+    "membrane_planata_vectored": {
       "conflitti": [],
+      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "membrane_planata_vectored",
+      "label": "Membrane Planata Vectored",
+      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5960,33 +7790,42 @@
           }
         }
       ],
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "membrane_planata_vectored"
-    },
-    "membrane_pneumatofori": {
-      "label": "Membrane Pneumatofori",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
+        "complementare": "cooperazione",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
+      "tier": "T1",
+      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+    },
+    "membrane_pneumatofori": {
       "conflitti": [],
+      "debolezza": "Risonanze errate possono generare microfratture.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "membrane_pneumatofori",
+      "label": "Membrane Pneumatofori",
+      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6001,33 +7840,42 @@
           }
         }
       ],
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "membrane_pneumatofori"
-    },
-    "midollo_antivibrazione": {
-      "label": "Midollo Antivibrazione",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
+        "complementare": "resilienza",
+        "core": "strutturale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "tier": "T1",
+      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+    },
+    "midollo_antivibrazione": {
       "conflitti": [],
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "midollo_antivibrazione",
+      "label": "Midollo Antivibrazione",
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6042,47 +7890,42 @@
           }
         }
       ],
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "midollo_antivibrazione"
-    },
-    "mimetismo_cromatico_passivo": {
-      "label": "Ghiandole di Mimetismo Cromatico Passivo",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Fase passiva)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "difensivo",
-        "core": "tegumentario"
+        "complementare": "analitico",
+        "core": "sensoriale"
       },
-      "sinergie": [
-        "ali_membrana_sonica",
-        "appendici_risonanti_marea",
-        "artigli_sette_vie",
-        "barriere_miasma_glaciale",
-        "branchie_microfiltri",
-        "capsule_paracadute",
-        "circolazione_bifasica",
-        "coda_coppia_retroattiva",
-        "cute_resistente_sali",
-        "enzimi_antipredatori_algali",
-        "filtri_planctonici",
-        "ghiandole_fango_coesivo",
-        "giunti_antitorsione",
-        "lingua_cristallina",
-        "mucose_barofile",
-        "struttura_elastica_amorfa"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+    },
+    "mimetismo_cromatico_passivo": {
       "conflitti": [],
+      "debolezza": "La colorazione è fissa finché non c'è un nuovo contatto prolungato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Fase passiva)",
+      "id": "mimetismo_cromatico_passivo",
+      "label": "Ghiandole di Mimetismo Cromatico Passivo",
+      "mutazione_indotta": "Cromatofori che richiedono un input tattile prolungato per la ricarica.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6109,28 +7952,108 @@
           }
         }
       ],
-      "mutazione_indotta": "Cromatofori che richiedono un input tattile prolungato per la ricarica.",
-      "uso_funzione": "Assorbire e replicare il colore dell'ambiente circostante dopo contatto.",
-      "spinta_selettiva": "Ambiente con pattern cromatici molto variabili che cambiano lentamente.",
-      "debolezza": "La colorazione è fissa finché non c'è un nuovo contatto prolungato.",
+      "sinergie": [
+        "ali_membrana_sonica",
+        "appendici_risonanti_marea",
+        "artigli_sette_vie",
+        "barriere_miasma_glaciale",
+        "branchie_microfiltri",
+        "capsule_paracadute",
+        "circolazione_bifasica",
+        "coda_coppia_retroattiva",
+        "cute_resistente_sali",
+        "enzimi_antipredatori_algali",
+        "filtri_planctonici",
+        "ghiandole_fango_coesivo",
+        "giunti_antitorsione",
+        "lingua_cristallina",
+        "mucose_barofile",
+        "struttura_elastica_amorfa"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "mimetismo_cromatico_passivo"
-    },
-    "mucillagine_simbionte_mangrovie": {
-      "label": "Mucillagine Simbionte delle Mangrovie",
-      "famiglia_tipologia": "Simbiotico/Difensivo",
-      "fattore_mantenimento_energetico": "Medio (Coltura simbiotica costante)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
         "complementare": "difensivo",
-        "core": "simbiotico"
+        "core": "tegumentario"
       },
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "ferrocolonia-magnetotattica",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "aurora-bridge-runner",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "zephyr-spore-courier",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Ambiente con pattern cromatici molto variabili che cambiano lentamente.",
+      "tier": "T1",
+      "uso_funzione": "Assorbire e replicare il colore dell'ambiente circostante dopo contatto."
+    },
+    "mucillagine_simbionte_mangrovie": {
+      "conflitti": [
+        "ghiandola_caustica"
+      ],
+      "debolezza": "Acque eccessivamente pure diluiscono la mucillagine riducendo la protezione.",
+      "famiglia_tipologia": "Simbiotico/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Coltura simbiotica costante)",
+      "id": "mucillagine_simbionte_mangrovie",
+      "label": "Mucillagine Simbionte delle Mangrovie",
+      "mutazione_indotta": "Strati mucosi che ospitano microfauna detossificante proveniente dalle radici di mangrovia.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovie_risonanti"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Foreste di mangrovie ipersature dove le radici cantano frequenze psioniche."
+          }
+        }
+      ],
       "sinergie": [
         "antenne_reagenti",
         "artigli_scivolo_silente",
@@ -6149,49 +8072,38 @@
         "membrane_planata_vectored",
         "nodi_micorrizici_oracolari"
       ],
-      "conflitti": [
-        "ghiandola_caustica"
-      ],
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "mangrovie_risonanti"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Foreste di mangrovie ipersature dove le radici cantano frequenze psioniche."
-          }
-        }
-      ],
-      "mutazione_indotta": "Strati mucosi che ospitano microfauna detossificante proveniente dalle radici di mangrovia.",
-      "uso_funzione": "Forma una barriera viva che neutralizza veleni e sigilla ferite.",
-      "spinta_selettiva": "Respinge tossine e predatori microbici tipici dei delta paludosi.",
-      "debolezza": "Acque eccessivamente pure diluiscono la mucillagine riducendo la protezione.",
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "mucillagine_simbionte_mangrovie"
-    },
-    "mucose_aderenza_sonica": {
-      "label": "Mucose Aderenza Sonica",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
+        "complementare": "difensivo",
+        "core": "simbiotico"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovie-risonanti-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Respinge tossine e predatori microbici tipici dei delta paludosi.",
+      "tier": "T1",
+      "uso_funzione": "Forma una barriera viva che neutralizza veleni e sigilla ferite."
+    },
+    "mucose_aderenza_sonica": {
       "conflitti": [],
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "mucose_aderenza_sonica",
+      "label": "Mucose Aderenza Sonica",
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6206,33 +8118,42 @@
           }
         }
       ],
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "mucose_aderenza_sonica"
-    },
-    "mucose_barofile": {
-      "label": "Mucose Barofile",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "mobilita",
+        "core": "locomotorio"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "tier": "T1",
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+    },
+    "mucose_barofile": {
       "conflitti": [],
+      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "mucose_barofile",
+      "label": "Mucose Barofile",
+      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6247,28 +8168,57 @@
           }
         }
       ],
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "mucose_barofile"
-    },
-    "nodi_micorrizici_oracolari": {
-      "label": "Nodi Micorrizici Oracolari",
-      "famiglia_tipologia": "Simbiotico/Nervoso",
-      "fattore_mantenimento_energetico": "Medio (Scambio continuo di segnali con simbionti)",
-      "tier": "T3",
       "slot": [],
       "slot_profile": {
-        "complementare": "nervoso",
-        "core": "simbiotico"
+        "complementare": "protezione",
+        "core": "difensivo"
       },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "tier": "T1",
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+    },
+    "nodi_micorrizici_oracolari": {
+      "conflitti": [
+        "spore_psichiche_silenziate"
+      ],
+      "debolezza": "Se la rete micorrizica viene recisa, l'organismo soffre crisi percettive e perdita di orientamento.",
+      "famiglia_tipologia": "Simbiotico/Nervoso",
+      "fattore_mantenimento_energetico": "Medio (Scambio continuo di segnali con simbionti)",
+      "id": "nodi_micorrizici_oracolari",
+      "label": "Nodi Micorrizici Oracolari",
+      "mutazione_indotta": "Radici dermiche che intrecciano funghi psionici capaci di predire variazioni ambientali.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reti_micorriziche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Sottoboschi viventi con reti fungine coscienti che emettono segnali premonitori."
+          }
+        }
+      ],
       "sinergie": [
         "antenne_reagenti",
         "artigli_scivolo_silente",
@@ -6287,48 +8237,117 @@
         "membrane_planata_vectored",
         "mucillagine_simbionte_mangrovie"
       ],
-      "conflitti": [
-        "spore_psichiche_silenziate"
-      ],
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "reti_micorriziche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Sottoboschi viventi con reti fungine coscienti che emettono segnali premonitori."
-          }
-        }
-      ],
-      "mutazione_indotta": "Radici dermiche che intrecciano funghi psionici capaci di predire variazioni ambientali.",
-      "uso_funzione": "Riceve presagi e segnali tattici dalla rete fungina per coordinare manovre di squadra.",
-      "spinta_selettiva": "Anticipare frane psioniche e predatori guidati da reti vegetali senzienti.",
-      "debolezza": "Se la rete micorrizica viene recisa, l'organismo soffre crisi percettive e perdita di orientamento.",
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "nodi_micorrizici_oracolari"
+      "slot": [],
+      "slot_profile": {
+        "complementare": "nervoso",
+        "core": "simbiotico"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reti-micorriziche-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Anticipare frane psioniche e predatori guidati da reti vegetali senzienti.",
+      "tier": "T3",
+      "uso_funzione": "Riceve presagi e segnali tattici dalla rete fungina per coordinare manovre di squadra."
     },
     "nucleo_ovomotore_rotante": {
-      "label": "Uovo rotaia, uovo grande e uova piccole dentro...",
+      "conflitti": [
+        "secrezione_rallentante_palmi"
+      ],
+      "debolezza": "Impossibilità di muoversi su superfici irregolari o in salita ripida.",
       "famiglia_tipologia": "Riproduttivo/Locomotorio",
       "fattore_mantenimento_energetico": "Alto (Rotolamento)",
-      "tier": "T1",
+      "id": "nucleo_ovomotore_rotante",
+      "label": "Uovo rotaia, uovo grande e uova piccole dentro...",
+      "mutazione_indotta": "Massa globulare rigida con giunto sferico al centro del petto.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+          }
+        }
+      ],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
       "slot": [],
       "slot_profile": {
         "complementare": "locomotorio",
         "core": "riproduttivo"
       },
-      "sinergie": [],
-      "conflitti": [
-        "secrezione_rallentante_palmi"
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "magnet-fathom-surveyor",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "orbital-ascendant",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "sand-burrower",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "rust-scavenger",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Necessità di spostarsi rapidamente su terreni uniformi in assenza di arti.",
+      "tier": "T1",
+      "uso_funzione": "Organo Motorio Rotante: usato come 'ruota' centrale per il rotolamento."
+    },
+    "occhi_infrarosso_composti": {
+      "conflitti": [],
+      "debolezza": "Accecamento temporaneo da fonti di calore intenso e concentrato.",
+      "famiglia_tipologia": "Sensoriale/Visivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "occhi_infrarosso_composti",
+      "label": "Occhi Composti ad Infrarosso",
+      "mutazione_indotta": "Sviluppo di un secondo strato retinico sensibile all'infrarosso.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6342,72 +8361,49 @@
           }
         }
       ],
-      "mutazione_indotta": "Massa globulare rigida con giunto sferico al centro del petto.",
-      "uso_funzione": "Organo Motorio Rotante: usato come 'ruota' centrale per il rotolamento.",
-      "spinta_selettiva": "Necessità di spostarsi rapidamente su terreni uniformi in assenza di arti.",
-      "debolezza": "Impossibilità di muoversi su superfici irregolari o in salita ripida.",
+      "sinergie": [
+        "sonno_emisferico_alternato"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "nucleo_ovomotore_rotante"
-    },
-    "occhi_infrarosso_composti": {
-      "label": "Occhi Composti ad Infrarosso",
-      "famiglia_tipologia": "Sensoriale/Visivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
         "complementare": "visivo",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "sonno_emisferico_alternato"
-      ],
-      "conflitti": [],
-      "requisiti_ambientali": [
+      "species_affinity": [
         {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
-          }
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "echo-wing",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
         }
       ],
-      "mutazione_indotta": "Sviluppo di un secondo strato retinico sensibile all'infrarosso.",
-      "uso_funzione": "Vista specializzata che percepisce il calore corporeo.",
       "spinta_selettiva": "Caccia notturna o nell'oscurità totale basata sul gradiente termico.",
-      "debolezza": "Accecamento temporaneo da fonti di calore intenso e concentrato.",
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "id": "occhi_infrarosso_composti"
+      "tier": "T1",
+      "uso_funzione": "Vista specializzata che percepisce il calore corporeo."
     },
     "olfatto_risonanza_magnetica": {
-      "label": "Olfatto di Risonanza Magnetica",
+      "conflitti": [],
+      "debolezza": "Sensibilità a forti interferenze elettromagnetiche (es. fulmini o minerali magnetici).",
       "famiglia_tipologia": "Sensoriale/Nervoso",
       "fattore_mantenimento_energetico": "Medio (Elaborazione sensoriale costante)",
-      "tier": "T2",
-      "slot": [],
-      "slot_profile": {
-        "complementare": "nervoso",
-        "core": "sensoriale"
-      },
-      "sinergie": [
-        "eco_interno_riflesso",
-        "lingua_tattile_trama"
-      ],
-      "conflitti": [],
+      "id": "olfatto_risonanza_magnetica",
+      "label": "Olfatto di Risonanza Magnetica",
+      "mutazione_indotta": "Organi sensoriali elettrorecettori concentrati su muso o antenne.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6434,37 +8430,103 @@
           }
         }
       ],
-      "mutazione_indotta": "Organi sensoriali elettrorecettori concentrati su muso o antenne.",
-      "uso_funzione": "Percepire la direzione e la composizione di metalli o campi energetici.",
-      "spinta_selettiva": "Orientamento in ambienti sotterranei senza luce o caccia a prede metallifere.",
-      "debolezza": "Sensibilità a forti interferenze elettromagnetiche (es. fulmini o minerali magnetici).",
+      "sinergie": [
+        "eco_interno_riflesso",
+        "lingua_tattile_trama"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "olfatto_risonanza_magnetica"
+      "slot": [],
+      "slot_profile": {
+        "complementare": "nervoso",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "magnet-fathom-surveyor",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "orbital-ascendant",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "slag-veil-ambusher",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cryo-lynx",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dune-stalker",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "magneto-ridge-hunter",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "orbita-psionica-inversa-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Orientamento in ambienti sotterranei senza luce o caccia a prede metallifere.",
+      "tier": "T2",
+      "uso_funzione": "Percepire la direzione e la composizione di metalli o campi energetici."
     },
     "pathfinder": {
-      "label": "Pathfinder",
+      "conflitti": [],
+      "debolezza": "Valore ridotto in scenari a corridoio o con tilt già stabilizzato.",
       "famiglia_tipologia": "Esplorazione/Tattico",
       "fattore_mantenimento_energetico": "Basso (Sincronizzazione con HUD di esplorazione)",
-      "tier": "T1",
-      "slot": [
-        "A"
-      ],
-      "slot_profile": {
-        "complementare": "ricognizione",
-        "core": "strategia"
-      },
-      "sinergie": [],
-      "conflitti": [],
-      "requisiti_ambientali": [],
+      "id": "pathfinder",
+      "label": "Pathfinder",
       "mutazione_indotta": "Suite sensoriale orientata a scouting e lettura minacce.",
-      "uso_funzione": "Ottimizza esplorazione e controllo mappe multi-bioma.",
-      "spinta_selettiva": "Missioni con indice explore alto e opzioni opzionali da capitalizzare.",
-      "debolezza": "Valore ridotto in scenari a corridoio o con tilt già stabilizzato.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
       "sinergie_pi": {
         "co_occorrenze": [
           "PE",
@@ -6477,21 +8539,35 @@
         ],
         "tabelle_random": []
       },
-      "id": "pathfinder"
-    },
-    "pianificatore": {
-      "label": "Pianificatore",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Medio (Analisi continua di stato squadre)",
-      "tier": "T1",
       "slot": [
-        "A",
-        "C"
+        "A"
       ],
       "slot_profile": {
-        "complementare": "tattico",
+        "complementare": "ricognizione",
         "core": "strategia"
       },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sentinella-radice",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Missioni con indice explore alto e opzioni opzionali da capitalizzare.",
+      "tier": "T1",
+      "uso_funzione": "Ottimizza esplorazione e controllo mappe multi-bioma."
+    },
+    "pianificatore": {
+      "conflitti": [],
+      "debolezza": "Rigidità tattica se gli input di telemetria arrivano in ritardo.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Medio (Analisi continua di stato squadre)",
+      "id": "pianificatore",
+      "label": "Pianificatore",
+      "mutazione_indotta": "Protocollo decisionale adattivo con buffer informativi dedicati.",
+      "requisiti_ambientali": [],
       "sinergie": [
         "antenne_microonde_cavernose",
         "artigli_radice",
@@ -6507,12 +8583,6 @@
         "lamelle_shear",
         "membrane_captura_rugiada"
       ],
-      "conflitti": [],
-      "requisiti_ambientali": [],
-      "mutazione_indotta": "Protocollo decisionale adattivo con buffer informativi dedicati.",
-      "uso_funzione": "Coordina finestre di danno e difesa, mantenendo la squadra allineata al piano PI.",
-      "spinta_selettiva": "Squadre che devono mantenere priorità multiple su turni lunghi.",
-      "debolezza": "Rigidità tattica se gli input di telemetria arrivano in ritardo.",
       "sinergie_pi": {
         "co_occorrenze": [
           "PE",
@@ -6531,25 +8601,37 @@
         ],
         "tabelle_random": []
       },
-      "id": "pianificatore"
+      "slot": [
+        "A",
+        "C"
+      ],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sentinella-radice",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Squadre che devono mantenere priorità multiple su turni lunghi.",
+      "tier": "T1",
+      "uso_funzione": "Coordina finestre di danno e difesa, mantenendo la squadra allineata al piano PI."
     },
     "piume_solari_fotovoltaiche": {
-      "label": "Piume Solari Fotovoltaiche",
-      "famiglia_tipologia": "Tegumentario/Energetico",
-      "fattore_mantenimento_energetico": "Alto (Richiede manutenzione delle lamine fotoreattive)",
-      "tier": "T2",
-      "slot": [],
-      "slot_profile": {
-        "complementare": "energetico",
-        "core": "tegumentario"
-      },
-      "sinergie": [
-        "membrane_eliofiltranti",
-        "sacche_spore_stratosferiche"
-      ],
       "conflitti": [
         "criostasi_adattiva"
       ],
+      "debolezza": "Ombre prolungate o polveri dense riducono drasticamente la produzione energetica.",
+      "famiglia_tipologia": "Tegumentario/Energetico",
+      "fattore_mantenimento_energetico": "Alto (Richiede manutenzione delle lamine fotoreattive)",
+      "id": "piume_solari_fotovoltaiche",
+      "label": "Piume Solari Fotovoltaiche",
+      "mutazione_indotta": "Piumaggio stratificato con pigmenti piezo-fotovoltaici che immagazzinano luce.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6563,34 +8645,44 @@
           }
         }
       ],
-      "mutazione_indotta": "Piumaggio stratificato con pigmenti piezo-fotovoltaici che immagazzinano luce.",
-      "uso_funzione": "Convertire la radiazione solare in riserve energetiche per abilità a lungo raggio.",
-      "spinta_selettiva": "Massimizzare l'autonomia energetica per migrazioni aeree sopra deserti e oceani.",
-      "debolezza": "Ombre prolungate o polveri dense riducono drasticamente la produzione energetica.",
+      "sinergie": [
+        "membrane_eliofiltranti",
+        "sacche_spore_stratosferiche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "piume_solari_fotovoltaiche"
-    },
-    "polmoni_cristallini_alta_quota": {
-      "label": "Polmoni Cristallini d'Alta Quota",
-      "famiglia_tipologia": "Respiratorio/Aerobico",
-      "fattore_mantenimento_energetico": "Medio (Pulizia periodica dei cristalli)",
-      "tier": "T2",
       "slot": [],
       "slot_profile": {
-        "complementare": "aerobico",
-        "core": "respiratorio"
+        "complementare": "energetico",
+        "core": "tegumentario"
       },
-      "sinergie": [
-        "membrane_eliofiltranti"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "altipiani-solari-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Massimizzare l'autonomia energetica per migrazioni aeree sopra deserti e oceani.",
+      "tier": "T2",
+      "uso_funzione": "Convertire la radiazione solare in riserve energetiche per abilità a lungo raggio."
+    },
+    "polmoni_cristallini_alta_quota": {
       "conflitti": [
         "branchie_osmotiche_salmastra"
       ],
+      "debolezza": "Particolato pesante o sabbia vulcanica graffia i cristalli riducendo l'efficienza respiratoria.",
+      "famiglia_tipologia": "Respiratorio/Aerobico",
+      "fattore_mantenimento_energetico": "Medio (Pulizia periodica dei cristalli)",
+      "id": "polmoni_cristallini_alta_quota",
+      "label": "Polmoni Cristallini d'Alta Quota",
+      "mutazione_indotta": "Sistemi alveolari irrobustiti da strutture cristalline che catturano ossigeno rarefatto.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6604,38 +8696,43 @@
           }
         }
       ],
-      "mutazione_indotta": "Sistemi alveolari irrobustiti da strutture cristalline che catturano ossigeno rarefatto.",
-      "uso_funzione": "Massimizza l'assorbimento di ossigeno rarefatto e filtra agenti nocivi.",
-      "spinta_selettiva": "Operare in missioni d'alta quota senza supporto logistico esterno.",
-      "debolezza": "Particolato pesante o sabbia vulcanica graffia i cristalli riducendo l'efficienza respiratoria.",
+      "sinergie": [
+        "membrane_eliofiltranti"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "polmoni_cristallini_alta_quota"
+      "slot": [],
+      "slot_profile": {
+        "complementare": "aerobico",
+        "core": "respiratorio"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "picchi-cristallini-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Operare in missioni d'alta quota senza supporto logistico esterno.",
+      "tier": "T2",
+      "uso_funzione": "Massimizza l'assorbimento di ossigeno rarefatto e filtra agenti nocivi."
     },
     "random": {
-      "label": "Trait Random",
+      "conflitti": [],
+      "debolezza": "Bassa affidabilità: richiede slot aggiuntivi per mitigare risultati sfavorevoli.",
       "famiglia_tipologia": "Flessibile/Generico",
       "fattore_mantenimento_energetico": "Variabile (Dipende dal tratto estratto)",
-      "tier": "T1",
-      "slot": [
-        "A",
-        "B"
-      ],
-      "slot_profile": {
-        "complementare": "adattivo",
-        "core": "strategia"
-      },
-      "sinergie": [],
-      "conflitti": [],
-      "requisiti_ambientali": [],
+      "id": "random",
+      "label": "Trait Random",
       "mutazione_indotta": "Selezione casuale da pool controllata per esperimenti di build.",
-      "uso_funzione": "Slot jolly per testing o pareggiare budget PI quando serve varietà.",
-      "spinta_selettiva": "Draft rapidi o recuperi quando il tavolo necessita sorprese adattive.",
-      "debolezza": "Bassa affidabilità: richiede slot aggiuntivi per mitigare risultati sfavorevoli.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
       "sinergie_pi": {
         "co_occorrenze": [
           "cap_pt",
@@ -6648,23 +8745,26 @@
         ],
         "tabelle_random": []
       },
-      "id": "random"
+      "slot": [
+        "A",
+        "B"
+      ],
+      "slot_profile": {
+        "complementare": "adattivo",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "Draft rapidi o recuperi quando il tavolo necessita sorprese adattive.",
+      "tier": "T1",
+      "uso_funzione": "Slot jolly per testing o pareggiare budget PI quando serve varietà."
     },
     "respiro_a_scoppio": {
-      "label": "Respiro a scoppio",
+      "conflitti": [],
+      "debolezza": "Vulnerabilità respiratoria subito dopo l'utilizzo (tempo di ricarica).",
       "famiglia_tipologia": "Respiratorio/Propulsivo",
       "fattore_mantenimento_energetico": "Alto (Richiede ricarica polmonare)",
-      "tier": "T1",
-      "slot": [],
-      "slot_profile": {
-        "complementare": "propulsivo",
-        "core": "respiratorio"
-      },
-      "sinergie": [
-        "sacche_galleggianti_ascensoriali",
-        "squame_rifrangenti_deserto"
-      ],
-      "conflitti": [],
+      "id": "respiro_a_scoppio",
+      "label": "Respiro a scoppio",
+      "mutazione_indotta": "Polmoni o sacche aeree ad alta pressione con valvole di rilascio rapide.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6678,32 +8778,79 @@
           }
         }
       ],
-      "mutazione_indotta": "Polmoni o sacche aeree ad alta pressione con valvole di rilascio rapide.",
-      "uso_funzione": "Rilasciare grandi quantità d'aria o energia in un getto potente.",
-      "spinta_selettiva": "Spostamento rapido tramite getto d'aria in ambienti a bassa resistenza.",
-      "debolezza": "Vulnerabilità respiratoria subito dopo l'utilizzo (tempo di ricarica).",
+      "sinergie": [
+        "sacche_galleggianti_ascensoriali",
+        "squame_rifrangenti_deserto"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "respiro_a_scoppio"
+      "slot": [],
+      "slot_profile": {
+        "complementare": "propulsivo",
+        "core": "respiratorio"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "rust-scavenger",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dune-stalker",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "magneto-ridge-hunter",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "slag-veil-ambusher",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-bison-mini",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Spostamento rapido tramite getto d'aria in ambienti a bassa resistenza.",
+      "tier": "T1",
+      "uso_funzione": "Rilasciare grandi quantità d'aria o energia in un getto potente."
     },
     "risonanza_di_branco": {
-      "label": "Risonanza di Branco",
+      "conflitti": [],
+      "debolezza": "Stress elevato se la coesione cala sotto i target di telemetria.",
       "famiglia_tipologia": "Supporto/Coordinativo",
       "fattore_mantenimento_energetico": "Basso (Richiede mantenimento empatico)",
-      "tier": "T1",
-      "slot": [
-        "A",
-        "B",
-        "C"
-      ],
-      "slot_profile": {
-        "complementare": "coordinazione",
-        "core": "supporto"
-      },
+      "id": "risonanza_di_branco",
+      "label": "Risonanza di Branco",
+      "mutazione_indotta": "Reticolo empatico che collega i canali PI cooperativi.",
+      "requisiti_ambientali": [],
       "sinergie": [
         "antenne_eco_turbina",
         "antenne_plasmatiche_tempesta",
@@ -6723,12 +8870,6 @@
         "luminescenza_hydrotermica",
         "aura_scudo_radianza"
       ],
-      "conflitti": [],
-      "requisiti_ambientali": [],
-      "mutazione_indotta": "Reticolo empatico che collega i canali PI cooperativi.",
-      "uso_funzione": "Amplifica buff condivisi sincronizzando i timer di squadra.",
-      "spinta_selettiva": "Forme che eccellono in difesa coordinata e scudi sovrapposti.",
-      "debolezza": "Stress elevato se la coesione cala sotto i target di telemetria.",
       "sinergie_pi": {
         "co_occorrenze": [
           "PE",
@@ -6744,25 +8885,72 @@
         ],
         "tabelle_random": []
       },
-      "id": "risonanza_di_branco"
+      "slot": [
+        "A",
+        "B",
+        "C"
+      ],
+      "slot_profile": {
+        "complementare": "coordinazione",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional",
+            "synergy"
+          ],
+          "species_id": "archon-solare",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 2
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 2
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "treant-portale",
+          "weight": 2
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "lupus-temperatus",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Forme che eccellono in difesa coordinata e scudi sovrapposti.",
+      "tier": "T1",
+      "uso_funzione": "Amplifica buff condivisi sincronizzando i timer di squadra."
     },
     "sacche_galleggianti_ascensoriali": {
-      "label": "Sacche galleggianti ascensoriali",
+      "conflitti": [],
+      "debolezza": "Rischio di barotrauma se la pressione esterna cambia troppo rapidamente.",
       "famiglia_tipologia": "Idrostatico/Locomotorio",
       "fattore_mantenimento_energetico": "Medio (Per il controllo della pressione)",
-      "tier": "T1",
-      "slot": [],
-      "slot_profile": {
-        "complementare": "locomotorio",
-        "core": "idrostatico"
-      },
-      "sinergie": [
-        "cartilagine_flessotermica_venti",
-        "respiro_a_scoppio",
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
-      "conflitti": [],
+      "id": "sacche_galleggianti_ascensoriali",
+      "label": "Sacche galleggianti ascensoriali",
+      "mutazione_indotta": "Sacche ripiene di gas leggeri con pompe muscolari.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6789,34 +8977,98 @@
           }
         }
       ],
-      "mutazione_indotta": "Sacche ripiene di gas leggeri con pompe muscolari.",
-      "uso_funzione": "Controllo preciso della profondità e del movimento verticale.",
-      "spinta_selettiva": "Vivere in un ambiente acquatico con forti correnti verticali.",
-      "debolezza": "Rischio di barotrauma se la pressione esterna cambia troppo rapidamente.",
+      "sinergie": [
+        "cartilagine_flessotermica_venti",
+        "respiro_a_scoppio",
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "sacche_galleggianti_ascensoriali"
-    },
-    "sacche_spore_stratosferiche": {
-      "label": "Sacche di Spore Stratosferiche",
-      "famiglia_tipologia": "Simbiotico/Supporto",
-      "fattore_mantenimento_energetico": "Alto (Coltura continua di spore portanti)",
-      "tier": "T3",
       "slot": [],
       "slot_profile": {
-        "complementare": "supporto",
-        "core": "simbiotico"
+        "complementare": "locomotorio",
+        "core": "idrostatico"
       },
-      "sinergie": [
-        "piume_solari_fotovoltaiche"
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "orbital-ascendant",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "sand-burrower",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "aurora-bridge-runner",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "echo-wing",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "orbita-psionica-inversa-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "zephyr-spore-courier",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Vivere in un ambiente acquatico con forti correnti verticali.",
+      "tier": "T1",
+      "uso_funzione": "Controllo preciso della profondità e del movimento verticale."
+    },
+    "sacche_spore_stratosferiche": {
       "conflitti": [
         "respiro_a_scoppio"
       ],
+      "debolezza": "Correnti ionizzate possono incendiare le sacche rendendo l'organismo instabile.",
+      "famiglia_tipologia": "Simbiotico/Supporto",
+      "fattore_mantenimento_energetico": "Alto (Coltura continua di spore portanti)",
+      "id": "sacche_spore_stratosferiche",
+      "label": "Sacche di Spore Stratosferiche",
+      "mutazione_indotta": "Vescicole dermiche che rilasciano spore portatrici capaci di galleggiare per chilometri.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6830,28 +9082,57 @@
           }
         }
       ],
-      "mutazione_indotta": "Vescicole dermiche che rilasciano spore portatrici capaci di galleggiare per chilometri.",
-      "uso_funzione": "Distribuisce simbionti di supporto e crea corridoi di movimento per la squadra.",
-      "spinta_selettiva": "Dispersone genetica rapida tra arcipelaghi aerei e piattaforme galleggianti.",
-      "debolezza": "Correnti ionizzate possono incendiare le sacche rendendo l'organismo instabile.",
+      "sinergie": [
+        "piume_solari_fotovoltaiche"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "sacche_spore_stratosferiche"
-    },
-    "sangue_piroforico": {
-      "label": "Sangue che prende fuoco a contatto con l'ossigeno",
-      "famiglia_tipologia": "Offensivo/Cinetico",
-      "fattore_mantenimento_energetico": "Medio (Sintesi dei composti)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "impatto",
-        "core": "offensivo"
+        "complementare": "supporto",
+        "core": "simbiotico"
       },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-portante-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Dispersone genetica rapida tra arcipelaghi aerei e piattaforme galleggianti.",
+      "tier": "T3",
+      "uso_funzione": "Distribuisce simbionti di supporto e crea corridoi di movimento per la squadra."
+    },
+    "sangue_piroforico": {
+      "conflitti": [
+        "criostasi_adattiva",
+        "scheletro_idro_regolante"
+      ],
+      "debolezza": "Rischio di auto-combustione in caso di ferita profonda in atmosfera ricca di ossigeno.",
+      "famiglia_tipologia": "Offensivo/Cinetico",
+      "fattore_mantenimento_energetico": "Medio (Sintesi dei composti)",
+      "id": "sangue_piroforico",
+      "label": "Sangue che prende fuoco a contatto con l'ossigeno",
+      "mutazione_indotta": "Presenza di composti piroforici nel sangue.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+          }
+        }
+      ],
       "sinergie": [
         "antenne_flusso_mareale",
         "artigli_induzione",
@@ -6868,10 +9149,62 @@
         "lamelle_termoforetiche",
         "mantelli_geotermici"
       ],
-      "conflitti": [
-        "criostasi_adattiva",
-        "scheletro_idro_regolante"
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "impatto",
+        "core": "offensivo"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "ferrocolonia-magnetotattica",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "nano-rust-bloom",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thaw-rot",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Difesa contro predatori che tentano di estrarre fluidi corporei.",
+      "tier": "T1",
+      "uso_funzione": "Meccanismo di difesa termico o chimico che si attiva con l'aria."
+    },
+    "scheletro_idro_regolante": {
+      "conflitti": [
+        "sangue_piroforico"
+      ],
+      "debolezza": "Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio.",
+      "famiglia_tipologia": "Strutturale/Omeostatico",
+      "fattore_mantenimento_energetico": "Medio (Scambio rapido di fluidi)",
+      "id": "scheletro_idro_regolante",
+      "label": "Scheletro Idro-Regolante",
+      "mutazione_indotta": "Struttura ossea porosa capace di scambio rapido di fluidi.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6885,28 +9218,6 @@
           }
         }
       ],
-      "mutazione_indotta": "Presenza di composti piroforici nel sangue.",
-      "uso_funzione": "Meccanismo di difesa termico o chimico che si attiva con l'aria.",
-      "spinta_selettiva": "Difesa contro predatori che tentano di estrarre fluidi corporei.",
-      "debolezza": "Rischio di auto-combustione in caso di ferita profonda in atmosfera ricca di ossigeno.",
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "id": "sangue_piroforico"
-    },
-    "scheletro_idro_regolante": {
-      "label": "Scheletro Idro-Regolante",
-      "famiglia_tipologia": "Strutturale/Omeostatico",
-      "fattore_mantenimento_energetico": "Medio (Scambio rapido di fluidi)",
-      "tier": "T1",
-      "slot": [],
-      "slot_profile": {
-        "complementare": "omeostatico",
-        "core": "strutturale"
-      },
       "sinergie": [
         "antenne_tesla",
         "artigli_vetrificati",
@@ -6925,9 +9236,108 @@
         "sacche_galleggianti_ascensoriali",
         "struttura_elastica_amorfa"
       ],
-      "conflitti": [
-        "sangue_piroforico"
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "omeostatico",
+        "core": "strutturale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "dune-stalker",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "magneto-ridge-hunter",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "nano-rust-bloom",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "sand-burrower",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "slag-veil-ambusher",
+          "weight": 2
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "magnet-fathom-surveyor",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "rust-scavenger",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-bison-mini",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Alternare vita terrestre e vita acquatica/aerea.",
+      "tier": "T1",
+      "uso_funzione": "Assorbire o espellere rapidamente acqua dai tessuti ossei per modificare il peso."
+    },
+    "secrezione_rallentante_palmi": {
+      "conflitti": [
+        "carapace_fase_variabile",
+        "nucleo_ovomotore_rotante"
+      ],
+      "debolezza": "Esaurimento rapido delle riserve di liquido con tempo di ricarica prolungato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Produzione del liquido)",
+      "id": "secrezione_rallentante_palmi",
+      "label": "Mani secernano liquido rallentante",
+      "mutazione_indotta": "Ghiandole mucose modificate sulle superfici prensili.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6941,73 +9351,47 @@
           }
         }
       ],
-      "mutazione_indotta": "Struttura ossea porosa capace di scambio rapido di fluidi.",
-      "uso_funzione": "Assorbire o espellere rapidamente acqua dai tessuti ossei per modificare il peso.",
-      "spinta_selettiva": "Alternare vita terrestre e vita acquatica/aerea.",
-      "debolezza": "Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio.",
+      "sinergie": [],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "scheletro_idro_regolante"
-    },
-    "secrezione_rallentante_palmi": {
-      "label": "Mani secernano liquido rallentante",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Medio (Produzione del liquido)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
         "complementare": "difensivo",
         "core": "tegumentario"
       },
-      "sinergie": [],
-      "conflitti": [
-        "carapace_fase_variabile",
-        "nucleo_ovomotore_rotante"
-      ],
-      "requisiti_ambientali": [
+      "species_affinity": [
         {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
-          }
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "ferrocolonia-magnetotattica",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
         }
       ],
-      "mutazione_indotta": "Ghiandole mucose modificate sulle superfici prensili.",
-      "uso_funzione": "Neutralizzare o immobilizzare prede/nemici.",
       "spinta_selettiva": "Cattura di prede veloci o difesa da aggressori corpo a corpo.",
-      "debolezza": "Esaurimento rapido delle riserve di liquido con tempo di ricarica prolungato.",
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "id": "secrezione_rallentante_palmi"
+      "tier": "T1",
+      "uso_funzione": "Neutralizzare o immobilizzare prede/nemici."
     },
     "sensori_geomagnetici": {
-      "label": "Sensori Geomagnetici",
+      "conflitti": [],
+      "debolezza": "Tempeste solari possono saturare il segnale magnetico, causando disorientamento prolungato.",
       "famiglia_tipologia": "Sensoriale/Navigazione",
       "fattore_mantenimento_energetico": "Basso (Ricettori passivi)",
-      "tier": "T1",
-      "slot": [],
-      "slot_profile": {
-        "complementare": "navigazione",
-        "core": "sensoriale"
-      },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "eco_interno_riflesso"
-      ],
-      "conflitti": [],
+      "id": "sensori_geomagnetici",
+      "label": "Sensori Geomagnetici",
+      "mutazione_indotta": "Cristalli ferromagnetici allineati lungo il cranio che fungono da bussola psionica.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -7021,28 +9405,78 @@
           }
         }
       ],
-      "mutazione_indotta": "Cristalli ferromagnetici allineati lungo il cranio che fungono da bussola psionica.",
-      "uso_funzione": "Traccia linee di campo e memorizza corridoi magnetici per la migrazione.",
-      "spinta_selettiva": "Orientarsi in steppe polarizzate e tunnel sotterranei privi di riferimenti visivi.",
-      "debolezza": "Tempeste solari possono saturare il segnale magnetico, causando disorientamento prolungato.",
+      "sinergie": [
+        "carapace_fase_variabile",
+        "eco_interno_riflesso"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "sensori_geomagnetici"
-    },
-    "sinapsi_coraline_polifoniche": {
-      "label": "Sinapsi Coraline Polifoniche",
-      "famiglia_tipologia": "Simbiotico/Comunicazione",
-      "fattore_mantenimento_energetico": "Medio (Scambio continuo di impulsi corallini)",
-      "tier": "T2",
       "slot": [],
       "slot_profile": {
-        "complementare": "comunicazione",
-        "core": "simbiotico"
+        "complementare": "navigazione",
+        "core": "sensoriale"
       },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianure-magnetiche-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Orientarsi in steppe polarizzate e tunnel sotterranei privi di riferimenti visivi.",
+      "tier": "T1",
+      "uso_funzione": "Traccia linee di campo e memorizza corridoi magnetici per la migrazione."
+    },
+    "sinapsi_coraline_polifoniche": {
+      "conflitti": [
+        "spore_psichiche_silenziate"
+      ],
+      "debolezza": "Vibrazioni sintonizzate male possono generare feedback dolorosi e perdita di coscienza.",
+      "famiglia_tipologia": "Simbiotico/Comunicazione",
+      "fattore_mantenimento_energetico": "Medio (Scambio continuo di impulsi corallini)",
+      "id": "sinapsi_coraline_polifoniche",
+      "label": "Sinapsi Coraline Polifoniche",
+      "mutazione_indotta": "Fibre nervose intrecciate con coralli sonori che trasmettono ordini tramite armoniche.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "barriere_coralline_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Scogliere viventi che rispondono a canti psionici e onde sonore."
+          }
+        }
+      ],
       "sinergie": [
         "ali_fulminee",
         "antenne_plasmatiche_tempesta",
@@ -7061,49 +9495,104 @@
         "lamine_scudo_silice",
         "midollo_antivibrazione"
       ],
-      "conflitti": [
-        "spore_psichiche_silenziate"
-      ],
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "barriere_coralline_psioniche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Scogliere viventi che rispondono a canti psionici e onde sonore."
-          }
-        }
-      ],
-      "mutazione_indotta": "Fibre nervose intrecciate con coralli sonori che trasmettono ordini tramite armoniche.",
-      "uso_funzione": "Trasmette comandi e pattern tattici sfruttando armoniche subacquee.",
-      "spinta_selettiva": "Coordinare banchi e alleati in ambienti tridimensionali complessi.",
-      "debolezza": "Vibrazioni sintonizzate male possono generare feedback dolorosi e perdita di coscienza.",
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "sinapsi_coraline_polifoniche"
+      "slot": [],
+      "slot_profile": {
+        "complementare": "comunicazione",
+        "core": "simbiotico"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "barriere-coralline-psioniche-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Coordinare banchi e alleati in ambienti tridimensionali complessi.",
+      "tier": "T2",
+      "uso_funzione": "Trasmette comandi e pattern tattici sfruttando armoniche subacquee."
     },
     "sonno_emisferico_alternato": {
-      "label": "Dormire con solo metà cervello alla volta",
+      "conflitti": [],
+      "debolezza": "Vulnerabilità a suoni/stimoli che colpiscono entrambi i lobi contemporaneamente.",
       "famiglia_tipologia": "Nervoso/Omeostatico",
       "fattore_mantenimento_energetico": "Medio (Mantenimento attivo di metà cervello)",
-      "tier": "T1",
+      "id": "sonno_emisferico_alternato",
+      "label": "Dormire con solo metà cervello alla volta",
+      "mutazione_indotta": "Encefalizzazione asimmetrica o due lobi cerebrali separati.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+          }
+        }
+      ],
+      "sinergie": [
+        "artigli_sghiaccio_glaciale",
+        "occhi_infrarosso_composti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
       "slot": [],
       "slot_profile": {
         "complementare": "omeostatico",
         "core": "nervoso"
       },
-      "sinergie": [
-        "artigli_sghiaccio_glaciale",
-        "occhi_infrarosso_composti"
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "echo-wing",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "aurora-gull",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        }
       ],
-      "conflitti": [],
+      "spinta_selettiva": "Monitoraggio costante dei predatori in ambienti ad alto rischio.",
+      "tier": "T1",
+      "uso_funzione": "Vigilanza continua pur garantendo riposo."
+    },
+    "spore_psichiche_silenziate": {
+      "conflitti": [
+        "respiro_a_scoppio"
+      ],
+      "debolezza": "Funzionalità ridotta in presenza di vento forte o umidità elevata.",
+      "famiglia_tipologia": "Escretorio/Psichico",
+      "fattore_mantenimento_energetico": "Alto (Produzione e rilascio)",
+      "id": "spore_psichiche_silenziate",
+      "label": "Spora Psichica Silenziosa",
+      "mutazione_indotta": "Pori che rilasciano nano-particelle attive chimicamente o psichicamente.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -7117,73 +9606,63 @@
           }
         }
       ],
-      "mutazione_indotta": "Encefalizzazione asimmetrica o due lobi cerebrali separati.",
-      "uso_funzione": "Vigilanza continua pur garantendo riposo.",
-      "spinta_selettiva": "Monitoraggio costante dei predatori in ambienti ad alto rischio.",
-      "debolezza": "Vulnerabilità a suoni/stimoli che colpiscono entrambi i lobi contemporaneamente.",
+      "sinergie": [],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "sonno_emisferico_alternato"
-    },
-    "spore_psichiche_silenziate": {
-      "label": "Spora Psichica Silenziosa",
-      "famiglia_tipologia": "Escretorio/Psichico",
-      "fattore_mantenimento_energetico": "Alto (Produzione e rilascio)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
         "complementare": "psichico",
         "core": "escretorio"
       },
-      "sinergie": [],
-      "conflitti": [
-        "respiro_a_scoppio"
-      ],
-      "requisiti_ambientali": [
+      "species_affinity": [
         {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
-          }
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "nano-rust-bloom",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "blight-micotico",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thaw-rot",
+          "weight": 1
         }
       ],
-      "mutazione_indotta": "Pori che rilasciano nano-particelle attive chimicamente o psichicamente.",
-      "uso_funzione": "Indurre uno stato di confusione o letargia negli individui vicini.",
       "spinta_selettiva": "Neutralizzare gruppi di prede o predatori senza impegnare in combattimento.",
-      "debolezza": "Funzionalità ridotta in presenza di vento forte o umidità elevata.",
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "id": "spore_psichiche_silenziate"
+      "tier": "T1",
+      "uso_funzione": "Indurre uno stato di confusione o letargia negli individui vicini."
     },
     "squame_rifrangenti_deserto": {
-      "label": "Squame Rifrangenti del Deserto",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Medio (Richiede riallineamento delle placche)",
-      "tier": "T2",
-      "slot": [],
-      "slot_profile": {
-        "complementare": "difensivo",
-        "core": "tegumentario"
-      },
-      "sinergie": [
-        "respiro_a_scoppio"
-      ],
       "conflitti": [
         "mimetismo_cromatico_passivo"
       ],
+      "debolezza": "Soffre danni da feedback termico se colpito da raggi concentrati o laser.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Richiede riallineamento delle placche)",
+      "id": "squame_rifrangenti_deserto",
+      "label": "Squame Rifrangenti del Deserto",
+      "mutazione_indotta": "Placche cristalline sovrapposte che deviano luce e calore lungo superfici multiple.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -7197,48 +9676,41 @@
           }
         }
       ],
-      "mutazione_indotta": "Placche cristalline sovrapposte che deviano luce e calore lungo superfici multiple.",
-      "uso_funzione": "Rifrange la luce generando miraggi e dissipando attacchi energetici.",
-      "spinta_selettiva": "Sopravvivere a intensi flare termici e accecanti miraggi desertici.",
-      "debolezza": "Soffre danni da feedback termico se colpito da raggi concentrati o laser.",
+      "sinergie": [
+        "respiro_a_scoppio"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "squame_rifrangenti_deserto"
-    },
-    "struttura_elastica_amorfa": {
-      "label": "Struttura elastica, allungabile, amorfa, retrattile",
-      "famiglia_tipologia": "Strutturale/Locomotorio",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "locomotorio",
-        "core": "strutturale"
+        "complementare": "difensivo",
+        "core": "tegumentario"
       },
-      "sinergie": [
-        "antenne_tesla",
-        "artigli_sette_vie",
-        "artigli_vetrificati",
-        "branchie_dual_mode",
-        "capillari_criogenici",
-        "cartilagini_pseudometalliche",
-        "cisti_iperbariche",
-        "cromofori_alert_acido",
-        "denti_tuning_fork",
-        "filamenti_magnetotrofi",
-        "ghiandole_condensa_ozono",
-        "ghiandole_nebbia_ionica",
-        "lamine_filtranti_aeree",
-        "membrane_pneumatofori",
-        "mimetismo_cromatico_passivo",
-        "sacche_galleggianti_ascensoriali",
-        "scheletro_idro_regolante"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dune-cristalline-trait-keeper",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Sopravvivere a intensi flare termici e accecanti miraggi desertici.",
+      "tier": "T2",
+      "uso_funzione": "Rifrange la luce generando miraggi e dissipando attacchi energetici."
+    },
+    "struttura_elastica_amorfa": {
       "conflitti": [],
+      "debolezza": "Vulnerabilità a danni da taglio o perforazione (difficile cauterizzazione).",
+      "famiglia_tipologia": "Strutturale/Locomotorio",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "struttura_elastica_amorfa",
+      "label": "Struttura elastica, allungabile, amorfa, retrattile",
+      "mutazione_indotta": "Tessuto con matrice di proteine elastiche iper-modificate.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -7265,30 +9737,118 @@
           }
         }
       ],
-      "mutazione_indotta": "Tessuto con matrice di proteine elastiche iper-modificate.",
-      "uso_funzione": "Flessibilità estrema e capacità di assumere forme diverse.",
-      "spinta_selettiva": "Fuga rapida da predatori in spazi confinati.",
-      "debolezza": "Vulnerabilità a danni da taglio o perforazione (difficile cauterizzazione).",
+      "sinergie": [
+        "antenne_tesla",
+        "artigli_sette_vie",
+        "artigli_vetrificati",
+        "branchie_dual_mode",
+        "capillari_criogenici",
+        "cartilagini_pseudometalliche",
+        "cisti_iperbariche",
+        "cromofori_alert_acido",
+        "denti_tuning_fork",
+        "filamenti_magnetotrofi",
+        "ghiandole_condensa_ozono",
+        "ghiandole_nebbia_ionica",
+        "lamine_filtranti_aeree",
+        "membrane_pneumatofori",
+        "mimetismo_cromatico_passivo",
+        "sacche_galleggianti_ascensoriali",
+        "scheletro_idro_regolante"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "struttura_elastica_amorfa"
+      "slot": [],
+      "slot_profile": {
+        "complementare": "locomotorio",
+        "core": "strutturale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "dune-stalker",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "magnet-fathom-surveyor",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "slag-veil-ambusher",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "magneto-ridge-hunter",
+          "weight": 2
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "glowcap-weaver",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "myco-spire-warden",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Fuga rapida da predatori in spazi confinati.",
+      "tier": "T1",
+      "uso_funzione": "Flessibilità estrema e capacità di assumere forme diverse."
     },
     "tattiche_di_branco": {
-      "label": "Tattiche di Branco",
+      "conflitti": [],
+      "debolezza": "Richiede formazione stabile; cala se la coesione precipita sotto il target.",
       "famiglia_tipologia": "Strategico/Tattico",
       "fattore_mantenimento_energetico": "Medio (Broadcast continuo di segnali)",
-      "tier": "T1",
-      "slot": [
-        "B"
-      ],
-      "slot_profile": {
-        "complementare": "coordinazione",
-        "core": "strategia"
-      },
+      "id": "tattiche_di_branco",
+      "label": "Tattiche di Branco",
+      "mutazione_indotta": "Canale condiviso per marcature e ingaggi simultanei.",
+      "requisiti_ambientali": [],
       "sinergie": [
         "antenne_microonde_cavernose",
         "artigli_radice",
@@ -7305,12 +9865,6 @@
         "lamelle_shear",
         "membrane_captura_rugiada"
       ],
-      "conflitti": [],
-      "requisiti_ambientali": [],
-      "mutazione_indotta": "Canale condiviso per marcature e ingaggi simultanei.",
-      "uso_funzione": "Coordina prese e focus bersaglio condividendo segnali di priorità.",
-      "spinta_selettiva": "Squadre che puntano a style bonus tramite assist e controllo spazio.",
-      "debolezza": "Richiede formazione stabile; cala se la coesione precipita sotto il target.",
       "sinergie_pi": {
         "co_occorrenze": [
           "PE",
@@ -7326,22 +9880,48 @@
         ],
         "tabelle_random": []
       },
-      "id": "tattiche_di_branco"
+      "slot": [
+        "B"
+      ],
+      "slot_profile": {
+        "complementare": "coordinazione",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "magneto-ridge-hunter",
+          "weight": 2
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "slag-veil-ambusher",
+          "weight": 2
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "lupus-temperatus",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Squadre che puntano a style bonus tramite assist e controllo spazio.",
+      "tier": "T1",
+      "uso_funzione": "Coordina prese e focus bersaglio condividendo segnali di priorità."
     },
     "vello_condensatore_nebbie": {
-      "label": "Vello Condensatore di Nebbie",
+      "conflitti": [],
+      "debolezza": "In ambienti aridi accumula detriti che riducono la capacità di condensa.",
       "famiglia_tipologia": "Tegumentario/Idratazione",
       "fattore_mantenimento_energetico": "Basso (Strutture passive a microfilo)",
-      "tier": "T1",
-      "slot": [],
-      "slot_profile": {
-        "complementare": "idratazione",
-        "core": "tegumentario"
-      },
-      "sinergie": [
-        "bulbi_radici_permafrost"
-      ],
-      "conflitti": [],
+      "id": "vello_condensatore_nebbie",
+      "label": "Vello Condensatore di Nebbie",
+      "mutazione_indotta": "Peli cavi microstriati che catturano e canalizzano la bruma atmosferica.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -7355,28 +9935,54 @@
           }
         }
       ],
-      "mutazione_indotta": "Peli cavi microstriati che catturano e canalizzano la bruma atmosferica.",
-      "uso_funzione": "Condensa acqua atmosferica per supportare abilità metaboliche ad alto consumo.",
-      "spinta_selettiva": "Garantire idratazione in climi montani dove l'acqua liquida è scarsa ma la nebbia abbondante.",
-      "debolezza": "In ambienti aridi accumula detriti che riducono la capacità di condensa.",
+      "sinergie": [
+        "bulbi_radici_permafrost"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "vello_condensatore_nebbie"
-    },
-    "ventriglio_gastroliti": {
-      "label": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
-      "famiglia_tipologia": "Digestivo/Alimentare",
-      "fattore_mantenimento_energetico": "Medio (Contrazione muscolare costante)",
-      "tier": "T1",
       "slot": [],
       "slot_profile": {
-        "complementare": "alimentare",
-        "core": "digestivo"
+        "complementare": "idratazione",
+        "core": "tegumentario"
       },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foreste-nubose-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Garantire idratazione in climi montani dove l'acqua liquida è scarsa ma la nebbia abbondante.",
+      "tier": "T1",
+      "uso_funzione": "Condensa acqua atmosferica per supportare abilità metaboliche ad alto consumo."
+    },
+    "ventriglio_gastroliti": {
+      "conflitti": [],
+      "debolezza": "Usura e rottura del ventriglio se i gastroliti sono esauriti o troppo lisci.",
+      "famiglia_tipologia": "Digestivo/Alimentare",
+      "fattore_mantenimento_energetico": "Medio (Contrazione muscolare costante)",
+      "id": "ventriglio_gastroliti",
+      "label": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
+      "mutazione_indotta": "Sviluppo di un organo muscolare (ventriglio) con gastroliti.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+          }
+        }
+      ],
       "sinergie": [
         "antenne_dustsense",
         "appendici_thermotattiche",
@@ -7393,45 +9999,61 @@
         "grassi_termici",
         "luminescenza_aurorale"
       ],
-      "conflitti": [],
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
-          }
-        }
-      ],
-      "mutazione_indotta": "Sviluppo di un organo muscolare (ventriglio) con gastroliti.",
-      "uso_funzione": "Macinazione di cibo duro all'interno di un ventriglio.",
-      "spinta_selettiva": "Dieta basata su semi, conchiglie o insetti corazzati.",
-      "debolezza": "Usura e rottura del ventriglio se i gastroliti sono esauriti o troppo lisci.",
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "ventriglio_gastroliti"
+      "slot": [],
+      "slot_profile": {
+        "complementare": "alimentare",
+        "core": "digestivo"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "rust-scavenger",
+          "weight": 4
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "ferrocolonia-magnetotattica",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-bison-mini",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Dieta basata su semi, conchiglie o insetti corazzati.",
+      "tier": "T1",
+      "uso_funzione": "Macinazione di cibo duro all'interno di un ventriglio."
     },
     "zampe_a_molla": {
-      "label": "Zampe a Molla",
+      "conflitti": [],
+      "debolezza": "Perdita di valore su mappe con spazi stretti o controllo setup elevato.",
       "famiglia_tipologia": "Mobilità/Cinetico",
       "fattore_mantenimento_energetico": "Basso (Carica elastica a turni alterni)",
-      "tier": "T1",
-      "slot": [
-        "A",
-        "B"
-      ],
-      "slot_profile": {
-        "complementare": "propulsione",
-        "core": "locomotorio"
-      },
+      "id": "zampe_a_molla",
+      "label": "Zampe a Molla",
+      "mutazione_indotta": "Arti potenziati con ammortizzatori ad alta compressione.",
+      "requisiti_ambientali": [],
       "sinergie": [
         "ali_ioniche",
         "antenne_wideband",
@@ -7449,12 +10071,6 @@
         "linfa_tampone",
         "mucose_aderenza_sonica"
       ],
-      "conflitti": [],
-      "requisiti_ambientali": [],
-      "mutazione_indotta": "Arti potenziati con ammortizzatori ad alta compressione.",
-      "uso_funzione": "Dash esplosivi per mantenere il ritmo di ingaggio o disimpegno.",
-      "spinta_selettiva": "Metagame con forte pressione di aggro e necessità di riposizionamento.",
-      "debolezza": "Perdita di valore su mappe con spazi stretti o controllo setup elevato.",
       "sinergie_pi": {
         "co_occorrenze": [
           "cap_pt",
@@ -7468,24 +10084,37 @@
         ],
         "tabelle_random": []
       },
-      "id": "zampe_a_molla"
-    },
-    "zoccoli_risonanti_steppe": {
-      "label": "Zoccoli Risonanti delle Steppe",
-      "famiglia_tipologia": "Locomotorio/Supporto",
-      "fattore_mantenimento_energetico": "Basso (Vibrazione passiva del suolo)",
-      "tier": "T1",
-      "slot": [],
+      "slot": [
+        "A",
+        "B"
+      ],
       "slot_profile": {
-        "complementare": "supporto",
+        "complementare": "propulsione",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "cartilagine_flessotermica_venti"
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sand-burrower",
+          "weight": 1
+        }
       ],
+      "spinta_selettiva": "Metagame con forte pressione di aggro e necessità di riposizionamento.",
+      "tier": "T1",
+      "uso_funzione": "Dash esplosivi per mantenere il ritmo di ingaggio o disimpegno."
+    },
+    "zoccoli_risonanti_steppe": {
       "conflitti": [
         "zampe_a_molla"
       ],
+      "debolezza": "Suoli cedevoli come sabbie mobili annullano la vibrazione e riducono la trazione.",
+      "famiglia_tipologia": "Locomotorio/Supporto",
+      "fattore_mantenimento_energetico": "Basso (Vibrazione passiva del suolo)",
+      "id": "zoccoli_risonanti_steppe",
+      "label": "Zoccoli Risonanti delle Steppe",
+      "mutazione_indotta": "Placche cornee cave che emettono onde sismiche ritmiche al contatto con il terreno.",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -7499,17 +10128,32 @@
           }
         }
       ],
-      "mutazione_indotta": "Placche cornee cave che emettono onde sismiche ritmiche al contatto con il terreno.",
-      "uso_funzione": "Propaga segnali ritmici che sincronizzano movimenti e abilità di squadra.",
-      "spinta_selettiva": "Mantenere coesione di branchi su grandi distanze e rilevare predatori sotterranei.",
-      "debolezza": "Suoli cedevoli come sabbie mobili annullano la vibrazione e riducono la trazione.",
+      "sinergie": [
+        "cartilagine_flessotermica_venti"
+      ],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
-      "id": "zoccoli_risonanti_steppe"
+      "slot": [],
+      "slot_profile": {
+        "complementare": "supporto",
+        "core": "locomotorio"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-risonanti-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Mantenere coesione di branchi su grandi distanze e rilevare predatori sotterranei.",
+      "tier": "T1",
+      "uso_funzione": "Propaga segnali ritmici che sincronizzano movimenti e abilità di squadra."
     }
   },
   "types": {

--- a/data/traits/species_affinity.json
+++ b/data/traits/species_affinity.json
@@ -1,0 +1,3353 @@
+{
+  "adattamento_volo": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "archon-solare",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "balor-fission",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "banshee-risonante",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "couatl-aurora",
+      "weight": 3
+    }
+  ],
+  "ali_fulminee": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ali_ioniche": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-ionica-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ali_membrana_sonica": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ali_solari_fotoni": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "archon-solare",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "couatl-aurora",
+      "weight": 1
+    }
+  ],
+  "antenne_dustsense": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "antenne_eco_turbina": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "antenne_flusso_mareale": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "laguna-bioreattiva-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "antenne_microonde_cavernose": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "antenne_plasmatiche_tempesta": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "cicloni-psionici-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "antenne_reagenti": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "foresta-acida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "antenne_tesla": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-ionica-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "antenne_waveguide": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "reef-luminescente-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "antenne_wideband": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "steppe-algoritmiche-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "appendici_risonanti_marea": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "laguna-bioreattiva-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "appendici_thermotattiche": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "armatura_pietra_planare": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "golem-runico",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "balor-fission",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "bulette-fase",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "treant-portale",
+      "weight": 1
+    }
+  ],
+  "artigli_acidofagi": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "foresta-acida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "artigli_induzione": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-ionica-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "artigli_psionici": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "rakshasa-corte",
+      "weight": 1
+    }
+  ],
+  "artigli_radice": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "mangrovieto-cinetico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "artigli_scivolo_silente": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "artigli_sette_vie": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "dune-stalker",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "magneto-ridge-hunter",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "balor-fission",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "couatl-aurora",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "cryo-lynx",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "marilith-vault",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "otyugh-sentinella",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "resonant-claw-hunter",
+      "weight": 1
+    }
+  ],
+  "artigli_sghiaccio_glaciale": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "calotte-glaciali-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "artigli_vetrificati": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caldera-glaciale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "assenza_respirazione": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "banshee-risonante",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "golem-runico",
+      "weight": 3
+    }
+  ],
+  "aura_scudo_radianza": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "archon-solare",
+      "weight": 4
+    }
+  ],
+  "baffi_mareomotori": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "mangrovieto-cinetico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "barbigli_sensori_plasma": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "barriere_miasma_glaciale": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caldera-glaciale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "batteri_endosimbionti_chemio": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "batteri_termofili_endosimbiosi": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "biochip_memoria": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "steppe-algoritmiche-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "biofilm_glow": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "reef-luminescente-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "biofilm_iperarido": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "branchie_dual_mode": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "laguna-bioreattiva-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "branchie_eoliche": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "branchie_metalloidi": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "branchie_microfiltri": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "reef-luminescente-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "branchie_osmotiche_salmastra": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "delta-salmastri-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "branchie_solfatiche": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caldera-glaciale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "branchie_turbina": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "bulbi_radici_permafrost": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "permafrost-psionico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "camere_anticorrosione": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "foresta-acida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "camere_mirage": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "camere_nutrienti_vent": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "capillari_criogenici": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caldera-glaciale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "capillari_fluoridici": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "foresta-acida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "capillari_fotovoltaici": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-ionica-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "capsule_paracadute": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "carapace_fase_variabile": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "balor-fission",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "bulette-fase",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-psionica-leggera-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "cryo-lynx",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "falde-magnetiche-psioniche-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "golem-runico",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "nano-rust-bloom",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "otyugh-sentinella",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "sand-burrower",
+      "weight": 1
+    }
+  ],
+  "carapace_luminiscente_abissale": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "abisso-luminescente-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "carapace_segmenti_logici": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "steppe-algoritmiche-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "carapaci_ferruginosi": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "cartilagine_flessotermica_venti": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "gole-ventose-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "cartilagini_biofibre": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "reef-luminescente-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "cartilagini_desertiche": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "cartilagini_flessoacustiche": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "cartilagini_pseudometalliche": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "cavita_risonanti_tundra": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "tundra-risonante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "cervelletto_equilibrio_statico": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-ionica-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "chemiorecettori_bromuro": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "chioma_parassita_canopica": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopie-sospese-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ciclo_vitale_anomalo": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "banshee-risonante",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "golem-runico",
+      "weight": 3
+    }
+  ],
+  "ciclo_vitale_completo": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "archon-solare",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "balor-fission",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "bulette-fase",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "couatl-aurora",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "marilith-vault",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "otyugh-sentinella",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "rakshasa-corte",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "treant-portale",
+      "weight": 3
+    }
+  ],
+  "circolazione_bifasica": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caldera-glaciale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "circolazione_bifasica_palude": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "paludi-gas-luminescenti-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "circolazione_cooling_loop": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "steppe-algoritmiche-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "circolazione_doppia": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "circolazione_supercritica": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ciste_riduttive": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "laguna-bioreattiva-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ciste_salmastre": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "cisti_iperbariche": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "coda_balanciere": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "coda_contrappeso": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "mangrovieto-cinetico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "coda_coppia_retroattiva": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "steppe-algoritmiche-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "coda_frusta_cinetica": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "dune-stalker",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "magneto-ridge-hunter",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "slag-veil-ambusher",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "bulette-fase",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "falde-magnetiche-psioniche-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "marilith-vault",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "orbita-psionica-inversa-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "coda_stabilizzatrice_filo": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-ionica-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "coda_stabilizzatrice_geiser": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "coda_stabilizzatrice_vortex": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "colonne_vibromagnetiche": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "coralli_partner": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "reef-luminescente-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "corteccia_memetica": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "treant-portale",
+      "weight": 1
+    }
+  ],
+  "criostasi_adattiva": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "aurora-gull",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-psionica-leggera-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "orbita-psionica-inversa-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "orbital-ascendant",
+      "weight": 1
+    }
+  ],
+  "cromofori_alert_acido": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "foresta-acida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "cuore_multicamera_bassa_pressione": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "cuscinetti_elettrostatici": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "cute_resistente_sali": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "evento-tempesta-ferrosa",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "badlands-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "global-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "cuticole_cerose": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "cactus-weaver",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "evento-brinastorm",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "evento-ondata-termica",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "global-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "noctule-termico",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "silica-bloom",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "thermo-raptor",
+      "weight": 1
+    }
+  ],
+  "cuticole_neutralizzanti": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "foresta-acida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "denti_chelatanti": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "foresta-acida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "denti_ossidoferro": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "denti_silice_termici": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "denti_tuning_fork": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "echi_risonanti": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "eco_interno_riflesso": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "echo-wing",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "aurora-bridge-runner",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "aurora-gull",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-psionica-leggera-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "falde-magnetiche-psioniche-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "orbital-ascendant",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "zephyr-spore-courier",
+      "weight": 1
+    }
+  ],
+  "eco_sismico": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "banshee-risonante",
+      "weight": 1
+    }
+  ],
+  "empatia_coordinativa": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "archon-solare",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "balor-fission",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "couatl-aurora",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "glowcap-weaver",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "lupus-temperatus",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "marilith-vault",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "myco-spire-warden",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "rakshasa-corte",
+      "weight": 1
+    }
+  ],
+  "enzimi_antifase_termica": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caldera-glaciale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "enzimi_antipredatori_algali": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "reef-luminescente-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "enzimi_chelanti": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "evento-tempesta-ferrosa",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "global-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "enzimi_chelatori_rapidi": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "foresta-acida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "enzimi_metanoossidanti": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "epidermide_dielettrica": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "epitelio_fosforescente": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "reef-luminescente-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "filamenti_digestivi_compattanti": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "magnet-fathom-surveyor",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "nano-rust-bloom",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "rust-scavenger",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "falde-magnetiche-psioniche-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "glowcap-weaver",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "myco-spire-warden",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "thaw-rot",
+      "weight": 1
+    }
+  ],
+  "filamenti_magnetotrofi": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "filamenti_superconduttivi": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caldera-glaciale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "filamenti_termoconduzione": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "filtri_bioattivi": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "otyugh-sentinella",
+      "weight": 1
+    }
+  ],
+  "filtri_planctonici": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "laguna-bioreattiva-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "fisiologia_predatoria": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "bulette-fase",
+      "weight": 3
+    }
+  ],
+  "flagelli_ancoranti": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "laguna-bioreattiva-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "focus_frazionato": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "orbital-ascendant",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "psionic-canopy-scout",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "marilith-vault",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "synergy"
+      ],
+      "species_id": "archon-solare",
+      "weight": 2
+    },
+    {
+      "roles": [
+        "synergy"
+      ],
+      "species_id": "balor-fission",
+      "weight": 2
+    },
+    {
+      "roles": [
+        "synergy"
+      ],
+      "species_id": "banshee-risonante",
+      "weight": 2
+    },
+    {
+      "roles": [
+        "synergy"
+      ],
+      "species_id": "couatl-aurora",
+      "weight": 2
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "sentinella-radice",
+      "weight": 1
+    }
+  ],
+  "foliage_fotocatodico": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "foresta-acida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "foliaggio_spugna": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "mangrovieto-cinetico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "frusta_fiammeggiante": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "balor-fission",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "marilith-vault",
+      "weight": 3
+    }
+  ],
+  "ghiaccio_piezoelettrico": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caldera-glaciale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ghiandola_caustica": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "blight-micotico",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "slag-veil-ambusher",
+      "weight": 1
+    }
+  ],
+  "ghiandole_cambio_salino": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "laguna-bioreattiva-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ghiandole_condensa_ozono": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ghiandole_eco_mappanti": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ghiandole_fango_calde": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ghiandole_fango_coesivo": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "mangrovieto-cinetico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ghiandole_grafene": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "steppe-algoritmiche-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ghiandole_inchiostro_luce": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "reef-luminescente-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ghiandole_iodoattive": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ghiandole_minerali": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ghiandole_nebbia_acida": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "foresta-acida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ghiandole_nebbia_ionica": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-ionica-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ghiandole_nettare_memetico": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "couatl-aurora",
+      "weight": 1
+    }
+  ],
+  "ghiandole_resina_conduttiva": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-ionica-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ghiandole_ventosa": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caldera-glaciale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "giunti_antitorsione": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "mangrovieto-cinetico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "grassi_termici": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "cactus-weaver",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "evento-brinastorm",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "evento-ondata-termica",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "global-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "noctule-termico",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "silica-bloom",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "thermo-raptor",
+      "weight": 1
+    }
+  ],
+  "gusci_criovetro": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caldera-glaciale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "gusci_magnesio": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "intangibilita_parziale": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "banshee-risonante",
+      "weight": 1
+    }
+  ],
+  "lamelle_shear": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "lamelle_sincroniche": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "steppe-algoritmiche-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "lamelle_termoforetiche": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "bulette-fase",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "couatl-aurora",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "magnet-fathom-surveyor",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "otyugh-sentinella",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "sorgenti-geotermiche-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "lamenti_diradanti": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "banshee-risonante",
+      "weight": 1
+    }
+  ],
+  "lamine_filtranti_aeree": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "mangrovieto-cinetico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "lamine_scudo_silice": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "linfa_tampone": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "foresta-acida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "lingua_cristallina": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "lingua_tattile_trama": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "blight-micotico",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "echo-wing",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "ferrocolonia-magnetotattica",
+      "weight": 1
+    }
+  ],
+  "luminescenza_aurorale": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caldera-glaciale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "luminescenza_hydrotermica": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "mantelli_geotermici": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caldera-glaciale-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "mantello_meteoritico": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "balor-fission",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "marilith-vault",
+      "weight": 3
+    }
+  ],
+  "maschera_illusoria": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "rakshasa-corte",
+      "weight": 1
+    }
+  ],
+  "matrice_antimagia": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "golem-runico",
+      "weight": 1
+    }
+  ],
+  "membrane_captura_rugiada": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "membrane_eliofiltranti": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "laghi-alcalini-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "membrane_osmotiche": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "otyugh-sentinella",
+      "weight": 1
+    }
+  ],
+  "membrane_planata_vectored": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-ionica-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "membrane_pneumatofori": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "mangrovieto-cinetico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "metabolismo_attivo": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "archon-solare",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "balor-fission",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "bulette-fase",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "couatl-aurora",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "marilith-vault",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "otyugh-sentinella",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "rakshasa-corte",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "treant-portale",
+      "weight": 3
+    }
+  ],
+  "metabolismo_sostentato": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "banshee-risonante",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "golem-runico",
+      "weight": 3
+    }
+  ],
+  "midollo_antivibrazione": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "mimetismo_cromatico_passivo": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "ferrocolonia-magnetotattica",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "psionic-canopy-scout",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "aurora-bridge-runner",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-psionica-leggera-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "falde-magnetiche-psioniche-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "zephyr-spore-courier",
+      "weight": 1
+    }
+  ],
+  "mucillagine_simbionte_mangrovie": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "mangrovie-risonanti-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "mucose_aderenza_sonica": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "mucose_barofile": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "nodi_micorrizici_oracolari": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "reti-micorriziche-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "nuclei_di_controllo": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "golem-runico",
+      "weight": 1
+    }
+  ],
+  "nucleo_ovomotore_rotante": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "magnet-fathom-surveyor",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "orbital-ascendant",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "sand-burrower",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "rust-scavenger",
+      "weight": 1
+    }
+  ],
+  "occhi_infrarosso_composti": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "echo-wing",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "olfatto_risonanza_magnetica": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "magnet-fathom-surveyor",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "orbital-ascendant",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "slag-veil-ambusher",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "cryo-lynx",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "dune-stalker",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "falde-magnetiche-psioniche-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "magneto-ridge-hunter",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "orbita-psionica-inversa-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "psionic-canopy-scout",
+      "weight": 1
+    }
+  ],
+  "origine_artificiale": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "banshee-risonante",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "golem-runico",
+      "weight": 3
+    }
+  ],
+  "pathfinder": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "sentinella-radice",
+      "weight": 1
+    }
+  ],
+  "pelli_anti_ustione": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "evento-tempesta-ferrosa",
+      "weight": 4
+    }
+  ],
+  "pelli_cave": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "cactus-weaver",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "evento-brinastorm",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "evento-ondata-termica",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "global-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "noctule-termico",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "silica-bloom",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "thermo-raptor",
+      "weight": 1
+    }
+  ],
+  "pelli_fitte": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "evento-seme-uragano",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "global-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "pianificatore": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "sentinella-radice",
+      "weight": 1
+    }
+  ],
+  "pigmenti_aurorali": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "cactus-weaver",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "evento-brinastorm",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "evento-ondata-termica",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "global-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "noctule-termico",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "silica-bloom",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "thermo-raptor",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "treant-portale",
+      "weight": 1
+    }
+  ],
+  "pigmenti_termici": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "evento-tempesta-ferrosa",
+      "weight": 4
+    }
+  ],
+  "piume_solari_fotovoltaiche": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "altipiani-solari-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "polmoni_cristallini_alta_quota": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "picchi-cristallini-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "proboscide_polifaga": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "otyugh-sentinella",
+      "weight": 1
+    }
+  ],
+  "proteine_shock_termico": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "cactus-weaver",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "evento-brinastorm",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "evento-ondata-termica",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "global-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "noctule-termico",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "silica-bloom",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "thermo-raptor",
+      "weight": 1
+    }
+  ],
+  "radici_ancora_planare": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "treant-portale",
+      "weight": 1
+    }
+  ],
+  "respirazione_biologica": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "archon-solare",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "balor-fission",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "bulette-fase",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "couatl-aurora",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "marilith-vault",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "otyugh-sentinella",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "rakshasa-corte",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "treant-portale",
+      "weight": 3
+    }
+  ],
+  "respiro_a_scoppio": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "rust-scavenger",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "dune-stalker",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "magneto-ridge-hunter",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "slag-veil-ambusher",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "steppe-bison-mini",
+      "weight": 1
+    }
+  ],
+  "reti_capillari_radici": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "cactus-weaver",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "evento-brinastorm",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "evento-ondata-termica",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "global-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "noctule-termico",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "silica-bloom",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "thermo-raptor",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "treant-portale",
+      "weight": 1
+    }
+  ],
+  "risonanza_di_branco": [
+    {
+      "roles": [
+        "optional",
+        "synergy"
+      ],
+      "species_id": "archon-solare",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "banshee-risonante",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "synergy"
+      ],
+      "species_id": "couatl-aurora",
+      "weight": 2
+    },
+    {
+      "roles": [
+        "synergy"
+      ],
+      "species_id": "rakshasa-corte",
+      "weight": 2
+    },
+    {
+      "roles": [
+        "synergy"
+      ],
+      "species_id": "treant-portale",
+      "weight": 2
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "lupus-temperatus",
+      "weight": 1
+    }
+  ],
+  "sacche_galleggianti_ascensoriali": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "orbital-ascendant",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "psionic-canopy-scout",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "sand-burrower",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "aurora-bridge-runner",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-psionica-leggera-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "echo-wing",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "orbita-psionica-inversa-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "zephyr-spore-courier",
+      "weight": 1
+    }
+  ],
+  "sacche_spore_stratosferiche": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "stratosfera-portante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "sangue_piroforico": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "ferrocolonia-magnetotattica",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "nano-rust-bloom",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "thaw-rot",
+      "weight": 1
+    }
+  ],
+  "scheletro_idro_regolante": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "dune-stalker",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "magneto-ridge-hunter",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "nano-rust-bloom",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "sand-burrower",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "synergy"
+      ],
+      "species_id": "slag-veil-ambusher",
+      "weight": 2
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "bulette-fase",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "magnet-fathom-surveyor",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "rust-scavenger",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "steppe-bison-mini",
+      "weight": 1
+    }
+  ],
+  "secrezione_rallentante_palmi": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "ferrocolonia-magnetotattica",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "sensori_chimici": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "otyugh-sentinella",
+      "weight": 1
+    }
+  ],
+  "sensori_geomagnetici": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "bulette-fase",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "couatl-aurora",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "marilith-vault",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "pianure-magnetiche-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "sinapsi_coraline_polifoniche": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "barriere-coralline-psioniche-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "sonno_emisferico_alternato": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "echo-wing",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "aurora-gull",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "spore_psichiche_silenziate": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "nano-rust-bloom",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "blight-micotico",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "thaw-rot",
+      "weight": 1
+    }
+  ],
+  "squame_rifrangenti_deserto": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "dune-cristalline-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "struttura_elastica_amorfa": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "dune-stalker",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "magnet-fathom-surveyor",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "psionic-canopy-scout",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "slag-veil-ambusher",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "synergy"
+      ],
+      "species_id": "magneto-ridge-hunter",
+      "weight": 2
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-psionica-leggera-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "falde-magnetiche-psioniche-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "glowcap-weaver",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "myco-spire-warden",
+      "weight": 1
+    }
+  ],
+  "tattiche_di_branco": [
+    {
+      "roles": [
+        "synergy"
+      ],
+      "species_id": "magneto-ridge-hunter",
+      "weight": 2
+    },
+    {
+      "roles": [
+        "synergy"
+      ],
+      "species_id": "slag-veil-ambusher",
+      "weight": 2
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "lupus-temperatus",
+      "weight": 1
+    }
+  ],
+  "tessuti_adattivi": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "rakshasa-corte",
+      "weight": 1
+    }
+  ],
+  "vello_condensatore_nebbie": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "foreste-nubose-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "ventriglio_gastroliti": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "rust-scavenger",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "ferrocolonia-magnetotattica",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "steppe-bison-mini",
+      "weight": 1
+    }
+  ],
+  "visione_spettrale": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "archon-solare",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "marilith-vault",
+      "weight": 1
+    }
+  ],
+  "voce_spettrale": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "banshee-risonante",
+      "weight": 1
+    }
+  ],
+  "zampe_a_molla": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "sand-burrower",
+      "weight": 1
+    }
+  ],
+  "zoccoli_risonanti_steppe": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "steppe-risonanti-trait-keeper",
+      "weight": 1
+    }
+  ]
+}

--- a/tools/py/build_species_trait_bridge.py
+++ b/tools/py/build_species_trait_bridge.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Genera la tabella ponte trait↔specie con pesi normalizzati."""
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+try:  # pragma: no cover - compatibilità ambienti minimal
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - fallback con messaggio chiaro
+    yaml = None  # type: ignore[assignment]
+
+
+ROLE_WEIGHTS: Mapping[str, int] = {"core": 3, "synergy": 2, "optional": 1}
+
+
+@dataclass
+class SpeciesTraitRoles:
+    """Accumula ruoli osservati per un tratto su una singola specie."""
+
+    roles: set[str] = field(default_factory=set)
+
+    def add_role(self, role: str) -> None:
+        if role in ROLE_WEIGHTS:
+            self.roles.add(role)
+
+    @property
+    def weight(self) -> int:
+        return sum(ROLE_WEIGHTS[role] for role in self.roles)
+
+    def as_payload(self, species_id: str) -> dict[str, Any]:
+        return {
+            "species_id": species_id,
+            "roles": sorted(self.roles),
+            "weight": self.weight,
+        }
+
+
+def _ensure_list(value: Iterable | None) -> list:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [item for item in value if item is not None]
+    return [value]
+
+
+def _load_yaml(path: Path) -> Mapping[str, Any]:
+    if yaml is None:
+        raise RuntimeError(
+            "Impossibile caricare file YAML: PyYAML non è disponibile nell'ambiente esecutivo."
+        )
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    return data if isinstance(data, Mapping) else {}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _gather_species_files(root: Path) -> list[Path]:
+    if root.is_file():
+        return [root]
+    return sorted(candidate for candidate in root.rglob("*.yaml") if candidate.is_file())
+
+
+def _collect_roles_from_species(data: Mapping[str, Any]) -> dict[str, SpeciesTraitRoles]:
+    traits_map: dict[str, SpeciesTraitRoles] = defaultdict(SpeciesTraitRoles)
+
+    genetic = data.get("genetic_traits")
+    if isinstance(genetic, Mapping):
+        for role_name, entries in genetic.items():
+            if role_name not in ROLE_WEIGHTS:
+                continue
+            for trait_id in _ensure_list(entries):
+                if trait_id:
+                    traits_map[trait_id].add_role(role_name)
+
+    derived = data.get("derived_from_environment")
+    if isinstance(derived, Mapping):
+        suggested = _ensure_list(derived.get("suggested_traits"))
+        for trait_id in suggested:
+            if trait_id:
+                # I suggerimenti ambientali sono assimilati a ruoli opzionali.
+                traits_map[trait_id].add_role("optional")
+
+    return traits_map
+
+
+def build_species_affinity(species_root: Path) -> dict[str, list[dict[str, Any]]]:
+    trait_index: dict[str, dict[str, SpeciesTraitRoles]] = defaultdict(lambda: {})
+
+    for species_file in _gather_species_files(species_root):
+        data = _load_yaml(species_file)
+        if not data:
+            continue
+        species_id = data.get("id") or species_file.stem
+        if not isinstance(species_id, str):
+            species_id = str(species_id)
+
+        roles_by_trait = _collect_roles_from_species(data)
+        if not roles_by_trait:
+            continue
+
+        for trait_id, roles in roles_by_trait.items():
+            if not roles.roles:
+                continue
+            trait_entry = trait_index.setdefault(trait_id, {})
+            trait_entry[species_id] = roles
+
+    affinity: dict[str, list[dict[str, Any]]] = {}
+    for trait_id, species_roles in trait_index.items():
+        payload = [roles.as_payload(species_id) for species_id, roles in species_roles.items()]
+        payload.sort(key=lambda item: (-item["weight"], item["species_id"]))
+        affinity[trait_id] = payload
+
+    return affinity
+
+
+def merge_into_trait_index(
+    trait_index_path: Path, affinity: Mapping[str, list[dict[str, Any]]]
+) -> dict[str, Any]:
+    index_data = _load_json(trait_index_path)
+    traits = index_data.get("traits")
+    if not isinstance(traits, dict):
+        raise RuntimeError("Indice tratti non valido: campo 'traits' assente o non è un dizionario")
+
+    updated_traits = set()
+    for trait_id, entries in affinity.items():
+        trait_payload = traits.get(trait_id)
+        if not isinstance(trait_payload, dict):
+            continue
+        trait_payload["species_affinity"] = entries
+        updated_traits.add(trait_id)
+
+    # Rimuove il campo per i tratti non presenti nella nuova mappa, mantenendo l'indice pulito.
+    for trait_id, trait_payload in traits.items():
+        if not isinstance(trait_payload, dict):
+            continue
+        if trait_id not in updated_traits and "species_affinity" in trait_payload:
+            trait_payload.pop("species_affinity", None)
+
+    return index_data
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--species-root",
+        type=Path,
+        default=Path("packs/evo_tactics_pack/data/species"),
+        help="Directory o file YAML da cui leggere le specie",
+    )
+    parser.add_argument(
+        "--trait-index",
+        type=Path,
+        default=Path("data/traits/index.json"),
+        help="Indice principale dei tratti da aggiornare",
+    )
+    parser.add_argument(
+        "--out-json",
+        type=Path,
+        default=Path("data/traits/species_affinity.json"),
+        help="Percorso di output per la mappa trait→specie",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Non scrive i file, stampa solo un riepilogo",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    affinity = build_species_affinity(args.species_root)
+
+    if args.dry_run:
+        print(f"Rilevati {len(affinity)} trait con associazioni specie")
+        return 0
+
+    _write_json(args.out_json, affinity)
+
+    index_payload = merge_into_trait_index(args.trait_index, affinity)
+    _write_json(args.trait_index, index_payload)
+
+    print(
+        "Specie associate a %d trait. File aggiornati: %s, %s"
+        % (len(affinity), args.out_json, args.trait_index)
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - entrypoint script
+    raise SystemExit(main())

--- a/tools/py/report_trait_coverage.py
+++ b/tools/py/report_trait_coverage.py
@@ -33,6 +33,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Directory o file YAML da cui estrarre le specie",
     )
     parser.add_argument(
+        "--species-affinity",
+        type=Path,
+        default=None,
+        help="Mappa trait→specie pre-calcolata per verificare la coverage",
+    )
+    parser.add_argument(
         "--trait-glossary",
         type=Path,
         default=None,
@@ -86,6 +92,7 @@ def main(argv: list[str] | None = None) -> int:
         args.env_traits,
         args.trait_reference,
         args.species_root,
+        args.species_affinity,
         args.trait_glossary,
     )
 


### PR DESCRIPTION
## Summary
- add a Python tool that scans the Evo Tactics species catalog to compute trait affinities and update the trait index
- store the generated trait→species affinity dataset and embed the affinity data into `data/traits/index.json`
- extend the coverage report utilities to consume the affinity map and surface validation metrics in the report output

## Testing
- python tools/py/build_species_trait_bridge.py
- python tools/py/report_trait_coverage.py --species-affinity data/traits/species_affinity.json


------
https://chatgpt.com/codex/tasks/task_e_690540213fa4833283b84a91b62107fa