### PR TITLE
Aggregate release telemetry and add go/no-go checks (follow-up)

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -285,9 +285,13 @@ async function updateDeploymentStatus(filePath, payload, options = {}) {
   status.updatedAt = new Date().toISOString();
   const reporter = options.releaseReporter;
   if (reporter && typeof reporter.buildReport === 'function') {
-    const enriched = await reporter.buildReport(status);
-    await writeJsonFile(filePath, enriched);
-    return { status: enriched, entry };
+    try {
+      const enriched = await reporter.buildReport(status);
+      await writeJsonFile(filePath, enriched);
+      return { status: enriched, entry };
+    } catch (error) {
+      console.warn('[release-reporter] buildReport fallito, utilizzo status base', error);
+    }
   }
   await writeJsonFile(filePath, status);
   return { status, entry };


### PR DESCRIPTION
## Summary
- add a releaseReporter service to aggregate snapshot, trait diagnostics, and Nebula telemetry into reports/status.json with go/no-go state
- update the recap generator, maintenance docs, and deploy checks script to consume the shared status payload
- add reusable go/no-go utilities and unit tests covering the deploy checks messaging
- guard the deployment hook against releaseReporter failures so deployment history is still persisted when telemetry enrichment fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6906299e5f808332a49cbbe9166c7913