### PR TITLE
Add rollout feature flags and monitoring assets

### DIFF
--- a/config/featureFlags.json
+++ b/config/featureFlags.json
@@ -1,76 +1,217 @@
 {
-  "featureFlags": {
-    "rollout": {
-      "qaMetricsMonitoring": {
-        "description": "Abilita il monitoraggio automatizzato delle metriche di rollout Mission Control.",
-        "default": false,
+    "featureFlags": {
         "rollout": {
-          "phase": "canary",
-          "stageGate": "qa-approval",
-          "start": "2025-11-20",
-          "target": "2025-12-05",
-          "cohorts": ["qa-bravo", "qa-delta", "ops-foxtrot"],
-          "pipeline": {
-            "jobId": "qa-rollout-metrics",
-            "config": "config/jobs/monitoring.yaml"
-          }
-        },
-        "owner": {
-          "team": "qa-insights",
-          "contact": "qa-insights@gamestudio.local"
-        },
-        "playbook": "docs/qa/rollout_checklist.md",
-        "metrics": [
-          {
-            "name": "mission_control_uptime",
-            "threshold": ">=99.5%",
-            "window": "24h",
-            "alertChannel": "ops-oncall"
-          },
-          {
-            "name": "hud_action_latency_p95",
-            "threshold": "<=3800ms",
-            "window": "6h",
-            "alertChannel": "qa-rollout"
-          },
-          {
-            "name": "playtest_squad_engagement",
-            "threshold": ">=0.62",
-            "window": "7d",
-            "alertChannel": "analytics-duty"
-          }
-        ]
-      },
-      "ideaEngineFeedback": {
-        "description": "Attiva il modulo feedback Idea Engine con canale Slack #feedback-enhancements.",
-        "default": true,
-        "rollout": {
-          "phase": "general_availability",
-          "cohorts": ["idea-engine", "qa-support", "webapp"],
-          "start": "2025-12-02",
-          "target": "2025-12-09"
-        },
-        "owner": {
-          "team": "support-qa",
-          "contact": "support-qa@gamestudio.local",
-          "slack": "#feedback-enhancements"
-        },
-        "playbook": "docs/tutorials/idea-engine-feedback.md",
-        "metrics": [
-          {
-            "name": "feedback_response_time_hours",
-            "threshold": "<=24",
-            "window": "7d",
-            "alertChannel": "#feedback-enhancements"
-          },
-          {
-            "name": "tutorial_views_weekly",
-            "threshold": ">=12",
-            "window": "7d",
-            "alertChannel": "analytics-duty"
-          }
-        ]
-      }
+            "qaMetricsMonitoring": {
+                "description": "Abilita il monitoraggio automatizzato delle metriche di rollout Mission Control.",
+                "default": false,
+                "rollout": {
+                    "phase": "canary",
+                    "stageGate": "qa-approval",
+                    "start": "2025-11-20",
+                    "target": "2025-12-05",
+                    "cohorts": [
+                        "qa-bravo",
+                        "qa-delta",
+                        "ops-foxtrot"
+                    ],
+                    "pipeline": {
+                        "jobId": "qa-rollout-metrics",
+                        "config": "config/jobs/monitoring.yaml"
+                    }
+                },
+                "owner": {
+                    "team": "qa-insights",
+                    "contact": "qa-insights@gamestudio.local"
+                },
+                "playbook": "docs/qa/rollout_checklist.md",
+                "metrics": [
+                    {
+                        "name": "mission_control_uptime",
+                        "threshold": ">=99.5%",
+                        "window": "24h",
+                        "alertChannel": "ops-oncall"
+                    },
+                    {
+                        "name": "hud_action_latency_p95",
+                        "threshold": "<=3800ms",
+                        "window": "6h",
+                        "alertChannel": "qa-rollout"
+                    },
+                    {
+                        "name": "playtest_squad_engagement",
+                        "threshold": ">=0.62",
+                        "window": "7d",
+                        "alertChannel": "analytics-duty"
+                    }
+                ]
+            },
+            "ideaEngineFeedback": {
+                "description": "Attiva il modulo feedback Idea Engine con canale Slack #feedback-enhancements.",
+                "default": true,
+                "rollout": {
+                    "phase": "general_availability",
+                    "cohorts": [
+                        "idea-engine",
+                        "qa-support",
+                        "webapp"
+                    ],
+                    "start": "2025-12-02",
+                    "target": "2025-12-09"
+                },
+                "owner": {
+                    "team": "support-qa",
+                    "contact": "support-qa@gamestudio.local",
+                    "slack": "#feedback-enhancements"
+                },
+                "playbook": "docs/tutorials/idea-engine-feedback.md",
+                "metrics": [
+                    {
+                        "name": "feedback_response_time_hours",
+                        "threshold": "<=24",
+                        "window": "7d",
+                        "alertChannel": "#feedback-enhancements"
+                    },
+                    {
+                        "name": "tutorial_views_weekly",
+                        "threshold": ">=12",
+                        "window": "7d",
+                        "alertChannel": "analytics-duty"
+                    }
+                ]
+            },
+            "eventiLiveOrchestration": {
+                "description": "Abilita il sistema di regia eventi live con sincronizzazione cross-shard.",
+                "default": false,
+                "rollout": {
+                    "phase": "canary",
+                    "stageGate": "eventi-go",
+                    "start": "2026-01-05",
+                    "target": "2026-01-19",
+                    "cohorts": [
+                        "eventi-internal",
+                        "eventi-beta"
+                    ],
+                    "pipeline": {
+                        "jobId": "eventi-rollout-health",
+                        "config": "config/jobs/eventi-rollout.yaml"
+                    }
+                },
+                "owner": {
+                    "team": "live-ops",
+                    "contact": "live-ops@gamestudio.local",
+                    "slack": "#eventi-control-room"
+                },
+                "playbook": "docs/qa/playbooks/eventi.md",
+                "metrics": [
+                    {
+                        "name": "eventi_active_instances",
+                        "threshold": ">=95%",
+                        "window": "1h",
+                        "alertChannel": "#eventi-control-room"
+                    },
+                    {
+                        "name": "eventi_sync_drift_ms",
+                        "threshold": "<=250",
+                        "window": "30m",
+                        "alertChannel": "ops-oncall"
+                    },
+                    {
+                        "name": "eventi_player_drop_rate",
+                        "threshold": "<=3%",
+                        "window": "2h",
+                        "alertChannel": "analytics-duty"
+                    }
+                ]
+            },
+            "loadoutDynamicTemplates": {
+                "description": "Rende disponibili i loadout dinamici con template stagionali e progressione QA.",
+                "default": false,
+                "rollout": {
+                    "phase": "limited_availability",
+                    "stageGate": "loadout-qa",
+                    "start": "2026-02-10",
+                    "target": "2026-02-24",
+                    "cohorts": [
+                        "qa-delta",
+                        "squad-alpha",
+                        "creators-program"
+                    ],
+                    "pipeline": {
+                        "jobId": "loadout-rollout-health",
+                        "config": "config/jobs/loadout-rollout.yaml"
+                    }
+                },
+                "owner": {
+                    "team": "progression-design",
+                    "contact": "progression-design@gamestudio.local",
+                    "slack": "#loadout-updates"
+                },
+                "playbook": "docs/qa/playbooks/loadout.md",
+                "metrics": [
+                    {
+                        "name": "loadout_publish_success_rate",
+                        "threshold": ">=98%",
+                        "window": "4h",
+                        "alertChannel": "#loadout-updates"
+                    },
+                    {
+                        "name": "loadout_build_time_p95",
+                        "threshold": "<=4200ms",
+                        "window": "2h",
+                        "alertChannel": "ops-oncall"
+                    },
+                    {
+                        "name": "loadout_rollbacks",
+                        "threshold": "<=1",
+                        "window": "24h",
+                        "alertChannel": "progression-oncall"
+                    }
+                ]
+            },
+            "moderazioneAssistedOps": {
+                "description": "Attiva il pannello di moderazione assistita con suggerimenti ML in tempo reale.",
+                "default": true,
+                "rollout": {
+                    "phase": "canary",
+                    "stageGate": "moderation-ops",
+                    "start": "2026-01-22",
+                    "target": "2026-02-05",
+                    "cohorts": [
+                        "moderation-core",
+                        "moderation-emea"
+                    ],
+                    "pipeline": {
+                        "jobId": "moderation-rollout-health",
+                        "config": "config/jobs/moderation-rollout.yaml"
+                    }
+                },
+                "owner": {
+                    "team": "moderation-ops",
+                    "contact": "moderation-ops@gamestudio.local",
+                    "slack": "#moderation-ops"
+                },
+                "playbook": "docs/qa/playbooks/moderazione.md",
+                "metrics": [
+                    {
+                        "name": "moderation_assist_accept_rate",
+                        "threshold": ">=0.65",
+                        "window": "6h",
+                        "alertChannel": "#moderation-ops"
+                    },
+                    {
+                        "name": "moderation_triage_latency_p95",
+                        "threshold": "<=900s",
+                        "window": "3h",
+                        "alertChannel": "ops-oncall"
+                    },
+                    {
+                        "name": "moderation_manual_escalations",
+                        "threshold": "<=12",
+                        "window": "24h",
+                        "alertChannel": "moderation-oncall"
+                    }
+                ]
+            }
+        }
     }
-  }
 }

--- a/docs/qa/playbooks/eventi.md
+++ b/docs/qa/playbooks/eventi.md
@@ -1,0 +1,23 @@
+# Playbook QA - Eventi Live Orchestration
+
+## Obiettivi
+- Garantire che ogni shard riceva i segnali di sincronizzazione entro la finestra prevista.
+- Validare la continuità dell'esperienza evento anche durante i picchi di traffico.
+- Monitorare la regressione su metriche di coinvolgimento durante l'orchestrazione.
+
+## Checklist pre-rollout
+- [ ] Verificare che il flag `eventiLiveOrchestration` sia configurato su ambiente di staging.
+- [ ] Eseguire test di carico simulando almeno 3 ondate simultanee usando `tools/loadtests/eventi.lua`.
+- [ ] Confermare la disponibilità del canale Slack `#eventi-control-room` con turni assegnati.
+- [ ] Validare l'allineamento delle schedule con il team Live Ops (documento `calendar_eventi.ics`).
+
+## Checklist monitoraggio
+- [ ] Attivare la dashboard `tools/monitoring/rollout/dashboard.yaml` sezione `eventi-live`.
+- [ ] Tracciare `eventi_active_instances` e aprire ticket se sotto soglia per 2 slot consecutivi.
+- [ ] Confermare che gli allarmi Ops su `eventi_sync_drift_ms` siano instradati a PagerDuty `ops-oncall`.
+- [ ] Annotare eventuali anomalie su `eventi_player_drop_rate` nel registro `logs/qa/eventi-drop.log`.
+
+## Checklist post-rollout
+- [ ] Raccolta feedback da canale #eventi-control-room e archivio retrospettiva.
+- [ ] Aggiornare il documento KPI in `reports/eventi/summary.md` con i grafici esportati.
+- [ ] Redigere action items e assegnarli via Jira board `LIVEOPS-QA`.

--- a/docs/qa/playbooks/loadout.md
+++ b/docs/qa/playbooks/loadout.md
@@ -1,0 +1,23 @@
+# Playbook QA - Loadout Dinamici
+
+## Obiettivi
+- Validare la generazione dei template stagionali con contenuti corretti per coorte.
+- Garantire la consistenza dei dati di progressione in presenza di rollback.
+- Misurare l'impatto sulle prestazioni durante la pubblicazione dei loadout.
+
+## Checklist pre-rollout
+- [ ] Confermare che il flag `loadoutDynamicTemplates` sia attivo solo per le coorti pilota.
+- [ ] Rieseguire la suite `tests/loadout/test_templates.py` con ambiente QA aggiornato.
+- [ ] Verificare la presenza di snapshot aggiornati in `data/loadout/templates/*.json`.
+- [ ] Sincronizzare con il team Progression Design sul piano di comunicazione (#loadout-updates).
+
+## Checklist monitoraggio
+- [ ] Abilitare la dashboard `tools/monitoring/rollout/dashboard.yaml` sezione `loadout-dinamici`.
+- [ ] Monitorare `loadout_publish_success_rate` e aprire incidente se sotto 98% per 3 slot.
+- [ ] Verificare che gli alert `loadout_build_time_p95` generino ticket automatico in `OPS-LOADOUT`.
+- [ ] Registrare ogni rollback manuale in `logs/qa/loadout-rollbacks.csv` con timestamp e responsabile.
+
+## Checklist post-rollout
+- [ ] Analizzare i tempi di pubblicazione confrontando i dati esportati da Grafana.
+- [ ] Aggiornare la documentazione utente in `docs/loadout/guide.md` se cambiano i flussi.
+- [ ] Pianificare retrospettiva con Progression Design e QA (riunione `Retro Loadout`).

--- a/docs/qa/playbooks/moderazione.md
+++ b/docs/qa/playbooks/moderazione.md
@@ -1,0 +1,23 @@
+# Playbook QA - Moderazione Assistita
+
+## Obiettivi
+- Validare la qualità dei suggerimenti ML nel pannello di moderazione assistita.
+- Garantire la riduzione del tempo di triage per i casi critici.
+- Assicurare il rispetto delle policy di sicurezza dati durante l'esecuzione.
+
+## Checklist pre-rollout
+- [ ] Verificare che il flag `moderazioneAssistedOps` sia attivo sulle code `moderation-core` e `moderation-emea`.
+- [ ] Eseguire test di regressione `tests/moderation/test_assisted_flows.py` in ambiente staging.
+- [ ] Coordinare con Security per il controllo log accessi in `logs/moderation/audit/`.
+- [ ] Aggiornare la knowledge base interna con la nuova guida operativa (`KB-Moderazione-Assistita`).
+
+## Checklist monitoraggio
+- [ ] Abilitare la dashboard `tools/monitoring/rollout/dashboard.yaml` sezione `moderazione-assistita`.
+- [ ] Monitorare `moderation_assist_accept_rate` e notificare se sotto soglia per 2 finestre.
+- [ ] Controllare `moderation_triage_latency_p95` confrontando i dati con baseline storica.
+- [ ] Registrare gli `moderation_manual_escalations` in `reports/moderation/escalations.xlsx`.
+
+## Checklist post-rollout
+- [ ] Analizzare il sentiment degli operatori tramite survey `forms/moderation_feedback`.
+- [ ] Aggiornare le policy in `rules/moderation/` se emergono nuove casistiche.
+- [ ] Organizzare retrospettiva con i referenti regionali e definire follow-up.

--- a/tools/monitoring/rollout/README.md
+++ b/tools/monitoring/rollout/README.md
@@ -1,0 +1,13 @@
+# Dashboard Mission Control Rollout
+
+La configurazione `dashboard.yaml` definisce la dashboard di monitoraggio dedicata alle fasi di rollout dei flag QA per eventi live, loadout dinamici e moderazione assistita.
+
+## Utilizzo
+1. Importare il file in Mission Control tramite `mc dashboards import --file tools/monitoring/rollout/dashboard.yaml`.
+2. Verificare che le datasource `mission-control-prod` e `mission-control-preview` siano disponibili nell'ambiente selezionato.
+3. Associare i canali di notifica indicati nella sezione `alerts` agli on-call correnti.
+
+## Convenzioni
+- Le metriche sono allineate ai flag definiti in `config/featureFlags.json`.
+- Ogni pannello include soglie `warning` e `critical` coerenti con i playbook QA.
+- Gli aggiornamenti devono essere tracciati nel changelog `reports/monitoring/rollout-dashboard.md`.

--- a/tools/monitoring/rollout/dashboard.yaml
+++ b/tools/monitoring/rollout/dashboard.yaml
@@ -1,0 +1,156 @@
+version: '1.0'
+dashboard: mission-control-rollout
+owner: qa-insights
+refreshInterval: 60
+panels:
+  - id: eventi-live
+    title: "Eventi Live - Stato"
+    description: "Monitoraggio salute orchestrazione eventi live nelle coorti canary."
+    layout:
+      row: 1
+      column: 1
+      width: 6
+      height: 8
+    queries:
+      - metric: eventi_active_instances
+        visualization: timeseries
+        thresholds:
+          - level: warning
+            condition: below
+            value: 0.97
+          - level: critical
+            condition: below
+            value: 0.95
+        annotations:
+          - text: "Soglia minima 95% istanze attive"
+      - metric: eventi_sync_drift_ms
+        visualization: timeseries
+        thresholds:
+          - level: warning
+            condition: above
+            value: 220
+          - level: critical
+            condition: above
+            value: 250
+        annotations:
+          - text: "Drift massimo 250ms"
+      - metric: eventi_player_drop_rate
+        visualization: timeseries
+        thresholds:
+          - level: warning
+            condition: above
+            value: 0.025
+          - level: critical
+            condition: above
+            value: 0.03
+        annotations:
+          - text: "Monitorare abbandoni durante evento"
+  - id: loadout-dinamici
+    title: "Loadout Dinamici - Stabilità"
+    description: "Performance pubblicazione loadout e rollback per coorti pilota."
+    layout:
+      row: 1
+      column: 7
+      width: 6
+      height: 8
+    queries:
+      - metric: loadout_publish_success_rate
+        visualization: timeseries
+        thresholds:
+          - level: warning
+            condition: below
+            value: 0.985
+          - level: critical
+            condition: below
+            value: 0.98
+        annotations:
+          - text: "Soglia accettazione 98%"
+      - metric: loadout_build_time_p95
+        visualization: timeseries
+        thresholds:
+          - level: warning
+            condition: above
+            value: 4000
+          - level: critical
+            condition: above
+            value: 4200
+        annotations:
+          - text: "Target tempo build 4.2s"
+      - metric: loadout_rollbacks
+        visualization: bar
+        thresholds:
+          - level: critical
+            condition: above
+            value: 1
+        annotations:
+          - text: "Rollback massimo 1 per giorno"
+  - id: moderazione-assistita
+    title: "Moderazione Assistita - Efficienza"
+    description: "Tassi di adozione e tempi di risposta per il pannello assistito."
+    layout:
+      row: 9
+      column: 1
+      width: 12
+      height: 8
+    queries:
+      - metric: moderation_assist_accept_rate
+        visualization: timeseries
+        thresholds:
+          - level: warning
+            condition: below
+            value: 0.68
+          - level: critical
+            condition: below
+            value: 0.65
+        annotations:
+          - text: "Accettazione minima 65%"
+      - metric: moderation_triage_latency_p95
+        visualization: timeseries
+        thresholds:
+          - level: warning
+            condition: above
+            value: 750
+          - level: critical
+            condition: above
+            value: 900
+        annotations:
+          - text: "Tempo triage massimo 15m"
+      - metric: moderation_manual_escalations
+        visualization: table
+        thresholds:
+          - level: warning
+            condition: above
+            value: 10
+          - level: critical
+            condition: above
+            value: 12
+        annotations:
+          - text: "Escalation >12 richiedono root cause"
+alerts:
+  - id: eventi-sla
+    panel: eventi-live
+    metric: eventi_active_instances
+    condition: below
+    value: 0.95
+    for: 10m
+    channels:
+      - slack:#eventi-control-room
+      - pagerduty:ops-oncall
+  - id: loadout-build-latency
+    panel: loadout-dinamici
+    metric: loadout_build_time_p95
+    condition: above
+    value: 4200
+    for: 15m
+    channels:
+      - slack:#loadout-updates
+      - jira:OPS-LOADOUT
+  - id: moderation-triage-breach
+    panel: moderazione-assistita
+    metric: moderation_triage_latency_p95
+    condition: above
+    value: 900
+    for: 20m
+    channels:
+      - slack:#moderation-ops
+      - pagerduty:moderation-oncall


### PR DESCRIPTION
## Summary
- add rollout feature flags for eventi, loadout, and moderazione with owner and metric metadata
- provide dedicated QA playbooks covering pre-rollout, monitoring, and post-rollout checklist steps
- configure Mission Control rollout dashboard with panels and alerts, including usage guidance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905415c854c8332aded0156fbea4045