### PR TITLE
Fix Codex review findings for external trait review pipeline

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pyyaml
 numpy
+jsonschema

--- a/tools/py/review_external_traits.py
+++ b/tools/py/review_external_traits.py
@@ -176,7 +176,11 @@ def review_draft(
 ) -> ReviewOutcome:
     payload = load_json(path)
     trait_id = payload.get("id") or path.stem
-    origin = payload.get("data_origin") or "<sconosciuta>"
+    raw_origin = payload.get("data_origin")
+    if raw_origin is None:
+        origin = "<sconosciuta>"
+    else:
+        origin = str(raw_origin).strip() or "<sconosciuta>"
 
     missing_fields = detect_missing_fields(payload)
     schema_errors = collect_schema_errors(payload, validator)


### PR DESCRIPTION
## Summary
- declare the jsonschema dependency required by the review pipeline
- coerce draft data origins to strings so malformed payloads do not break summaries

## Testing
- python tools/py/review_external_traits.py --dry-run

------
https://chatgpt.com/codex/tasks/task_e_690629aa67508332a7b5961e6ed41741