### PR TITLE
Fix trait species affinity bridge validation and coverage

### DIFF
--- a/config/schemas/trait.schema.json
+++ b/config/schemas/trait.schema.json
@@ -93,6 +93,13 @@
       "minLength": 1,
       "description": "Motivazione evolutiva o tattica."
     },
+    "species_affinity": {
+      "type": "array",
+      "description": "Elenco di specie associate al tratto con ruoli e pesi normalizzati.",
+      "items": {
+        "$ref": "#/$defs/species_affinity_entry"
+      }
+    },
     "debolezza": {
       "type": "string",
       "description": "Limitazioni o vulnerabilità note."
@@ -102,6 +109,32 @@
     }
   },
   "$defs": {
+    "species_affinity_entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "species_id",
+        "roles",
+        "weight"
+      ],
+      "properties": {
+        "species_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "weight": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
     "slot_profile": {
       "type": "object",
       "additionalProperties": false,

--- a/data/derived/analysis/trait_coverage_report.json
+++ b/data/derived/analysis/trait_coverage_report.json
@@ -1,170 +1,74 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-10-31T23:06:22+00:00",
+  "generated_at": "2025-10-31T23:21:39+00:00",
   "sources": {
     "env_traits": "packs/evo_tactics_pack/docs/catalog/env_traits.json",
     "trait_reference": "data/traits/index.json",
     "trait_glossary": "/workspace/Game/data/core/traits/glossary.json",
     "species_root": "packs/evo_tactics_pack/data/species",
-    "species_affinity": "/workspace/Game/data/traits/species_affinity.json"
+    "species_affinity": null
   },
   "summary": {
     "traits_total": 174,
     "traits_with_rules": 147,
-    "traits_with_species": 4,
-    "traits_with_affinity": 173,
+    "traits_with_species": 172,
+    "traits_with_affinity": 0,
     "rule_combos_total": 177,
-    "species_combos_total": 8,
-    "rules_missing_species_total": 173,
+    "species_combos_total": 391,
+    "rules_missing_species_total": 0,
     "affinity_missing_species_total": 0,
-    "affinity_missing_matrix_total": 318,
-    "traits_missing_species": [
-      "ali_fulminee",
-      "ali_ioniche",
-      "ali_membrana_sonica",
-      "antenne_dustsense",
-      "antenne_eco_turbina",
-      "antenne_flusso_mareale",
-      "antenne_microonde_cavernose",
-      "antenne_reagenti",
-      "antenne_tesla",
-      "antenne_waveguide",
-      "antenne_wideband",
-      "appendici_risonanti_marea",
-      "appendici_thermotattiche",
-      "artigli_acidofagi",
-      "artigli_induzione",
-      "artigli_radice",
-      "artigli_scivolo_silente",
+    "affinity_missing_matrix_total": 0,
+    "traits_missing_species": [],
+    "traits_missing_rules": [
+      "antenne_plasmatiche_tempesta",
+      "armatura_pietra_planare",
       "artigli_sette_vie",
-      "artigli_vetrificati",
-      "baffi_mareomotori",
-      "barbigli_sensori_plasma",
-      "barriere_miasma_glaciale",
-      "batteri_endosimbionti_chemio",
-      "batteri_termofili_endosimbiosi",
-      "biochip_memoria",
-      "biofilm_glow",
-      "biofilm_iperarido",
-      "branchie_dual_mode",
-      "branchie_eoliche",
-      "branchie_metalloidi",
-      "branchie_microfiltri",
-      "branchie_solfatiche",
-      "branchie_turbina",
-      "camere_anticorrosione",
-      "camere_mirage",
-      "camere_nutrienti_vent",
-      "capillari_criogenici",
-      "capillari_fluoridici",
-      "capillari_fotovoltaici",
-      "capsule_paracadute",
+      "artigli_sghiaccio_glaciale",
+      "aura_scudo_radianza",
+      "branchie_osmotiche_salmastra",
+      "bulbi_radici_permafrost",
       "carapace_fase_variabile",
-      "carapace_segmenti_logici",
-      "carapaci_ferruginosi",
-      "cartilagini_biofibre",
-      "cartilagini_desertiche",
-      "cartilagini_flessoacustiche",
-      "cartilagini_pseudometalliche",
-      "cervelletto_equilibrio_statico",
-      "chemiorecettori_bromuro",
-      "circolazione_bifasica",
-      "circolazione_cooling_loop",
-      "circolazione_doppia",
-      "circolazione_supercritica",
-      "ciste_riduttive",
-      "ciste_salmastre",
-      "cisti_iperbariche",
-      "coda_balanciere",
-      "coda_contrappeso",
-      "coda_coppia_retroattiva",
+      "carapace_luminiscente_abissale",
+      "cartilagine_flessotermica_venti",
+      "cavita_risonanti_tundra",
+      "chioma_parassita_canopica",
+      "circolazione_bifasica_palude",
       "coda_frusta_cinetica",
-      "coda_stabilizzatrice_filo",
-      "coda_stabilizzatrice_geiser",
-      "coda_stabilizzatrice_vortex",
-      "colonne_vibromagnetiche",
-      "coralli_partner",
       "criostasi_adattiva",
-      "cromofori_alert_acido",
-      "cuore_multicamera_bassa_pressione",
-      "cuscinetti_elettrostatici",
       "cute_resistente_sali",
-      "cuticole_neutralizzanti",
-      "denti_chelatanti",
-      "denti_ossidoferro",
-      "denti_silice_termici",
-      "denti_tuning_fork",
-      "echi_risonanti",
+      "cuticole_cerose",
       "eco_interno_riflesso",
       "empatia_coordinativa",
-      "enzimi_antifase_termica",
-      "enzimi_antipredatori_algali",
-      "enzimi_chelatori_rapidi",
-      "enzimi_metanoossidanti",
-      "epidermide_dielettrica",
-      "epitelio_fosforescente",
+      "enzimi_chelanti",
       "filamenti_digestivi_compattanti",
-      "filamenti_magnetotrofi",
-      "filamenti_superconduttivi",
-      "filamenti_termoconduzione",
-      "filtri_planctonici",
-      "flagelli_ancoranti",
-      "focus_frazionato",
-      "foliage_fotocatodico",
-      "foliaggio_spugna",
-      "ghiaccio_piezoelettrico",
-      "ghiandola_caustica",
-      "ghiandole_cambio_salino",
-      "ghiandole_condensa_ozono",
-      "ghiandole_eco_mappanti",
-      "ghiandole_fango_calde",
-      "ghiandole_fango_coesivo",
-      "ghiandole_grafene",
-      "ghiandole_inchiostro_luce",
-      "ghiandole_iodoattive",
-      "ghiandole_minerali",
-      "ghiandole_nebbia_acida",
-      "ghiandole_nebbia_ionica",
-      "ghiandole_resina_conduttiva",
-      "ghiandole_ventosa",
-      "giunti_antitorsione",
-      "gusci_criovetro",
-      "gusci_magnesio",
-      "lamelle_shear",
-      "lamelle_sincroniche",
-      "lamine_filtranti_aeree",
-      "lamine_scudo_silice",
-      "linfa_tampone",
-      "lingua_cristallina",
+      "frusta_fiammeggiante",
+      "grassi_termici",
+      "lamelle_termoforetiche",
       "lingua_tattile_trama",
-      "luminescenza_aurorale",
-      "luminescenza_hydrotermica",
-      "mantelli_geotermici",
-      "membrane_captura_rugiada",
-      "membrane_planata_vectored",
-      "membrane_pneumatofori",
-      "midollo_antivibrazione",
+      "mantello_meteoritico",
+      "membrane_eliofiltranti",
       "mimetismo_cromatico_passivo",
-      "mucose_aderenza_sonica",
-      "mucose_barofile",
+      "mucillagine_simbionte_mangrovie",
+      "nodi_micorrizici_oracolari",
       "nucleo_ovomotore_rotante",
       "occhi_infrarosso_composti",
-      "olfatto_risonanza_magnetica",
-      "pathfinder",
-      "pianificatore",
+      "piume_solari_fotovoltaiche",
+      "polmoni_cristallini_alta_quota",
       "respiro_a_scoppio",
       "risonanza_di_branco",
-      "sacche_galleggianti_ascensoriali",
+      "sacche_spore_stratosferiche",
       "sangue_piroforico",
       "scheletro_idro_regolante",
       "secrezione_rallentante_palmi",
+      "sensori_geomagnetici",
+      "sinapsi_coraline_polifoniche",
       "sonno_emisferico_alternato",
       "spore_psichiche_silenziate",
-      "struttura_elastica_amorfa",
-      "tattiche_di_branco",
-      "ventriglio_gastroliti"
-    ],
-    "traits_missing_rules": []
+      "squame_rifrangenti_deserto",
+      "vello_condensatore_nebbie",
+      "ventriglio_gastroliti",
+      "zoccoli_risonanti_steppe"
+    ]
   },
   "traits": {
     "ali_fulminee": {
@@ -183,30 +87,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "stratosfera_tempestosa",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          },
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "stratosfera-tempestosa-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "stratosfera-tempestosa-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ali_ioniche": {
@@ -225,30 +130,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "canopia_ionica",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          },
+          {
+            "biome": "canopia_ionica",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "canopia-ionica-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "canopia-ionica-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ali_membrana_sonica": {
@@ -267,30 +173,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caverna_risonante",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caverna-risonante-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "antenne_dustsense": {
@@ -309,30 +216,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "pianura_salina_iperarida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "pianura-salina-iperarida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "pianura-salina-iperarida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "antenne_eco_turbina": {
@@ -351,30 +259,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "dorsale-termale-tropicale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "dorsale-termale-tropicale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "antenne_flusso_mareale": {
@@ -393,30 +302,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "laguna_bioreattiva",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
+          },
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "laguna-bioreattiva-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "laguna-bioreattiva-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "antenne_microonde_cavernose": {
@@ -435,30 +345,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caverna_risonante",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caverna-risonante-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "antenne_plasmatiche_tempesta": {
@@ -471,25 +382,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "cicloni_psionici",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "cicloni-psionici-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "cicloni_psionici",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "cicloni-psionici-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "cicloni-psionici-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "antenne_reagenti": {
@@ -508,30 +422,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "foresta_acida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "foresta_acida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "foresta-acida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "foresta-acida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "antenne_tesla": {
@@ -550,30 +465,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "canopia_ionica",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          },
+          {
+            "biome": "canopia_ionica",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "canopia-ionica-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "canopia-ionica-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "antenne_waveguide": {
@@ -592,30 +508,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "reef_luminescente",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          },
+          {
+            "biome": "reef_luminescente",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "reef-luminescente-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "reef-luminescente-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "antenne_wideband": {
@@ -634,30 +551,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "steppe_algoritmiche",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
+          },
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "steppe-algoritmiche-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "steppe-algoritmiche-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "appendici_risonanti_marea": {
@@ -676,30 +594,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "laguna_bioreattiva",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
+          },
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "laguna-bioreattiva-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "laguna-bioreattiva-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "appendici_thermotattiche": {
@@ -718,30 +637,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "abisso_vulcanico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "abisso-vulcanico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "abisso-vulcanico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "armatura_pietra_planare": {
@@ -754,32 +674,40 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 2,
+        "coverage": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "balor-fission"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "golem-runico"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "balor-fission",
-          "bulette-fase",
-          "golem-runico",
-          "treant-portale"
-        ]
-      },
-      "affinity": {
-        "total_species": 4,
-        "roles_breakdown": {
-          "core": 1,
-          "optional": 4
-        },
-        "top_species": [
-          "golem-runico",
-          "balor-fission",
-          "bulette-fase",
-          "treant-portale"
-        ]
+        "missing_in_matrix": []
       }
     },
     "artigli_acidofagi": {
@@ -798,30 +726,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "foresta_acida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "foresta_acida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "foresta-acida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "foresta-acida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "artigli_induzione": {
@@ -840,30 +769,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "canopia_ionica",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          },
+          {
+            "biome": "canopia_ionica",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "canopia-ionica-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "canopia-ionica-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "artigli_radice": {
@@ -882,30 +812,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "mangrovieto_cinetico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "mangrovieto-cinetico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "mangrovieto-cinetico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "artigli_scivolo_silente": {
@@ -924,30 +855,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caverna_risonante",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caverna-risonante-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "artigli_sette_vie": {
@@ -976,55 +908,64 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 9,
+        "coverage": [
           {
             "biome": "caverna_risonante",
-            "morphotype": null
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "caverna-risonante-trait-keeper",
+              "resonant-claw-hunter"
+            ]
+          },
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 2,
+            "examples": [
+              "caverna-risonante-trait-keeper",
+              "resonant-claw-hunter"
+            ]
           },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede"
+            "morphotype": "cursoriale_quadrupede",
+            "count": 2,
+            "examples": [
+              "dune-stalker",
+              "magneto-ridge-hunter"
+            ]
           },
           {
             "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "cryo-lynx"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 2,
+            "examples": [
+              "balor-fission",
+              "marilith-vault"
+            ]
+          }
+        ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
             "morphotype": "cursoriale_quadrupede"
           }
         ],
-        "missing_in_rules": [],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "balor-fission",
-          "caverna-risonante-trait-keeper",
-          "couatl-aurora",
-          "cryo-lynx",
-          "dune-stalker",
-          "magneto-ridge-hunter",
-          "marilith-vault",
-          "otyugh-sentinella",
-          "resonant-claw-hunter"
-        ]
-      },
-      "affinity": {
-        "total_species": 9,
-        "roles_breakdown": {
-          "core": 2,
-          "optional": 9
-        },
-        "top_species": [
-          "dune-stalker",
-          "magneto-ridge-hunter",
-          "balor-fission",
-          "caverna-risonante-trait-keeper",
-          "couatl-aurora",
-          "cryo-lynx",
-          "marilith-vault",
-          "otyugh-sentinella",
-          "resonant-claw-hunter"
-        ]
+        "missing_in_matrix": []
       }
     },
     "artigli_sghiaccio_glaciale": {
@@ -1037,25 +978,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "calotte_glaciali",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "calotte-glaciali-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "calotte_glaciali",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "calotte-glaciali-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "calotte-glaciali-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "artigli_vetrificati": {
@@ -1074,30 +1018,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caldera_glaciale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caldera-glaciale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caldera-glaciale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "aura_scudo_radianza": {
@@ -1110,26 +1055,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "archon-solare"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "archon-solare"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "core": 1,
-          "optional": 1
-        },
-        "top_species": [
-          "archon-solare"
-        ]
+        "missing_in_matrix": []
       }
     },
     "baffi_mareomotori": {
@@ -1148,30 +1095,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "mangrovieto_cinetico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "mangrovieto-cinetico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "mangrovieto-cinetico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "barbigli_sensori_plasma": {
@@ -1190,30 +1138,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "stratosfera_tempestosa",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          },
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "stratosfera-tempestosa-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "stratosfera-tempestosa-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "barriere_miasma_glaciale": {
@@ -1232,30 +1181,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caldera_glaciale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caldera-glaciale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caldera-glaciale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "batteri_endosimbionti_chemio": {
@@ -1274,30 +1224,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "abisso_vulcanico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "abisso-vulcanico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "abisso-vulcanico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "batteri_termofili_endosimbiosi": {
@@ -1316,30 +1267,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "dorsale-termale-tropicale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "dorsale-termale-tropicale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "biochip_memoria": {
@@ -1358,30 +1310,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "steppe_algoritmiche",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
+          },
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "steppe-algoritmiche-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "steppe-algoritmiche-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "biofilm_glow": {
@@ -1400,30 +1353,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "reef_luminescente",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          },
+          {
+            "biome": "reef_luminescente",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "reef-luminescente-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "reef-luminescente-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "biofilm_iperarido": {
@@ -1442,30 +1396,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "pianura_salina_iperarida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "pianura-salina-iperarida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "pianura-salina-iperarida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "branchie_dual_mode": {
@@ -1484,30 +1439,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "laguna_bioreattiva",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
+          },
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "laguna-bioreattiva-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "laguna-bioreattiva-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "branchie_eoliche": {
@@ -1526,30 +1482,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "stratosfera_tempestosa",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          },
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "stratosfera-tempestosa-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "stratosfera-tempestosa-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "branchie_metalloidi": {
@@ -1568,30 +1525,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "abisso_vulcanico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "abisso-vulcanico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "abisso-vulcanico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "branchie_microfiltri": {
@@ -1610,30 +1568,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "reef_luminescente",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          },
+          {
+            "biome": "reef_luminescente",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "reef-luminescente-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "reef-luminescente-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "branchie_osmotiche_salmastra": {
@@ -1646,25 +1605,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "delta_salmastri",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "delta-salmastri-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "delta_salmastri",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "delta-salmastri-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "delta-salmastri-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "branchie_solfatiche": {
@@ -1683,30 +1645,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caldera_glaciale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caldera-glaciale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caldera-glaciale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "branchie_turbina": {
@@ -1725,30 +1688,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "dorsale-termale-tropicale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "dorsale-termale-tropicale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "bulbi_radici_permafrost": {
@@ -1761,25 +1725,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "permafrost_psionico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "permafrost-psionico-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "permafrost_psionico",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "permafrost-psionico-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "permafrost-psionico-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "camere_anticorrosione": {
@@ -1798,30 +1765,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "foresta_acida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "foresta_acida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "foresta-acida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "foresta-acida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "camere_mirage": {
@@ -1840,30 +1808,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "pianura_salina_iperarida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "pianura-salina-iperarida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "pianura-salina-iperarida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "camere_nutrienti_vent": {
@@ -1882,30 +1851,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "dorsale-termale-tropicale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "dorsale-termale-tropicale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "capillari_criogenici": {
@@ -1924,30 +1894,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caldera_glaciale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caldera-glaciale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caldera-glaciale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "capillari_fluoridici": {
@@ -1966,30 +1937,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "foresta_acida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "foresta_acida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "foresta-acida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "foresta-acida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "capillari_fotovoltaici": {
@@ -2008,30 +1980,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "canopia_ionica",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          },
+          {
+            "biome": "canopia_ionica",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "canopia-ionica-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "canopia-ionica-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "capsule_paracadute": {
@@ -2050,30 +2023,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "stratosfera_tempestosa",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          },
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "stratosfera-tempestosa-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "stratosfera-tempestosa-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "carapace_fase_variabile": {
@@ -2092,46 +2066,72 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 5,
+        "coverage": [
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopia-psionica-leggera-trait-keeper"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "falde-magnetiche-psioniche-trait-keeper"
+            ]
+          },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "cursoriale_quadrupede"
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "cryo-lynx"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "balor-fission"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "golem-runico"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "balor-fission",
-          "bulette-fase",
-          "canopia-psionica-leggera-trait-keeper",
-          "cryo-lynx",
-          "falde-magnetiche-psioniche-trait-keeper",
-          "golem-runico",
-          "nano-rust-bloom",
-          "otyugh-sentinella",
-          "sand-burrower"
         ]
       },
-      "affinity": {
-        "total_species": 9,
-        "roles_breakdown": {
-          "optional": 9
-        },
-        "top_species": [
-          "balor-fission",
-          "bulette-fase",
-          "canopia-psionica-leggera-trait-keeper",
-          "cryo-lynx",
-          "falde-magnetiche-psioniche-trait-keeper",
-          "golem-runico",
-          "nano-rust-bloom",
-          "otyugh-sentinella",
-          "sand-burrower"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato"
+          }
+        ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "carapace_luminiscente_abissale": {
@@ -2144,25 +2144,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "abisso_luminescente",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "abisso-luminescente-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "abisso_luminescente",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "abisso-luminescente-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "abisso-luminescente-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "carapace_segmenti_logici": {
@@ -2181,30 +2184,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "steppe_algoritmiche",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
+          },
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "steppe-algoritmiche-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "steppe-algoritmiche-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "carapaci_ferruginosi": {
@@ -2223,30 +2227,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "abisso_vulcanico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "abisso-vulcanico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "abisso-vulcanico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "cartilagine_flessotermica_venti": {
@@ -2259,25 +2264,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "gole_ventose",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "gole-ventose-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "gole_ventose",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "gole-ventose-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "gole-ventose-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "cartilagini_biofibre": {
@@ -2296,30 +2304,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "reef_luminescente",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          },
+          {
+            "biome": "reef_luminescente",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "reef-luminescente-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "reef-luminescente-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "cartilagini_desertiche": {
@@ -2338,30 +2347,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "pianura_salina_iperarida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "pianura-salina-iperarida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "pianura-salina-iperarida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "cartilagini_flessoacustiche": {
@@ -2380,30 +2390,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caverna_risonante",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caverna-risonante-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "cartilagini_pseudometalliche": {
@@ -2422,30 +2433,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "abisso_vulcanico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "abisso-vulcanico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "abisso-vulcanico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "cavita_risonanti_tundra": {
@@ -2458,25 +2470,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "tundra_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "tundra-risonante-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "tundra_risonante",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "tundra-risonante-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "tundra-risonante-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "cervelletto_equilibrio_statico": {
@@ -2495,30 +2510,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "canopia_ionica",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          },
+          {
+            "biome": "canopia_ionica",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "canopia-ionica-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "canopia-ionica-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "chemiorecettori_bromuro": {
@@ -2537,30 +2553,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "pianura_salina_iperarida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "pianura-salina-iperarida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "pianura-salina-iperarida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "chioma_parassita_canopica": {
@@ -2573,25 +2590,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "canopie_sospese",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopie-sospese-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "canopie_sospese",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "canopie-sospese-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "canopie-sospese-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "circolazione_bifasica": {
@@ -2610,30 +2630,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caldera_glaciale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caldera-glaciale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caldera-glaciale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "circolazione_bifasica_palude": {
@@ -2646,25 +2667,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "paludi_gas_luminescenti",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "paludi-gas-luminescenti-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "paludi_gas_luminescenti",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "paludi-gas-luminescenti-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "paludi-gas-luminescenti-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "circolazione_cooling_loop": {
@@ -2683,30 +2707,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "steppe_algoritmiche",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
+          },
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "steppe-algoritmiche-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "steppe-algoritmiche-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "circolazione_doppia": {
@@ -2725,30 +2750,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "dorsale-termale-tropicale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "dorsale-termale-tropicale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "circolazione_supercritica": {
@@ -2767,30 +2793,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "abisso_vulcanico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "abisso-vulcanico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "abisso-vulcanico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ciste_riduttive": {
@@ -2809,30 +2836,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "laguna_bioreattiva",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
+          },
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "laguna-bioreattiva-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "laguna-bioreattiva-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ciste_salmastre": {
@@ -2851,30 +2879,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "pianura_salina_iperarida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "pianura-salina-iperarida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "pianura-salina-iperarida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "cisti_iperbariche": {
@@ -2893,30 +2922,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "abisso_vulcanico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "abisso-vulcanico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "abisso-vulcanico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "coda_balanciere": {
@@ -2935,30 +2965,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caverna_risonante",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caverna-risonante-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "coda_contrappeso": {
@@ -2977,30 +3008,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "mangrovieto_cinetico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "mangrovieto-cinetico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "mangrovieto-cinetico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "coda_coppia_retroattiva": {
@@ -3019,30 +3051,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "steppe_algoritmiche",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
+          },
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "steppe-algoritmiche-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "steppe-algoritmiche-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "coda_frusta_cinetica": {
@@ -3061,43 +3094,63 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 7,
+        "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 3,
+            "examples": [
+              "dune-stalker",
+              "magneto-ridge-hunter",
+              "slag-veil-ambusher"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "falde-magnetiche-psioniche-trait-keeper"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "orbita-psionica-inversa-trait-keeper"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 2,
+            "examples": [
+              "bulette-fase",
+              "marilith-vault"
+            ]
+          }
+        ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
             "morphotype": "cursoriale_quadrupede"
           }
         ],
-        "missing_in_rules": [],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "bulette-fase",
-          "dune-stalker",
-          "falde-magnetiche-psioniche-trait-keeper",
-          "magneto-ridge-hunter",
-          "marilith-vault",
-          "orbita-psionica-inversa-trait-keeper",
-          "slag-veil-ambusher"
-        ]
-      },
-      "affinity": {
-        "total_species": 7,
-        "roles_breakdown": {
-          "core": 3,
-          "optional": 7
-        },
-        "top_species": [
-          "dune-stalker",
-          "magneto-ridge-hunter",
-          "slag-veil-ambusher",
-          "bulette-fase",
-          "falde-magnetiche-psioniche-trait-keeper",
-          "marilith-vault",
-          "orbita-psionica-inversa-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "coda_stabilizzatrice_filo": {
@@ -3116,30 +3169,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "canopia_ionica",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          },
+          {
+            "biome": "canopia_ionica",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "canopia-ionica-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "canopia-ionica-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "coda_stabilizzatrice_geiser": {
@@ -3158,30 +3212,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "dorsale-termale-tropicale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "dorsale-termale-tropicale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "coda_stabilizzatrice_vortex": {
@@ -3200,30 +3255,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "stratosfera_tempestosa",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          },
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "stratosfera-tempestosa-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "stratosfera-tempestosa-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "colonne_vibromagnetiche": {
@@ -3242,30 +3298,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caverna_risonante",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caverna-risonante-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "coralli_partner": {
@@ -3284,30 +3341,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "reef_luminescente",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          },
+          {
+            "biome": "reef_luminescente",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "reef-luminescente-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "reef-luminescente-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "criostasi_adattiva": {
@@ -3326,36 +3384,48 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 3,
+        "coverage": [
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopia-psionica-leggera-trait-keeper"
+            ]
+          },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore"
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "aurora-gull"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "orbita-psionica-inversa-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "aurora-gull",
-          "canopia-psionica-leggera-trait-keeper",
-          "orbita-psionica-inversa-trait-keeper",
-          "orbital-ascendant"
         ]
       },
-      "affinity": {
-        "total_species": 4,
-        "roles_breakdown": {
-          "optional": 4
-        },
-        "top_species": [
-          "aurora-gull",
-          "canopia-psionica-leggera-trait-keeper",
-          "orbita-psionica-inversa-trait-keeper",
-          "orbital-ascendant"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "cromofori_alert_acido": {
@@ -3374,30 +3444,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "foresta_acida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "foresta_acida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "foresta-acida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "foresta-acida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "cuore_multicamera_bassa_pressione": {
@@ -3416,30 +3487,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "stratosfera_tempestosa",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          },
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "stratosfera-tempestosa-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "stratosfera-tempestosa-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "cuscinetti_elettrostatici": {
@@ -3458,30 +3530,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "pianura_salina_iperarida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "pianura-salina-iperarida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "pianura-salina-iperarida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "cute_resistente_sali": {
@@ -3505,7 +3578,7 @@
         ]
       },
       "species": {
-        "total": 2,
+        "total": 5,
         "coverage": [
           {
             "biome": null,
@@ -3522,34 +3595,43 @@
             "examples": [
               "global-trait-keeper"
             ]
+          },
+          {
+            "biome": "badlands",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "badlands-trait-keeper"
+            ]
+          },
+          {
+            "biome": "badlands",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "badlands-trait-keeper"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "evento-tempesta-ferrosa"
+            ]
           }
         ]
       },
       "diff": {
-        "missing_in_species": [
+        "missing_in_species": [],
+        "missing_in_rules": [
           {
-            "biome": "badlands",
-            "morphotype": null
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "volatore_planatore"
           }
         ],
-        "missing_in_rules": [],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "badlands-trait-keeper",
-          "evento-tempesta-ferrosa"
-        ]
-      },
-      "affinity": {
-        "total_species": 3,
-        "roles_breakdown": {
-          "core": 1,
-          "optional": 3
-        },
-        "top_species": [
-          "evento-tempesta-ferrosa",
-          "badlands-trait-keeper",
-          "global-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "cuticole_cerose": {
@@ -3568,7 +3650,7 @@
         ]
       },
       "species": {
-        "total": 2,
+        "total": 8,
         "coverage": [
           {
             "biome": null,
@@ -3585,36 +3667,76 @@
             "examples": [
               "global-trait-keeper"
             ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "thermo-raptor"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "ingegnere_radicante",
+            "count": 1,
+            "examples": [
+              "cactus-weaver"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "silica-bloom"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "volatore_planatore",
+            "count": 2,
+            "examples": [
+              "evento-ondata-termica",
+              "noctule-termico"
+            ]
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "evento-brinastorm"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "ingegnere_radicante"
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "scavenger_corazzato"
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "volatore_planatore"
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "cactus-weaver",
-          "evento-brinastorm",
-          "evento-ondata-termica",
-          "noctule-termico",
-          "silica-bloom",
-          "thermo-raptor"
-        ]
-      },
-      "affinity": {
-        "total_species": 7,
-        "roles_breakdown": {
-          "optional": 7
-        },
-        "top_species": [
-          "cactus-weaver",
-          "evento-brinastorm",
-          "evento-ondata-termica",
-          "global-trait-keeper",
-          "noctule-termico",
-          "silica-bloom",
-          "thermo-raptor"
-        ]
+        "missing_in_matrix": []
       }
     },
     "cuticole_neutralizzanti": {
@@ -3633,30 +3755,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "foresta_acida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "foresta_acida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "foresta-acida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "foresta-acida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "denti_chelatanti": {
@@ -3675,30 +3798,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "foresta_acida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "foresta_acida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "foresta-acida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "foresta-acida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "denti_ossidoferro": {
@@ -3717,30 +3841,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "abisso_vulcanico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "abisso-vulcanico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "abisso-vulcanico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "denti_silice_termici": {
@@ -3759,30 +3884,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "dorsale-termale-tropicale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "dorsale-termale-tropicale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "denti_tuning_fork": {
@@ -3801,30 +3927,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caverna_risonante",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caverna-risonante-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "echi_risonanti": {
@@ -3843,30 +3970,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caverna_risonante",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caverna-risonante-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "eco_interno_riflesso": {
@@ -3890,47 +4018,58 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 6,
+        "coverage": [
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopia-psionica-leggera-trait-keeper"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "volatore_planatore"
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "echo-wing"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "falde-magnetiche-psioniche-trait-keeper"
+            ]
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore"
+            "morphotype": "volatore_planatore",
+            "count": 3,
+            "examples": [
+              "aurora-bridge-runner",
+              "aurora-gull",
+              "zephyr-spore-courier"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "aurora-bridge-runner",
-          "aurora-gull",
-          "canopia-psionica-leggera-trait-keeper",
-          "echo-wing",
-          "falde-magnetiche-psioniche-trait-keeper",
-          "orbital-ascendant",
-          "zephyr-spore-courier"
         ]
       },
-      "affinity": {
-        "total_species": 7,
-        "roles_breakdown": {
-          "core": 1,
-          "optional": 7
-        },
-        "top_species": [
-          "echo-wing",
-          "aurora-bridge-runner",
-          "aurora-gull",
-          "canopia-psionica-leggera-trait-keeper",
-          "falde-magnetiche-psioniche-trait-keeper",
-          "orbital-ascendant",
-          "zephyr-spore-courier"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "empatia_coordinativa": {
@@ -3949,44 +4088,60 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 8,
+        "coverage": [
           {
             "biome": "foresta_miceliale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 3,
+            "examples": [
+              "glowcap-weaver",
+              "lupus-temperatus",
+              "myco-spire-warden"
+            ]
+          },
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": "scavenger_corazzato",
+            "count": 2,
+            "examples": [
+              "glowcap-weaver",
+              "myco-spire-warden"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "rakshasa-corte"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore",
+            "count": 2,
+            "examples": [
+              "archon-solare",
+              "couatl-aurora"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "archon-solare",
-          "balor-fission",
-          "couatl-aurora",
-          "glowcap-weaver",
-          "lupus-temperatus",
-          "marilith-vault",
-          "myco-spire-warden",
-          "rakshasa-corte"
         ]
       },
-      "affinity": {
-        "total_species": 8,
-        "roles_breakdown": {
-          "optional": 8
-        },
-        "top_species": [
-          "archon-solare",
-          "balor-fission",
-          "couatl-aurora",
-          "glowcap-weaver",
-          "lupus-temperatus",
-          "marilith-vault",
-          "myco-spire-warden",
-          "rakshasa-corte"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore"
+          }
+        ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "enzimi_antifase_termica": {
@@ -4005,30 +4160,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caldera_glaciale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caldera-glaciale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caldera-glaciale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "enzimi_antipredatori_algali": {
@@ -4047,30 +4203,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "reef_luminescente",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          },
+          {
+            "biome": "reef_luminescente",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "reef-luminescente-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "reef-luminescente-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "enzimi_chelanti": {
@@ -4089,7 +4246,7 @@
         ]
       },
       "species": {
-        "total": 2,
+        "total": 3,
         "coverage": [
           {
             "biome": null,
@@ -4106,27 +4263,27 @@
             "examples": [
               "global-trait-keeper"
             ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "evento-tempesta-ferrosa"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "volatore_planatore"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "evento-tempesta-ferrosa"
-        ]
-      },
-      "affinity": {
-        "total_species": 2,
-        "roles_breakdown": {
-          "core": 1,
-          "optional": 2
-        },
-        "top_species": [
-          "evento-tempesta-ferrosa",
-          "global-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "enzimi_chelatori_rapidi": {
@@ -4145,30 +4302,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "foresta_acida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "foresta_acida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "foresta-acida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "foresta-acida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "enzimi_metanoossidanti": {
@@ -4187,30 +4345,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "abisso_vulcanico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "abisso-vulcanico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "abisso-vulcanico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "epidermide_dielettrica": {
@@ -4229,30 +4388,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "stratosfera_tempestosa",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          },
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "stratosfera-tempestosa-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "stratosfera-tempestosa-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "epitelio_fosforescente": {
@@ -4271,30 +4431,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "reef_luminescente",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          },
+          {
+            "biome": "reef_luminescente",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "reef-luminescente-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "reef-luminescente-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "filamenti_digestivi_compattanti": {
@@ -4328,57 +4489,88 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 12,
+        "coverage": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "scavenger_corazzato"
+            "morphotype": "scavenger_corazzato",
+            "count": 2,
+            "examples": [
+              "nano-rust-bloom",
+              "rust-scavenger"
+            ]
           },
           {
             "biome": "falde_magnetiche_psioniche",
-            "morphotype": null
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "falde-magnetiche-psioniche-trait-keeper",
+              "magnet-fathom-surveyor"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "falde-magnetiche-psioniche-trait-keeper"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "magnet-fathom-surveyor"
+            ]
           },
           {
             "biome": "foresta_miceliale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "glowcap-weaver",
+              "myco-spire-warden"
+            ]
+          },
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": "scavenger_corazzato",
+            "count": 2,
+            "examples": [
+              "glowcap-weaver",
+              "myco-spire-warden"
+            ]
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "scavenger_corazzato"
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "thaw-rot"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper",
-          "falde-magnetiche-psioniche-trait-keeper",
-          "glowcap-weaver",
-          "magnet-fathom-surveyor",
-          "myco-spire-warden",
-          "nano-rust-bloom",
-          "rust-scavenger",
-          "thaw-rot"
         ]
       },
-      "affinity": {
-        "total_species": 8,
-        "roles_breakdown": {
-          "core": 3,
-          "optional": 8
-        },
-        "top_species": [
-          "magnet-fathom-surveyor",
-          "nano-rust-bloom",
-          "rust-scavenger",
-          "caverna-risonante-trait-keeper",
-          "falde-magnetiche-psioniche-trait-keeper",
-          "glowcap-weaver",
-          "myco-spire-warden",
-          "thaw-rot"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "filamenti_magnetotrofi": {
@@ -4397,30 +4589,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "abisso_vulcanico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "abisso-vulcanico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "abisso-vulcanico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "filamenti_superconduttivi": {
@@ -4439,30 +4632,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caldera_glaciale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caldera-glaciale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caldera-glaciale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "filamenti_termoconduzione": {
@@ -4481,30 +4675,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "dorsale-termale-tropicale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "dorsale-termale-tropicale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "filtri_planctonici": {
@@ -4523,30 +4718,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "laguna_bioreattiva",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
+          },
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "laguna-bioreattiva-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "laguna-bioreattiva-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "flagelli_ancoranti": {
@@ -4565,30 +4761,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "laguna_bioreattiva",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
+          },
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "laguna-bioreattiva-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "laguna-bioreattiva-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "focus_frazionato": {
@@ -4617,54 +4814,55 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 5,
+        "coverage": [
           {
             "biome": "canopia_psionica_leggera",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "psionic-canopy-scout"
+            ]
+          },
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "psionic-canopy-scout"
+            ]
           },
           {
             "biome": "foresta_miceliale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "sentinella-radice"
+            ]
           },
           {
             "biome": "orbita_psionica_inversa",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "orbital-ascendant"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "orbital-ascendant"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "archon-solare",
-          "balor-fission",
-          "banshee-risonante",
-          "couatl-aurora",
-          "marilith-vault",
-          "orbital-ascendant",
-          "psionic-canopy-scout",
-          "sentinella-radice"
         ]
       },
-      "affinity": {
-        "total_species": 8,
-        "roles_breakdown": {
-          "core": 3,
-          "optional": 3,
-          "synergy": 4
-        },
-        "top_species": [
-          "orbital-ascendant",
-          "psionic-canopy-scout",
-          "marilith-vault",
-          "archon-solare",
-          "balor-fission",
-          "banshee-risonante",
-          "couatl-aurora",
-          "sentinella-radice"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "foliage_fotocatodico": {
@@ -4683,30 +4881,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "foresta_acida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "foresta_acida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "foresta-acida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "foresta-acida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "foliaggio_spugna": {
@@ -4725,30 +4924,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "mangrovieto_cinetico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "mangrovieto-cinetico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "mangrovieto-cinetico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "frusta_fiammeggiante": {
@@ -4761,28 +4961,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "balor-fission"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "balor-fission",
-          "marilith-vault"
-        ]
-      },
-      "affinity": {
-        "total_species": 2,
-        "roles_breakdown": {
-          "core": 2,
-          "optional": 1
-        },
-        "top_species": [
-          "balor-fission",
-          "marilith-vault"
-        ]
+        "missing_in_matrix": []
       }
     },
     "ghiaccio_piezoelettrico": {
@@ -4801,30 +5001,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caldera_glaciale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caldera-glaciale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caldera-glaciale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ghiandola_caustica": {
@@ -4843,32 +5044,23 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 1,
+        "coverage": [
           {
             "biome": "foresta_miceliale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "blight-micotico"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "blight-micotico",
-          "slag-veil-ambusher"
         ]
       },
-      "affinity": {
-        "total_species": 2,
-        "roles_breakdown": {
-          "optional": 2
-        },
-        "top_species": [
-          "blight-micotico",
-          "slag-veil-ambusher"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ghiandole_cambio_salino": {
@@ -4887,30 +5079,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "laguna_bioreattiva",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
+          },
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "laguna-bioreattiva-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "laguna-bioreattiva-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ghiandole_condensa_ozono": {
@@ -4929,30 +5122,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "stratosfera_tempestosa",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          },
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "stratosfera-tempestosa-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "stratosfera-tempestosa-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ghiandole_eco_mappanti": {
@@ -4971,30 +5165,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caverna_risonante",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caverna-risonante-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ghiandole_fango_calde": {
@@ -5013,30 +5208,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "abisso_vulcanico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "abisso-vulcanico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "abisso-vulcanico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ghiandole_fango_coesivo": {
@@ -5055,30 +5251,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "mangrovieto_cinetico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "mangrovieto-cinetico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "mangrovieto-cinetico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ghiandole_grafene": {
@@ -5097,30 +5294,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "steppe_algoritmiche",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
+          },
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "steppe-algoritmiche-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "steppe-algoritmiche-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ghiandole_inchiostro_luce": {
@@ -5139,30 +5337,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "reef_luminescente",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          },
+          {
+            "biome": "reef_luminescente",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "reef-luminescente-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "reef-luminescente-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ghiandole_iodoattive": {
@@ -5181,30 +5380,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "pianura_salina_iperarida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "pianura-salina-iperarida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "pianura-salina-iperarida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ghiandole_minerali": {
@@ -5223,30 +5423,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "dorsale-termale-tropicale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "dorsale-termale-tropicale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ghiandole_nebbia_acida": {
@@ -5265,30 +5466,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "foresta_acida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "foresta_acida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "foresta-acida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "foresta-acida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ghiandole_nebbia_ionica": {
@@ -5307,30 +5509,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "canopia_ionica",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          },
+          {
+            "biome": "canopia_ionica",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "canopia-ionica-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "canopia-ionica-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ghiandole_resina_conduttiva": {
@@ -5349,30 +5552,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "canopia_ionica",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          },
+          {
+            "biome": "canopia_ionica",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "canopia-ionica-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "canopia-ionica-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "ghiandole_ventosa": {
@@ -5391,30 +5595,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caldera_glaciale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caldera-glaciale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caldera-glaciale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "giunti_antitorsione": {
@@ -5433,30 +5638,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "mangrovieto_cinetico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "mangrovieto-cinetico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "mangrovieto-cinetico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "grassi_termici": {
@@ -5475,7 +5681,7 @@
         ]
       },
       "species": {
-        "total": 2,
+        "total": 8,
         "coverage": [
           {
             "biome": null,
@@ -5492,36 +5698,76 @@
             "examples": [
               "global-trait-keeper"
             ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "thermo-raptor"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "ingegnere_radicante",
+            "count": 1,
+            "examples": [
+              "cactus-weaver"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "silica-bloom"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "volatore_planatore",
+            "count": 2,
+            "examples": [
+              "evento-ondata-termica",
+              "noctule-termico"
+            ]
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "evento-brinastorm"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "ingegnere_radicante"
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "scavenger_corazzato"
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "volatore_planatore"
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "cactus-weaver",
-          "evento-brinastorm",
-          "evento-ondata-termica",
-          "noctule-termico",
-          "silica-bloom",
-          "thermo-raptor"
-        ]
-      },
-      "affinity": {
-        "total_species": 7,
-        "roles_breakdown": {
-          "optional": 7
-        },
-        "top_species": [
-          "cactus-weaver",
-          "evento-brinastorm",
-          "evento-ondata-termica",
-          "global-trait-keeper",
-          "noctule-termico",
-          "silica-bloom",
-          "thermo-raptor"
-        ]
+        "missing_in_matrix": []
       }
     },
     "gusci_criovetro": {
@@ -5540,30 +5786,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caldera_glaciale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caldera-glaciale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caldera-glaciale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "gusci_magnesio": {
@@ -5582,30 +5829,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "dorsale-termale-tropicale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "dorsale-termale-tropicale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "lamelle_shear": {
@@ -5624,30 +5872,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "stratosfera_tempestosa",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          },
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "stratosfera-tempestosa-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "stratosfera-tempestosa-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "lamelle_sincroniche": {
@@ -5666,30 +5915,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "steppe_algoritmiche",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
+          },
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "steppe-algoritmiche-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "steppe-algoritmiche-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "lamelle_termoforetiche": {
@@ -5702,33 +5952,40 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 2,
+        "coverage": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "bulette-fase"
+            ]
+          },
+          {
+            "biome": "sorgenti_geotermiche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "sorgenti-geotermiche-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "sorgenti_geotermiche",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "bulette-fase",
-          "couatl-aurora",
-          "magnet-fathom-surveyor",
-          "otyugh-sentinella",
-          "sorgenti-geotermiche-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 5,
-        "roles_breakdown": {
-          "optional": 5
-        },
-        "top_species": [
-          "bulette-fase",
-          "couatl-aurora",
-          "magnet-fathom-surveyor",
-          "otyugh-sentinella",
-          "sorgenti-geotermiche-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "lamine_filtranti_aeree": {
@@ -5747,30 +6004,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "mangrovieto_cinetico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "mangrovieto-cinetico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "mangrovieto-cinetico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "lamine_scudo_silice": {
@@ -5789,30 +6047,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "dorsale-termale-tropicale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "dorsale-termale-tropicale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "linfa_tampone": {
@@ -5831,30 +6090,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "foresta_acida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "foresta_acida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "foresta-acida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "foresta-acida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "lingua_cristallina": {
@@ -5873,30 +6133,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "pianura_salina_iperarida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "pianura-salina-iperarida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "pianura-salina-iperarida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "lingua_tattile_trama": {
@@ -5915,36 +6176,36 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
           {
             "biome": "foresta_miceliale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "blight-micotico"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "blight-micotico",
-          "caverna-risonante-trait-keeper",
-          "echo-wing",
-          "ferrocolonia-magnetotattica"
         ]
       },
-      "affinity": {
-        "total_species": 4,
-        "roles_breakdown": {
-          "optional": 4
-        },
-        "top_species": [
-          "blight-micotico",
-          "caverna-risonante-trait-keeper",
-          "echo-wing",
-          "ferrocolonia-magnetotattica"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "luminescenza_aurorale": {
@@ -5963,30 +6224,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caldera_glaciale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caldera-glaciale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caldera-glaciale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "luminescenza_hydrotermica": {
@@ -6005,30 +6267,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "abisso_vulcanico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "abisso-vulcanico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "abisso-vulcanico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "mantelli_geotermici": {
@@ -6047,30 +6310,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caldera_glaciale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caldera-glaciale-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caldera-glaciale-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "mantello_meteoritico": {
@@ -6083,28 +6347,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "balor-fission"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "balor-fission",
-          "marilith-vault"
-        ]
-      },
-      "affinity": {
-        "total_species": 2,
-        "roles_breakdown": {
-          "core": 2,
-          "optional": 1
-        },
-        "top_species": [
-          "balor-fission",
-          "marilith-vault"
-        ]
+        "missing_in_matrix": []
       }
     },
     "membrane_captura_rugiada": {
@@ -6123,30 +6387,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "pianura_salina_iperarida",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          },
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "pianura-salina-iperarida-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "pianura-salina-iperarida-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "membrane_eliofiltranti": {
@@ -6159,25 +6424,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "laghi_alcalini",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "laghi-alcalini-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "laghi_alcalini",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "laghi-alcalini-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "laghi-alcalini-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "membrane_planata_vectored": {
@@ -6196,30 +6464,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "canopia_ionica",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          },
+          {
+            "biome": "canopia_ionica",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "canopia-ionica-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "canopia-ionica-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "membrane_pneumatofori": {
@@ -6238,30 +6507,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "mangrovieto_cinetico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "mangrovieto-cinetico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "mangrovieto-cinetico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "midollo_antivibrazione": {
@@ -6280,30 +6550,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caverna_risonante",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caverna-risonante-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "mimetismo_cromatico_passivo": {
@@ -6332,49 +6603,70 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 8,
+        "coverage": [
           {
             "biome": "canopia_psionica_leggera",
-            "morphotype": null
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "canopia-psionica-leggera-trait-keeper",
+              "psionic-canopy-scout"
+            ]
+          },
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopia-psionica-leggera-trait-keeper"
+            ]
+          },
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "psionic-canopy-scout"
+            ]
           },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "ingegnere_radicante"
+            "morphotype": "ingegnere_radicante",
+            "count": 1,
+            "examples": [
+              "ferrocolonia-magnetotattica"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "falde-magnetiche-psioniche-trait-keeper"
+            ]
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore"
+            "morphotype": "volatore_planatore",
+            "count": 2,
+            "examples": [
+              "aurora-bridge-runner",
+              "zephyr-spore-courier"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "aurora-bridge-runner",
-          "canopia-psionica-leggera-trait-keeper",
-          "falde-magnetiche-psioniche-trait-keeper",
-          "ferrocolonia-magnetotattica",
-          "psionic-canopy-scout",
-          "zephyr-spore-courier"
         ]
       },
-      "affinity": {
-        "total_species": 6,
-        "roles_breakdown": {
-          "core": 2,
-          "optional": 6
-        },
-        "top_species": [
-          "ferrocolonia-magnetotattica",
-          "psionic-canopy-scout",
-          "aurora-bridge-runner",
-          "canopia-psionica-leggera-trait-keeper",
-          "falde-magnetiche-psioniche-trait-keeper",
-          "zephyr-spore-courier"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "mucillagine_simbionte_mangrovie": {
@@ -6387,25 +6679,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "mangrovie_risonanti",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "mangrovie-risonanti-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "mangrovie_risonanti",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "mangrovie-risonanti-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "mangrovie-risonanti-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "mucose_aderenza_sonica": {
@@ -6424,30 +6719,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "caverna_risonante",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "caverna-risonante-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "mucose_barofile": {
@@ -6466,30 +6762,31 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "abisso_vulcanico",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          },
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "abisso-vulcanico-trait-keeper"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "abisso-vulcanico-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "nodi_micorrizici_oracolari": {
@@ -6502,25 +6799,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "reti_micorriziche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "reti-micorriziche-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "reti_micorriziche",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "reti-micorriziche-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "reti-micorriziche-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "nucleo_ovomotore_rotante": {
@@ -6549,47 +6849,68 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 6,
+        "coverage": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede"
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "sand-burrower"
+            ]
           },
           {
             "biome": "falde_magnetiche_psioniche",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "magnet-fathom-surveyor"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "magnet-fathom-surveyor"
+            ]
           },
           {
             "biome": "orbita_psionica_inversa",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "orbital-ascendant"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "orbital-ascendant"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper",
-          "magnet-fathom-surveyor",
-          "orbital-ascendant",
-          "rust-scavenger",
-          "sand-burrower"
         ]
       },
-      "affinity": {
-        "total_species": 5,
-        "roles_breakdown": {
-          "core": 3,
-          "optional": 5
-        },
-        "top_species": [
-          "magnet-fathom-surveyor",
-          "orbital-ascendant",
-          "sand-burrower",
-          "caverna-risonante-trait-keeper",
-          "rust-scavenger"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "occhi_infrarosso_composti": {
@@ -6608,33 +6929,36 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "volatore_planatore"
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "echo-wing"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper",
-          "echo-wing"
         ]
       },
-      "affinity": {
-        "total_species": 2,
-        "roles_breakdown": {
-          "core": 1,
-          "optional": 2
-        },
-        "top_species": [
-          "echo-wing",
-          "caverna-risonante-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "olfatto_risonanza_magnetica": {
@@ -6668,59 +6992,81 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 10,
+        "coverage": [
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede"
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "slag-veil-ambusher"
+            ]
           },
           {
             "biome": "falde_magnetiche_psioniche",
-            "morphotype": null
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "falde-magnetiche-psioniche-trait-keeper",
+              "magnet-fathom-surveyor"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "falde-magnetiche-psioniche-trait-keeper"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "magnet-fathom-surveyor"
+            ]
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "cursoriale_quadrupede"
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "cryo-lynx"
+            ]
           },
           {
             "biome": "orbita_psionica_inversa",
-            "morphotype": null
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "orbita-psionica-inversa-trait-keeper",
+              "orbital-ascendant"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "orbita-psionica-inversa-trait-keeper"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "orbital-ascendant"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "cryo-lynx",
-          "dune-stalker",
-          "falde-magnetiche-psioniche-trait-keeper",
-          "magnet-fathom-surveyor",
-          "magneto-ridge-hunter",
-          "orbita-psionica-inversa-trait-keeper",
-          "orbital-ascendant",
-          "psionic-canopy-scout",
-          "slag-veil-ambusher"
         ]
       },
-      "affinity": {
-        "total_species": 9,
-        "roles_breakdown": {
-          "core": 3,
-          "optional": 9
-        },
-        "top_species": [
-          "magnet-fathom-surveyor",
-          "orbital-ascendant",
-          "slag-veil-ambusher",
-          "cryo-lynx",
-          "dune-stalker",
-          "falde-magnetiche-psioniche-trait-keeper",
-          "magneto-ridge-hunter",
-          "orbita-psionica-inversa-trait-keeper",
-          "psionic-canopy-scout"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "pathfinder": {
@@ -6739,30 +7085,23 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 1,
+        "coverage": [
           {
             "biome": "foresta_miceliale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "sentinella-radice"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "sentinella-radice"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "sentinella-radice"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "pianificatore": {
@@ -6781,30 +7120,23 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 1,
+        "coverage": [
           {
             "biome": "foresta_miceliale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "sentinella-radice"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "sentinella-radice"
         ]
       },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "sentinella-radice"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "piume_solari_fotovoltaiche": {
@@ -6817,25 +7149,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "altipiani_solari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "altipiani-solari-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "altipiani_solari",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "altipiani-solari-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "altipiani-solari-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "polmoni_cristallini_alta_quota": {
@@ -6848,25 +7183,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "picchi_cristallini",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "picchi-cristallini-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "picchi_cristallini",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "picchi-cristallini-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "picchi-cristallini-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "random": {
@@ -6910,45 +7248,44 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 3,
+        "coverage": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "scavenger_corazzato"
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "rust-scavenger"
+            ]
           },
           {
             "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "steppe-bison-mini"
+            ]
+          }
+        ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "caverna_risonante",
             "morphotype": "cursoriale_quadrupede"
           }
         ],
-        "missing_in_rules": [],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper",
-          "dune-stalker",
-          "magneto-ridge-hunter",
-          "rust-scavenger",
-          "slag-veil-ambusher",
-          "steppe-bison-mini"
-        ]
-      },
-      "affinity": {
-        "total_species": 6,
-        "roles_breakdown": {
-          "core": 1,
-          "optional": 6
-        },
-        "top_species": [
-          "rust-scavenger",
-          "caverna-risonante-trait-keeper",
-          "dune-stalker",
-          "magneto-ridge-hunter",
-          "slag-veil-ambusher",
-          "steppe-bison-mini"
-        ]
+        "missing_in_matrix": []
       }
     },
     "risonanza_di_branco": {
@@ -6967,42 +7304,36 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
           {
             "biome": "foresta_miceliale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "lupus-temperatus"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "archon-solare"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "archon-solare",
-          "banshee-risonante",
-          "couatl-aurora",
-          "lupus-temperatus",
-          "rakshasa-corte",
-          "treant-portale"
         ]
       },
-      "affinity": {
-        "total_species": 6,
-        "roles_breakdown": {
-          "core": 1,
-          "optional": 2,
-          "synergy": 4
-        },
-        "top_species": [
-          "archon-solare",
-          "banshee-risonante",
-          "couatl-aurora",
-          "rakshasa-corte",
-          "treant-portale",
-          "lupus-temperatus"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore"
+          }
+        ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "sacche_galleggianti_ascensoriali": {
@@ -7036,57 +7367,82 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 11,
+        "coverage": [
           {
             "biome": "canopia_psionica_leggera",
-            "morphotype": null
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "canopia-psionica-leggera-trait-keeper",
+              "psionic-canopy-scout"
+            ]
+          },
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopia-psionica-leggera-trait-keeper"
+            ]
+          },
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "psionic-canopy-scout"
+            ]
           },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede"
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "sand-burrower"
+            ]
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore"
+            "morphotype": "volatore_planatore",
+            "count": 2,
+            "examples": [
+              "aurora-bridge-runner",
+              "zephyr-spore-courier"
+            ]
           },
           {
             "biome": "orbita_psionica_inversa",
-            "morphotype": null
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "orbita-psionica-inversa-trait-keeper",
+              "orbital-ascendant"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "orbita-psionica-inversa-trait-keeper"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "orbital-ascendant"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "aurora-bridge-runner",
-          "canopia-psionica-leggera-trait-keeper",
-          "echo-wing",
-          "orbita-psionica-inversa-trait-keeper",
-          "orbital-ascendant",
-          "psionic-canopy-scout",
-          "sand-burrower",
-          "zephyr-spore-courier"
         ]
       },
-      "affinity": {
-        "total_species": 8,
-        "roles_breakdown": {
-          "core": 3,
-          "optional": 8
-        },
-        "top_species": [
-          "orbital-ascendant",
-          "psionic-canopy-scout",
-          "sand-burrower",
-          "aurora-bridge-runner",
-          "canopia-psionica-leggera-trait-keeper",
-          "echo-wing",
-          "orbita-psionica-inversa-trait-keeper",
-          "zephyr-spore-courier"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "sacche_spore_stratosferiche": {
@@ -7099,25 +7455,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "stratosfera_portante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "stratosfera-portante-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "stratosfera_portante",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "stratosfera-portante-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "stratosfera-portante-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "sangue_piroforico": {
@@ -7141,41 +7500,44 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 3,
+        "coverage": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "ingegnere_radicante"
+            "morphotype": "ingegnere_radicante",
+            "count": 1,
+            "examples": [
+              "ferrocolonia-magnetotattica"
+            ]
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "scavenger_corazzato"
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "thaw-rot"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper",
-          "ferrocolonia-magnetotattica",
-          "nano-rust-bloom",
-          "thaw-rot"
         ]
       },
-      "affinity": {
-        "total_species": 4,
-        "roles_breakdown": {
-          "core": 1,
-          "optional": 4
-        },
-        "top_species": [
-          "ferrocolonia-magnetotattica",
-          "caverna-risonante-trait-keeper",
-          "nano-rust-bloom",
-          "thaw-rot"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "scheletro_idro_regolante": {
@@ -7204,58 +7566,66 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 7,
+        "coverage": [
           {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede"
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
           },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "scavenger_corazzato"
+            "morphotype": "cursoriale_quadrupede",
+            "count": 3,
+            "examples": [
+              "dune-stalker",
+              "magneto-ridge-hunter",
+              "sand-burrower"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "nano-rust-bloom"
+            ]
           },
           {
             "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "steppe-bison-mini"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "bulette-fase"
+            ]
+          }
+        ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
             "morphotype": "cursoriale_quadrupede"
           }
         ],
-        "missing_in_rules": [],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "bulette-fase",
-          "caverna-risonante-trait-keeper",
-          "dune-stalker",
-          "magnet-fathom-surveyor",
-          "magneto-ridge-hunter",
-          "nano-rust-bloom",
-          "rust-scavenger",
-          "sand-burrower",
-          "slag-veil-ambusher",
-          "steppe-bison-mini"
-        ]
-      },
-      "affinity": {
-        "total_species": 10,
-        "roles_breakdown": {
-          "core": 4,
-          "optional": 9,
-          "synergy": 1
-        },
-        "top_species": [
-          "dune-stalker",
-          "magneto-ridge-hunter",
-          "nano-rust-bloom",
-          "sand-burrower",
-          "slag-veil-ambusher",
-          "bulette-fase",
-          "caverna-risonante-trait-keeper",
-          "magnet-fathom-surveyor",
-          "rust-scavenger",
-          "steppe-bison-mini"
-        ]
+        "missing_in_matrix": []
       }
     },
     "secrezione_rallentante_palmi": {
@@ -7274,33 +7644,36 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 2,
+        "coverage": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "ingegnere_radicante"
+            "morphotype": "ingegnere_radicante",
+            "count": 1,
+            "examples": [
+              "ferrocolonia-magnetotattica"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper",
-          "ferrocolonia-magnetotattica"
         ]
       },
-      "affinity": {
-        "total_species": 2,
-        "roles_breakdown": {
-          "core": 1,
-          "optional": 2
-        },
-        "top_species": [
-          "ferrocolonia-magnetotattica",
-          "caverna-risonante-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "sensori_geomagnetici": {
@@ -7313,31 +7686,53 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 4,
+        "coverage": [
+          {
+            "biome": "pianure_magnetiche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "pianure-magnetiche-trait-keeper"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 2,
+            "examples": [
+              "bulette-fase",
+              "marilith-vault"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "couatl-aurora"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "pianure_magnetiche",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "bulette-fase",
-          "couatl-aurora",
-          "marilith-vault",
-          "pianure-magnetiche-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 4,
-        "roles_breakdown": {
-          "optional": 4
-        },
-        "top_species": [
-          "bulette-fase",
-          "couatl-aurora",
-          "marilith-vault",
-          "pianure-magnetiche-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "sinapsi_coraline_polifoniche": {
@@ -7350,25 +7745,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "barriere_coralline_psioniche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "barriere-coralline-psioniche-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "barriere_coralline_psioniche",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "barriere-coralline-psioniche-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "barriere-coralline-psioniche-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "sonno_emisferico_alternato": {
@@ -7392,39 +7790,44 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 3,
+        "coverage": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "volatore_planatore"
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "echo-wing"
+            ]
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore"
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "aurora-gull"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "aurora-gull",
-          "caverna-risonante-trait-keeper",
-          "echo-wing"
         ]
       },
-      "affinity": {
-        "total_species": 3,
-        "roles_breakdown": {
-          "core": 1,
-          "optional": 3
-        },
-        "top_species": [
-          "echo-wing",
-          "aurora-gull",
-          "caverna-risonante-trait-keeper"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "spore_psichiche_silenziate": {
@@ -7453,45 +7856,52 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 4,
+        "coverage": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "scavenger_corazzato"
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "nano-rust-bloom"
+            ]
           },
           {
             "biome": "foresta_miceliale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "blight-micotico"
+            ]
           },
           {
             "biome": "mezzanotte_orbitale",
-            "morphotype": "scavenger_corazzato"
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "thaw-rot"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "blight-micotico",
-          "caverna-risonante-trait-keeper",
-          "nano-rust-bloom",
-          "thaw-rot"
         ]
       },
-      "affinity": {
-        "total_species": 4,
-        "roles_breakdown": {
-          "core": 1,
-          "optional": 4
-        },
-        "top_species": [
-          "nano-rust-bloom",
-          "blight-micotico",
-          "caverna-risonante-trait-keeper",
-          "thaw-rot"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "squame_rifrangenti_deserto": {
@@ -7504,25 +7914,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "dune_cristalline",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "dune-cristalline-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "dune_cristalline",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "dune-cristalline-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "dune-cristalline-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "struttura_elastica_amorfa": {
@@ -7556,60 +7969,92 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 14,
+        "coverage": [
           {
             "biome": "canopia_psionica_leggera",
-            "morphotype": null
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "canopia-psionica-leggera-trait-keeper",
+              "psionic-canopy-scout"
+            ]
+          },
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "canopia-psionica-leggera-trait-keeper"
+            ]
+          },
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "psionic-canopy-scout"
+            ]
           },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede"
+            "morphotype": "cursoriale_quadrupede",
+            "count": 2,
+            "examples": [
+              "dune-stalker",
+              "slag-veil-ambusher"
+            ]
           },
           {
             "biome": "falde_magnetiche_psioniche",
-            "morphotype": null
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "falde-magnetiche-psioniche-trait-keeper",
+              "magnet-fathom-surveyor"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "falde-magnetiche-psioniche-trait-keeper"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "magnet-fathom-surveyor"
+            ]
           },
           {
             "biome": "foresta_miceliale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "glowcap-weaver",
+              "myco-spire-warden"
+            ]
+          },
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": "scavenger_corazzato",
+            "count": 2,
+            "examples": [
+              "glowcap-weaver",
+              "myco-spire-warden"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "canopia-psionica-leggera-trait-keeper",
-          "dune-stalker",
-          "falde-magnetiche-psioniche-trait-keeper",
-          "glowcap-weaver",
-          "magnet-fathom-surveyor",
-          "magneto-ridge-hunter",
-          "myco-spire-warden",
-          "psionic-canopy-scout",
-          "slag-veil-ambusher"
         ]
       },
-      "affinity": {
-        "total_species": 9,
-        "roles_breakdown": {
-          "core": 4,
-          "optional": 8,
-          "synergy": 1
-        },
-        "top_species": [
-          "dune-stalker",
-          "magnet-fathom-surveyor",
-          "psionic-canopy-scout",
-          "slag-veil-ambusher",
-          "magneto-ridge-hunter",
-          "canopia-psionica-leggera-trait-keeper",
-          "falde-magnetiche-psioniche-trait-keeper",
-          "glowcap-weaver",
-          "myco-spire-warden"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "tattiche_di_branco": {
@@ -7628,35 +8073,23 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 1,
+        "coverage": [
           {
             "biome": "foresta_miceliale",
-            "morphotype": null
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "lupus-temperatus"
+            ]
           }
-        ],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "lupus-temperatus",
-          "magneto-ridge-hunter",
-          "slag-veil-ambusher"
         ]
       },
-      "affinity": {
-        "total_species": 3,
-        "roles_breakdown": {
-          "optional": 1,
-          "synergy": 2
-        },
-        "top_species": [
-          "magneto-ridge-hunter",
-          "slag-veil-ambusher",
-          "lupus-temperatus"
-        ]
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       }
     },
     "vello_condensatore_nebbie": {
@@ -7669,25 +8102,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "foreste_nubose",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "foreste-nubose-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "foreste_nubose",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "foreste-nubose-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "foreste-nubose-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     },
     "ventriglio_gastroliti": {
@@ -7711,41 +8147,44 @@
         ]
       },
       "species": {
-        "total": 0,
-        "coverage": []
-      },
-      "diff": {
-        "missing_in_species": [
+        "total": 3,
+        "coverage": [
+          {
+            "biome": "caverna_risonante",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
-            "morphotype": "scavenger_corazzato"
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "rust-scavenger"
+            ]
           },
           {
             "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "steppe-bison-mini"
+            ]
+          }
+        ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [
+          {
+            "biome": "caverna_risonante",
             "morphotype": "cursoriale_quadrupede"
           }
         ],
-        "missing_in_rules": [],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "caverna-risonante-trait-keeper",
-          "ferrocolonia-magnetotattica",
-          "rust-scavenger",
-          "steppe-bison-mini"
-        ]
-      },
-      "affinity": {
-        "total_species": 4,
-        "roles_breakdown": {
-          "core": 1,
-          "optional": 4
-        },
-        "top_species": [
-          "rust-scavenger",
-          "caverna-risonante-trait-keeper",
-          "ferrocolonia-magnetotattica",
-          "steppe-bison-mini"
-        ]
+        "missing_in_matrix": []
       }
     },
     "zampe_a_molla": {
@@ -7765,18 +8204,7 @@
         "missing_in_species": [],
         "missing_in_rules": [],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "sand-burrower"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "sand-burrower"
-        ]
+        "missing_in_matrix": []
       }
     },
     "zoccoli_risonanti_steppe": {
@@ -7789,25 +8217,28 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "steppe_risonanti",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "steppe-risonanti-trait-keeper"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "steppe_risonanti",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
-        "missing_in_matrix": [
-          "steppe-risonanti-trait-keeper"
-        ]
-      },
-      "affinity": {
-        "total_species": 1,
-        "roles_breakdown": {
-          "optional": 1
-        },
-        "top_species": [
-          "steppe-risonanti-trait-keeper"
-        ]
+        "missing_in_matrix": []
       }
     }
   },

--- a/reports/schema_validation.json
+++ b/reports/schema_validation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2025-10-31T13:55:58Z",
+  "generated_at": "2025-10-31T23:21:35Z",
   "files": [
     {
       "path": "data/traits/index.json",

--- a/tools/py/game_utils/trait_coverage.py
+++ b/tools/py/game_utils/trait_coverage.py
@@ -196,23 +196,24 @@ def generate_trait_coverage(
             combos = [(biome, morph) for biome in biomes]
         else:
             combos = [(None, morph)]
-            for trait_id in traits:
-                rule_counter = rule_matrix.get(trait_id, Counter())
-                for combo in combos:
-                    species_matrix[trait_id][combo] += 1
-                    species_examples[trait_id][combo].add(species_id)
-                    species_seen[trait_id].add(species_id)
 
-                    biome, morph_combo = combo
-                    if (
-                        morph_combo is not None
-                        and rule_counter
-                        and (biome, None) in rule_counter
-                    ):
-                        wildcard_combo = (biome, None)
-                        species_matrix[trait_id][wildcard_combo] += 1
-                        species_examples[trait_id][wildcard_combo].add(species_id)
-                        species_seen[trait_id].add(species_id)
+        for trait_id in traits:
+            rule_counter = rule_matrix.get(trait_id, Counter())
+            for combo in combos:
+                species_matrix[trait_id][combo] += 1
+                species_examples[trait_id][combo].add(species_id)
+                species_seen[trait_id].add(species_id)
+
+                biome, morph_combo = combo
+                if (
+                    morph_combo is not None
+                    and rule_counter
+                    and (biome, None) in rule_counter
+                ):
+                    wildcard_combo = (biome, None)
+                    species_matrix[trait_id][wildcard_combo] += 1
+                    species_examples[trait_id][wildcard_combo].add(species_id)
+                    species_seen[trait_id].add(species_id)
 
     summary = {
         "traits_total": len(target_traits),

--- a/tools/py/trait_template_validator.py
+++ b/tools/py/trait_template_validator.py
@@ -50,6 +50,8 @@ def validate_trait_files(
     for path in sorted(directory.rglob("*.json")):
         if path.name == "index.json":
             continue
+        if path.name == "species_affinity.json":
+            continue
         rel_path = str(path.relative_to(ROOT))
         try:
             payload = load_json(path)


### PR DESCRIPTION
## Summary
- allow trait entries to expose species affinity metadata and skip validating the generated map as a trait file
- fix the trait coverage matrix so species associations are counted for every biome
- regenerate audit and coverage reports after updating the schema and utilities

## Testing
- python tools/py/trait_template_validator.py --summary
- python scripts/trait_audit.py --check
- python scripts/trait_audit.py
- python3 tools/py/report_trait_coverage.py

------
https://chatgpt.com/codex/tasks/task_e_690543d6d6288332ba6193bc182e3703