### PR TITLE
Fix Nebula progress toError helper fallback handling

### DIFF
--- a/webapp/src/modules/useNebulaProgressModule.ts
+++ b/webapp/src/modules/useNebulaProgressModule.ts
@@ -315,11 +315,11 @@ function createEmptyTelemetry(updatedAt?: string | null): NebulaTelemetry {
   };
 }
 
-function toError(value: unknown): Error {
+function toError(value: unknown, fallbackMessage = 'Errore sconosciuto'): Error {
   if (value instanceof Error) {
     return value;
   }
-  const message = typeof value === 'string' ? value : 'Errore sconosciuto';
+  const message = typeof value === 'string' && value.trim().length > 0 ? value : fallbackMessage;
   return new Error(message);
 }
 


### PR DESCRIPTION
## Summary
- allow the Nebula progress module's `toError` helper to accept an optional fallback message
- ensure fallback loader can surface a meaningful error message when the local dataset is unavailable

## Testing
- npm --prefix webapp run test -- tests/webapp/NebulaAtlasView.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_69055d24b4e483328fe5eac10a961b5e