### PR TITLE
feat: persist generation snapshot state

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test:web": "npm --prefix tools/ts run test:web --",
     "build": "npm --prefix tools/ts run build --",
     "test": "npm run test:api && npm --prefix tools/ts run test -- && npm --prefix webapp run test",
-    "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 tools/ts/node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 tools/ts/node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && tools/ts/node_modules/.bin/tsx tests/scripts/tune_items.test.ts && tools/ts/node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts",
+    "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 tools/ts/node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && node --test tests/server/generationSnapshot.spec.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 tools/ts/node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && tools/ts/node_modules/.bin/tsx tests/scripts/tune_items.test.ts && tools/ts/node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts",
     "start:api": "node server/index.js",
     "build:idea-taxonomy": "node scripts/build-idea-taxonomy.js",
     "drive:generate-approved": "node tools/drive/generate-approved-assets.mjs",

--- a/server/services/generationSnapshotStore.js
+++ b/server/services/generationSnapshotStore.js
@@ -1,0 +1,219 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const DEFAULT_DATASET_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'data',
+  'flow-shell',
+  'atlas-snapshot.json',
+);
+
+function clone(value) {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+async function readJson(filePath) {
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(content);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function writeJson(filePath, payload) {
+  const targetDir = path.dirname(filePath);
+  await fs.mkdir(targetDir, { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function mergeSection(baseSection, patchSection) {
+  const base = baseSection && typeof baseSection === 'object' ? baseSection : {};
+  const patch = patchSection && typeof patchSection === 'object' ? patchSection : {};
+  const result = { ...base };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      result[key] = mergeSection(base[key], value);
+    } else {
+      result[key] = clone(value);
+    }
+  }
+  return result;
+}
+
+function buildRuntimeSummary(result, error) {
+  if (error) {
+    return {
+      lastBlueprintId: null,
+      fallbackUsed: null,
+      validationMessages: 0,
+      lastRequestId: null,
+      error: error.message || String(error),
+    };
+  }
+  if (!result) {
+    return null;
+  }
+  const validationMessages = Array.isArray(result?.validation?.messages)
+    ? result.validation.messages.length
+    : 0;
+  const fallbackUsed = Boolean(
+    result?.meta?.fallback_used ?? result?.meta?.fallbackUsed ?? result?.meta?.fallback_active,
+  );
+  return {
+    lastBlueprintId: result?.blueprint?.id || null,
+    fallbackUsed,
+    validationMessages,
+    lastRequestId: result?.meta?.request_id || result?.meta?.requestId || null,
+  };
+}
+
+function applySnapshotPatch(currentSnapshot, patch = {}) {
+  const next = { ...clone(currentSnapshot) };
+
+  if (Object.prototype.hasOwnProperty.call(patch, 'runtime')) {
+    next.runtime = patch.runtime ? { ...patch.runtime } : null;
+  }
+
+  if (patch.overview) {
+    next.overview = mergeSection(next.overview, patch.overview);
+  }
+
+  if (patch.species) {
+    next.species = mergeSection(next.species, patch.species);
+  }
+
+  if (patch.speciesStatus) {
+    next.species = mergeSection(next.species, patch.speciesStatus);
+  }
+
+  if (patch.biomeSummary) {
+    next.biomeSummary = mergeSection(next.biomeSummary, patch.biomeSummary);
+  }
+
+  if (patch.encounterSummary) {
+    next.encounterSummary = mergeSection(next.encounterSummary, patch.encounterSummary);
+  }
+
+  const reservedKeys = new Set([
+    'runtime',
+    'overview',
+    'species',
+    'speciesStatus',
+    'biomeSummary',
+    'encounterSummary',
+  ]);
+
+  Object.entries(patch).forEach(([key, value]) => {
+    if (reservedKeys.has(key)) {
+      return;
+    }
+    if (value === undefined) {
+      return;
+    }
+    next[key] = clone(value);
+  });
+
+  return next;
+}
+
+function createGenerationSnapshotStore(options = {}) {
+  const datasetPath = options.datasetPath || DEFAULT_DATASET_PATH;
+  let cachedSnapshot = null;
+  let staticSnapshot = options.staticDataset ? clone(options.staticDataset) : null;
+
+  async function loadStaticSnapshot() {
+    if (staticSnapshot) {
+      return staticSnapshot;
+    }
+    const fallback = await readJson(datasetPath);
+    staticSnapshot = fallback ? clone(fallback) : null;
+    return staticSnapshot;
+  }
+
+  async function loadSnapshotFromDisk() {
+    const snapshot = await readJson(datasetPath);
+    return snapshot ? clone(snapshot) : null;
+  }
+
+  async function persistSnapshot(snapshot) {
+    await writeJson(datasetPath, snapshot);
+  }
+
+  async function getSnapshot({ refresh = false } = {}) {
+    if (refresh) {
+      cachedSnapshot = null;
+    }
+    if (cachedSnapshot) {
+      return clone(cachedSnapshot);
+    }
+    let snapshot = await loadSnapshotFromDisk();
+    if (!snapshot) {
+      snapshot = (await loadStaticSnapshot()) || {};
+    }
+    cachedSnapshot = clone(snapshot);
+    return clone(snapshot);
+  }
+
+  async function resolveBaseSnapshotForPatch() {
+    const diskSnapshot = await loadSnapshotFromDisk();
+    if (diskSnapshot) {
+      cachedSnapshot = clone(diskSnapshot);
+      return diskSnapshot;
+    }
+    const fallbackSnapshot = await loadStaticSnapshot();
+    const base = fallbackSnapshot ? clone(fallbackSnapshot) : {};
+    cachedSnapshot = clone(base);
+    return base;
+  }
+
+  async function applyPatch(patch = {}) {
+    const current = await resolveBaseSnapshotForPatch();
+    const next = applySnapshotPatch(current, patch);
+    cachedSnapshot = clone(next);
+    await persistSnapshot(next);
+    return clone(next);
+  }
+
+  async function recordRuntime(result, error) {
+    const summary = buildRuntimeSummary(result, error);
+    if (!summary) {
+      return getSnapshot();
+    }
+    return applyPatch({ runtime: summary });
+  }
+
+  async function invalidate() {
+    cachedSnapshot = null;
+  }
+
+  return {
+    getSnapshot,
+    applyPatch,
+    recordRuntime,
+    invalidate,
+    get datasetPath() {
+      return datasetPath;
+    },
+  };
+}
+
+module.exports = {
+  createGenerationSnapshotStore,
+  buildRuntimeSummary,
+  __internals__: {
+    clone,
+    mergeSection,
+    applySnapshotPatch,
+    readJson,
+    writeJson,
+  },
+};

--- a/tests/generation/flow-shell.spec.ts
+++ b/tests/generation/flow-shell.spec.ts
@@ -58,11 +58,11 @@ test('GET /api/generation/snapshot aggrega dataset, diagnostics e orchestrator',
     'flow-shell',
     'atlas-snapshot.json',
   );
-
   const { app } = createApp({
     generationOrchestrator: stubOrchestrator,
     traitDiagnosticsSync,
     generationSnapshot: { datasetPath },
+    repo: {},
   });
 
   const response = await request(app).get('/api/generation/snapshot').expect(200);
@@ -123,6 +123,7 @@ test('GET /api/generation/snapshot?refresh=1 ricarica il dataset da disco', asyn
     generationOrchestrator: stubOrchestrator,
     traitDiagnosticsSync,
     generationSnapshot: { datasetPath },
+    repo: {},
   });
 
   const responseV1 = await request(app).get('/api/generation/snapshot').expect(200);

--- a/tests/server/generationSnapshot.spec.js
+++ b/tests/server/generationSnapshot.spec.js
@@ -1,0 +1,101 @@
+const assert = require('node:assert/strict');
+const { mkdtemp, rm, writeFile, readFile } = require('node:fs/promises');
+const path = require('node:path');
+const { tmpdir } = require('node:os');
+const test = require('node:test');
+
+const { createGenerationSnapshotStore } = require('../../server/services/generationSnapshotStore');
+
+function createTempDir(prefix) {
+  return mkdtemp(path.join(tmpdir(), prefix));
+}
+
+test('applyPatch aggiorna la cache e persiste i dati su disco', async (t) => {
+  const tempDir = await createTempDir('snapshot-store-');
+  t.after(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+  const datasetPath = path.join(tempDir, 'atlas-snapshot.json');
+  const initialDataset = {
+    overview: { completion: { completed: 1, total: 4 } },
+    species: { curated: 2, total: 10, shortlist: ['alpha'] },
+    biomeSummary: { validated: 1, pending: 2 },
+    encounterSummary: { variants: 0, seeds: 0, warnings: 0 },
+  };
+  await writeFile(datasetPath, `${JSON.stringify(initialDataset, null, 2)}\n`, 'utf8');
+
+  const store = createGenerationSnapshotStore({ datasetPath });
+  const baseline = await store.getSnapshot();
+  assert.equal(baseline.species.curated, 2);
+
+  await store.applyPatch({
+    runtime: {
+      lastBlueprintId: 'blueprint-42',
+      fallbackUsed: false,
+      validationMessages: 1,
+      lastRequestId: 'req-42',
+    },
+    speciesStatus: { curated: 3, shortlist: ['alpha', 'beta'] },
+    overview: { completion: { completed: 2 } },
+    biomeSummary: { pending: 1 },
+    encounterSummary: { variants: 1, seeds: 3 },
+  });
+
+  const cached = await store.getSnapshot();
+  assert.equal(cached.runtime.lastBlueprintId, 'blueprint-42');
+  assert.equal(cached.species.curated, 3);
+  assert.deepEqual(cached.species.shortlist, ['alpha', 'beta']);
+  assert.deepEqual(cached.overview.completion, { completed: 2, total: 4 });
+  assert.deepEqual(cached.biomeSummary, { validated: 1, pending: 1 });
+  assert.deepEqual(cached.encounterSummary, { variants: 1, seeds: 3, warnings: 0 });
+
+  const persisted = JSON.parse(await readFile(datasetPath, 'utf8'));
+  assert.equal(persisted.runtime.lastBlueprintId, 'blueprint-42');
+  assert.equal(persisted.species.curated, 3);
+  assert.deepEqual(persisted.overview.completion, { completed: 2, total: 4 });
+});
+
+test('getSnapshot({ refresh: true }) invalida la cache e ricarica il file', async (t) => {
+  const tempDir = await createTempDir('snapshot-store-refresh-');
+  t.after(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+  const datasetPath = path.join(tempDir, 'atlas.json');
+  const datasetV1 = { overview: { title: 'Versione 1' } };
+  const datasetV2 = { overview: { title: 'Versione 2' } };
+  await writeFile(datasetPath, `${JSON.stringify(datasetV1, null, 2)}\n`, 'utf8');
+
+  const store = createGenerationSnapshotStore({ datasetPath });
+  const first = await store.getSnapshot();
+  assert.equal(first.overview.title, 'Versione 1');
+
+  await writeFile(datasetPath, `${JSON.stringify(datasetV2, null, 2)}\n`, 'utf8');
+
+  const cached = await store.getSnapshot();
+  assert.equal(cached.overview.title, 'Versione 1');
+
+  const refreshed = await store.getSnapshot({ refresh: true });
+  assert.equal(refreshed.overview.title, 'Versione 2');
+});
+
+test('usa il dataset statico quando il file non è disponibile', async (t) => {
+  const tempDir = await createTempDir('snapshot-store-static-');
+  t.after(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+  const datasetPath = path.join(tempDir, 'missing.json');
+  const staticDataset = {
+    overview: { title: 'Statico' },
+    species: { curated: 0, total: 5 },
+  };
+
+  const store = createGenerationSnapshotStore({ datasetPath, staticDataset });
+  const snapshot = await store.getSnapshot();
+  assert.equal(snapshot.overview.title, 'Statico');
+  assert.equal(snapshot.species.total, 5);
+
+  await store.applyPatch({ speciesStatus: { curated: 1 } });
+  const persisted = JSON.parse(await readFile(datasetPath, 'utf8'));
+  assert.equal(persisted.species.curated, 1);
+  assert.equal(persisted.species.total, 5);
+});


### PR DESCRIPTION
## Summary
- add a generation snapshot store with in-memory cache, disk mirroring, and runtime/species merging
- wire the snapshot route, app bootstrap, and orchestrator bridge to use the shared store
- expand automated coverage for snapshot refresh/persistence and integrate the new test into the API suite

## Testing
- npm run test:api

------
https://chatgpt.com/codex/tasks/task_e_690551b18ae883329fb782405e46a20a