### PR TITLE
feat: estendi export QA e recap automatico

### DIFF
--- a/.github/workflows/qa-export.yml
+++ b/.github/workflows/qa-export.yml
@@ -1,0 +1,196 @@
+name: QA export manual
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Numero PR su cui pubblicare il commento (opzionale)'
+        required: false
+
+jobs:
+  export:
+    name: Run QA export
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f tools/py/requirements.txt ]; then
+            python -m pip install -r tools/py/requirements.txt
+          fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate QA reports
+        run: node scripts/export-qa-report.js
+
+      - name: Upload QA artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: qa-reports-${{ github.run_id }}
+          path: |
+            reports/qa_badges.json
+            reports/trait_baseline.json
+            reports/generator_validation.json
+            reports/qa-changelog.md
+          if-no-files-found: error
+
+      - name: Post QA badge comment
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { pathToFileURL } = require('url');
+
+            function safeColor(value) {
+              if (!value) return 'blue';
+              return String(value).replace(/[^a-zA-Z0-9_-]/g, '') || 'blue';
+            }
+
+            function encodeSegment(value) {
+              return encodeURIComponent(String(value).replace(/\s+/g, ' ').trim());
+            }
+
+            const badgesPath = path.join(process.env.GITHUB_WORKSPACE, 'reports', 'qa_badges.json');
+            const badgePayload = JSON.parse(fs.readFileSync(badgesPath, 'utf8'));
+            let highlightSummary = null;
+            try {
+              const formatterModule = await import(
+                pathToFileURL(path.join(process.env.GITHUB_WORKSPACE, 'webapp/src/services/qaHighlightFormatter.js'))
+              );
+              if (formatterModule?.buildQaHighlightsSummary) {
+                highlightSummary = formatterModule.buildQaHighlightsSummary(badgePayload, { limit: 6 });
+              }
+            } catch (error) {
+              core.warning(`Impossibile caricare il formatter QA: ${error.message || error}`);
+            }
+
+            const badges = highlightSummary?.badges || [];
+            const badgeLine = badges.length
+              ? badges
+                  .map((badge) =>
+                    `![${badge.label} ${badge.value}](https://img.shields.io/badge/${encodeSegment(badge.label)}-${encodeSegment(badge.value)}-${safeColor(badge.color)})`,
+                  )
+                  .join(' ')
+              : '_Badge non disponibili_';
+
+            const highlightSections = highlightSummary?.sections || [];
+            const highlights = [];
+            for (const section of highlightSections) {
+              if (!section.items || !section.items.length) continue;
+              highlights.push(`- **${section.title} (${section.total})**: ${section.items.join(', ')}`);
+            }
+            if (!highlights.length) {
+              highlights.push('- Nessun highlight critico.');
+            }
+
+            const topConflicts = highlightSummary?.topConflicts || [];
+            const conflictLines = topConflicts.length
+              ? ['**Top conflitti**', ...topConflicts.map((entry) => `- ${entry.id || 'n/d'}: ${entry.conflicts}`)]
+              : [];
+
+            const generatedAt = highlightSummary?.generatedAt || badgePayload.generated_at || new Date().toISOString();
+            const artifactLinks = [
+              `[Trait baseline](./reports/trait_baseline.json)`,
+              `[Generator validation](./reports/generator_validation.json)`,
+              `[QA changelog](./reports/qa-changelog.md)`,
+            ].join(' · ');
+
+            const bodyLines = [
+              '<!-- qa-export-comment -->',
+              `### QA Export (${generatedAt})`,
+              '',
+              badgeLine,
+              '',
+              '**Highlights**',
+              ...highlights,
+            ];
+
+            if (conflictLines.length) {
+              bodyLines.push('', ...conflictLines);
+            }
+
+            bodyLines.push('', `Artefatti: ${artifactLinks}`);
+
+            const body = bodyLines.join('\n');
+
+            const prNumber = process.env.PR_NUMBER ? Number(process.env.PR_NUMBER) : null;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            if (prNumber) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number: prNumber,
+                per_page: 100,
+              });
+              const existing = comments.find((comment) => comment.body && comment.body.includes('<!-- qa-export-comment -->'));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  body,
+                });
+              }
+            } else {
+              const commitSha = context.sha;
+              const { data: commitComments } = await github.rest.repos.listCommentsForCommit({
+                owner,
+                repo,
+                commit_sha: commitSha,
+                per_page: 100,
+              });
+              const existing = commitComments.find(
+                (comment) => comment.body && comment.body.includes('<!-- qa-export-comment -->'),
+              );
+              if (existing) {
+                await github.rest.repos.updateCommitComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.repos.createCommitComment({
+                  owner,
+                  repo,
+                  commit_sha: commitSha,
+                  body,
+                });
+              }
+            }
+
+            core.summary.addHeading('QA export');
+            core.summary.addRaw(badgeLine);
+            core.summary.addEOL();
+            core.summary.addList(highlights.map((line) => line.replace(/^-\s*/, '')));
+            await core.summary.write();

--- a/docs/recap/qa-playbook.md
+++ b/docs/recap/qa-playbook.md
@@ -4,10 +4,12 @@ Questo playbook riassume come mantenere allineati i report QA orchestrati e come
 
 ## Rigenerare i report QA
 
-I report vengono generati dal bridge Node ↔ orchestrator Python (`scripts/export-qa-report.js`). Il job avvia un worker Python, raccoglie i trait diagnostics e normalizza due output:
+I report vengono generati dal bridge Node ↔ orchestrator Python (`scripts/export-qa-report.js`). Il job avvia un worker Python, raccoglie i trait diagnostics e normalizza quattro output coordinati:
 
-* `reports/trait_baseline.json` – dump completo degli stati dei tratti con copertura, conflitti e sorgenti dati.
+* `reports/trait_baseline.json` – dump completo degli stati dei tratti con copertura, conflitti, sorgenti dati e tassonomia.
+* `reports/generator_validation.json` – fotografia dei check runtime sull'orchestrator (pass/fail, warning e note contestuali).
 * `reports/qa_badges.json` – riepilogo per i badge UI (totali superati, conflitti, tratti senza copertura) con gli highlight principali.
+* `reports/qa-changelog.md` – changelog sintetico con delta rispetto allo snapshot precedente, utile per note recap e Flow Shell.
 
 ### Requisiti
 
@@ -24,7 +26,17 @@ python -m pip install -r tools/py/requirements.txt
 npm run export:qa
 ```
 
-Il comando è un wrapper di `node scripts/export-qa-report.js` e aggiorna i file in `reports/`. Lo stesso script gira in CI (`.github/workflows/qa-reports.yml`) e fallisce se i report non sono in sync: se vedi il job rosso, esegui i comandi sopra e committa i JSON aggiornati. Il bridge Node avvia automaticamente l'orchestrator Python e chiude il pool al termine, quindi non servono processi manuali aggiuntivi.
+Il comando è un wrapper di `node scripts/export-qa-report.js` e aggiorna i file in `reports/`. Lo stesso script gira in CI (`.github/workflows/qa-reports.yml`) e fallisce se i report non sono in sync: se vedi il job rosso, esegui i comandi sopra e committa i JSON/Markdown aggiornati. Il bridge Node avvia automaticamente l'orchestrator Python e chiude il pool al termine, quindi non servono processi manuali aggiuntivi.
+
+### Workflow manuale GitHub
+
+Per produrre un export on-demand e allegarlo al recap, usa il workflow `QA export manual` (`.github/workflows/qa-export.yml`):
+
+1. Apri **Actions → QA export manual → Run workflow** e (opzionale) indica il numero di PR da commentare.
+2. Il job esegue `scripts/export-qa-report.js`, carica gli artefatti (`qa_badges.json`, `trait_baseline.json`, `generator_validation.json`, `qa-changelog.md`) e pubblica un commento con i badge QA.
+3. Il commento include i badge `shields.io`, gli highlight principali e link diretti agli artefatti: usalo come fonte per il canale Flow Shell e per la sezione “QA Highlights” del recap.
+
+Gli stessi artefatti restano scaricabili dall'esecuzione Actions e sono già formattati per essere caricati nella Flow Shell (`Quality Release → QA Highlights`).
 
 ## Esportare i log dalla console UI
 
@@ -39,19 +51,21 @@ Il filtro scope applicato nella toolbar (Tutti/Specie/Biomi/Foodweb/Publishing) 
 
 ## Interpretare i badge UI
 
-I badge che compaiono nella console QA (`Specie`, `Biomi`, `Foodweb` e il badge addizionale `Traits`) si basano sulle metriche caricate via snapshot orchestrator e sul riepilogo di `qa_badges.json`:
+I badge che compaiono nella console QA (`Specie`, `Biomi`, `Foodweb` e il badge addizionale `Traits`) si basano sulle metriche caricate via snapshot orchestrator e sul riepilogo di `qa_badges.json`. Il servizio UI (`webapp/src/services/clientLogger.js`) trasforma gli stessi dati in highlight, riusati dal recap (`tools/recap/generateRecap.js`) e dal commento automatico del workflow:
 
 * `checks.traits.passed / total` evidenzia quanti tratti hanno metadati glossary completi.
 * `checks.traits.matrix_mismatch` e `highlights.matrix_mismatch_traits` aiutano a individuare tratti senza copertura nel matrix.
 * `highlights.glossary_missing` e `highlights.zero_coverage_traits` elencano priorità per gli interventi manuali.
 
-Per un controllo rapido confronta i badge UI con i JSON:
+Per un controllo rapido confronta i badge UI con i report esportati:
 
-1. Apri `reports/qa_badges.json` e verifica gli ID presenti nelle liste highlight.
-2. Usa i pulsanti di esportazione della console per scaricare i log pertinenti e allegarli alle note QA.
+1. Apri `reports/qa_badges.json` (o la sezione artefatti del workflow) e verifica gli ID presenti nelle liste highlight.
+2. Consulta `reports/qa-changelog.md` per capire cosa è cambiato rispetto all’ultimo ciclo.
+3. In Flow Shell (`Quality Release → QA Highlights`) controlla che badge e highlight coincidano con il commento Actions.
+4. Usa i pulsanti di esportazione della console per scaricare i log pertinenti e allegarli alle note QA.
 
 In caso di incongruenze tra badge e dataset:
 
-* rigenera i report (`npm run export:qa`),
-* controlla che il worker orchestrator abbia prodotto `trait_baseline.json` aggiornato,
+* rigenera i report (`npm run export:qa`) oppure rilancia il workflow manuale,
+* controlla che il worker orchestrator abbia prodotto `trait_baseline.json` e `generator_validation.json` aggiornati,
 * aggiorna la dashboard UI ricaricando lo snapshot (`/api/generation/snapshot`).

--- a/scripts/export-qa-report.js
+++ b/scripts/export-qa-report.js
@@ -10,6 +10,8 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 const REPORTS_DIR = path.join(REPO_ROOT, 'reports');
 const TRAIT_BASELINE_PATH = path.join(REPORTS_DIR, 'trait_baseline.json');
 const QA_BADGES_PATH = path.join(REPORTS_DIR, 'qa_badges.json');
+const GENERATOR_VALIDATION_PATH = path.join(REPORTS_DIR, 'generator_validation.json');
+const QA_CHANGELOG_PATH = path.join(REPORTS_DIR, 'qa-changelog.md');
 
 function toNumber(value) {
   const numeric = Number(value);
@@ -21,6 +23,10 @@ function normaliseArray(value) {
     return value.filter((item) => item !== null && item !== undefined);
   }
   return [];
+}
+
+function toStringArray(value) {
+  return normaliseArray(value).map((item) => String(item));
 }
 
 function normaliseTraitEntry(entry) {
@@ -129,10 +135,272 @@ function buildQaBadgesReport(baseline) {
   };
 }
 
+function normaliseValidationCheck(entry, index) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  const label = entry.label || entry.name || entry.id || `check_${index}`;
+  const status = String(entry.status || entry.result || '').toLowerCase() || 'unknown';
+  const errors = toNumber(entry.errors);
+  const warnings = toNumber(entry.warnings);
+  const traits = toStringArray(entry.traits);
+  const dataset = toStringArray(entry.dataset);
+  const metadata = entry.metadata && typeof entry.metadata === 'object' ? entry.metadata : null;
+  return {
+    id: entry.id || entry.name || String(index),
+    label,
+    status,
+    passed:
+      status === 'ok' ||
+      status === 'pass' ||
+      status === 'passed' ||
+      (errors === 0 && status !== 'fail' && status !== 'error'),
+    errors,
+    warnings,
+    traits,
+    dataset,
+    message: entry.message || entry.summary || null,
+    metadata,
+  };
+}
+
+function buildGeneratorValidationReport(diagnostics) {
+  const payload = diagnostics?.generator_validation || diagnostics?.generatorValidation || {};
+  const generatedAt =
+    payload?.generated_at || payload?.generatedAt || diagnostics?.generated_at || new Date().toISOString();
+  const summarySource = payload?.summary || {};
+  const rawChecks = Array.isArray(payload?.checks)
+    ? payload.checks
+    : Array.isArray(payload?.results)
+      ? payload.results
+      : [];
+  const checks = rawChecks
+    .map((entry, index) => normaliseValidationCheck(entry, index))
+    .filter(Boolean);
+  const errors = toStringArray(payload?.errors);
+  const warnings = toStringArray(payload?.warnings);
+  const totalChecks = checks.length;
+  const passedChecks = checks.filter((entry) => entry.passed).length;
+  const failedChecks = totalChecks - passedChecks;
+  const summary = {
+    total_traits: toNumber(summarySource.total_traits) || null,
+    validated_traits: toNumber(summarySource.validated_traits) || null,
+    failed_traits: toNumber(summarySource.failed_traits) || failedChecks || null,
+    checks_total: totalChecks || null,
+    checks_passed: passedChecks || null,
+    checks_failed: failedChecks || null,
+  };
+  const context = payload?.context && typeof payload.context === 'object' ? payload.context : {};
+  const sources = payload?.sources && typeof payload.sources === 'object' ? payload.sources : {};
+
+  return {
+    generated_at: generatedAt,
+    summary,
+    checks,
+    warnings,
+    errors,
+    context,
+    sources,
+  };
+}
+
+function extractTraitSet(baseline, predicate) {
+  const traits = Array.isArray(baseline?.traits) ? baseline.traits : [];
+  return new Set(
+    traits
+      .filter((trait) => predicate(trait))
+      .map((trait) => trait.id)
+      .filter(Boolean),
+  );
+}
+
+function computeZeroCoverageSet(baseline) {
+  return extractTraitSet(baseline, (trait) => !toNumber(trait?.coverage?.total));
+}
+
+function computeMissingGlossarySet(baseline) {
+  return extractTraitSet(baseline, (trait) => (trait?.statuses?.glossary || 'missing') !== 'ok');
+}
+
+function computeMatrixMismatchSet(baseline) {
+  return extractTraitSet(baseline, (trait) => (trait?.statuses?.matrix || 'mismatch') !== 'ok');
+}
+
+function computeMatrixOnlySet(baseline) {
+  return new Set(toStringArray(baseline?.matrix_only_traits));
+}
+
+function diffTraitSets(label, currentSet, previousSet) {
+  const added = [];
+  const resolved = [];
+  for (const value of currentSet) {
+    if (!previousSet.has(value)) {
+      added.push(value);
+    }
+  }
+  for (const value of previousSet) {
+    if (!currentSet.has(value)) {
+      resolved.push(value);
+    }
+  }
+  return { label, added, resolved };
+}
+
+function formatDelta(label, previousValue, nextValue) {
+  const previous = toNumber(previousValue);
+  const current = toNumber(nextValue);
+  const delta = current - previous;
+  const deltaLabel = delta > 0 ? `+${delta}` : delta < 0 ? `${delta}` : '0';
+  return `- ${label}: ${current} (${deltaLabel} vs precedente)`;
+}
+
+function limitList(values, max = 20) {
+  return Array.isArray(values) ? values.filter(Boolean).slice(0, max) : [];
+}
+
+function buildQaChangelog({
+  baseline,
+  previousBaseline,
+  generatorValidation,
+  previousGeneratorValidation,
+  qaBadges,
+  previousQaBadges,
+}) {
+  const lines = ['# QA export changelog'];
+  const generatedAt = baseline?.generated_at || qaBadges?.generated_at || new Date().toISOString();
+  lines.push('', `Generato: ${generatedAt}`);
+  if (previousBaseline?.generated_at) {
+    lines.push(`Baseline precedente: ${previousBaseline.generated_at}`);
+  }
+
+  const currentSummary = baseline?.summary || {};
+  const previousSummary = previousBaseline?.summary || {};
+
+  lines.push('', '## Metriche baseline');
+  lines.push(
+    formatDelta('Tratti totali', previousSummary.total_traits || 0, currentSummary.total_traits || 0),
+  );
+  lines.push(
+    formatDelta('Glossario OK', previousSummary.glossary_ok || 0, currentSummary.glossary_ok || 0),
+  );
+  lines.push(
+    formatDelta('Glossario mancanti', previousSummary.glossary_missing || 0, currentSummary.glossary_missing || 0),
+  );
+  lines.push(
+    formatDelta('Mismatch matrice', previousSummary.matrix_mismatch || 0, currentSummary.matrix_mismatch || 0),
+  );
+  lines.push(
+    formatDelta('Tratti con conflitti', previousSummary.with_conflicts || 0, currentSummary.with_conflicts || 0),
+  );
+
+  const missingDiff = diffTraitSets(
+    'tratti senza glossario',
+    computeMissingGlossarySet(baseline),
+    computeMissingGlossarySet(previousBaseline),
+  );
+  const matrixDiff = diffTraitSets(
+    'tratti con mismatch matrice',
+    computeMatrixMismatchSet(baseline),
+    computeMatrixMismatchSet(previousBaseline),
+  );
+  const matrixOnlyDiff = diffTraitSets(
+    'tratti presenti solo nel matrix',
+    computeMatrixOnlySet(baseline),
+    computeMatrixOnlySet(previousBaseline),
+  );
+  const zeroCoverageDiff = diffTraitSets(
+    'tratti senza copertura QA',
+    computeZeroCoverageSet(baseline),
+    computeZeroCoverageSet(previousBaseline),
+  );
+
+  const traitDiffs = [missingDiff, matrixDiff, matrixOnlyDiff, zeroCoverageDiff];
+  for (const diff of traitDiffs) {
+    if (!diff.added.length && !diff.resolved.length) {
+      continue;
+    }
+    lines.push('', `### ${diff.label}`);
+    if (diff.added.length) {
+      lines.push('- Nuovi:', `  - ${limitList(diff.added).join(', ')}`);
+      if (diff.added.length > 20) {
+        lines.push(`  - … (${diff.added.length - 20} ulteriori)`);
+      }
+    }
+    if (diff.resolved.length) {
+      lines.push('- Risolti:', `  - ${limitList(diff.resolved).join(', ')}`);
+      if (diff.resolved.length > 20) {
+        lines.push(`  - … (${diff.resolved.length - 20} ulteriori)`);
+      }
+    }
+  }
+
+  if (qaBadges?.highlights) {
+    const highlights = qaBadges.highlights;
+    lines.push('', '## Highlights UI');
+    const highlightEntries = [
+      ['Glossario mancante', highlights.glossary_missing],
+      ['Solo matrice', highlights.matrix_only_traits],
+      ['Mismatch matrice', highlights.matrix_mismatch_traits],
+      ['Zero coverage', highlights.zero_coverage_traits],
+    ];
+    for (const [label, values] of highlightEntries) {
+      const list = limitList(values, 10);
+      if (list.length) {
+        lines.push(`- ${label}: ${list.join(', ')}`);
+      }
+    }
+    const topConflicts = limitList(highlights.top_conflicts, 10);
+    if (topConflicts.length) {
+      lines.push('- Top conflitti:', ...topConflicts.map((entry) => `  - ${entry.id}: ${entry.conflicts}`));
+    }
+  }
+
+  if (generatorValidation) {
+    const genSummary = generatorValidation.summary || {};
+    const prevSummary = previousGeneratorValidation?.summary || {};
+    lines.push('', '## Validazione generatore');
+    lines.push(
+      formatDelta('Check passati', prevSummary.checks_passed || 0, genSummary.checks_passed || 0),
+    );
+    lines.push(
+      formatDelta('Check falliti', prevSummary.checks_failed || 0, genSummary.checks_failed || 0),
+    );
+    lines.push(
+      formatDelta('Tratti validati', prevSummary.validated_traits || 0, genSummary.validated_traits || 0),
+    );
+    const failingChecks = (Array.isArray(generatorValidation.checks) ? generatorValidation.checks : [])
+      .filter((entry) => !entry.passed)
+      .map((entry) => `${entry.label} (${entry.status})`);
+    if (failingChecks.length) {
+      lines.push('', '### Check da monitorare', ...limitList(failingChecks, 10).map((item) => `- ${item}`));
+    }
+  }
+
+  if (qaBadges && previousQaBadges) {
+    const currentChecks = qaBadges?.checks?.traits || {};
+    const previousChecks = previousQaBadges?.checks?.traits || {};
+    lines.push('', '## Badge QA');
+    lines.push(
+      formatDelta('Tratti passed', previousChecks.passed || 0, currentChecks.passed || 0),
+    );
+    lines.push(
+      formatDelta('Conflitti badge', previousChecks.conflicts || 0, currentChecks.conflicts || 0),
+    );
+  }
+
+  lines.push('', '_Report generato da scripts/export-qa-report.js_');
+  return `${lines.join('\n')}\n`;
+}
+
 async function writeJson(filePath, payload) {
   const text = `${JSON.stringify(payload, null, 2)}\n`;
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, text, 'utf8');
+}
+
+async function writeText(filePath, content) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, 'utf8');
 }
 
 async function readJson(filePath) {
@@ -183,11 +451,30 @@ async function run() {
     const previousQaBadges = await readJson(QA_BADGES_PATH);
     const qaBadges = preserveGeneratedAt(previousQaBadges, buildQaBadgesReport(baseline));
 
+    const previousGeneratorValidation = await readJson(GENERATOR_VALIDATION_PATH);
+    const generatorValidation = preserveGeneratedAt(
+      previousGeneratorValidation,
+      buildGeneratorValidationReport(diagnostics),
+    );
+
+    const changelog = buildQaChangelog({
+      baseline,
+      previousBaseline,
+      generatorValidation,
+      previousGeneratorValidation,
+      qaBadges,
+      previousQaBadges,
+    });
+
     await writeJson(TRAIT_BASELINE_PATH, baseline);
     await writeJson(QA_BADGES_PATH, qaBadges);
+    await writeJson(GENERATOR_VALIDATION_PATH, generatorValidation);
+    await writeText(QA_CHANGELOG_PATH, changelog);
 
     console.log('[export-qa-report] trait baseline aggiornato:', TRAIT_BASELINE_PATH);
     console.log('[export-qa-report] badge QA aggiornati:', QA_BADGES_PATH);
+    console.log('[export-qa-report] validazione generatore aggiornata:', GENERATOR_VALIDATION_PATH);
+    console.log('[export-qa-report] changelog QA aggiornato:', QA_CHANGELOG_PATH);
   } finally {
     try {
       await orchestrator.close();

--- a/webapp/src/services/qaHighlightFormatter.js
+++ b/webapp/src/services/qaHighlightFormatter.js
@@ -1,0 +1,143 @@
+const DEFAULT_LIMIT = 10;
+
+function toNumber(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function normaliseArray(value) {
+  return Array.isArray(value) ? value.filter((item) => item !== null && item !== undefined) : [];
+}
+
+function formatPercentage(part, total) {
+  if (!total) {
+    return null;
+  }
+  const ratio = Number(part) / Number(total);
+  if (!Number.isFinite(ratio) || total === 0) {
+    return null;
+  }
+  return `${Math.round(ratio * 100)}%`;
+}
+
+function badgeColorForScore(passed, total) {
+  if (!total) {
+    return 'lightgrey';
+  }
+  if (passed >= total) {
+    return 'brightgreen';
+  }
+  if (passed / total >= 0.8) {
+    return 'green';
+  }
+  if (passed / total >= 0.6) {
+    return 'yellow';
+  }
+  return 'orange';
+}
+
+function badgeColorForAlert(count) {
+  return count > 0 ? 'orange' : 'brightgreen';
+}
+
+export function buildQaHighlightsSummary(payload, options = {}) {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+  const limit = Number(options.limit || DEFAULT_LIMIT) || DEFAULT_LIMIT;
+  const summary = payload.summary || payload.baseline_summary || payload.diagnostics?.summary || {};
+  const traitsCheck = payload.checks?.traits || payload.diagnostics?.checks?.traits || {};
+  const highlights = payload.highlights || payload.diagnostics?.highlights || {};
+
+  const totalTraits = toNumber(summary.total_traits || summary.totalTraits);
+  const glossaryOk = toNumber(summary.glossary_ok || summary.glossaryOk);
+  const glossaryMissing = toNumber(summary.glossary_missing || summary.glossaryMissing);
+  const conflicts = toNumber(summary.with_conflicts || summary.conflicts);
+  const matrixMismatch = toNumber(summary.matrix_mismatch || summary.matrixMismatch);
+  const matrixOnly = normaliseArray(highlights.matrix_only_traits || highlights.matrixOnlyTraits).length;
+  const zeroCoverageArray = normaliseArray(highlights.zero_coverage_traits || highlights.zeroCoverageTraits);
+  const zeroCoverage = zeroCoverageArray.length;
+
+  const badges = [
+    {
+      key: 'traits',
+      label: 'Traits',
+      value: `${glossaryOk}/${totalTraits || 'n/d'}`,
+      color: badgeColorForScore(glossaryOk, totalTraits || traitsCheck.total),
+      description: 'Tratti con metadati glossary validi',
+    },
+    {
+      key: 'conflicts',
+      label: 'Conflicts',
+      value: String(traitsCheck.conflicts ?? conflicts ?? 0),
+      color: badgeColorForAlert(traitsCheck.conflicts ?? conflicts ?? 0),
+      description: 'Conflitti rilevati dal matrix QA',
+    },
+    {
+      key: 'matrix',
+      label: 'Matrix mismatch',
+      value: String(traitsCheck.matrix_mismatch ?? matrixMismatch ?? 0),
+      color: badgeColorForAlert(traitsCheck.matrix_mismatch ?? matrixMismatch ?? 0),
+      description: 'Tratti non allineati con la coverage matrix',
+    },
+    {
+      key: 'coverage',
+      label: 'Zero coverage',
+      value: String(zeroCoverage),
+      color: badgeColorForAlert(zeroCoverage),
+      description: 'Tratti senza copertura QA',
+    },
+  ];
+
+  const sectionDefinitions = [
+    { key: 'glossary_missing', title: 'Glossario mancante' },
+    { key: 'matrix_only_traits', title: 'Solo matrice' },
+    { key: 'matrix_mismatch_traits', title: 'Mismatch matrice' },
+    { key: 'zero_coverage_traits', title: 'Zero coverage' },
+  ];
+
+  const sections = sectionDefinitions.map((section) => {
+    const source = highlights[section.key] || highlights[section.key.replace(/_(.)/g, (_, char) => char.toUpperCase())];
+    const values = normaliseArray(source).map((item) => String(item));
+    return {
+      key: section.key,
+      title: section.title,
+      total: values.length,
+      items: values.slice(0, limit),
+    };
+  });
+
+  const topConflicts = normaliseArray(highlights.top_conflicts || highlights.topConflicts).map((entry) => ({
+    id: entry?.id || entry?.name || '',
+    conflicts: toNumber(entry?.conflicts || entry?.count),
+  }));
+
+  const checksTotal = toNumber(traitsCheck.total || summary.total_traits);
+  const checksPassed = toNumber(traitsCheck.passed || summary.glossary_ok);
+
+  return {
+    generatedAt: payload.generated_at || payload.generatedAt || null,
+    metrics: {
+      totalTraits,
+      glossaryOk,
+      glossaryMissing,
+      glossaryPercent: formatPercentage(glossaryOk, totalTraits),
+      conflicts,
+      matrixMismatch,
+      matrixOnly,
+      zeroCoverage,
+    },
+    badges,
+    sections,
+    topConflicts: topConflicts.slice(0, limit),
+    checks: {
+      total: checksTotal,
+      passed: checksPassed,
+      percent: formatPercentage(checksPassed, checksTotal),
+    },
+  };
+}
+
+export default {
+  buildQaHighlightsSummary,
+};


### PR DESCRIPTION
## Summary
- extend the QA export script to produce generator validation JSON and a markdown changelog alongside trait baselines and badges
- add a manual GitHub Actions workflow that runs the export on demand, uploads artifacts and posts shield-based QA badge comments
- expose shared QA highlight utilities for the UI and recap generator, updating the recap script and QA playbook documentation

## Testing
- node tools/recap/generateRecap.js --output /tmp/recap.md

------
https://chatgpt.com/codex/tasks/task_e_69055ecadc0c8332992d880f2c3ed8e8