### PR TITLE
Add feedback documentation and toolkit configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Starter repository per il progetto tattico co-op con sistema d20 e progressione 
 - [QA & test](#qa--test)
 - [Integrazioni esterne](#integrazioni-esterne)
 - [Distribuzione & condivisione](#distribuzione--condivisione)
+- [In arrivo](#in-arrivo)
 - [Licenza](#licenza)
 
 ## Panoramica
@@ -272,6 +273,13 @@ git push -u origin main
 - Comprimi la cartella del progetto o utilizza lo script `scripts/driveSync.gs` per automatizzare l'upload.
 - Per invii manuali, mantieni sincronizzati gli artifact rigenerati (`docs/presentations/showcase/*`, report in `packs/.../out/`).
 - Consulta `docs/drive-sync.md` per setup credenziali, test e trigger automatici.
+
+## In arrivo
+- **Feedback toolkit**: lancio del pacchetto `tools/feedback` con form centralizzato e workflow di triage automatizzato.
+- **Dashboard insight**: report settimanale generato da `tools/feedback/report_generator.py` e pubblicato in `reports/feedback/`.
+- **Documentazione aggiornata**: guide operative in `docs/process/feedback_collection_pipeline.md` e `docs/tutorials/feedback-form.md`.
+
+Condividi suggerimenti e richieste tramite il [form di feedback](docs/tutorials/feedback-form.md).
 
 ## Licenza
 MIT — vedi [`LICENSE`](LICENSE).

--- a/docs/process/feedback_collection_pipeline.md
+++ b/docs/process/feedback_collection_pipeline.md
@@ -1,0 +1,46 @@
+# Pipeline di raccolta feedback
+
+Questa guida descrive in dettaglio il flusso operativo per raccogliere, filtrare e integrare i feedback provenienti da playtest, demo interne e canali asincroni. È pensata per accompagnare il nuovo form centralizzato definito in `tools/feedback/form_config.yaml` e per fornire riferimenti rapidi a chi gestisce triage, follow-up e comunicazione.
+
+## 1. Obiettivi principali
+- Garantire una **raccolta strutturata** dei feedback, con metadati minimi per identificare build, feature e intensità dei problemi.
+- Ridurre il tempo di **triage** combinando etichette automatiche e code prioritarie.
+- Fornire al team di design e alle pipeline di qualità un set di **azionabili** chiaro e versionato.
+
+## 2. Panoramica del flusso
+1. **Invio**: i tester compilano il form centralizzato (webapp, dashboard docs o CLI) includendo build ID, scenario giocato e livello di severità.
+2. **Ingest**: un job programmato (`feedback_intake`) salva le submission nel datastore `data/feedback/` e pubblica il riepilogo nel canale Slack `#feedback-intake`.
+3. **Triage giornaliero**: gli owner (vedi tabella ruoli) smistano ogni ticket assegnando label `gameplay`, `tecnica`, `narrativa` o `ux` e definiscono priorità.
+4. **Routing**: i feedback prioritari generano task in `incoming/FEATURE_MAP_EVO_TACTICS.md` tramite lo script `tools/feedback/sync_tasks.py`.
+5. **Follow-up**: stato e note vengono sincronizzati verso il form (per email) e verso la dashboard `docs/playtest-log-guidelines.md`.
+
+## 3. Ruoli e responsabilità
+| Ruolo | Owner | Responsabilità | Frequenza |
+| --- | --- | --- | --- |
+| Intake steward | Ops QA | Monitorare Slack `#feedback-intake`, assicurare completezza metadati | 2 volte al giorno |
+| Gameplay curator | Lead Design | Validare priorità, assegnare follow-up a design o narrative | Giornaliera |
+| Tech curator | Lead Engineering | Triagiare bug tecnici, aprire ticket in `services/` o `webapp/` | Giornaliera |
+| Report maintainer | Producer | Aggiornare report settimanale e comunicare gli highlight | Settimanale |
+
+## 4. Checklist operativa
+- [ ] Verificare che ogni submission abbia `build_version` e `scenario_slug`.
+- [ ] Applicare label prioritaria (`P0`, `P1`, `P2`) e categoria.
+- [ ] Aggiornare il campo `status` in `tools/feedback/collection_pipeline.yaml` quando il follow-up è completato.
+- [ ] Notificare il tester se `requires_followup` è vero e l'azione è stata implementata.
+
+## 5. Metriche e dashboard
+- **Tempo medio di triage** (Target: < 12h) — calcolato nel report generato da `tools/feedback/report_generator.py`.
+- **Feedback chiusi per sprint** (Target: ≥ 15) — monitorati in `analytics/feedback/weekly_summary.csv`.
+- **Copertura build** (Target: 100% build principali) — confrontare con `docs/roadmap_generator.md`.
+
+## 6. Automazioni collegate
+- `tools/feedback/sync_tasks.py`: esporta priorità su backlog.
+- `tools/feedback/report_generator.py`: crea snapshot HTML/CSV per il playtest weekly.
+- `tools/feedback/cleanup.py`: archivia submission vecchie di 90 giorni.
+
+## 7. Risorse correlate
+- [Tutorial form feedback](../tutorials/feedback-form.md)
+- [Linee guida playtest](../playtest/playtest-log-guidelines.md)
+- [Schema telemetria VC](../24-TELEMETRIA_VC.md)
+
+> Mantieni questa pagina aggiornata ad ogni revisione del processo: annota in `docs/changelog.md` le modifiche rilevanti in modo da garantire tracciabilità.

--- a/docs/tutorials/feedback-form.md
+++ b/docs/tutorials/feedback-form.md
@@ -1,0 +1,51 @@
+# Tutorial · Form feedback unificato
+
+Questa guida illustra come accedere, compilare e monitorare il nuovo form di feedback introdotto con la pipeline descritta in `docs/process/feedback_collection_pipeline.md`.
+
+## 1. Accesso al form
+- **Dashboard documentazione**: link rapido nel menu "Supporto" → "Invia feedback".
+- **Webapp di playtest**: pulsante `Invia feedback` in basso a destra, sincronizzato con questa configurazione.
+- **CLI**: eseguire `python tools/py/game_cli.py feedback --open-form` per aprire l'URL precompilato.
+
+> Il form è ospitato nell'app Notion condivisa del team. Copia sempre l'URL generato dal comando CLI per includere l'ID build.
+
+## 2. Compilazione step-by-step
+1. **Contesto build**
+   - `build_version`: seleziona dal menu la build in test (es. `v0.8.3-nightly`).
+   - `platform`: indica il device principale (`pc`, `steamdeck`, `cloud`).
+   - `session_type`: scegli tra `playtest_guidato`, `regressione`, `sandbox`.
+2. **Scenario e feature**
+   - `scenario_slug`: inserisci l'identificativo scenario (`badlands_intro`, `nido_difensivo`).
+   - `feature_area`: scegli la categoria (gameplay, tecnica, narrativa, ux).
+   - `mutations_tested`: elenca i trait o mutazioni principali coinvolte.
+3. **Valutazione**
+   - `severity`: scala 1-4 (1 = suggerimento, 4 = blocco).
+   - `impact_scope`: indica se impatta `solo_party`, `biome`, `metagame`.
+   - `confidence`: 1-5 sulla riproducibilità.
+4. **Dettagli e allegati**
+   - `summary`: descrizione breve (max 120 caratteri).
+   - `description`: dettaglia i passi per riprodurre l'anomalia o il feedback.
+   - `attachments`: incolla link a video, log o screenshot.
+5. **Follow-up opzionale**
+   - `requires_followup`: seleziona se desideri aggiornamenti.
+   - `contact`: email o handle Discord/Slack.
+
+## 3. Linee guida qualitative
+- Preferisci **descrizioni osservabili** alle interpretazioni (es. "la mutazione non attiva il bonus" invece di "non funziona").
+- Se il problema è critico (`severity >= 3`), fornisci sempre **passi di riproduzione** e, se possibile, un log estratto.
+- Seleziona `sandbox` solo per sessioni esplorative; per regressioni indica sempre la build di riferimento.
+
+## 4. Dopo l'invio
+- Riceverai una conferma via email con l'ID feedback (es. `FDB-2024-051`).
+- Quando il feedback entra nel backlog, l'owner aggiorna lo stato in `tools/feedback/collection_pipeline.yaml`.
+- Puoi monitorare i progressi nel report settimanale pubblicato in `docs/playtest/INSIGHTS-2025-11.md`.
+
+## 5. Risoluzione dei problemi
+- **Il form non carica?** Verifica la VPN aziendale; il dominio Notion è accessibile solo da IP autorizzati.
+- **Non trovi la build in elenco?** Apri un ticket `#feedback-intake` con l'ID commit e l'ambiente.
+- **Serve supporto audio/video?** Allegare file superiori a 50MB direttamente su Drive e incollare il link con permessi `comment`.
+
+## 6. Link utili
+- Configurazione del form: [`tools/feedback/form_config.yaml`](../../tools/feedback/form_config.yaml)
+- Pipeline di raccolta: [`docs/process/feedback_collection_pipeline.md`](../process/feedback_collection_pipeline.md)
+- Changelog delle revisioni: [`docs/changelog.md`](../changelog.md)

--- a/tools/feedback/README.md
+++ b/tools/feedback/README.md
@@ -1,0 +1,20 @@
+# Feedback toolkit
+
+Questo modulo raccoglie configurazioni, script e flussi operativi per centralizzare la raccolta feedback. I file sono pensati per essere consumati dalla webapp, dalla documentazione e dagli script CLI.
+
+## Struttura
+- `form_config.yaml`: definizione del form (sezioni, campi, vincoli).
+- `collection_pipeline.yaml`: processi post-intake e stati operativi.
+- `sync_tasks.py`: sincronizza i feedback prioritari con il backlog incoming.
+- `report_generator.py`: compila report settimanali in HTML/CSV.
+- `cleanup.py`: archivia e ripulisce le submission storiche.
+
+## Workflow rapido
+1. Aggiorna `form_config.yaml` quando aggiungi nuove feature o mutazioni da tracciare.
+2. Personalizza `collection_pipeline.yaml` per riflettere SLA e owner correnti.
+3. Esegui `python sync_tasks.py --dry-run` per verificare la sincronizzazione con il backlog.
+4. Pianifica `report_generator.py` tramite cron/CI per ricevere report automatici.
+
+Per istruzioni operative consulta:
+- [Pipeline di raccolta feedback](../../docs/process/feedback_collection_pipeline.md)
+- [Tutorial form feedback](../../docs/tutorials/feedback-form.md)

--- a/tools/feedback/cleanup.py
+++ b/tools/feedback/cleanup.py
@@ -1,0 +1,93 @@
+"""Archivia submission di feedback oltre la soglia temporale configurata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+DEFAULT_INTAKE_PATH = Path("data/feedback/intake.jsonl")
+DEFAULT_ARCHIVE_DIR = Path("data/feedback/archive")
+ISO_FORMATS = [
+    "%Y-%m-%dT%H:%M:%S.%fZ",
+    "%Y-%m-%dT%H:%M:%SZ",
+    "%Y-%m-%d %H:%M:%S",
+]
+
+
+def parse_timestamp(value: str | None) -> datetime:
+    if not value:
+        return datetime.utcnow()
+    for fmt in ISO_FORMATS:
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    return datetime.utcnow()
+
+
+def load_payloads(path: Path) -> List[dict]:
+    if not path.exists():
+        return []
+    payloads: List[dict] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            payloads.append(json.loads(line))
+    return payloads
+
+
+def split_payloads(payloads: Iterable[dict], threshold: datetime) -> Tuple[List[dict], List[dict]]:
+    keep: List[dict] = []
+    archive: List[dict] = []
+    for payload in payloads:
+        created_at = parse_timestamp(payload.get("created_at") or payload.get("timestamp"))
+        if created_at < threshold:
+            archive.append(payload)
+        else:
+            keep.append(payload)
+    return keep, archive
+
+
+def write_jsonl(path: Path, payloads: Iterable[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for payload in payloads:
+            handle.write(json.dumps(payload, ensure_ascii=False))
+            handle.write("\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Archivia feedback oltre la soglia di giorni indicata")
+    parser.add_argument("--intake", type=Path, default=DEFAULT_INTAKE_PATH, help="Percorso file JSONL intake")
+    parser.add_argument("--archive-dir", type=Path, default=DEFAULT_ARCHIVE_DIR, help="Directory archivio")
+    parser.add_argument("--days", type=int, default=90, help="Numero di giorni da mantenere nell'intake")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    payloads = load_payloads(args.intake)
+    if not payloads:
+        print(f"Nessuna submission trovata in {args.intake}.")
+        return
+
+    cutoff = datetime.utcnow() - timedelta(days=args.days)
+    keep, archive = split_payloads(payloads, cutoff)
+    if not archive:
+        print("Nessuna submission da archiviare.")
+        return
+
+    archive_name = f"feedback_archive_{datetime.utcnow():%Y%m%d_%H%M%S}.jsonl"
+    archive_path = args.archive_dir / archive_name
+    write_jsonl(args.intake, keep)
+    write_jsonl(archive_path, archive)
+    print(f"Archiviati {len(archive)} feedback in {archive_path}. Rimangono {len(keep)} elementi attivi.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/feedback/collection_pipeline.yaml
+++ b/tools/feedback/collection_pipeline.yaml
@@ -1,0 +1,87 @@
+pipeline:
+  version: 1.0.0
+  description: >-
+    Definizione dei passaggi di raccolta e triage feedback dopo l'intake automatico.
+    Utilizzato dagli owner per tracciare stato e responsabilità.
+  states:
+    - id: new
+      label: "Nuovo"
+      description: "Feedback appena ricevuto, in attesa di triage."
+      sla_hours: 12
+    - id: triaged
+      label: "Triagiato"
+      description: "Classificato con categoria, severità confermata e owner assegnato."
+      sla_hours: 24
+    - id: in_progress
+      label: "In lavorazione"
+      description: "Task aperto su backlog e in lavorazione attiva."
+      sla_hours: 72
+    - id: awaiting_feedback
+      label: "In attesa tester"
+      description: "Richieste informazioni aggiuntive al tester."
+      sla_hours: 48
+    - id: resolved
+      label: "Risolto"
+      description: "Fix completato, in attesa di conferma tester."
+      sla_hours: 24
+    - id: closed
+      label: "Chiuso"
+      description: "Feedback confermato risolto o archiviato."
+      sla_hours: 0
+  transitions:
+    - from: new
+      to: triaged
+      required_actions:
+        - "Compila triage note"
+        - "Assegna owner"
+    - from: triaged
+      to: in_progress
+      required_actions:
+        - "Crea task su incoming/FEATURE_MAP_EVO_TACTICS.md"
+        - "Notifica owner su Slack"
+    - from: triaged
+      to: awaiting_feedback
+      required_actions:
+        - "Contatta tester"
+    - from: in_progress
+      to: resolved
+      required_actions:
+        - "Aggiorna stato task"
+        - "Valida fix in ambiente staging"
+    - from: awaiting_feedback
+      to: triaged
+      required_actions:
+        - "Ricevi info tester"
+    - from: resolved
+      to: closed
+      required_actions:
+        - "Conferma con tester"
+  owners:
+    gameplay:
+      default: "lead.design@evo-tactics.dev"
+      backup: "design.producer@evo-tactics.dev"
+    tecnica:
+      default: "lead.engineering@evo-tactics.dev"
+      backup: "qa.automation@evo-tactics.dev"
+    narrativa:
+      default: "narrative.lead@evo-tactics.dev"
+      backup: "narrative.support@evo-tactics.dev"
+    ux:
+      default: "ux.lead@evo-tactics.dev"
+      backup: "ux.research@evo-tactics.dev"
+  cadence:
+    daily_sync:
+      time: "09:30"
+      timezone: "Europe/Rome"
+      agenda:
+        - "Review nuove submission"
+        - "Aggiornare stato in_progress"
+        - "Identificare blocchi"
+    weekly_digest:
+      day: "Friday"
+      time: "16:00"
+      deliverable: "Report generato da tools/feedback/report_generator.py"
+  reporting:
+    dashboard: "analytics/feedback/weekly_summary.csv"
+    changelog: "docs/changelog.md"
+    archive_path: "data/feedback/archive/"

--- a/tools/feedback/form_config.yaml
+++ b/tools/feedback/form_config.yaml
@@ -1,0 +1,164 @@
+metadata:
+  name: evo_tactics_feedback
+  version: 1.0.0
+  description: >-
+    Form unificato per raccogliere feedback da playtest, regressioni e sessioni sandbox
+    del progetto Evo-Tactics. La configurazione è condivisa da webapp, documentazione
+    e CLI ed espone campi obbligatori per build, scenario e severità.
+  distribution_channels:
+    - docs_portal
+    - webapp_overlay
+    - cli_launcher
+  notifications:
+    slack_channel: "#feedback-intake"
+    email_digest: "playtest-producer@evo-tactics.dev"
+    auto_reply_template: templates/auto_reply_feedback.md
+form:
+  sections:
+    - id: build_context
+      title: "Contesto build"
+      description: "Identifica build e ambiente per riproducibilità."
+      fields:
+        - id: build_version
+          label: "Build in test"
+          type: select
+          required: true
+          placeholder: "Seleziona build"
+          options_source:
+            type: file
+            path: ../../config/builds/latest_builds.yaml
+        - id: platform
+          label: "Piattaforma"
+          type: select
+          required: true
+          options:
+            - pc
+            - steamdeck
+            - cloud
+        - id: session_type
+          label: "Tipo sessione"
+          type: select
+          required: true
+          options:
+            - playtest_guidato
+            - regressione
+            - sandbox
+        - id: environment
+          label: "Ambiente"
+          type: select
+          required: false
+          options:
+            - staging
+            - production
+            - local
+    - id: scenario_feature
+      title: "Scenario e feature"
+      description: "Dettagli sul contenuto o feature testata."
+      fields:
+        - id: scenario_slug
+          label: "Scenario"
+          type: text
+          required: true
+          validation:
+            pattern: "^[a-z0-9_\-]{3,40}$"
+            message: "Usa slug minuscoli con trattini o underscore."
+        - id: feature_area
+          label: "Area"
+          type: select
+          required: true
+          options:
+            - gameplay
+            - tecnica
+            - narrativa
+            - ux
+        - id: mutations_tested
+          label: "Mutazioni/trait"
+          type: textarea
+          required: false
+          placeholder: "Elenca trait o mutazioni principali"
+    - id: evaluation
+      title: "Valutazione"
+      description: "Classifica severità, impatto e confidenza."
+      fields:
+        - id: severity
+          label: "Severità"
+          type: select
+          required: true
+          options:
+            - 1
+            - 2
+            - 3
+            - 4
+          help: "1 = suggerimento, 4 = blocco"
+        - id: impact_scope
+          label: "Impatto"
+          type: select
+          required: true
+          options:
+            - solo_party
+            - biome
+            - metagame
+        - id: confidence
+          label: "Confidenza"
+          type: slider
+          required: true
+          min: 1
+          max: 5
+          step: 1
+    - id: details
+      title: "Dettagli"
+      description: "Descrivi comportamento atteso e osservato."
+      fields:
+        - id: summary
+          label: "Sommario"
+          type: text
+          required: true
+          max_length: 120
+        - id: description
+          label: "Descrizione"
+          type: textarea
+          required: true
+          min_length: 50
+        - id: attachments
+          label: "Allegati"
+          type: url_list
+          required: false
+          max_items: 5
+    - id: follow_up
+      title: "Follow-up"
+      description: "Opzioni per contatto e visibilità."
+      fields:
+        - id: requires_followup
+          label: "Richiede follow-up"
+          type: checkbox
+          required: false
+        - id: contact
+          label: "Contatto"
+          type: text
+          required: false
+          validation:
+            pattern: "^.{0,120}$"
+            message: "Inserisci email o handle (max 120 caratteri)."
+workflow:
+  storage:
+    driver: notion
+    database_id: "notion-db-feedback"
+  automations:
+    - name: publish_to_slack
+      trigger: on_submit
+      action: slack.post_message
+      config:
+        channel: "#feedback-intake"
+        template: templates/slack_notification.md
+    - name: open_triage_ticket
+      trigger: severity>=3
+      action: scripts.create_ticket
+      config:
+        script: sync_tasks.py
+        args:
+          priority_map:
+            "3": P1
+            "4": P0
+  sla:
+    triage_hours: 12
+    followup_days: 5

--- a/tools/feedback/report_generator.py
+++ b/tools/feedback/report_generator.py
@@ -1,0 +1,106 @@
+"""Genera report settimanale a partire dalle submission di feedback."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List
+
+import sync_tasks
+
+DEFAULT_INTAKE_PATH = Path("data/feedback/intake.jsonl")
+DEFAULT_OUTPUT_DIR = Path("reports/feedback")
+
+
+def summarise_by(entries: Iterable[sync_tasks.FeedbackEntry], attribute: str) -> Counter:
+    counter: Counter = Counter()
+    for entry in entries:
+        counter[getattr(entry, attribute, "unknown") or "unknown"] += 1
+    return counter
+
+
+def write_markdown_report(entries: List[sync_tasks.FeedbackEntry], output_path: Path) -> None:
+    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+    severity_counts = summarise_by(entries, "severity")
+    area_counts = summarise_by(entries, "feature_area")
+
+    lines = [
+        "# Feedback weekly digest",
+        "",
+        f"Generato il: {timestamp}",
+        "",
+        "## Totali",
+        f"- Submission totali: {len(entries)}",
+    ]
+    lines.append("- Distribuzione severità:")
+    for severity in sorted(severity_counts.keys(), reverse=True):
+        lines.append(f"  - S{severity}: {severity_counts[severity]}")
+    lines.append("- Distribuzione area:")
+    for area, count in sorted(area_counts.items(), key=lambda item: item[1], reverse=True):
+        lines.append(f"  - {area}: {count}")
+
+    lines.append("\n## Dettaglio priorità")
+    for entry in entries:
+        lines.append(
+            f"- [{entry.priority}] {entry.feedback_id or 'UNSET'} — {entry.summary} (build {entry.build_version}, scenario {entry.scenario_slug})"
+        )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def write_csv_snapshot(entries: List[sync_tasks.FeedbackEntry], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "feedback_id",
+        "priority",
+        "severity",
+        "feature_area",
+        "scenario_slug",
+        "build_version",
+        "status",
+    ]
+    with output_path.open("w", encoding="utf-8", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for entry in entries:
+            writer.writerow(
+                {
+                    "feedback_id": entry.feedback_id,
+                    "priority": entry.priority,
+                    "severity": entry.severity,
+                    "feature_area": entry.feature_area,
+                    "scenario_slug": entry.scenario_slug,
+                    "build_version": entry.build_version,
+                    "status": entry.status,
+                }
+            )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Genera report feedback in Markdown e CSV")
+    parser.add_argument("--intake", type=Path, default=DEFAULT_INTAKE_PATH, help="Percorso file JSONL intake")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR, help="Directory di output")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    entries = sync_tasks.read_intake_file(args.intake)
+    if not entries:
+        print(f"Nessuna submission trovata in {args.intake}.")
+        return
+
+    markdown_path = args.output_dir / "weekly_digest.md"
+    csv_path = args.output_dir / "weekly_digest.csv"
+
+    write_markdown_report(entries, markdown_path)
+    write_csv_snapshot(entries, csv_path)
+    print(f"Report generato in {markdown_path} e {csv_path}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/feedback/sync_tasks.py
+++ b/tools/feedback/sync_tasks.py
@@ -1,0 +1,130 @@
+"""Sincronizza i feedback prioritari con il backlog incoming.
+
+Lo script legge un file JSONL contenente le submission raccolte dal form
+(`intake.jsonl`), filtra quelle con severità pari o superiore alla soglia
+configurata e aggiorna `incoming/FEATURE_MAP_EVO_TACTICS.md` aggiungendo
+entry strutturate.
+
+Esecuzione tipica:
+    python tools/feedback/sync_tasks.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+SEVERITY_PRIORITY = {
+    "4": "P0",
+    "3": "P1",
+    "2": "P2",
+    "1": "P3",
+}
+
+DEFAULT_INTAKE_PATH = Path("data/feedback/intake.jsonl")
+DEFAULT_BACKLOG_PATH = Path("incoming/FEATURE_MAP_EVO_TACTICS.md")
+
+
+@dataclass
+class FeedbackEntry:
+    """Rappresentazione normalizzata di una submission di feedback."""
+
+    feedback_id: str
+    summary: str
+    severity: str
+    feature_area: str
+    scenario_slug: str
+    build_version: str
+    status: str
+
+    @classmethod
+    def from_payload(cls, payload: dict) -> "FeedbackEntry":
+        return cls(
+            feedback_id=str(payload.get("feedback_id") or payload.get("id") or ""),
+            summary=str(payload.get("summary") or payload.get("title") or ""),
+            severity=str(payload.get("severity") or "0"),
+            feature_area=str(payload.get("feature_area") or payload.get("area") or "uncategorized"),
+            scenario_slug=str(payload.get("scenario_slug") or payload.get("scenario") or "unknown"),
+            build_version=str(payload.get("build_version") or "n/a"),
+            status=str(payload.get("status") or "new"),
+        )
+
+    @property
+    def priority(self) -> str:
+        return SEVERITY_PRIORITY.get(self.severity, "P3")
+
+    def to_markdown(self) -> str:
+        return (
+            f"- [{self.priority}] {self.feedback_id or 'UNSET'} — {self.summary}\n"
+            f"  - build: `{self.build_version}` · scenario: `{self.scenario_slug}`\n"
+            f"  - area: `{self.feature_area}` · status: `{self.status}`\n"
+        )
+
+
+def read_intake_file(path: Path) -> List[FeedbackEntry]:
+    """Carica le submission dal file JSONL specificato."""
+
+    if not path.exists():
+        return []
+
+    entries: List[FeedbackEntry] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            entries.append(FeedbackEntry.from_payload(payload))
+    return entries
+
+
+def filter_priorities(entries: Sequence[FeedbackEntry], min_severity: int) -> List[FeedbackEntry]:
+    threshold = max(1, min(4, min_severity))
+    return [entry for entry in entries if int(entry.severity or 0) >= threshold]
+
+
+def append_to_backlog(backlog_path: Path, entries: Iterable[FeedbackEntry]) -> None:
+    backlog_path.parent.mkdir(parents=True, exist_ok=True)
+    with backlog_path.open("a", encoding="utf-8") as handle:
+        handle.write("\n## Feedback prioritari\n")
+        for entry in entries:
+            handle.write(entry.to_markdown())
+            handle.write("\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sincronizza feedback prioritari nel backlog.")
+    parser.add_argument("--intake", type=Path, default=DEFAULT_INTAKE_PATH, help="Percorso file JSONL intake")
+    parser.add_argument("--backlog", type=Path, default=DEFAULT_BACKLOG_PATH, help="Percorso file backlog Markdown")
+    parser.add_argument("--min-severity", type=int, default=3, help="Severità minima da sincronizzare (1-4)")
+    parser.add_argument("--dry-run", action="store_true", help="Mostra i task senza scrivere il backlog")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    entries = read_intake_file(args.intake)
+    if not entries:
+        print(f"Nessuna submission trovata in {args.intake}.")
+        return
+
+    selected = filter_priorities(entries, args.min_severity)
+    if not selected:
+        print("Nessun feedback supera la soglia di severità.")
+        return
+
+    if args.dry_run:
+        print("Anteprima task da sincronizzare:\n")
+        for entry in selected:
+            print(entry.to_markdown())
+        return
+
+    append_to_backlog(args.backlog, selected)
+    print(f"Aggiunti {len(selected)} feedback al backlog {args.backlog}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add detailed guides for the new feedback workflow and form usage in the documentation
- introduce a feedback toolkit module with form configuration and processing scripts
- update the main README with an "In arrivo" section and feedback link

## Testing
- python -m compileall tools/feedback

------
https://chatgpt.com/codex/tasks/task_e_69054a3beb308332a7ee77ebd4d09a4d