### PR TITLE
Improve QA log export tooling

### DIFF
--- a/docs/recap/qa-playbook.md
+++ b/docs/recap/qa-playbook.md
@@ -24,7 +24,7 @@ python -m pip install -r tools/py/requirements.txt
 npm run export:qa
 ```
 
-Il comando è un wrapper di `node scripts/export-qa-report.js` e aggiorna i file in `reports/`. Lo stesso script gira in CI (`.github/workflows/qa-reports.yml`) e fallisce se i report non sono in sync: se vedi il job rosso, esegui i comandi sopra e committa i JSON aggiornati.
+Il comando è un wrapper di `node scripts/export-qa-report.js` e aggiorna i file in `reports/`. Lo stesso script gira in CI (`.github/workflows/qa-reports.yml`) e fallisce se i report non sono in sync: se vedi il job rosso, esegui i comandi sopra e committa i JSON aggiornati. Il bridge Node avvia automaticamente l'orchestrator Python e chiude il pool al termine, quindi non servono processi manuali aggiuntivi.
 
 ## Esportare i log dalla console UI
 
@@ -32,6 +32,8 @@ Nella sezione **Log runtime** della `QualityReleaseView` sono disponibili due pu
 
 * **Esporta JSON QA** – esporta l'elenco filtrato in JSON.
 * **Esporta CSV QA** – esporta lo stesso set in CSV, utile per spreadsheet e share rapide.
+
+I pulsanti restano disabilitati quando non ci sono log visibili per evitare export vuoti. Ogni azione produce un evento `quality.logs.exported` che include formato, filename generato e numero di righe esportate (`data.count`).
 
 Il filtro scope applicato nella toolbar (Tutti/Specie/Biomi/Foodweb/Publishing) determina le righe esportate. Ogni azione viene tracciata nei log client per audit (`quality.logs.exported`).
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "drive:push-approved": "node tools/drive/push-approved-assets.mjs",
     "drive-sync": "node tools/drive/sync-approved-assets.mjs",
     "stage:publishing": "node services/publishing/staging.js",
-    "export:qa": "python tools/py/export_qa_reports.py",
+    "export:qa": "node scripts/export-qa-report.js",
     "webapp:deploy": "npm --prefix webapp install && npm --prefix webapp run build && npm --prefix webapp run preview"
   },
   "dependencies": {

--- a/webapp/src/views/QualityReleaseView.vue
+++ b/webapp/src/views/QualityReleaseView.vue
@@ -324,10 +324,20 @@
           </button>
         </div>
         <div class="quality-logs__actions">
-          <button type="button" class="quality-logs__export" @click="exportQaLogs('json')">
+          <button
+            type="button"
+            class="quality-logs__export"
+            :disabled="!filteredLogs.length"
+            @click="exportQaLogs('json')"
+          >
             Esporta JSON QA
           </button>
-          <button type="button" class="quality-logs__export" @click="exportQaLogs('csv')">
+          <button
+            type="button"
+            class="quality-logs__export"
+            :disabled="!filteredLogs.length"
+            @click="exportQaLogs('csv')"
+          >
             Esporta CSV QA
           </button>
         </div>
@@ -1092,10 +1102,13 @@ async function applySuggestion(suggestion) {
 }
 
 function exportQaLogs(format = 'json') {
+  if (!filteredLogs.value.length) {
+    return;
+  }
   const scope = scopeFilter.value;
   const filenameScope = scope === 'all' ? 'all-scopes' : scope;
   const extension = format === 'csv' ? 'csv' : 'json';
-  clientLogger.exportLogs({
+  const exportResult = clientLogger.exportLogs({
     filename: `qa-flow-logs-${filenameScope}.${extension}`,
     filter: scope === 'all' ? undefined : (entry) => entry.scope === scope,
     format,
@@ -1107,8 +1120,12 @@ function exportQaLogs(format = 'json') {
   logClientEvent('quality.logs.exported', {
     scope,
     level: 'info',
-    message: `${scopeMessage} (${extension.toUpperCase()})`,
-    data: { format: extension },
+    message: `${scopeMessage} (${exportResult.format.toUpperCase()})`,
+    data: {
+      format: exportResult.format,
+      filename: exportResult.filename,
+      count: exportResult.entries.length,
+    },
     source: 'quality-console',
   });
 }


### PR DESCRIPTION
## Summary
- extend the client logger with reusable JSON/CSV export helpers and expose them to consumers
- wire the QualityReleaseView export buttons to the new helpers, preventing empty downloads and logging metadata
- document the QA export workflow and point npm run export:qa to the Node orchestrator job

## Testing
- npm --prefix webapp run build

------
https://chatgpt.com/codex/tasks/task_e_69054a4a628c83329dc2a2f241f9756e