### PR TITLE
Add monthly trait maintenance automation workflow

### DIFF
--- a/.github/workflows/traits-monthly-maintenance.yml
+++ b/.github/workflows/traits-monthly-maintenance.yml
@@ -1,0 +1,83 @@
+name: Traits Monthly Maintenance
+
+on:
+  schedule:
+    - cron: '0 6 1 * *'
+  workflow_dispatch:
+
+jobs:
+  maintenance:
+    name: Run monthly trait maintenance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install maintenance dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements-dev.txt ]; then
+            pip install -r requirements-dev.txt
+          else
+            pip install jsonschema pyyaml
+          fi
+
+      - name: Execute monthly maintenance script
+        run: |
+          bash scripts/cron/traits_monthly_maintenance.sh
+
+      - name: Upload maintenance logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: monthly-trait-maintenance-${{ github.run_id }}
+          path: logs/monthly_trait_maintenance/
+          retention-days: 30
+
+      - name: Extract anomaly status
+        id: status
+        run: |
+          STATUS_FILE=$(ls logs/monthly_trait_maintenance/status-*.json | sort | tail -n 1)
+          echo "status_file=$STATUS_FILE" >> "$GITHUB_OUTPUT"
+          ANOMALY_COUNT=$(python -c "import json,sys; data=json.load(open('$STATUS_FILE', encoding='utf-8')); print(data.get('anomaly_count', 0))")
+          echo "anomaly_count=$ANOMALY_COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$ANOMALY_COUNT" -gt 0 ]; then
+            echo "has_anomalies=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_anomalies=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open anomaly issue
+        if: steps.status.outputs.has_anomalies == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = '${{ steps.status.outputs.status_file }}';
+            const status = JSON.parse(fs.readFileSync(path, 'utf8'));
+            const title = `Anomalie manutenzione trait ${status.generated_at}`;
+            const notes = status.notes && status.notes.length
+              ? status.notes.map((note) => `- ${note}`).join('\n')
+              : '- Nessun dettaglio aggiuntivo.';
+            const body = [
+              `Manutenzione mensile trait completata con ${status.anomaly_count} anomalie.`,
+              '',
+              `Report: ${status.report_markdown}`,
+              '',
+              'Note:',
+              notes,
+              '',
+              '_Questo issue è stato aperto automaticamente dall\'automazione di manutenzione._'
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['maintenance', 'automation', 'needs-triage']
+            });

--- a/docs/process/operations_calendar.md
+++ b/docs/process/operations_calendar.md
@@ -1,0 +1,42 @@
+# Calendario Operazioni
+
+Questo calendario consolida le principali attività ricorrenti di manutenzione e controllo operative. Le finestre temporali sono espresse in UTC salvo indicazioni differenti.
+
+## Panoramica mensile
+
+| Frequenza | Finestra | Attività | Automazione | Owner principale | Output | Checklist |
+|-----------|----------|----------|-------------|------------------|--------|-----------|
+| Mensile (1° giorno) | 06:00 UTC | Manutenzione dataset trait | Workflow GitHub Actions `Traits Monthly Maintenance` | Data Operations (rotazione: @biome-lead, @traits-curator) | `logs/monthly_trait_maintenance/` (report + status) | Vedi [Checklist manutenzione trait](#checklist-manutenzione-trait) |
+
+## Dettaglio attività
+
+### Manutenzione mensile trait
+
+- **Trigger**: pianificazione automatica il primo giorno di ogni mese alle 06:00 UTC (`cron: 0 6 1 * *`).
+- **Script eseguito**: [`scripts/cron/traits_monthly_maintenance.sh`](../../scripts/cron/traits_monthly_maintenance.sh) (richiama audit principali, pulizia cache e verifica campi deprecati).
+- **Output**:
+  - Report Markdown time-stamped in `logs/monthly_trait_maintenance/`.
+  - File di stato JSON con contatore anomalie (`status-*.json`).
+  - Report dettagliato degli audit (`trait_audit_*.md` + log runtime).
+- **Notifiche**:
+  - In caso di anomalie il workflow apre automaticamente un'issue etichettata `maintenance`, `automation`, `needs-triage` con il riepilogo e i link al report.
+  - Gli owner sono responsabili di triagare l'issue entro 48 ore.
+
+#### Checklist manutenzione trait
+
+1. Verificare l'issue automatica (se presente) e confermare le anomalie nel report Markdown più recente.
+2. Aggiornare o riparare i dataset (`data/traits/` e fonti correlate) secondo le indicazioni dell'audit.
+3. Rieseguire localmente lo script se sono stati applicati fix correttivi importanti per confermare la risoluzione.
+4. Chiudere l'issue automatica annotando le azioni intraprese e allegando eventuali patch aggiuntive.
+
+### Note su responsabilità e escalation
+
+- **Owner primari**: Data Operations segue una rotazione mensile fra i referenti `@biome-lead` e `@traits-curator` che devono garantire la revisione del report.
+- **Backup**: in caso di assenza degli owner, il referente `@operations-squad` assume la responsabilità di triage.
+- **Escalation**: anomalie bloccanti che impattano la pipeline di pubblicazione vanno riportate nel canale `#ops-critical` con link al report e issue automatica.
+
+### Checklist generale operazioni mensili
+
+- [ ] Confermare che la workflow `Traits Monthly Maintenance` abbia completato l'ultima run programmata.
+- [ ] Archiviare gli artefatti dei report rilevanti nel drive condiviso operativo (cartella `Traits/Manutenzione`).
+- [ ] Aggiornare questo calendario se cambiano frequenze, owner o checklist.

--- a/scripts/cron/traits_monthly_maintenance.sh
+++ b/scripts/cron/traits_monthly_maintenance.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_DIR="$REPO_ROOT/logs/monthly_trait_maintenance"
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H-%M-%SZ")"
+REPORT_FILE="$LOG_DIR/${TIMESTAMP}.md"
+STATUS_FILE="$LOG_DIR/status-${TIMESTAMP}.json"
+AUDIT_REPORT="$LOG_DIR/trait_audit_${TIMESTAMP}.md"
+AUDIT_LOG="$LOG_DIR/trait_audit_${TIMESTAMP}.log"
+DEPRECATION_REPORT="$LOG_DIR/deprecated_fields_${TIMESTAMP}.json"
+CACHE_LOG="$LOG_DIR/cache_cleanup_${TIMESTAMP}.log"
+
+mkdir -p "$LOG_DIR"
+
+anomaly_count=0
+anomaly_messages=()
+
+relpath() {
+  python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" "$1" "$REPO_ROOT"
+}
+
+log_section() {
+  local title="$1"
+  printf '\n## %s\n\n' "$title" >>"$REPORT_FILE"
+}
+
+append_line() {
+  printf '%s\n' "$1" >>"$REPORT_FILE"
+}
+
+echo "# Manutenzione mensile trait - ${TIMESTAMP} (UTC)" >"$REPORT_FILE"
+append_line "Esecuzione automatizzata di audit, pulizia cache e controllo campi deprecati."
+
+log_section "Audit principali"
+if python3 "$REPO_ROOT/scripts/trait_audit.py" --output "$AUDIT_REPORT" >"$AUDIT_LOG" 2>&1; then
+  append_line "- ✅ Audit tratti completato. Report: \`$(relpath "$AUDIT_REPORT")\` (log: \`$(relpath "$AUDIT_LOG")\`)."
+else
+  audit_status=$?
+  anomaly_count=$((anomaly_count + 1))
+  anomaly_messages+=("Audit trait fallito (codice ${audit_status}).")
+  append_line "- ❌ Audit tratti con errori (log: \`$(relpath "$AUDIT_LOG")\`)."
+fi
+
+log_section "Pulizia cache temporanee"
+{
+  echo "| Percorso | Azione |"
+  echo "| --- | --- |"
+} >>"$REPORT_FILE"
+
+: >"$CACHE_LOG"
+CACHE_TARGETS=(
+  "$REPO_ROOT/logs/tmp_traits"
+  "$REPO_ROOT/logs/trait_audit/tmp"
+  "$REPO_ROOT/tmp/trait_cache"
+  "$REPO_ROOT/.cache/trait_import"
+)
+for path in "${CACHE_TARGETS[@]}"; do
+  relative_path="$(relpath "$path")"
+  if [ -d "$path" ]; then
+    rm -rf "$path"
+    printf "[%s] rimossa %s\n" "$(date -u +"%H:%M:%SZ")" "$relative_path" >>"$CACHE_LOG"
+    printf "| %s | Rimossa |\n" "$relative_path" >>"$REPORT_FILE"
+  else
+    printf "| %s | Nessuna azione |\n" "$relative_path" >>"$REPORT_FILE"
+  fi
+done
+append_line ""
+append_line "Log dettagliato: \`$(relpath "$CACHE_LOG")\`"
+
+log_section "Verifica campi deprecati"
+DEPRECATED_COUNT=$(python3 - "$REPO_ROOT" "$DEPRECATION_REPORT" "$TIMESTAMP" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+output = Path(sys.argv[2])
+timestamp = sys.argv[3]
+index_path = repo / "data" / "traits" / "index.json"
+schema_path = repo / "config" / "schemas" / "trait.schema.json"
+
+traits_index = json.loads(index_path.read_text(encoding="utf-8"))
+trait_schema = json.loads(schema_path.read_text(encoding="utf-8"))
+allowed_fields = set(trait_schema.get("properties", {}).keys())
+deprecated_fields = []
+traits = traits_index.get("traits", {})
+if isinstance(traits, dict):
+    for trait_id, payload in sorted(traits.items()):
+        if isinstance(payload, dict):
+            for field in sorted(payload.keys()):
+                if field not in allowed_fields:
+                    deprecated_fields.append({"trait": trait_id, "field": field})
+        else:
+            deprecated_fields.append({"trait": trait_id, "field": "<non-dict payload>"})
+output.write_text(
+    json.dumps(
+        {
+            "generated_at": timestamp,
+            "schema_allowed_fields": sorted(allowed_fields),
+            "deprecated_fields": deprecated_fields,
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+    + "\n",
+    encoding="utf-8",
+)
+print(len(deprecated_fields))
+PY
+)
+DEPRECATED_COUNT="${DEPRECATED_COUNT//$'\n'/}"
+if [ -z "$DEPRECATED_COUNT" ]; then
+  DEPRECATED_COUNT=0
+fi
+if [ "$DEPRECATED_COUNT" -gt 0 ]; then
+  anomaly_count=$((anomaly_count + DEPRECATED_COUNT))
+  anomaly_messages+=("${DEPRECATED_COUNT} campi non conformi allo schema trait.")
+  append_line "- ❌ Rilevati ${DEPRECATED_COUNT} campi non presenti nello schema (dettagli in \`$(relpath "$DEPRECATION_REPORT")\`)."
+else
+  append_line "- ✅ Nessun campo deprecato individuato."
+fi
+
+append_line ""
+append_line "### Esito"
+if [ "$anomaly_count" -gt 0 ]; then
+  append_line "- ⚠️ Manutenzione completata con anomalie ($anomaly_count)."
+else
+  append_line "- ✅ Manutenzione completata senza anomalie."
+fi
+
+python3 - "$STATUS_FILE" "$REPORT_FILE" "$REPO_ROOT" "$TIMESTAMP" "$anomaly_count" "${anomaly_messages[@]}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+status_path = Path(sys.argv[1])
+report_path = Path(sys.argv[2])
+repo_root = Path(sys.argv[3])
+timestamp = sys.argv[4]
+anomaly_count = int(sys.argv[5])
+notes = list(sys.argv[6:])
+payload = {
+    "generated_at": timestamp,
+    "anomaly_count": anomaly_count,
+    "notes": notes,
+    "report_markdown": str(report_path.relative_to(repo_root)),
+}
+status_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+PY
+
+echo "Report disponibile in $(relpath "$REPORT_FILE")"
+echo "Stato sintetico in $(relpath "$STATUS_FILE")"
+
+action_status="ok"
+if [ "$anomaly_count" -gt 0 ]; then
+  action_status="warning"
+fi
+
+echo "Esito manutenzione: ${action_status} (anomalie=$anomaly_count)"
+
+exit 0


### PR DESCRIPTION
## Summary
- add a cron-style housekeeping script that runs the trait audit, cleans caches, and validates deprecated fields
- schedule a GitHub Actions workflow to execute the maintenance, archive logs, and raise an issue when anomalies are detected
- document the monthly maintenance calendar with owners and checklist, and ensure the log directory is tracked

## Testing
- bash scripts/cron/traits_monthly_maintenance.sh

------
https://chatgpt.com/codex/tasks/task_e_690624031fc08332ba0ed624990322a6