### PR TITLE
Add Nebula telemetry aggregator and live status UI

### DIFF
--- a/config/nebula.json
+++ b/config/nebula.json
@@ -1,0 +1,14 @@
+{
+  "cache": {
+    "ttlMs": 20000
+  },
+  "telemetry": {
+    "defaultLimit": 120,
+    "timelineDays": 7
+  },
+  "orchestrator": {
+    "logDirectory": "logs/tooling",
+    "filePattern": "*.jsonl",
+    "maxEvents": 150
+  }
+}

--- a/server/routes/nebula.js
+++ b/server/routes/nebula.js
@@ -1,8 +1,8 @@
 const express = require('express');
-const fs = require('node:fs/promises');
+const fs = require('node:fs');
 const path = require('node:path');
 
-const { atlasDataset } = require('../../data/nebula/atlasDataset.js');
+const { createNebulaTelemetryAggregator } = require('../services/nebulaTelemetryAggregator');
 
 const DEFAULT_TELEMETRY_EXPORT = path.resolve(
   __dirname,
@@ -23,288 +23,117 @@ const DEFAULT_GENERATOR_TELEMETRY = path.resolve(
   'generator_run_profile.json',
 );
 
-function cloneDataset() {
-  return JSON.parse(JSON.stringify(atlasDataset));
+const DEFAULT_ORCHESTRATOR_LOG_DIR = path.resolve(__dirname, '..', '..', 'logs', 'tooling');
+const DEFAULT_CONFIG_PATH = path.resolve(__dirname, '..', '..', 'config', 'nebula.json');
+
+const DEFAULT_CONFIG = {
+  cache: { ttlMs: 30_000 },
+  telemetry: { defaultLimit: 200, timelineDays: 7 },
+  orchestrator: {
+    logDirectory: DEFAULT_ORCHESTRATOR_LOG_DIR,
+    filePattern: '*.jsonl',
+    maxEvents: 250,
+  },
+};
+
+function mergeConfig(base, override) {
+  const result = { ...base };
+  for (const [key, value] of Object.entries(override || {})) {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      result[key] = mergeConfig(base[key] || {}, value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
 }
 
-async function loadTelemetryRecords(filePath) {
+function loadConfig(configPath, inlineConfig) {
+  if (inlineConfig && typeof inlineConfig === 'object') {
+    return mergeConfig(DEFAULT_CONFIG, inlineConfig);
+  }
   try {
-    const content = await fs.readFile(filePath, 'utf8');
+    const content = fs.readFileSync(configPath, 'utf8');
     const parsed = JSON.parse(content);
-    return Array.isArray(parsed) ? parsed : [];
+    return mergeConfig(DEFAULT_CONFIG, parsed);
   } catch (error) {
-    if (error && error.code === 'ENOENT') {
-      return [];
+    if (error && error.code !== 'ENOENT') {
+      console.warn('[nebula-route] impossibile leggere config Nebula', error);
     }
-    throw error;
+    return { ...DEFAULT_CONFIG };
   }
 }
 
-async function loadGeneratorTelemetry(filePath) {
-  try {
-    const content = await fs.readFile(filePath, 'utf8');
-    const parsed = JSON.parse(content);
-    return parsed && typeof parsed === 'object' ? parsed : null;
-  } catch (error) {
-    if (error && error.code === 'ENOENT') {
-      return null;
-    }
-    throw error;
+function resolveOrchestratorDir(dirPath) {
+  if (!dirPath) {
+    return DEFAULT_ORCHESTRATOR_LOG_DIR;
   }
+  if (path.isAbsolute(dirPath)) {
+    return dirPath;
+  }
+  return path.resolve(__dirname, '..', '..', dirPath);
 }
 
-function readinessTone(readiness) {
-  if (!readiness) {
-    return 'neutral';
+function parseLimit(value, defaultLimit, maxEvents) {
+  const fallback = Number.isFinite(defaultLimit) && defaultLimit > 0 ? Math.floor(defaultLimit) : 50;
+  if (value === undefined) {
+    return fallback;
   }
-  const value = String(readiness).toLowerCase();
-  if (value.includes('richiede')) {
-    return 'critical';
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
   }
-  if (value.includes('approvazione') || value.includes('attesa')) {
-    return 'warning';
-  }
-  if (value.includes('freeze') || value.includes('validazione completata') || value.includes('pronto')) {
-    return 'success';
-  }
-  return 'neutral';
+  const hardLimit = Number.isFinite(maxEvents) && maxEvents > 0 ? Math.floor(maxEvents) : fallback;
+  return Math.min(parsed, hardLimit);
 }
 
-function averageCoveragePercent(species) {
-  if (!Array.isArray(species) || !species.length) {
-    return 0;
-  }
-  const total = species.reduce((acc, entry) => acc + (Number(entry?.telemetry?.coverage) || 0), 0);
-  return Math.round((total / species.length) * 100);
-}
-
-function buildCoverageHistory(species) {
-  const average = averageCoveragePercent(species);
-  if (!average) {
-    return [0, 0, 0, 0];
-  }
-  const base = Math.max(average - 15, 0);
-  return [
-    Math.max(Math.round(average * 0.55), 0),
-    Math.max(Math.round((base + average * 0.75) / 2), 0),
-    Math.max(Math.round((average + base) / 2), 0),
-    average,
-  ];
-}
-
-function buildReadinessDistribution(species) {
-  const distribution = { success: 0, warning: 0, neutral: 0, critical: 0 };
-  if (!Array.isArray(species)) {
-    return distribution;
-  }
-  for (const entry of species) {
-    const tone = readinessTone(entry?.readiness);
-    if (distribution[tone] !== undefined) {
-      distribution[tone] += 1;
-    }
-  }
-  return distribution;
-}
-
-function buildTelemetrySummary(records) {
-  const summary = {
-    totalEvents: 0,
-    openEvents: 0,
-    acknowledgedEvents: 0,
-    highPriorityEvents: 0,
-    lastEventAt: null,
-  };
-  if (!Array.isArray(records)) {
-    return summary;
-  }
-  let lastTimestamp = null;
-  for (const record of records) {
-    summary.totalEvents += 1;
-    const priority = String(record?.priority || '').toLowerCase();
-    if (priority === 'high') {
-      summary.highPriorityEvents += 1;
-    }
-    const status = String(record?.status || '').toLowerCase();
-    const isClosed = status.includes('closed') || status.includes('risolto');
-    const isAcknowledged =
-      status.includes('ack') || status.includes('resolved') || status.includes('triaged') || status.includes('chiuso');
-    if (!isClosed) {
-      summary.openEvents += 1;
-    }
-    if (isAcknowledged) {
-      summary.acknowledgedEvents += 1;
-    }
-    const timestamp = record?.event_timestamp || record?.timestamp || record?.created_at;
-    if (timestamp) {
-      const date = new Date(timestamp);
-      if (!Number.isNaN(date.getTime())) {
-        if (!lastTimestamp || date.getTime() > lastTimestamp.getTime()) {
-          lastTimestamp = date;
-        }
-      }
-    }
-  }
-  summary.lastEventAt = lastTimestamp ? lastTimestamp.toISOString() : null;
-  return summary;
-}
-
-function buildIncidentTimeline(records, days = 7) {
-  const now = new Date();
-  const buckets = [];
-  const bucketMap = new Map();
-  for (let offset = days - 1; offset >= 0; offset -= 1) {
-    const bucketDate = new Date(now);
-    bucketDate.setUTCDate(bucketDate.getUTCDate() - offset);
-    const key = bucketDate.toISOString().slice(0, 10);
-    const bucket = { date: key, total: 0, highPriority: 0 };
-    buckets.push(bucket);
-    bucketMap.set(key, bucket);
-  }
-  if (!Array.isArray(records)) {
-    return buckets;
-  }
-  for (const record of records) {
-    const timestamp = record?.event_timestamp || record?.timestamp || record?.created_at;
-    if (!timestamp) {
-      continue;
-    }
-    const date = new Date(timestamp);
-    if (Number.isNaN(date.getTime())) {
-      continue;
-    }
-    const key = date.toISOString().slice(0, 10);
-    const bucket = bucketMap.get(key);
-    if (!bucket) {
-      continue;
-    }
-    bucket.total += 1;
-    const priority = String(record?.priority || '').toLowerCase();
-    if (priority === 'high') {
-      bucket.highPriority += 1;
-    }
-  }
-  return buckets;
-}
-
-function buildTelemetryPayload(dataset, records) {
-  const species = Array.isArray(dataset?.species) ? dataset.species : [];
-  const coverageHistory = buildCoverageHistory(species);
-  const distribution = buildReadinessDistribution(species);
-  const summary = buildTelemetrySummary(records);
-  const incidentTimeline = buildIncidentTimeline(records);
-  return {
-    summary,
-    coverage: {
-      average: averageCoveragePercent(species),
-      history: coverageHistory,
-      distribution,
-    },
-    incidents: {
-      timeline: incidentTimeline,
-    },
-    updatedAt: new Date().toISOString(),
-    sample: Array.isArray(records) ? records.slice(0, 20) : [],
-  };
-}
-
-function normaliseNumber(value, fallback = 0) {
-  const numeric = Number(value);
-  return Number.isFinite(numeric) ? numeric : fallback;
-}
-
-function buildTrendSeries(latest, { points = 6, baseline } = {}) {
-  const totalPoints = Math.max(points, 2);
-  const value = normaliseNumber(latest, 0);
+function parseSince(value) {
   if (!value) {
-    return Array.from({ length: totalPoints }, () => 0);
+    return null;
   }
-  const resolvedBaseline = baseline !== undefined ? baseline : Math.round(value * 0.6);
-  let start = normaliseNumber(resolvedBaseline, value);
-  if (start <= 0 || start >= value) {
-    start = Math.max(Math.round(value * 0.55), Math.max(Math.round(value * 0.35), 1));
+  const date = new Date(String(value));
+  if (Number.isNaN(date.getTime())) {
+    return null;
   }
-  const step = (value - start) / (totalPoints - 1);
-  const series = [];
-  for (let index = 0; index < totalPoints; index += 1) {
-    const point = start + step * index;
-    series.push(Math.max(Math.round(point), 0));
-  }
-  return series;
+  return date.toISOString();
 }
 
-function buildGeneratorPayload(dataset, generatorProfile) {
-  const species = Array.isArray(dataset?.species) ? dataset.species : [];
-  const metrics = generatorProfile?.metrics || {};
-  const status = String(generatorProfile?.status || 'unknown').toLowerCase();
-  const generationTimeMs = normaliseNumber(metrics.generation_time_ms, null);
-  const speciesTotal = normaliseNumber(metrics.species_total, species.length);
-  const enrichedSpecies = normaliseNumber(metrics.enriched_species, Math.round(species.length * 0.6));
-  const eventTotal = normaliseNumber(metrics.event_total, 0);
-  const coreTraits = normaliseNumber(metrics.core_traits_total, 0);
-  const optionalTraits = normaliseNumber(metrics.optional_traits_total, 0);
-  const synergyTraits = normaliseNumber(metrics.synergy_traits_total, 0);
-  const expectedCoreTraits = normaliseNumber(metrics.expected_core_traits, 0);
-
-  const trendOptions = { points: 6 };
-  const streams = {
-    generationTime: buildTrendSeries(generationTimeMs || 0, trendOptions),
-    species: buildTrendSeries(speciesTotal, { ...trendOptions, baseline: species.length }),
-    enriched: buildTrendSeries(enrichedSpecies, { ...trendOptions, baseline: Math.round(species.length * 0.5) || 1 }),
-  };
-
-  const label =
-    status === 'success'
-      ? 'Generatore online'
-      : status === 'warning' || status === 'degraded'
-        ? 'Generatore in osservazione'
-        : 'Generatore offline';
-
+function extractRequestParams(query, config) {
+  const defaultLimit = config.telemetry?.defaultLimit ?? DEFAULT_CONFIG.telemetry.defaultLimit;
+  const maxEvents = config.orchestrator?.maxEvents ?? DEFAULT_CONFIG.orchestrator.maxEvents;
   return {
-    status,
-    label,
-    generatedAt: generatorProfile?.generated_at || generatorProfile?.generatedAt || null,
-    dataRoot: generatorProfile?.data_root || generatorProfile?.dataRoot || null,
-    metrics: {
-      generationTimeMs: generationTimeMs !== null ? generationTimeMs : null,
-      speciesTotal,
-      enrichedSpecies,
-      eventTotal,
-      datasetSpeciesTotal: species.length,
-      coverageAverage: averageCoveragePercent(species),
-      coreTraits,
-      optionalTraits,
-      synergyTraits,
-      expectedCoreTraits,
-    },
-    streams,
-    updatedAt: new Date().toISOString(),
-    sourceLabel: 'Generator telemetry',
+    since: parseSince(query?.since),
+    limit: parseLimit(query?.limit, defaultLimit, maxEvents),
   };
 }
 
 function createNebulaRouter(options = {}) {
   const router = express.Router();
-  const telemetryPath = options.telemetryPath || DEFAULT_TELEMETRY_EXPORT;
-  const generatorPath = options.generatorTelemetryPath || DEFAULT_GENERATOR_TELEMETRY;
 
-  async function loadData() {
-    const dataset = cloneDataset();
-    const records = await loadTelemetryRecords(telemetryPath).catch((error) => {
-      console.warn('[nebula-route] impossibile caricare telemetria', error);
-      return [];
+  const configPath = options.configPath || DEFAULT_CONFIG_PATH;
+  const config = loadConfig(configPath, options.config);
+
+  const aggregator =
+    options.aggregator ||
+    createNebulaTelemetryAggregator({
+      telemetryPath: options.telemetryPath || DEFAULT_TELEMETRY_EXPORT,
+      generatorTelemetryPath: options.generatorTelemetryPath || DEFAULT_GENERATOR_TELEMETRY,
+      cacheTTL: config.cache?.ttlMs,
+      telemetry: {
+        defaultLimit: config.telemetry?.defaultLimit,
+        timelineDays: config.telemetry?.timelineDays,
+      },
+      orchestrator: {
+        logDir: resolveOrchestratorDir(config.orchestrator?.logDirectory),
+        filePattern: config.orchestrator?.filePattern,
+        maxEvents: config.orchestrator?.maxEvents,
+      },
     });
-    const generatorProfile = await loadGeneratorTelemetry(generatorPath).catch((error) => {
-      console.warn('[nebula-route] impossibile caricare telemetria generatore', error);
-      return null;
-    });
-    const telemetry = buildTelemetryPayload(dataset, records);
-    const generator = buildGeneratorPayload(dataset, generatorProfile);
-    return { dataset, telemetry, generator };
-  }
 
   router.get('/atlas', async (req, res) => {
+    const params = extractRequestParams(req.query, config);
     try {
-      const payload = await loadData();
+      const payload = await aggregator.getAtlas(params);
       res.json(payload);
     } catch (error) {
       console.error('[nebula-route] errore aggregazione dataset', error);
@@ -315,8 +144,9 @@ function createNebulaRouter(options = {}) {
   });
 
   router.get('/atlas/telemetry', async (req, res) => {
+    const params = extractRequestParams(req.query, config);
     try {
-      const { telemetry } = await loadData();
+      const telemetry = await aggregator.getTelemetry(params);
       res.json(telemetry);
     } catch (error) {
       console.error('[nebula-route] errore aggregazione telemetria', error);
@@ -328,12 +158,25 @@ function createNebulaRouter(options = {}) {
 
   router.get('/atlas/generator', async (req, res) => {
     try {
-      const { generator } = await loadData();
+      const generator = await aggregator.getGenerator();
       res.json(generator);
     } catch (error) {
       console.error('[nebula-route] errore aggregazione telemetria generatore', error);
       res.status(500).json({
         error: error?.message || 'Errore caricamento telemetria generatore Nebula',
+      });
+    }
+  });
+
+  router.get('/atlas/orchestrator', async (req, res) => {
+    const params = extractRequestParams(req.query, config);
+    try {
+      const orchestrator = await aggregator.getOrchestrator(params);
+      res.json(orchestrator);
+    } catch (error) {
+      console.error('[nebula-route] errore aggregazione orchestratore', error);
+      res.status(500).json({
+        error: error?.message || 'Errore caricamento orchestratore Nebula',
       });
     }
   });
@@ -344,17 +187,11 @@ function createNebulaRouter(options = {}) {
 module.exports = {
   createNebulaRouter,
   __internals__: {
-    cloneDataset,
-    loadTelemetryRecords,
-    loadGeneratorTelemetry,
-    readinessTone,
-    averageCoveragePercent,
-    buildCoverageHistory,
-    buildReadinessDistribution,
-    buildTelemetrySummary,
-    buildIncidentTimeline,
-    buildTelemetryPayload,
-    buildGeneratorPayload,
-    buildTrendSeries,
+    loadConfig,
+    mergeConfig,
+    extractRequestParams,
+    parseSince,
+    parseLimit,
+    resolveOrchestratorDir,
   },
 };

--- a/server/services/nebulaTelemetryAggregator.js
+++ b/server/services/nebulaTelemetryAggregator.js
@@ -1,0 +1,571 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const { atlasDataset } = require('../../data/nebula/atlasDataset.js');
+
+const DEFAULT_CACHE_TTL = 30_000;
+const DEFAULT_TELEMETRY_LIMIT = 200;
+const DEFAULT_TIMELINE_DAYS = 7;
+const DEFAULT_ORCHESTRATOR_MAX_EVENTS = 250;
+
+function cloneValue(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function normaliseNumber(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function readinessTone(readiness) {
+  if (!readiness) {
+    return 'neutral';
+  }
+  const value = String(readiness).toLowerCase();
+  if (value.includes('richiede')) {
+    return 'critical';
+  }
+  if (value.includes('approvazione') || value.includes('attesa')) {
+    return 'warning';
+  }
+  if (value.includes('freeze') || value.includes('validazione completata') || value.includes('pronto')) {
+    return 'success';
+  }
+  return 'neutral';
+}
+
+function averageCoveragePercent(species) {
+  if (!Array.isArray(species) || !species.length) {
+    return 0;
+  }
+  const total = species.reduce((acc, entry) => acc + (Number(entry?.telemetry?.coverage) || 0), 0);
+  return Math.round((total / species.length) * 100);
+}
+
+function buildCoverageHistory(species) {
+  const average = averageCoveragePercent(species);
+  if (!average) {
+    return [0, 0, 0, 0];
+  }
+  const base = Math.max(average - 15, 0);
+  return [
+    Math.max(Math.round(average * 0.55), 0),
+    Math.max(Math.round((base + average * 0.75) / 2), 0),
+    Math.max(Math.round((average + base) / 2), 0),
+    average,
+  ];
+}
+
+function buildReadinessDistribution(species) {
+  const distribution = { success: 0, warning: 0, neutral: 0, critical: 0 };
+  if (!Array.isArray(species)) {
+    return distribution;
+  }
+  for (const entry of species) {
+    const tone = readinessTone(entry?.readiness);
+    if (distribution[tone] !== undefined) {
+      distribution[tone] += 1;
+    }
+  }
+  return distribution;
+}
+
+function buildTelemetrySummary(records) {
+  const summary = {
+    totalEvents: 0,
+    openEvents: 0,
+    acknowledgedEvents: 0,
+    highPriorityEvents: 0,
+    lastEventAt: null,
+  };
+  if (!Array.isArray(records)) {
+    return summary;
+  }
+  let lastTimestamp = null;
+  for (const record of records) {
+    summary.totalEvents += 1;
+    const priority = String(record?.priority || '').toLowerCase();
+    if (priority === 'high') {
+      summary.highPriorityEvents += 1;
+    }
+    const status = String(record?.status || '').toLowerCase();
+    const isClosed = status.includes('closed') || status.includes('risolto');
+    const isAcknowledged =
+      status.includes('ack') ||
+      status.includes('resolved') ||
+      status.includes('triaged') ||
+      status.includes('chiuso');
+    if (!isClosed) {
+      summary.openEvents += 1;
+    }
+    if (isAcknowledged) {
+      summary.acknowledgedEvents += 1;
+    }
+    const timestamp = record?.event_timestamp || record?.timestamp || record?.created_at;
+    if (timestamp) {
+      const date = new Date(timestamp);
+      if (!Number.isNaN(date.getTime())) {
+        if (!lastTimestamp || date.getTime() > lastTimestamp.getTime()) {
+          lastTimestamp = date;
+        }
+      }
+    }
+  }
+  summary.lastEventAt = lastTimestamp ? lastTimestamp.toISOString() : null;
+  return summary;
+}
+
+function buildIncidentTimeline(records, days = DEFAULT_TIMELINE_DAYS) {
+  const now = new Date();
+  const buckets = [];
+  const bucketMap = new Map();
+  const totalDays = Math.max(days, 1);
+  for (let offset = totalDays - 1; offset >= 0; offset -= 1) {
+    const bucketDate = new Date(now);
+    bucketDate.setUTCDate(bucketDate.getUTCDate() - offset);
+    const key = bucketDate.toISOString().slice(0, 10);
+    const bucket = { date: key, total: 0, highPriority: 0 };
+    buckets.push(bucket);
+    bucketMap.set(key, bucket);
+  }
+  if (!Array.isArray(records)) {
+    return buckets;
+  }
+  for (const record of records) {
+    const timestamp = record?.event_timestamp || record?.timestamp || record?.created_at;
+    if (!timestamp) {
+      continue;
+    }
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) {
+      continue;
+    }
+    const key = date.toISOString().slice(0, 10);
+    const bucket = bucketMap.get(key);
+    if (!bucket) {
+      continue;
+    }
+    bucket.total += 1;
+    const priority = String(record?.priority || '').toLowerCase();
+    if (priority === 'high') {
+      bucket.highPriority += 1;
+    }
+  }
+  return buckets;
+}
+
+function buildTrendSeries(latest, { points = 6, baseline } = {}) {
+  const totalPoints = Math.max(points, 2);
+  const value = normaliseNumber(latest, 0);
+  if (!value) {
+    return Array.from({ length: totalPoints }, () => 0);
+  }
+  const resolvedBaseline = baseline !== undefined ? baseline : Math.round(value * 0.6);
+  let start = normaliseNumber(resolvedBaseline, value);
+  if (start <= 0 || start >= value) {
+    start = Math.max(Math.round(value * 0.55), Math.max(Math.round(value * 0.35), 1));
+  }
+  const step = (value - start) / (totalPoints - 1);
+  const series = [];
+  for (let index = 0; index < totalPoints; index += 1) {
+    const point = start + step * index;
+    series.push(Math.max(Math.round(point), 0));
+  }
+  return series;
+}
+
+function buildTelemetryPayload(dataset, records, options = {}) {
+  const species = Array.isArray(dataset?.species) ? dataset.species : [];
+  const coverageHistory = buildCoverageHistory(species);
+  const distribution = buildReadinessDistribution(species);
+  const summary = buildTelemetrySummary(records);
+  const incidentTimeline = buildIncidentTimeline(records, options.timelineDays);
+  return {
+    summary,
+    coverage: {
+      average: averageCoveragePercent(species),
+      history: coverageHistory,
+      distribution,
+    },
+    incidents: {
+      timeline: incidentTimeline,
+    },
+    updatedAt: new Date().toISOString(),
+    sample: Array.isArray(records)
+      ? records.slice(0, normaliseNumber(options.limit, DEFAULT_TELEMETRY_LIMIT))
+      : [],
+    state: options.state || 'live',
+  };
+}
+
+function buildGeneratorPayload(dataset, generatorProfile) {
+  const species = Array.isArray(dataset?.species) ? dataset.species : [];
+  const metrics = generatorProfile?.metrics || {};
+  const status = String(generatorProfile?.status || 'unknown').toLowerCase();
+  const generationTimeMs = normaliseNumber(metrics.generation_time_ms ?? metrics.generationTimeMs, null);
+  const speciesTotal = normaliseNumber(metrics.species_total ?? metrics.speciesTotal, species.length);
+  const enrichedSpecies = normaliseNumber(
+    metrics.enriched_species ?? metrics.enrichedSpecies,
+    Math.round(species.length * 0.6),
+  );
+  const eventTotal = normaliseNumber(metrics.event_total ?? metrics.eventTotal, 0);
+  const coreTraits = normaliseNumber(metrics.core_traits_total ?? metrics.coreTraitsTotal, 0);
+  const optionalTraits = normaliseNumber(metrics.optional_traits_total ?? metrics.optionalTraitsTotal, 0);
+  const synergyTraits = normaliseNumber(metrics.synergy_traits_total ?? metrics.synergyTraitsTotal, 0);
+  const expectedCoreTraits = normaliseNumber(metrics.expected_core_traits ?? metrics.expectedCoreTraits, 0);
+
+  const trendOptions = { points: 6 };
+  const streams = {
+    generationTime: buildTrendSeries(generationTimeMs || 0, trendOptions),
+    species: buildTrendSeries(speciesTotal, { ...trendOptions, baseline: species.length }),
+    enriched: buildTrendSeries(enrichedSpecies, {
+      ...trendOptions,
+      baseline: Math.round(species.length * 0.5) || 1,
+    }),
+  };
+
+  const label =
+    status === 'success'
+      ? 'Generatore online'
+      : status === 'warning' || status === 'degraded'
+        ? 'Generatore in osservazione'
+        : 'Generatore offline';
+
+  return {
+    status,
+    label,
+    generatedAt: generatorProfile?.generated_at || generatorProfile?.generatedAt || null,
+    dataRoot: generatorProfile?.data_root || generatorProfile?.dataRoot || null,
+    metrics: {
+      generationTimeMs: generationTimeMs !== null ? generationTimeMs : null,
+      speciesTotal,
+      enrichedSpecies,
+      eventTotal,
+      datasetSpeciesTotal: species.length,
+      coverageAverage: averageCoveragePercent(species),
+      coreTraits,
+      optionalTraits,
+      synergyTraits,
+      expectedCoreTraits,
+    },
+    streams,
+    updatedAt: new Date().toISOString(),
+    sourceLabel: 'Generator telemetry',
+  };
+}
+
+function createFileMatcher(pattern) {
+  if (!pattern) {
+    return () => true;
+  }
+  if (pattern instanceof RegExp) {
+    return (value) => pattern.test(value);
+  }
+  const segments = String(pattern)
+    .split('*')
+    .map((segment) => segment.replace(/[.+?^${}()|[\]\\]/g, '\\$&'));
+  const escaped = segments.join('.*');
+  const regex = new RegExp(`^${escaped}$`, 'i');
+  return (value) => regex.test(value);
+}
+
+async function readJsonFile(filePath, fallback = null) {
+  if (!filePath) {
+    return fallback;
+  }
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(content);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return fallback;
+    }
+    throw error;
+  }
+}
+
+async function loadTelemetryRecords(filePath) {
+  const parsed = await readJsonFile(filePath, []);
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  return parsed;
+}
+
+async function loadGeneratorTelemetry(filePath) {
+  const parsed = await readJsonFile(filePath, null);
+  if (!parsed || typeof parsed !== 'object') {
+    return null;
+  }
+  return parsed;
+}
+
+function normaliseTimestamp(value) {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toISOString();
+}
+
+function normaliseLogEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  const timestamp =
+    entry.timestamp || entry.time || entry.ts || entry.logged_at || entry.loggedAt || entry.date || entry.created_at;
+  const level = String(entry.level || entry.severity || entry.status || 'info').toLowerCase();
+  const message = entry.message || entry.msg || entry.event || entry.description || 'orchestrator event';
+  const details = entry.details || entry.context || entry.meta || null;
+  return {
+    timestamp: normaliseTimestamp(timestamp),
+    level,
+    message,
+    details: details && typeof details === 'object' ? details : null,
+  };
+}
+
+async function loadOrchestratorLogEntries(options = {}) {
+  const directory = options.logDir;
+  if (!directory) {
+    return [];
+  }
+  const matcher = createFileMatcher(options.filePattern || '*.jsonl');
+  let entries = [];
+  try {
+    const dirEntries = await fs.readdir(directory, { withFileTypes: true });
+    for (const fileEntry of dirEntries) {
+      if (!fileEntry.isFile()) {
+        continue;
+      }
+      if (!matcher(fileEntry.name)) {
+        continue;
+      }
+      const filePath = path.join(directory, fileEntry.name);
+      const content = await fs.readFile(filePath, 'utf8');
+      const lines = content.split(/\r?\n/).filter((line) => line.trim().length > 0);
+      for (const line of lines) {
+        try {
+          const parsed = JSON.parse(line);
+          const normalised = normaliseLogEntry(parsed);
+          if (normalised) {
+            entries.push(normalised);
+          }
+        } catch (error) {
+          // ignora righe non valide
+        }
+      }
+    }
+  } catch (error) {
+    if (!error || error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+  entries.sort((a, b) => {
+    const timeA = a.timestamp ? new Date(a.timestamp).getTime() : 0;
+    const timeB = b.timestamp ? new Date(b.timestamp).getTime() : 0;
+    return timeB - timeA;
+  });
+  return entries;
+}
+
+function filterBySince(entries, sinceDate) {
+  if (!sinceDate || !Array.isArray(entries)) {
+    return Array.isArray(entries) ? entries : [];
+  }
+  const since = new Date(sinceDate);
+  if (Number.isNaN(since.getTime())) {
+    return Array.isArray(entries) ? entries : [];
+  }
+  return entries.filter((entry) => {
+    const timestamp = entry?.timestamp || entry?.event_timestamp || entry?.created_at;
+    if (!timestamp) {
+      return false;
+    }
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) {
+      return false;
+    }
+    return date.getTime() >= since.getTime();
+  });
+}
+
+function limitEntries(entries, limit, maxLimit) {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  const effectiveMax = Number.isFinite(maxLimit) && maxLimit > 0 ? maxLimit : entries.length;
+  const safeLimit = Math.min(
+    effectiveMax,
+    Number.isFinite(limit) && limit > 0 ? Math.min(Math.floor(limit), effectiveMax) : effectiveMax,
+  );
+  return entries.slice(0, safeLimit);
+}
+
+function buildOrchestratorSummary(entries) {
+  const summary = {
+    totalEntries: 0,
+    errorCount: 0,
+    warningCount: 0,
+    infoCount: 0,
+    lastEventAt: null,
+  };
+  if (!Array.isArray(entries)) {
+    return summary;
+  }
+  let lastTimestamp = null;
+  for (const entry of entries) {
+    summary.totalEntries += 1;
+    const level = entry?.level || 'info';
+    if (level === 'error' || level === 'fatal') {
+      summary.errorCount += 1;
+    } else if (level === 'warn' || level === 'warning') {
+      summary.warningCount += 1;
+    } else {
+      summary.infoCount += 1;
+    }
+    if (entry?.timestamp) {
+      const date = new Date(entry.timestamp);
+      if (!Number.isNaN(date.getTime())) {
+        if (!lastTimestamp || date.getTime() > lastTimestamp.getTime()) {
+          lastTimestamp = date;
+        }
+      }
+    }
+  }
+  summary.lastEventAt = lastTimestamp ? lastTimestamp.toISOString() : null;
+  return summary;
+}
+
+function resolveOptions(options = {}) {
+  const telemetryOptions = {
+    path: options.telemetryPath,
+    limit: options.telemetry?.defaultLimit ?? DEFAULT_TELEMETRY_LIMIT,
+    timelineDays: options.telemetry?.timelineDays ?? DEFAULT_TIMELINE_DAYS,
+  };
+  const generatorOptions = {
+    path: options.generatorTelemetryPath,
+  };
+  const orchestratorOptions = {
+    logDir: options.orchestrator?.logDir,
+    filePattern: options.orchestrator?.filePattern || '*.jsonl',
+    maxEvents: options.orchestrator?.maxEvents ?? DEFAULT_ORCHESTRATOR_MAX_EVENTS,
+  };
+  const cacheTTL = options.cacheTTL ?? DEFAULT_CACHE_TTL;
+  const dataset = options.staticDataset ? cloneValue(options.staticDataset) : cloneValue(atlasDataset);
+  return {
+    telemetry: telemetryOptions,
+    generator: generatorOptions,
+    orchestrator: orchestratorOptions,
+    cacheTTL,
+    dataset,
+  };
+}
+
+function createNebulaTelemetryAggregator(options = {}) {
+  const resolved = resolveOptions(options);
+
+  let cache = null;
+  let cacheExpiresAt = 0;
+
+  async function loadAllSources() {
+    const [telemetryRecords, generatorProfile, orchestratorEntries] = await Promise.all([
+      loadTelemetryRecords(resolved.telemetry.path),
+      loadGeneratorTelemetry(resolved.generator.path),
+      loadOrchestratorLogEntries(resolved.orchestrator),
+    ]);
+    return {
+      dataset: cloneValue(resolved.dataset),
+      telemetryRecords,
+      generatorProfile,
+      orchestratorEntries,
+      fetchedAt: new Date().toISOString(),
+    };
+  }
+
+  async function getCache({ refresh } = {}) {
+    if (!refresh && cache && cacheExpiresAt > Date.now()) {
+      return cache;
+    }
+    const next = await loadAllSources();
+    cache = next;
+    cacheExpiresAt = Date.now() + resolved.cacheTTL;
+    return cache;
+  }
+
+  function buildTelemetry(dataset, records, params = {}) {
+    const filtered = filterBySince(records, params.since);
+    const limit = params.limit ?? resolved.telemetry.limit;
+    return buildTelemetryPayload(dataset, filtered, {
+      limit,
+      timelineDays: resolved.telemetry.timelineDays,
+      state: params.offline ? 'offline' : 'live',
+    });
+  }
+
+  function buildGenerator(dataset, generatorProfile) {
+    return buildGeneratorPayload(dataset, generatorProfile);
+  }
+
+  function buildOrchestrator(entries, params = {}) {
+    const filtered = filterBySince(entries, params.since);
+    const limited = limitEntries(filtered, params.limit, resolved.orchestrator.maxEvents);
+    return {
+      summary: buildOrchestratorSummary(filtered),
+      events: limited,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  return {
+    async getAtlas(params = {}) {
+      const snapshot = await getCache(params);
+      return {
+        dataset: cloneValue(snapshot.dataset),
+        telemetry: buildTelemetry(snapshot.dataset, snapshot.telemetryRecords, params),
+        generator: buildGenerator(snapshot.dataset, snapshot.generatorProfile),
+        orchestrator: buildOrchestrator(snapshot.orchestratorEntries, params),
+        updatedAt: snapshot.fetchedAt,
+      };
+    },
+    async getTelemetry(params = {}) {
+      const snapshot = await getCache(params);
+      return buildTelemetry(snapshot.dataset, snapshot.telemetryRecords, params);
+    },
+    async getGenerator(params = {}) {
+      const snapshot = await getCache(params);
+      return buildGenerator(snapshot.dataset, snapshot.generatorProfile, params);
+    },
+    async getOrchestrator(params = {}) {
+      const snapshot = await getCache(params);
+      return buildOrchestrator(snapshot.orchestratorEntries, params);
+    },
+    invalidateCache() {
+      cache = null;
+      cacheExpiresAt = 0;
+    },
+    __internals__: {
+      buildTelemetryPayload,
+      buildGeneratorPayload,
+      buildTrendSeries,
+      buildIncidentTimeline,
+      buildTelemetrySummary,
+      buildOrchestratorSummary,
+      readinessTone,
+      averageCoveragePercent,
+    },
+  };
+}
+
+module.exports = {
+  createNebulaTelemetryAggregator,
+  DEFAULTS: {
+    cacheTTL: DEFAULT_CACHE_TTL,
+    telemetryLimit: DEFAULT_TELEMETRY_LIMIT,
+    timelineDays: DEFAULT_TIMELINE_DAYS,
+    orchestratorMaxEvents: DEFAULT_ORCHESTRATOR_MAX_EVENTS,
+  },
+};

--- a/tests/server/nebula-route.spec.js
+++ b/tests/server/nebula-route.spec.js
@@ -1,0 +1,143 @@
+const assert = require('node:assert/strict');
+const { mkdtemp, rm, mkdir, writeFile } = require('node:fs/promises');
+const path = require('node:path');
+const { tmpdir } = require('node:os');
+const express = require('express');
+const test = require('node:test');
+const request = require('supertest');
+
+const { createNebulaRouter } = require('../../server/routes/nebula');
+const { createNebulaTelemetryAggregator } = require('../../server/services/nebulaTelemetryAggregator');
+
+function createTempDir(prefix) {
+  return mkdtemp(path.join(tmpdir(), prefix));
+}
+
+test('nebula router aggrega dataset, telemetria e orchestrator con filtri e caching', async (t) => {
+  const tempDir = await createTempDir('nebula-route-');
+  const logsDir = path.join(tempDir, 'logs');
+  await mkdir(logsDir, { recursive: true });
+  t.after(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  const telemetryPath = path.join(tempDir, 'qa-telemetry.json');
+  const generatorPath = path.join(tempDir, 'generator.json');
+  const orchestratorLog = path.join(logsDir, 'orchestrator.jsonl');
+
+  const telemetryRecords = [
+    {
+      id: 'evt-001',
+      event_timestamp: '2024-05-18T09:00:00Z',
+      priority: 'high',
+      status: 'open',
+    },
+    {
+      id: 'evt-002',
+      event_timestamp: '2024-05-17T11:00:00Z',
+      priority: 'low',
+      status: 'closed',
+    },
+    {
+      id: 'evt-003',
+      event_timestamp: '2024-05-16T18:30:00Z',
+      priority: 'medium',
+      status: 'acknowledged',
+    },
+  ];
+  await writeFile(telemetryPath, `${JSON.stringify(telemetryRecords)}\n`, 'utf8');
+
+  const generatorProfile = {
+    status: 'success',
+    metrics: {
+      generation_time_ms: 420,
+      species_total: 5,
+      enriched_species: 3,
+      event_total: 4,
+    },
+    generated_at: '2024-05-18T09:10:00Z',
+  };
+  await writeFile(generatorPath, `${JSON.stringify(generatorProfile)}\n`, 'utf8');
+
+  const orchestratorLines = [
+    { timestamp: '2024-05-18T09:05:00Z', level: 'info', message: 'bootstrap orchestrator' },
+    { timestamp: '2024-05-18T09:15:00Z', level: 'error', message: 'workflow failure' },
+    { timestamp: '2024-05-16T20:00:00Z', level: 'warn', message: 'retry scheduled' },
+  ]
+    .map((entry) => JSON.stringify(entry))
+    .join('\n');
+  await writeFile(orchestratorLog, `${orchestratorLines}\n`, 'utf8');
+
+  const staticDataset = {
+    id: 'nebula-test',
+    title: 'Nebula Test Dataset',
+    summary: 'Dataset di test per il router Nebula.',
+    species: [
+      { id: 'wolf-01', name: 'Lupo Alfa', readiness: 'Pronto', telemetry: { coverage: 0.82 } },
+      { id: 'wolf-02', name: 'Lupo Beta', readiness: 'Richiede validazione', telemetry: { coverage: 0.67 } },
+    ],
+  };
+
+  const aggregator = createNebulaTelemetryAggregator({
+    telemetryPath,
+    generatorTelemetryPath: generatorPath,
+    orchestrator: {
+      logDir: logsDir,
+      filePattern: '*.jsonl',
+      maxEvents: 5,
+    },
+    telemetry: {
+      defaultLimit: 5,
+      timelineDays: 7,
+    },
+    cacheTTL: 5_000,
+    staticDataset,
+  });
+
+  const app = express();
+  app.use(
+    '/nebula',
+    createNebulaRouter({
+      aggregator,
+      config: {
+        cache: { ttlMs: 5_000 },
+        telemetry: { defaultLimit: 5, timelineDays: 7 },
+        orchestrator: { maxEvents: 5 },
+      },
+    }),
+  );
+
+  const response = await request(app)
+    .get('/nebula/atlas')
+    .query({ since: '2024-05-17T00:00:00Z', limit: 2 })
+    .expect(200);
+
+  assert.equal(response.body.dataset.id, 'nebula-test');
+  assert.equal(response.body.telemetry.summary.totalEvents, 2);
+  assert.equal(response.body.telemetry.sample.length, 2);
+  assert.equal(response.body.telemetry.state, 'live');
+  assert.equal(response.body.generator.status, 'success');
+  assert.ok(Array.isArray(response.body.orchestrator.events));
+  assert.equal(response.body.orchestrator.events.length, 2);
+  assert.equal(response.body.orchestrator.summary.errorCount, 1);
+  assert.equal(response.body.orchestrator.summary.totalEntries, 2);
+  assert.equal(response.body.orchestrator.summary.lastEventAt, '2024-05-18T09:15:00.000Z');
+
+  const telemetryResponse = await request(app)
+    .get('/nebula/atlas/telemetry')
+    .query({ since: '2024-05-17T00:00:00Z', limit: 1 })
+    .expect(200);
+
+  assert.equal(telemetryResponse.body.summary.totalEvents, 2);
+  assert.equal(telemetryResponse.body.sample.length, 1);
+  assert.equal(telemetryResponse.body.state, 'live');
+
+  const orchestratorResponse = await request(app)
+    .get('/nebula/atlas/orchestrator')
+    .query({ limit: 1 })
+    .expect(200);
+
+  assert.equal(orchestratorResponse.body.events.length, 1);
+  assert.equal(orchestratorResponse.body.summary.errorCount, 1);
+  assert.ok(orchestratorResponse.body.summary.lastEventAt);
+});

--- a/tests/webapp/NebulaAtlasView.spec.ts
+++ b/tests/webapp/NebulaAtlasView.spec.ts
@@ -107,8 +107,10 @@ describe('NebulaAtlasView', () => {
       await Promise.resolve();
       expect(wrapper.text()).toContain('Telemetria live');
       expect(wrapper.text()).toContain('Generatore Nebula');
+      expect(wrapper.text()).toContain('LIVE');
       expect(wrapper.html()).toMatchSnapshot();
       expect(fetchStub).toHaveBeenCalled();
+      wrapper.unmount();
     } finally {
       global.fetch = originalFetch;
       dateSpy.mockRestore();

--- a/tests/webapp/__snapshots__/NebulaAtlasView.spec.ts.snap
+++ b/tests/webapp/__snapshots__/NebulaAtlasView.spec.ts.snap
@@ -10,7 +10,9 @@ exports[`NebulaAtlasView > renderizza indicatori live e snapshot coerente 1`] = 
         <h3 data-v-43e6e8ac="">Telemetria live</h3>
         <p data-v-43e6e8ac="">Indicatori dal generatore Nebula combinati con il dataset atlas.</p>
       </div>
-      <div data-v-43e6e8ac="" class="nebula-atlas-view__status"><span data-v-43e6e8ac="" class="nebula-atlas-view__badge" data-tone="warning">Sync 30 min fa</span><small data-v-43e6e8ac="">Ultimo sync: 2024-05-18T10:45:00Z</small></div>
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__status">
+        <div data-v-43e6e8ac="" class="nebula-atlas-view__status-badges"><span data-v-43e6e8ac="" class="nebula-atlas-view__badge nebula-atlas-view__badge--live" data-state="live" data-tone="success">LIVE</span><span data-v-43e6e8ac="" class="nebula-atlas-view__badge" data-tone="warning">Sync 30 min fa</span></div><small data-v-43e6e8ac="">Ultimo sync: 2024-05-18T10:45:00Z</small>
+      </div>
     </header>
     <div data-v-43e6e8ac="" class="nebula-atlas-view__grid">
       <div data-v-43e6e8ac="" class="nebula-atlas-view__metrics">
@@ -52,19 +54,19 @@ exports[`NebulaAtlasView > renderizza indicatori live e snapshot coerente 1`] = 
           </li>
         </ul>
       </div>
-      <div data-v-43e6e8ac="" class="nebula-atlas-view__chart" aria-label="Copertura QA">
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__chart" data-live="true" aria-label="Copertura QA">
         <header data-v-43e6e8ac="">
           <h4 data-v-43e6e8ac="">Copertura QA media</h4><span data-v-43e6e8ac="">78%</span>
         </header>
         <div data-v-43e6e8ac="" class="sparkline-stub" color="#61d5ff" variant="live">60,70,80</div>
       </div>
-      <div data-v-43e6e8ac="" class="nebula-atlas-view__chart" aria-label="Incidenti telemetria">
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__chart" data-live="true" aria-label="Incidenti telemetria">
         <header data-v-43e6e8ac="">
           <h4 data-v-43e6e8ac="">Incidenti ultimi 7 giorni</h4><span data-v-43e6e8ac="">4</span>
         </header>
         <div data-v-43e6e8ac="" class="sparkline-stub" color="#ff6982" variant="live">1,2,1</div>
       </div>
-      <div data-v-43e6e8ac="" class="nebula-atlas-view__chart" aria-label="High priority">
+      <div data-v-43e6e8ac="" class="nebula-atlas-view__chart" data-live="true" aria-label="High priority">
         <header data-v-43e6e8ac="">
           <h4 data-v-43e6e8ac="">High priority</h4><span data-v-43e6e8ac="">1</span>
         </header>


### PR DESCRIPTION
## Summary
- add a telemetry aggregation service and configuration for Nebula data sources
- refactor Nebula API routes to use the aggregator, support since/limit filters, and expose orchestrator logs
- enhance the Nebula progress module and view with live/offline status, polling controls, and updated snapshots

## Testing
- node --test tests/server/nebula-route.spec.js
- npm --prefix webapp run test -- tests/webapp/NebulaAtlasView.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_6905591b0c6c833286eb3bee43887c81