### PR TITLE
Refactor webapp data source integration

### DIFF
--- a/webapp/src/services/generationOrchestratorService.js
+++ b/webapp/src/services/generationOrchestratorService.js
@@ -146,7 +146,6 @@ export async function generateSpecies(request, options = {}) {
   const fallbackPath = resolveFallback(options, config.fallback);
   const fallbackUrl = fallbackPath ? resolveAssetUrl(fallbackPath) : null;
   const response = await fetchJsonWithFallback(endpoint, {
-    fetchImpl: options.fetchImpl,
     requestInit: {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -198,7 +197,6 @@ export async function generateSpeciesBatch(batchPayload, options = {}) {
   const fallbackUrl = fallbackPath ? resolveAssetUrl(fallbackPath) : null;
   const body = { batch: entries };
   const batchResponse = await fetchJsonWithFallback(endpoint, {
-    fetchImpl: options.fetchImpl,
     requestInit: {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/webapp/src/services/qualityReleaseService.js
+++ b/webapp/src/services/qualityReleaseService.js
@@ -33,7 +33,6 @@ export async function applyQualitySuggestion(suggestion, options = {}) {
   const fallbackPath = resolveFallback(options, config.fallback);
   const fallbackUrl = fallbackPath ? resolveAssetUrl(fallbackPath) : null;
   const response = await fetchJsonWithFallback(endpoint, {
-    fetchImpl: options.fetchImpl,
     requestInit: {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/webapp/src/services/runtimeValidationService.js
+++ b/webapp/src/services/runtimeValidationService.js
@@ -49,7 +49,6 @@ async function postRuntime(kind, payload, options = {}) {
   const fallbackPath = resolveFallback(kind, options, config.fallback);
   const fallbackUrl = fallbackPath ? resolveAssetUrl(fallbackPath) : null;
   const response = await fetchJsonWithFallback(endpoint, {
-    fetchImpl: options.fetchImpl,
     requestInit: {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/webapp/src/services/speciesPreviewService.js
+++ b/webapp/src/services/speciesPreviewService.js
@@ -50,7 +50,6 @@ export async function requestSpeciesPreviewBatch(entries, options = {}) {
   const fallbackPath = resolveFallback(options, config.fallback);
   const fallbackUrl = fallbackPath ? resolveAssetUrl(fallbackPath) : null;
   const response = await fetchJsonWithFallback(endpoint, {
-    fetchImpl: options.fetchImpl,
     requestInit: {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/webapp/src/services/traitDiagnosticsService.js
+++ b/webapp/src/services/traitDiagnosticsService.js
@@ -32,7 +32,6 @@ export async function fetchTraitDiagnostics(options = {}) {
   const fallbackPath = resolveFallback(options, config.fallback);
   const fallbackUrl = fallbackPath ? resolveAssetUrl(fallbackPath) : null;
   const response = await fetchJsonWithFallback(targetUrl, {
-    fetchImpl: options.fetchImpl,
     requestInit: {
       method: 'GET',
       headers: { Accept: 'application/json' },

--- a/webapp/src/state/useSnapshotLoader.ts
+++ b/webapp/src/state/useSnapshotLoader.ts
@@ -70,10 +70,13 @@ function determineFallbackLabel(url?: string | null): string | null {
   if (!url) {
     return null;
   }
+  const normalised = url.toLowerCase();
   if (
-    url.includes('/data/flow/snapshots/') ||
-    url.includes('data/flow/snapshots/') ||
-    url.includes('assets/demo/')
+    normalised.includes('/data/flow/') ||
+    normalised.includes('data/flow/') ||
+    normalised.includes('/data/nebula/') ||
+    normalised.includes('data/nebula/') ||
+    normalised.includes('assets/demo/')
   ) {
     return 'demo';
   }

--- a/webapp/tests/config/dataSources.spec.ts
+++ b/webapp/tests/config/dataSources.spec.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const env = vi.hoisted(() => ({
+  values: {} as Record<string, string | undefined>,
+}));
+
+vi.mock('../../src/services/apiEndpoints.js', () => ({
+  readEnvString: (key: string) => env.values[key],
+}));
+
+afterEach(() => {
+  env.values = {};
+});
+
+describe('data sources registry', () => {
+  beforeEach(() => {
+    env.values = {};
+    vi.resetModules();
+  });
+
+  it('espone le configurazioni di default', async () => {
+    const { getDataSource, listDataSourceIds } = await import('../../src/config/dataSources.ts');
+    expect(listDataSourceIds()).toContain('flowSnapshot');
+    expect(listDataSourceIds()).toContain('generationSpecies');
+    expect(listDataSourceIds()).toContain('nebulaAtlas');
+
+    const flowSnapshot = getDataSource('flowSnapshot');
+    expect(flowSnapshot).toEqual({
+      id: 'flowSnapshot',
+      endpoint: '/api/generation/snapshot',
+      fallback: 'data/flow/snapshots/flow-shell-snapshot.json',
+      mock: null,
+    });
+
+    const nebula = getDataSource('nebulaAtlas');
+    expect(nebula.endpoint).toBe('/api/nebula/atlas');
+    expect(nebula.fallback).toBe('data/nebula/atlas.json');
+    expect(nebula.mock).toBe('data/nebula/telemetry.json');
+  });
+
+  it('applica le variabili di ambiente se presenti', async () => {
+    env.values = {
+      VITE_FLOW_SNAPSHOT_URL: 'https://example.test/api/snapshot',
+      VITE_FLOW_SNAPSHOT_FALLBACK: 'null',
+      VITE_NEBULA_ATLAS_FALLBACK: '/custom/atlas.json',
+      VITE_NEBULA_TELEMETRY_MOCK: '/custom/mock.json',
+    };
+    vi.resetModules();
+    const { getDataSource } = await import('../../src/config/dataSources.ts');
+
+    const snapshot = getDataSource('flowSnapshot');
+    expect(snapshot.endpoint).toBe('https://example.test/api/snapshot');
+    expect(snapshot.fallback).toBeNull();
+
+    const nebula = getDataSource('nebulaAtlas');
+    expect(nebula.fallback).toBe('/custom/atlas.json');
+    expect(nebula.mock).toBe('/custom/mock.json');
+  });
+
+  it('consente override puntuali tramite resolveDataSource', async () => {
+    const { resolveDataSource } = await import('../../src/config/dataSources.ts');
+    const overridden = resolveDataSource('generationSpecies', {
+      endpoint: 'https://override.test/species',
+      fallback: 'data/custom/species.json',
+    });
+    expect(overridden.endpoint).toBe('https://override.test/species');
+    expect(overridden.fallback).toBe('data/custom/species.json');
+    expect(overridden.mock).toBeNull();
+  });
+
+  it('solleva errore per sorgenti non configurate', async () => {
+    const { getDataSource } = await import('../../src/config/dataSources.ts');
+    expect(() => getDataSource('unknown-source' as any)).toThrow(/non configurato/);
+  });
+});

--- a/webapp/tests/state/flowStores.spec.ts
+++ b/webapp/tests/state/flowStores.spec.ts
@@ -9,11 +9,17 @@ vi.mock('../../src/services/apiEndpoints.js', () => ({
 
 const dataSourceMock = vi.hoisted(() => {
   const defaults = new Map<string, { endpoint: string | null; fallback: string | null; mock: string | null }>([
-    ['flowSnapshot', { endpoint: '/api/generation/snapshot', fallback: 'assets/demo/fallback.json', mock: null }],
+    [
+      'flowSnapshot',
+      { endpoint: '/api/generation/snapshot', fallback: 'data/flow/snapshots/flow-shell-snapshot.json', mock: null },
+    ],
     ['generationSpecies', { endpoint: '/api/generation/species', fallback: null, mock: null }],
     ['generationSpeciesBatch', { endpoint: '/api/generation/species/batch', fallback: null, mock: null }],
     ['generationSpeciesPreview', { endpoint: '/api/generation/species/batch', fallback: null, mock: null }],
-    ['traitDiagnostics', { endpoint: '/api/traits/diagnostics', fallback: 'assets/demo/traits.json', mock: null }],
+    [
+      'traitDiagnostics',
+      { endpoint: '/api/traits/diagnostics', fallback: 'data/flow/traits/diagnostics.json', mock: null },
+    ],
   ]);
   return {
     resolveDataSource(id: string, overrides: Record<string, unknown> = {}) {
@@ -130,7 +136,7 @@ describe('flow stores', () => {
         if (url === '/api/generation/snapshot') {
           return { ok: false, status: 503, json: async () => ({}) };
         }
-        if (url === 'assets/demo/fallback.json') {
+        if (url === 'data/flow/snapshots/flow-shell-snapshot.json') {
           return {
             ok: true,
             status: 200,
@@ -144,7 +150,7 @@ describe('flow stores', () => {
         logger,
         fetch: fetchMock as unknown as typeof fetch,
         snapshotUrl: '/api/generation/snapshot',
-        fallbackSnapshotUrl: 'assets/demo/fallback.json',
+        fallbackSnapshotUrl: 'data/flow/snapshots/flow-shell-snapshot.json',
       });
       await store.fetchSnapshot();
       expect(store.source.value).toBe('fallback');
@@ -213,7 +219,7 @@ describe('flow stores', () => {
         })
         .mockResolvedValueOnce({
           diagnostics: { summary: { total_traits: 2, glossary_ok: 2 } },
-          meta: { endpoint_source: 'fallback', endpoint_url: 'assets/demo/traits.json' },
+        meta: { endpoint_source: 'fallback', endpoint_url: 'data/flow/traits/diagnostics.json' },
         });
       const logger = { log: vi.fn() };
       const store = useTraitDiagnostics({ logger, service });


### PR DESCRIPTION
## Summary
- remove custom fetch injection from webapp services while keeping registry-driven fallbacks
- broaden demo fallback detection to cover the reorganised static data paths
- add unit tests for the data source registry and update flow store specs for the new asset locations

## Testing
- npm --prefix webapp test

------
https://chatgpt.com/codex/tasks/task_e_69055147453c8332858e84878c32d097