### PR TITLE
feat: theme flow shell with pokedex layout

### DIFF
--- a/webapp/src/components/pokedex/PokedexBiomeCard.vue
+++ b/webapp/src/components/pokedex/PokedexBiomeCard.vue
@@ -1,0 +1,172 @@
+<template>
+  <article class="pokedex-biome-card" :data-tone="readinessTone">
+    <header class="pokedex-biome-card__header">
+      <div>
+        <p class="pokedex-biome-card__kicker">Bioma operativo</p>
+        <h3 class="pokedex-biome-card__title">{{ biome.name }}</h3>
+        <p v-if="biome.hazard" class="pokedex-biome-card__subtitle">{{ biome.hazard }}</p>
+      </div>
+      <div class="pokedex-biome-card__telemetry">
+        <PokedexTelemetryBadge label="Readiness" :value="`${biome.readiness || 0}/${biome.total || 0}`" :tone="readinessTone" />
+        <PokedexTelemetryBadge v-if="biome.risk" label="Rischio" :value="biome.risk" tone="warning" />
+      </div>
+    </header>
+
+    <section v-if="lanes.length" class="pokedex-biome-card__section">
+      <h4>Corridoi</h4>
+      <ul class="pokedex-biome-card__chips">
+        <li v-for="lane in lanes" :key="lane">{{ lane }}</li>
+      </ul>
+    </section>
+
+    <section v-if="operations.length" class="pokedex-biome-card__section">
+      <h4>Operazioni</h4>
+      <ul class="pokedex-biome-card__list">
+        <li v-for="operation in operations" :key="operation">{{ operation }}</li>
+      </ul>
+    </section>
+
+    <section v-if="biome.infiltration" class="pokedex-biome-card__section">
+      <h4>Infiltrazione</h4>
+      <p>{{ biome.infiltration }}</p>
+    </section>
+
+    <footer class="pokedex-biome-card__footer">
+      <p v-if="biome.storyHook">{{ biome.storyHook }}</p>
+      <slot name="footer"></slot>
+    </footer>
+  </article>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import PokedexTelemetryBadge from './PokedexTelemetryBadge.vue';
+
+const props = defineProps({
+  biome: {
+    type: Object,
+    required: true,
+  },
+});
+
+const lanes = computed(() => props.biome?.lanes || props.biome?.paths || []);
+const operations = computed(() => props.biome?.operations || props.biome?.opportunities || []);
+
+const readinessTone = computed(() => {
+  const total = Number(props.biome?.total) || 0;
+  const readiness = Number(props.biome?.readiness) || 0;
+  if (!total) {
+    return 'warning';
+  }
+  const percent = Math.round((readiness / total) * 100);
+  if (percent >= 80) return 'success';
+  if (percent < 50) return 'critical';
+  return 'warning';
+});
+</script>
+
+<style scoped>
+.pokedex-biome-card {
+  position: relative;
+  display: grid;
+  gap: 1.1rem;
+  padding: 1.5rem;
+  border-radius: 1.6rem;
+  background: rgba(4, 18, 32, 0.82);
+  border: 1px solid rgba(77, 208, 255, 0.24);
+  box-shadow: inset 0 0 0 1px rgba(77, 208, 255, 0.08);
+}
+
+.pokedex-biome-card[data-tone='success'] {
+  border-color: rgba(94, 252, 159, 0.45);
+}
+
+.pokedex-biome-card[data-tone='critical'] {
+  border-color: rgba(255, 91, 107, 0.55);
+}
+
+.pokedex-biome-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.pokedex-biome-card__kicker {
+  margin: 0;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(242, 248, 255, 0.55);
+}
+
+.pokedex-biome-card__title {
+  margin: 0.35rem 0 0;
+  font-size: 1.35rem;
+  letter-spacing: 0.04em;
+  color: var(--pokedex-text-primary);
+}
+
+.pokedex-biome-card__subtitle {
+  margin: 0.2rem 0 0;
+  color: var(--pokedex-text-secondary);
+  font-size: 0.9rem;
+}
+
+.pokedex-biome-card__telemetry {
+  display: grid;
+  gap: 0.5rem;
+  justify-items: end;
+}
+
+.pokedex-biome-card__section h4 {
+  margin: 0 0 0.5rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(242, 248, 255, 0.6);
+}
+
+.pokedex-biome-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pokedex-biome-card__chips li {
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(77, 208, 255, 0.12);
+  color: var(--pokedex-text-primary);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+}
+
+.pokedex-biome-card__list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.35rem;
+  color: var(--pokedex-text-primary);
+  font-size: 0.85rem;
+}
+
+.pokedex-biome-card__section p {
+  margin: 0;
+  color: var(--pokedex-text-primary);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.pokedex-biome-card__footer {
+  border-top: 1px solid rgba(77, 208, 255, 0.16);
+  padding-top: 0.75rem;
+  display: grid;
+  gap: 0.5rem;
+  color: var(--pokedex-text-secondary);
+  font-size: 0.8rem;
+}
+</style>

--- a/webapp/src/components/pokedex/PokedexShell.vue
+++ b/webapp/src/components/pokedex/PokedexShell.vue
@@ -1,0 +1,125 @@
+<template>
+  <div class="pokedex-shell">
+    <div class="pokedex-shell__frame">
+      <div class="pokedex-shell__inner">
+        <div class="pokedex-shell__lights">
+          <span
+            v-for="light in indicatorLights"
+            :key="light.id"
+            class="pokedex-light"
+            :data-state="light.state"
+            :data-label="light.label"
+          ></span>
+        </div>
+
+        <div class="pokedex-shell__content">
+          <header class="pokedex-shell__header">
+            <slot name="header"></slot>
+          </header>
+
+          <section v-if="$slots.status" class="pokedex-shell__status">
+            <slot name="status"></slot>
+          </section>
+
+          <main class="pokedex-shell__main">
+            <slot></slot>
+          </main>
+
+          <footer v-if="$slots.footer" class="pokedex-shell__footer">
+            <slot name="footer"></slot>
+          </footer>
+        </div>
+
+        <aside class="pokedex-shell__logs" aria-live="polite">
+          <div class="pokedex-logs">
+            <header class="pokedex-logs__header">
+              <span class="pokedex-logs__title">Mission Log</span>
+              <span class="pokedex-logs__count">{{ previewLogs.length }}</span>
+            </header>
+            <ol class="pokedex-logs__feed">
+              <li
+                v-for="entry in previewLogs"
+                :key="entry.id"
+                class="pokedex-logs__entry"
+                :data-level="entry.level"
+              >
+                <span class="pokedex-logs__timestamp">{{ entry.time }}</span>
+                <p class="pokedex-logs__message">
+                  <strong>{{ entry.scope }}</strong>
+                  <span>{{ entry.message }}</span>
+                </p>
+              </li>
+              <li v-if="!previewLogs.length" class="pokedex-logs__entry pokedex-logs__entry--empty">
+                <span class="pokedex-logs__timestamp">—</span>
+                <p class="pokedex-logs__message">
+                  <strong>Nessun log</strong>
+                  <span>In attesa dei segnali dell'orchestratore…</span>
+                </p>
+              </li>
+            </ol>
+          </div>
+        </aside>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  lights: {
+    type: Array,
+    default: () => [],
+  },
+  logs: {
+    type: Array,
+    default: () => [],
+  },
+  logLimit: {
+    type: Number,
+    default: 10,
+  },
+});
+
+const indicatorLights = computed(() =>
+  props.lights.map((light, index) => ({
+    id: light.id ?? index,
+    label: light.label ?? String(light.id ?? index + 1),
+    state: light.state ?? 'idle',
+  })),
+);
+
+const previewLogs = computed(() =>
+  props.logs.slice(0, props.logLimit).map((entry, index) => ({
+    id: entry.id ?? `${entry.level || 'info'}-${index}`,
+    level: entry.level || 'info',
+    scope: entry.scope || 'Flow',
+    message: entry.message || entry.event || 'Evento registrato',
+    time: formatTimestamp(entry.timestamp),
+  })),
+);
+
+function formatTimestamp(timestamp) {
+  if (!timestamp) {
+    return '—';
+  }
+  try {
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) {
+      throw new Error('Invalid timestamp');
+    }
+    return date.toLocaleTimeString('it-IT', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  } catch (error) {
+    return String(timestamp).slice(0, 8);
+  }
+}
+</script>
+
+<style scoped>
+.pokedex-logs__entry--empty {
+  border-style: dashed;
+  border-color: rgba(77, 208, 255, 0.14);
+  color: rgba(242, 248, 255, 0.65);
+}
+</style>

--- a/webapp/src/components/pokedex/PokedexSpeciesCard.vue
+++ b/webapp/src/components/pokedex/PokedexSpeciesCard.vue
@@ -1,0 +1,55 @@
+<template>
+  <section class="pokedex-card" :data-tone="tone">
+    <header v-if="title || icon || $slots.badge" class="pokedex-card__header">
+      <div class="pokedex-card__title-group">
+        <span v-if="icon" class="pokedex-card__icon" aria-hidden="true">{{ icon }}</span>
+        <h3 v-if="title" class="pokedex-card__title">{{ title }}</h3>
+      </div>
+      <slot name="badge"></slot>
+    </header>
+
+    <div class="pokedex-card__body">
+      <slot />
+    </div>
+
+    <footer v-if="$slots.footer" class="pokedex-card__footer">
+      <slot name="footer"></slot>
+    </footer>
+  </section>
+</template>
+
+<script setup>
+const props = defineProps({
+  title: {
+    type: String,
+    default: '',
+  },
+  icon: {
+    type: String,
+    default: '',
+  },
+  tone: {
+    type: String,
+    default: 'neutral',
+  },
+});
+</script>
+
+<style scoped>
+.pokedex-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pokedex-card__title-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.pokedex-card__title {
+  margin: 0;
+}
+</style>

--- a/webapp/src/components/pokedex/PokedexTelemetryBadge.vue
+++ b/webapp/src/components/pokedex/PokedexTelemetryBadge.vue
@@ -1,0 +1,25 @@
+<template>
+  <span class="pokedex-telemetry" :data-tone="tone">
+    <span class="pokedex-telemetry__label">{{ label }}</span>
+    <span class="pokedex-telemetry__value">
+      <slot>{{ value }}</slot>
+    </span>
+  </span>
+</template>
+
+<script setup>
+const props = defineProps({
+  label: {
+    type: String,
+    required: true,
+  },
+  value: {
+    type: [String, Number],
+    default: '—',
+  },
+  tone: {
+    type: String,
+    default: 'neutral',
+  },
+});
+</script>

--- a/webapp/src/main.js
+++ b/webapp/src/main.js
@@ -1,6 +1,7 @@
 import { createApp } from 'vue';
 import App from './App.vue';
 import router from './router/index.js';
+import './styles/pokedex.css';
 
 const app = createApp(App);
 app.use(router);

--- a/webapp/src/styles/pokedex.css
+++ b/webapp/src/styles/pokedex.css
@@ -1,0 +1,568 @@
+:root {
+  --pokedex-bg: #030912;
+  --pokedex-surface: #071523;
+  --pokedex-surface-alt: #0b1f33;
+  --pokedex-surface-soft: rgba(6, 27, 44, 0.72);
+  --pokedex-border: rgba(77, 208, 255, 0.24);
+  --pokedex-border-strong: rgba(77, 208, 255, 0.55);
+  --pokedex-glow: rgba(77, 208, 255, 0.65);
+  --pokedex-text-primary: #f2f8ff;
+  --pokedex-text-secondary: rgba(242, 248, 255, 0.7);
+  --pokedex-text-muted: rgba(242, 248, 255, 0.55);
+  --pokedex-font: 'Rajdhani', 'Segoe UI', 'Roboto', sans-serif;
+  --pokedex-success: #5efc9f;
+  --pokedex-warning: #ffc857;
+  --pokedex-danger: #ff5b6b;
+  --pokedex-critical: #ff466d;
+  --pokedex-info: #4dd0ff;
+  --pokedex-shadow: 0 22px 65px rgba(6, 24, 44, 0.55);
+}
+
+@keyframes pokedex-scan {
+  0% {
+    opacity: 0.35;
+    transform: translateY(-60%);
+  }
+  50% {
+    opacity: 0.55;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0.35;
+    transform: translateY(60%);
+  }
+}
+
+@keyframes pokedex-pulse {
+  0% {
+    box-shadow: 0 0 12px rgba(77, 208, 255, 0.3);
+  }
+  50% {
+    box-shadow: 0 0 18px rgba(77, 208, 255, 0.6);
+  }
+  100% {
+    box-shadow: 0 0 12px rgba(77, 208, 255, 0.3);
+  }
+}
+
+@keyframes pokedex-alert {
+  0%,
+  100% {
+    box-shadow: 0 0 12px rgba(255, 91, 107, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 22px rgba(255, 91, 107, 0.7);
+  }
+}
+
+body {
+  font-family: var(--pokedex-font);
+  background-color: var(--pokedex-bg);
+  color: var(--pokedex-text-primary);
+}
+
+.pokedex-shell {
+  position: relative;
+  display: grid;
+  padding: clamp(2rem, 4vw, 3rem);
+  background:
+    radial-gradient(circle at top left, rgba(32, 246, 255, 0.12), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(255, 70, 109, 0.08), transparent 50%),
+    var(--pokedex-bg);
+  min-height: 100vh;
+}
+
+.pokedex-shell__frame {
+  display: grid;
+  border-radius: 2.4rem;
+  padding: 0.65rem;
+  background: linear-gradient(140deg, rgba(25, 122, 171, 0.7), rgba(5, 12, 24, 0.95));
+  border: 1px solid rgba(77, 208, 255, 0.35);
+  box-shadow: var(--pokedex-shadow);
+}
+
+.pokedex-shell__inner {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
+  gap: 1.2rem;
+  background: linear-gradient(160deg, rgba(3, 14, 24, 0.95), rgba(12, 35, 58, 0.9));
+  border-radius: 2rem;
+  overflow: hidden;
+  position: relative;
+}
+
+.pokedex-shell__inner::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(0deg, rgba(77, 208, 255, 0.08), transparent 45%);
+}
+
+.pokedex-shell__lights {
+  position: absolute;
+  inset: 1.2rem auto auto 2.4rem;
+  display: flex;
+  gap: 0.75rem;
+  z-index: 2;
+}
+
+.pokedex-light {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 50%;
+  background: rgba(77, 208, 255, 0.35);
+  border: 2px solid rgba(255, 255, 255, 0.18);
+  position: relative;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.pokedex-light::after {
+  content: attr(data-label);
+  position: absolute;
+  bottom: -1.6rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--pokedex-text-muted);
+}
+
+.pokedex-light[data-state='ready'] {
+  background: rgba(94, 252, 159, 0.7);
+  animation: pokedex-pulse 3s ease-in-out infinite;
+}
+
+.pokedex-light[data-state='loading'] {
+  background: rgba(77, 208, 255, 0.8);
+  animation: pokedex-scan 1.8s ease-in-out infinite;
+}
+
+.pokedex-light[data-state='error'] {
+  background: rgba(255, 91, 107, 0.85);
+  animation: pokedex-alert 1.2s ease-in-out infinite;
+}
+
+.pokedex-light[data-state='idle'] {
+  background: rgba(77, 208, 255, 0.3);
+}
+
+.pokedex-shell__content {
+  position: relative;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  gap: 1.4rem;
+  padding: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.pokedex-shell__header {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.pokedex-shell__status {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.pokedex-shell__main {
+  position: relative;
+  display: grid;
+  min-height: 320px;
+  padding: 1.25rem;
+  background: var(--pokedex-surface-soft);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(77, 208, 255, 0.22);
+  box-shadow: inset 0 0 0 1px rgba(77, 208, 255, 0.08);
+}
+
+.pokedex-shell__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.pokedex-shell__logs {
+  position: relative;
+  padding: 1.2rem 1.1rem 1.8rem;
+  background: linear-gradient(180deg, rgba(5, 18, 35, 0.95), rgba(3, 12, 24, 0.92));
+  border-left: 1px solid rgba(77, 208, 255, 0.18);
+  display: grid;
+}
+
+.pokedex-logs {
+  display: grid;
+  gap: 1rem;
+  position: relative;
+}
+
+.pokedex-logs::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(77, 208, 255, 0.12), transparent 55%);
+  pointer-events: none;
+}
+
+.pokedex-logs__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--pokedex-text-muted);
+}
+
+.pokedex-logs__title {
+  font-weight: 600;
+}
+
+.pokedex-logs__count {
+  font-variant-numeric: tabular-nums;
+}
+
+.pokedex-logs__feed {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+  max-height: 520px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(77, 208, 255, 0.32) transparent;
+}
+
+.pokedex-logs__feed::-webkit-scrollbar {
+  width: 6px;
+}
+
+.pokedex-logs__feed::-webkit-scrollbar-thumb {
+  background: rgba(77, 208, 255, 0.32);
+  border-radius: 999px;
+}
+
+.pokedex-logs__entry {
+  padding: 0.65rem 0.75rem;
+  border-radius: 1rem;
+  background: rgba(4, 18, 32, 0.75);
+  border: 1px solid rgba(77, 208, 255, 0.12);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.pokedex-logs__entry[data-level='error'] {
+  border-color: rgba(255, 91, 107, 0.5);
+}
+
+.pokedex-logs__entry[data-level='warn'] {
+  border-color: rgba(255, 200, 87, 0.4);
+}
+
+.pokedex-logs__timestamp {
+  font-size: 0.65rem;
+  letter-spacing: 0.12em;
+  color: var(--pokedex-text-muted);
+}
+
+.pokedex-logs__message {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--pokedex-text-primary);
+  display: grid;
+  gap: 0.25rem;
+}
+
+.pokedex-logs__message strong {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--pokedex-info);
+}
+
+.pokedex-status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.pokedex-status-card {
+  position: relative;
+  padding: 1rem 1.2rem;
+  border-radius: 1.2rem;
+  background: rgba(7, 23, 39, 0.82);
+  border: 1px solid rgba(77, 208, 255, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(77, 208, 255, 0.08);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.pokedex-status-card[data-state='loading'] {
+  border-color: rgba(77, 208, 255, 0.4);
+}
+
+.pokedex-status-card[data-state='error'] {
+  border-color: rgba(255, 91, 107, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(255, 91, 107, 0.25);
+}
+
+.pokedex-status-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pokedex-status-card__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--pokedex-text-secondary);
+}
+
+.pokedex-status-card__spinner {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  border-top-color: var(--pokedex-info);
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.pokedex-status-card__message {
+  font-size: 0.85rem;
+  color: var(--pokedex-text-primary);
+  min-height: 1.6rem;
+}
+
+.pokedex-status-card__actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.pokedex-status-card__retry {
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  background: rgba(77, 208, 255, 0.16);
+  color: var(--pokedex-info);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.pokedex-status-card__retry:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: rgba(77, 208, 255, 0.24);
+}
+
+.pokedex-status-card__retry:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pokedex-button {
+  background: rgba(7, 23, 39, 0.82);
+  border: 1px solid rgba(77, 208, 255, 0.35);
+  border-radius: 0.9rem;
+  padding: 0.65rem 1.4rem;
+  color: var(--pokedex-text-primary);
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.pokedex-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pokedex-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  border-color: rgba(77, 208, 255, 0.55);
+}
+
+.pokedex-step-indicator {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  color: var(--pokedex-text-secondary);
+}
+
+.pokedex-telemetry {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(77, 208, 255, 0.25);
+  background: rgba(7, 23, 39, 0.65);
+  min-width: 120px;
+}
+
+.pokedex-telemetry[data-tone='success'] {
+  border-color: rgba(94, 252, 159, 0.5);
+}
+
+.pokedex-telemetry[data-tone='warning'] {
+  border-color: rgba(255, 200, 87, 0.5);
+}
+
+.pokedex-telemetry[data-tone='critical'],
+.pokedex-telemetry[data-tone='error'] {
+  border-color: rgba(255, 91, 107, 0.55);
+}
+
+.pokedex-telemetry__label {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--pokedex-text-muted);
+}
+
+.pokedex-telemetry__value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--pokedex-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.pokedex-card {
+  background: rgba(7, 23, 39, 0.8);
+  border: 1px solid rgba(77, 208, 255, 0.16);
+  border-radius: 1.3rem;
+  padding: 1.1rem 1.25rem;
+  display: grid;
+  gap: 0.65rem;
+  position: relative;
+}
+
+.pokedex-card[data-tone='success'] {
+  border-color: rgba(94, 252, 159, 0.45);
+}
+
+.pokedex-card[data-tone='warning'] {
+  border-color: rgba(255, 200, 87, 0.4);
+}
+
+.pokedex-card[data-tone='critical'],
+.pokedex-card[data-tone='error'] {
+  border-color: rgba(255, 91, 107, 0.5);
+}
+
+.pokedex-card__title {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--pokedex-text-secondary);
+}
+
+.pokedex-card__icon {
+  font-size: 1rem;
+  color: var(--pokedex-info);
+}
+
+.pokedex-card__body {
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+  color: var(--pokedex-text-primary);
+}
+
+.pokedex-card__footer {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  color: var(--pokedex-text-secondary);
+}
+
+.pokedex-card__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.pokedex-card__badge-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.pokedex-card__badge-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.pokedex-card__badge-label {
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  background: rgba(77, 208, 255, 0.16);
+  color: var(--pokedex-info);
+}
+
+.pokedex-card__badge-label[data-tone='success'] {
+  background: rgba(94, 252, 159, 0.22);
+  color: var(--pokedex-text-primary);
+}
+
+.pokedex-card__badge-label[data-tone='warning'] {
+  background: rgba(255, 200, 87, 0.22);
+  color: rgba(255, 241, 198, 0.95);
+}
+
+.pokedex-card__badge-label[data-tone='critical'] {
+  background: rgba(255, 91, 107, 0.22);
+  color: rgba(255, 219, 228, 0.95);
+}
+
+.pokedex-card__badge-value {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--pokedex-text-primary);
+}
+
+@media (max-width: 1280px) {
+  .pokedex-shell__inner {
+    grid-template-columns: 1fr;
+  }
+
+  .pokedex-shell__logs {
+    border-left: none;
+    border-top: 1px solid rgba(77, 208, 255, 0.18);
+  }
+}
+
+@media (max-width: 900px) {
+  .pokedex-shell {
+    padding: clamp(1rem, 5vw, 2rem);
+  }
+
+  .pokedex-shell__content {
+    padding: clamp(1.2rem, 4vw, 1.8rem);
+  }
+}

--- a/webapp/src/views/EncounterView.vue
+++ b/webapp/src/views/EncounterView.vue
@@ -6,10 +6,16 @@
         <p>Configura template, parametri e slot prima della visualizzazione finale.</p>
       </div>
       <div class="encounter-workspace__summary">
-        <span><strong>{{ summary.seeds }}</strong> seed</span>
-        <span><strong>{{ summary.variants }}</strong> varianti</span>
-        <span><strong>{{ summary.warnings }}</strong> warning</span>
-        <span v-if="lastExportMessage" class="encounter-workspace__export">{{ lastExportMessage }}</span>
+        <PokedexTelemetryBadge label="Seed" :value="summary.seeds" />
+        <PokedexTelemetryBadge label="Varianti" :value="summary.variants" />
+        <PokedexTelemetryBadge
+          label="Warning"
+          :value="summary.warnings"
+          :tone="summary.warnings ? 'warning' : 'success'"
+        />
+        <PokedexTelemetryBadge v-if="lastExportMessage" label="Ultimo export" tone="success">
+          {{ lastExportMessage }}
+        </PokedexTelemetryBadge>
       </div>
     </header>
     <div class="encounter-workspace__grid">
@@ -48,6 +54,7 @@ import EncounterPanel from '../components/EncounterPanel.vue';
 import EncounterEditor from '../components/encounter/EncounterEditor.vue';
 import EncounterMetricsPanel from '../components/encounter/EncounterMetricsPanel.vue';
 import VariantComparison from '../components/encounter/VariantComparison.vue';
+import PokedexTelemetryBadge from '../components/pokedex/PokedexTelemetryBadge.vue';
 import { ENCOUNTER_BLUEPRINTS } from '../state/generator/encounters.js';
 import { calculateEncounterMetrics, buildEncounterSuggestions } from '../services/encounterMetrics.js';
 
@@ -252,21 +259,18 @@ function handleExport({ variantId, target }) {
 
 .encounter-workspace__header p {
   margin: 0.35rem 0 0;
-  color: rgba(240, 244, 255, 0.7);
+  color: var(--pokedex-text-secondary);
 }
 
 .encounter-workspace__summary {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  font-size: 0.95rem;
-  color: rgba(240, 244, 255, 0.75);
+  align-items: center;
 }
 
-.encounter-workspace__export {
-  background: rgba(96, 213, 255, 0.12);
-  border-radius: 999px;
-  padding: 0.25rem 0.75rem;
+.encounter-workspace__summary .pokedex-telemetry {
+  min-width: 130px;
 }
 
 .encounter-workspace__grid {


### PR DESCRIPTION
## Summary
- introduce a dedicated PokedexShell wrapper with indicator lights and a mission log sidebar for the flow orchestrator
- add reusable Pokedex biome, species, and telemetry components and refit the species, biome, and encounter views to use them
- centralize Digivice-inspired palette, typography, and animations in a new pokedex theme stylesheet

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6906275f3e8c8332a085cc293ca17d67