### PR TITLE
Expose trait metadata across generators and diagnostics

### DIFF
--- a/docs/catalog/catalog_data.json
+++ b/docs/catalog/catalog_data.json
@@ -7,17 +7,19 @@
     "trait_reference": "data/traits/index.json"
   },
   "traits": {
-    "artigli_sette_vie": {
+    "ali_fulminee": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -42,7 +44,1494 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "stratosfera_tempestosa"
+      ],
+      "families": [
+        "Sensoriale",
+        "Analitico"
+      ],
+      "glossary_ok": true,
+      "id": "ali_fulminee",
+      "label": "Ali Fulminee",
+      "mutation": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "selective_drive": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T1",
+      "usage": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
+    },
+    "ali_ioniche": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "canopia_ionica"
+      ],
+      "families": [
+        "Locomotorio",
+        "Mobilità"
+      ],
+      "glossary_ok": true,
+      "id": "ali_ioniche",
+      "label": "Ali Ioniche",
+      "mutation": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "selective_drive": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "tier": "T1",
+      "usage": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede manutenzione costante delle strutture propulsive."
+    },
+    "ali_membrana_sonica": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "ali_membrana_sonica",
+      "label": "Ali Membrana Sonica",
+      "mutation": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "selective_drive": "Assorbire shock continui proteggendo unità di supporto.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "tier": "T1",
+      "usage": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
+    },
+    "antenne_dustsense": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "pianura_salina_iperarida"
+      ],
+      "families": [
+        "Digestivo",
+        "Metabolico"
+      ],
+      "glossary_ok": true,
+      "id": "antenne_dustsense",
+      "label": "Antenne Dustsense",
+      "mutation": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "selective_drive": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "tier": "T1",
+      "usage": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
+    },
+    "antenne_eco_turbina": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "dorsale_termale_tropicale"
+      ],
+      "families": [
+        "Supporto",
+        "Logistico"
+      ],
+      "glossary_ok": true,
+      "id": "antenne_eco_turbina",
+      "label": "Antenne Eco Turbina",
+      "mutation": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "selective_drive": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
+    },
+    "antenne_flusso_mareale": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "laguna_bioreattiva"
+      ],
+      "families": [
+        "Offensivo",
+        "Assalto"
+      ],
+      "glossary_ok": true,
+      "id": "antenne_flusso_mareale",
+      "label": "Antenne Flusso Mareale",
+      "mutation": "forgia condotti muscolari che accumulano energia di impatto.",
+      "selective_drive": "Garantire pressione costante sulle difese avversarie.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "tier": "T1",
+      "usage": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Rischio di sovraccarico se scaricato senza controllo."
+    },
+    "antenne_microonde_cavernose": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Strategico",
+        "Tattico"
+      ],
+      "glossary_ok": true,
+      "id": "antenne_microonde_cavernose",
+      "label": "Antenne Microonde Cavernose",
+      "mutation": "espande gangli pianificatori e nodi logici distribuiti.",
+      "selective_drive": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
+    },
+    "antenne_plasmatiche_tempesta": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Alto (Canalizzazione costante di plasma atmosferico)",
+      "environments": [
+        "cicloni_psionici"
+      ],
+      "families": [
+        "Sensoriale",
+        "Offensivo"
+      ],
+      "glossary_ok": true,
+      "id": "antenne_plasmatiche_tempesta",
+      "label": "Antenne Plasmatiche di Tempesta",
+      "mutation": "Flagelli coronati da nodi plasma-sensibili che captano e deviano fulmini.",
+      "selective_drive": "Comandare fulmini e navigare in cieli turbolenti durante campagne aeree.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cicloni-psionici-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_luminiscente_abissale",
+        "focus_frazionato",
+        "risonanza_di_branco",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T3",
+      "usage": "Canalizza scariche atmosferiche in attacchi direzionati o scudi ionici.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Scariche elettriche massicce possono bruciare i recettori e compromettere la coordinazione."
+    },
+    "antenne_reagenti": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "foresta_acida"
+      ],
+      "families": [
+        "Simbiotico",
+        "Cooperativo"
+      ],
+      "glossary_ok": true,
+      "id": "antenne_reagenti",
+      "label": "Antenne Reagenti",
+      "mutation": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "selective_drive": "Coltivare ecosistemi interdipendenti resilienti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "tier": "T1",
+      "usage": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
+    },
+    "antenne_tesla": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "canopia_ionica"
+      ],
+      "families": [
+        "Strutturale",
+        "Adattivo"
+      ],
+      "glossary_ok": true,
+      "id": "antenne_tesla",
+      "label": "Antenne Tesla",
+      "mutation": "compatta matrici scheletriche con fibre autoreattive.",
+      "selective_drive": "Mantenere integrità strutturale durante stress ciclici.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Risonanze errate possono generare microfratture."
+    },
+    "antenne_waveguide": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "reef_luminescente"
+      ],
+      "families": [
+        "Sensoriale",
+        "Analitico"
+      ],
+      "glossary_ok": true,
+      "id": "antenne_waveguide",
+      "label": "Antenne Waveguide",
+      "mutation": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "selective_drive": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T1",
+      "usage": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
+    },
+    "antenne_wideband": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "steppe_algoritmiche"
+      ],
+      "families": [
+        "Locomotorio",
+        "Mobilità"
+      ],
+      "glossary_ok": true,
+      "id": "antenne_wideband",
+      "label": "Antenne Wideband",
+      "mutation": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "selective_drive": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "tier": "T1",
+      "usage": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede manutenzione costante delle strutture propulsive."
+    },
+    "appendici_risonanti_marea": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "laguna_bioreattiva"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "appendici_risonanti_marea",
+      "label": "Appendici Risonanti Marea",
+      "mutation": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "selective_drive": "Assorbire shock continui proteggendo unità di supporto.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "tier": "T1",
+      "usage": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
+    },
+    "appendici_thermotattiche": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "abisso_vulcanico"
+      ],
+      "families": [
+        "Digestivo",
+        "Metabolico"
+      ],
+      "glossary_ok": true,
+      "id": "appendici_thermotattiche",
+      "label": "Appendici Thermotattiche",
+      "mutation": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "selective_drive": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "tier": "T1",
+      "usage": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
+    },
+    "armatura_pietra_planare": {
+      "completion_flags": {},
+      "conflicts": [
+        "frusta_fiammeggiante"
+      ],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Risonanza geodetica stabile)",
+      "environments": [
+        "rovine_planari"
+      ],
+      "families": [
+        "Difesa",
+        "Strutturale"
+      ],
+      "glossary_ok": true,
+      "id": "armatura_pietra_planare",
+      "label": "Armatura di Pietra Planare",
+      "mutation": "Cristallizza il dermascheletro con nodi rune che deviano energia.",
+      "selective_drive": "Stabilizzare varchi e proteggere infrastrutture dalle onde d'urto.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "golem-runico",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "balor-fission",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "treant-portale",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile"
+      ],
+      "tier": "T2",
+      "usage": "Offre schermatura massiva e ancoraggio durante le aperture dimensionali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Pesante: riduce mobilità in ambienti non supportati o a bassa gravità."
+    },
+    "artigli_acidofagi": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "foresta_acida"
+      ],
+      "families": [
+        "Supporto",
+        "Logistico"
+      ],
+      "glossary_ok": true,
+      "id": "artigli_acidofagi",
+      "label": "Artigli Acidofagi",
+      "mutation": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "selective_drive": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
+    },
+    "artigli_induzione": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "canopia_ionica"
+      ],
+      "families": [
+        "Offensivo",
+        "Assalto"
+      ],
+      "glossary_ok": true,
+      "id": "artigli_induzione",
+      "label": "Artigli Induzione",
+      "mutation": "forgia condotti muscolari che accumulano energia di impatto.",
+      "selective_drive": "Garantire pressione costante sulle difese avversarie.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "tier": "T1",
+      "usage": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Rischio di sovraccarico se scaricato senza controllo."
+    },
+    "artigli_radice": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "mangrovieto_cinetico"
+      ],
+      "families": [
+        "Strategico",
+        "Tattico"
+      ],
+      "glossary_ok": true,
+      "id": "artigli_radice",
+      "label": "Artigli Radice",
+      "mutation": "espande gangli pianificatori e nodi logici distribuiti.",
+      "selective_drive": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
+    },
+    "artigli_scivolo_silente": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Simbiotico",
+        "Cooperativo"
+      ],
+      "glossary_ok": true,
+      "id": "artigli_scivolo_silente",
+      "label": "Artigli Scivolo Silente",
+      "mutation": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "selective_drive": "Coltivare ecosistemi interdipendenti resilienti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "tier": "T1",
+      "usage": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
+    },
+    "artigli_sette_vie": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -55,12 +1544,83 @@
         "Locomotorio",
         "Prensile"
       ],
+      "glossary_ok": true,
       "id": "artigli_sette_vie",
       "label": "Artigli a Sette Vie",
       "mutation": "Dita lunghe e segmentate con punte a uncino multiplo.",
       "selective_drive": "Arrampicarsi su pareti rocciose o vegetazione densa.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "dune-stalker",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "magneto-ridge-hunter",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "balor-fission",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cryo-lynx",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "resonant-claw-hunter",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
-        "struttura_elastica_amorfa"
+        "coda_frusta_cinetica",
+        "mimetismo_cromatico_passivo",
+        "struttura_elastica_amorfa",
+        "tattiche_di_branco"
       ],
       "tier": "T1",
       "usage": "Afferrare superfici irregolari o oggetti multipli.",
@@ -73,21 +1633,22 @@
         "optional": [],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Angoli di presa limitati se la superficie è perfettamente liscia."
     },
-    "carapace_fase_variabile": {
-      "conflicts": [
-        "struttura_elastica_amorfa"
-      ],
+    "artigli_sghiaccio_glaciale": {
+      "completion_flags": {},
+      "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -112,24 +1673,2117 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Raffreddamento endogeno controllato)",
+      "environments": [
+        "calotte_glaciali"
+      ],
+      "families": [
+        "Locomotorio",
+        "Predatorio"
+      ],
+      "glossary_ok": true,
+      "id": "artigli_sghiaccio_glaciale",
+      "label": "Artigli Sghiaccio Glaciale",
+      "mutation": "Falangi rivestite da ghiaccio strutturale che si espande creando lame traslucide.",
+      "selective_drive": "Cacciare su superfici gelate e pareti verticali di ghiaccio vivo.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "calotte-glaciali-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "cartilagine_flessotermica_venti",
+        "sonno_emisferico_alternato",
+        "zampe_a_molla"
+      ],
+      "tier": "T2",
+      "usage": "Scalza e immobilizza i bersagli congelandoli al contatto.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "In ambienti temperati i tessuti subiscono microfratture e richiedono continue riparazioni."
+    },
+    "artigli_vetrificati": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caldera_glaciale"
+      ],
+      "families": [
+        "Strutturale",
+        "Adattivo"
+      ],
+      "glossary_ok": true,
+      "id": "artigli_vetrificati",
+      "label": "Artigli Vetrificati",
+      "mutation": "compatta matrici scheletriche con fibre autoreattive.",
+      "selective_drive": "Mantenere integrità strutturale durante stress ciclici.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Risonanze errate possono generare microfratture."
+    },
+    "aura_scudo_radianza": {
+      "completion_flags": {},
+      "conflicts": [
+        "mantello_meteoritico"
+      ],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Alto (Canalizzazione fotonica continua)",
+      "environments": [
+        "rovine_planari"
+      ],
+      "families": [
+        "Supporto",
+        "Difesa"
+      ],
+      "glossary_ok": true,
+      "id": "aura_scudo_radianza",
+      "label": "Aura Scudo di Radianza",
+      "mutation": "Innesta organi fotoplasmatici che diffondono uno scudo radiante sugli alleati vicini.",
+      "selective_drive": "Proteggere gli hub di evacuazione durante tempeste di energia planare.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "archon-solare",
+          "weight": 4.0
+        }
+      ],
+      "synergies": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "tier": "T3",
+      "usage": "Proietta schermature luminose sincronizzate con i segnali tattici della squadra.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Soffre saturazione se esposta a ombre gravitazionali o zone di antimagia."
+    },
+    "baffi_mareomotori": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "mangrovieto_cinetico"
+      ],
+      "families": [
+        "Sensoriale",
+        "Analitico"
+      ],
+      "glossary_ok": true,
+      "id": "baffi_mareomotori",
+      "label": "Baffi Mareomotori",
+      "mutation": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "selective_drive": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T1",
+      "usage": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
+    },
+    "barbigli_sensori_plasma": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "stratosfera_tempestosa"
+      ],
+      "families": [
+        "Locomotorio",
+        "Mobilità"
+      ],
+      "glossary_ok": true,
+      "id": "barbigli_sensori_plasma",
+      "label": "Barbigli Sensori Plasma",
+      "mutation": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "selective_drive": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "tier": "T1",
+      "usage": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede manutenzione costante delle strutture propulsive."
+    },
+    "barriere_miasma_glaciale": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caldera_glaciale"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "barriere_miasma_glaciale",
+      "label": "Barriere Miasma Glaciale",
+      "mutation": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "selective_drive": "Assorbire shock continui proteggendo unità di supporto.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "tier": "T1",
+      "usage": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
+    },
+    "batteri_endosimbionti_chemio": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "abisso_vulcanico"
+      ],
+      "families": [
+        "Digestivo",
+        "Metabolico"
+      ],
+      "glossary_ok": true,
+      "id": "batteri_endosimbionti_chemio",
+      "label": "Batteri Endosimbionti Chemio",
+      "mutation": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "selective_drive": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "tier": "T1",
+      "usage": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
+    },
+    "batteri_termofili_endosimbiosi": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "dorsale_termale_tropicale"
+      ],
+      "families": [
+        "Supporto",
+        "Logistico"
+      ],
+      "glossary_ok": true,
+      "id": "batteri_termofili_endosimbiosi",
+      "label": "Batteri Termofili Endosimbiosi",
+      "mutation": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "selective_drive": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
+    },
+    "biochip_memoria": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "steppe_algoritmiche"
+      ],
+      "families": [
+        "Offensivo",
+        "Assalto"
+      ],
+      "glossary_ok": true,
+      "id": "biochip_memoria",
+      "label": "Biochip Memoria",
+      "mutation": "forgia condotti muscolari che accumulano energia di impatto.",
+      "selective_drive": "Garantire pressione costante sulle difese avversarie.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "tier": "T1",
+      "usage": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Rischio di sovraccarico se scaricato senza controllo."
+    },
+    "biofilm_glow": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "reef_luminescente"
+      ],
+      "families": [
+        "Strategico",
+        "Tattico"
+      ],
+      "glossary_ok": true,
+      "id": "biofilm_glow",
+      "label": "Biofilm Glow",
+      "mutation": "espande gangli pianificatori e nodi logici distribuiti.",
+      "selective_drive": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
+    },
+    "biofilm_iperarido": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "pianura_salina_iperarida"
+      ],
+      "families": [
+        "Simbiotico",
+        "Cooperativo"
+      ],
+      "glossary_ok": true,
+      "id": "biofilm_iperarido",
+      "label": "Biofilm Iperarido",
+      "mutation": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "selective_drive": "Coltivare ecosistemi interdipendenti resilienti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "tier": "T1",
+      "usage": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
+    },
+    "branchie_dual_mode": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "laguna_bioreattiva"
+      ],
+      "families": [
+        "Strutturale",
+        "Adattivo"
+      ],
+      "glossary_ok": true,
+      "id": "branchie_dual_mode",
+      "label": "Branchie Dual Mode",
+      "mutation": "compatta matrici scheletriche con fibre autoreattive.",
+      "selective_drive": "Mantenere integrità strutturale durante stress ciclici.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Risonanze errate possono generare microfratture."
+    },
+    "branchie_eoliche": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "stratosfera_tempestosa"
+      ],
+      "families": [
+        "Sensoriale",
+        "Analitico"
+      ],
+      "glossary_ok": true,
+      "id": "branchie_eoliche",
+      "label": "Branchie Eoliche",
+      "mutation": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "selective_drive": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T1",
+      "usage": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
+    },
+    "branchie_metalloidi": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "abisso_vulcanico"
+      ],
+      "families": [
+        "Locomotorio",
+        "Mobilità"
+      ],
+      "glossary_ok": true,
+      "id": "branchie_metalloidi",
+      "label": "Branchie Metalloidi",
+      "mutation": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "selective_drive": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "tier": "T1",
+      "usage": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede manutenzione costante delle strutture propulsive."
+    },
+    "branchie_microfiltri": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "reef_luminescente"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "branchie_microfiltri",
+      "label": "Branchie Microfiltri",
+      "mutation": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "selective_drive": "Assorbire shock continui proteggendo unità di supporto.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "tier": "T1",
+      "usage": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
+    },
+    "branchie_osmotiche_salmastra": {
+      "completion_flags": {},
+      "conflicts": [
+        "polmoni_cristallini_alta_quota"
+      ],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Pompe ioniche attive)",
+      "environments": [
+        "delta_salmastri"
+      ],
+      "families": [
+        "Respiratorio",
+        "Osmoregolazione"
+      ],
+      "glossary_ok": true,
+      "id": "branchie_osmotiche_salmastra",
+      "label": "Branchie Osmotiche Salmastre",
+      "mutation": "Lamelle branchiali multilivello con valvole che separano sali e tossine.",
+      "selective_drive": "Colonizzare mangrovie psioniche e barriere di estuario soggette a maree estreme.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "delta-salmastri-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "mucillagine_simbionte_mangrovie",
+        "scheletro_idro_regolante"
+      ],
+      "tier": "T2",
+      "usage": "Bilancia sali e tossine sfruttando microvalvole controllate psionicamente.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede accesso costante ad acqua salmastra; ambienti d'acqua dolce provocano stress ionico."
+    },
+    "branchie_solfatiche": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caldera_glaciale"
+      ],
+      "families": [
+        "Digestivo",
+        "Metabolico"
+      ],
+      "glossary_ok": true,
+      "id": "branchie_solfatiche",
+      "label": "Branchie Solfatiche",
+      "mutation": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "selective_drive": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "tier": "T1",
+      "usage": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
+    },
+    "branchie_turbina": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "dorsale_termale_tropicale"
+      ],
+      "families": [
+        "Supporto",
+        "Logistico"
+      ],
+      "glossary_ok": true,
+      "id": "branchie_turbina",
+      "label": "Branchie Turbina",
+      "mutation": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "selective_drive": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
+    },
+    "bulbi_radici_permafrost": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Accumulo e rilascio lento di nutrienti)",
+      "environments": [
+        "permafrost_psionico"
+      ],
+      "families": [
+        "Simbiotico",
+        "Nutrizione"
+      ],
+      "glossary_ok": true,
+      "id": "bulbi_radici_permafrost",
+      "label": "Bulbi Radici del Permafrost",
+      "mutation": "Bulbi radicali multipli che immagazzinano energia nelle stagioni fredde per rilasciarla durante le missioni.",
+      "selective_drive": "Sostenere campagne lunghe in climi artici con riserve nutrizionali concentrate.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "permafrost-psionico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "chioma_parassita_canopica",
+        "nodi_micorrizici_oracolari",
+        "vello_condensatore_nebbie"
+      ],
+      "tier": "T2",
+      "usage": "Rilascia energia e calore agli alleati radicati nella stessa rete subglaciale.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Disgeli improvvisi trasformano i bulbi in masse gelatinose che rallentano i movimenti."
+    },
+    "camere_anticorrosione": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "foresta_acida"
+      ],
+      "families": [
+        "Offensivo",
+        "Assalto"
+      ],
+      "glossary_ok": true,
+      "id": "camere_anticorrosione",
+      "label": "Camere Anticorrosione",
+      "mutation": "forgia condotti muscolari che accumulano energia di impatto.",
+      "selective_drive": "Garantire pressione costante sulle difese avversarie.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "tier": "T1",
+      "usage": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Rischio di sovraccarico se scaricato senza controllo."
+    },
+    "camere_mirage": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "pianura_salina_iperarida"
+      ],
+      "families": [
+        "Strategico",
+        "Tattico"
+      ],
+      "glossary_ok": true,
+      "id": "camere_mirage",
+      "label": "Camere Mirage",
+      "mutation": "espande gangli pianificatori e nodi logici distribuiti.",
+      "selective_drive": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
+    },
+    "camere_nutrienti_vent": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "dorsale_termale_tropicale"
+      ],
+      "families": [
+        "Simbiotico",
+        "Cooperativo"
+      ],
+      "glossary_ok": true,
+      "id": "camere_nutrienti_vent",
+      "label": "Camere Nutrienti Vent",
+      "mutation": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "selective_drive": "Coltivare ecosistemi interdipendenti resilienti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "tier": "T1",
+      "usage": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
+    },
+    "capillari_criogenici": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caldera_glaciale"
+      ],
+      "families": [
+        "Strutturale",
+        "Adattivo"
+      ],
+      "glossary_ok": true,
+      "id": "capillari_criogenici",
+      "label": "Capillari Criogenici",
+      "mutation": "compatta matrici scheletriche con fibre autoreattive.",
+      "selective_drive": "Mantenere integrità strutturale durante stress ciclici.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Risonanze errate possono generare microfratture."
+    },
+    "capillari_fluoridici": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "foresta_acida"
+      ],
+      "families": [
+        "Sensoriale",
+        "Analitico"
+      ],
+      "glossary_ok": true,
+      "id": "capillari_fluoridici",
+      "label": "Capillari Fluoridici",
+      "mutation": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "selective_drive": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T1",
+      "usage": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
+    },
+    "capillari_fotovoltaici": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "canopia_ionica"
+      ],
+      "families": [
+        "Locomotorio",
+        "Mobilità"
+      ],
+      "glossary_ok": true,
+      "id": "capillari_fotovoltaici",
+      "label": "Capillari Fotovoltaici",
+      "mutation": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "selective_drive": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "tier": "T1",
+      "usage": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede manutenzione costante delle strutture propulsive."
+    },
+    "capsule_paracadute": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "stratosfera_tempestosa"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "capsule_paracadute",
+      "label": "Capsule Paracadute",
+      "mutation": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "selective_drive": "Assorbire shock continui proteggendo unità di supporto.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "tier": "T1",
+      "usage": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
+    },
+    "carapace_fase_variabile": {
+      "completion_flags": {},
+      "conflicts": [
+        "struttura_elastica_amorfa"
+      ],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
       ],
       "energy_profile": "Alto (Richiede energia per il cambio di fase)",
       "environments": [
-        "caverna_risonante"
+        "canopia_psionica_leggera",
+        "falde_magnetiche_psioniche"
       ],
       "families": [
         "Strutturale",
         "Difensivo"
       ],
+      "glossary_ok": true,
       "id": "carapace_fase_variabile",
       "label": "Carapace a Variazione di Fase",
       "mutation": "Strutture minerali a legame reversibile o micro-strutture a rigidità controllata.",
       "selective_drive": "Alternanza tra ambienti con attacchi cinetici pesanti e ambienti che richiedono velocità.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "balor-fission",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cryo-lynx",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "golem-runico",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "nano-rust-bloom",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sand-burrower",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
+        "ali_membrana_sonica",
+        "appendici_risonanti_marea",
+        "barriere_miasma_glaciale",
+        "branchie_microfiltri",
+        "capsule_paracadute",
+        "cartilagine_flessotermica_venti",
+        "circolazione_bifasica",
+        "coda_coppia_retroattiva",
+        "cute_resistente_sali",
+        "enzimi_antipredatori_algali",
+        "filtri_planctonici",
+        "ghiandole_fango_coesivo",
+        "giunti_antitorsione",
+        "lingua_cristallina",
+        "mucose_barofile",
+        "sensori_geomagnetici",
         "armatura_pietra_planare",
         "mantello_meteoritico"
       ],
@@ -143,19 +3797,24 @@
         ],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Debolezza strutturale durante la transizione tra le fasi di durezza."
     },
-    "coda_frusta_cinetica": {
-      "conflicts": [],
+    "carapace_luminiscente_abissale": {
+      "completion_flags": {},
+      "conflicts": [
+        "carapace_fase_variabile"
+      ],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -180,25 +3839,1886 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Alto (Bioluminescenza controllata)",
+      "environments": [
+        "abisso_luminescente"
+      ],
+      "families": [
+        "Strutturale",
+        "Sensoriale"
+      ],
+      "glossary_ok": true,
+      "id": "carapace_luminiscente_abissale",
+      "label": "Carapace Luminiscente Abissale",
+      "mutation": "Placche chitino-minerali con microrganismi luminescenti che comunicano in pattern.",
+      "selective_drive": "Comunicare e mimetizzarsi nelle profondità prive di luce naturale.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-luminescente-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "antenne_plasmatiche_tempesta",
+        "risonanza_di_branco",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T3",
+      "usage": "Emette segnali di branco e devia attacchi grazie a pattern luminosi cangianti.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Luce intensa di superficie sovraccarica i biofotoni rendendo la corazza fragile."
+    },
+    "carapace_segmenti_logici": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "steppe_algoritmiche"
+      ],
+      "families": [
+        "Digestivo",
+        "Metabolico"
+      ],
+      "glossary_ok": true,
+      "id": "carapace_segmenti_logici",
+      "label": "Carapace Segmenti Logici",
+      "mutation": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "selective_drive": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "tier": "T1",
+      "usage": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
+    },
+    "carapaci_ferruginosi": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "abisso_vulcanico"
+      ],
+      "families": [
+        "Supporto",
+        "Logistico"
+      ],
+      "glossary_ok": true,
+      "id": "carapaci_ferruginosi",
+      "label": "Carapaci Ferruginosi",
+      "mutation": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "selective_drive": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
+    },
+    "cartilagine_flessotermica_venti": {
+      "completion_flags": {},
+      "conflicts": [
+        "scheletro_idro_regolante"
+      ],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Richiede frequenti riallineamenti fibrosi)",
+      "environments": [
+        "gole_ventose"
+      ],
+      "families": [
+        "Locomotorio",
+        "Adattivo"
+      ],
+      "glossary_ok": true,
+      "id": "cartilagine_flessotermica_venti",
+      "label": "Cartilagine Flessotermica dei Venti",
+      "mutation": "Giunzioni cartilaginee che cambiano rigidità in risposta a gradienti termici e eolici.",
+      "selective_drive": "Scalare falesie e planare tra correnti ascensionali turbolente.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "gole-ventose-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "artigli_sghiaccio_glaciale",
+        "carapace_fase_variabile",
+        "sacche_galleggianti_ascensoriali",
+        "zoccoli_risonanti_steppe"
+      ],
+      "tier": "T2",
+      "usage": "Modula elasticità e rigidità muscolo-scheletrica per manovre evasive rapide.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Temperature stabili riducono la reattività della cartilagine rendendo l'organismo lento."
+    },
+    "cartilagini_biofibre": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "reef_luminescente"
+      ],
+      "families": [
+        "Offensivo",
+        "Assalto"
+      ],
+      "glossary_ok": true,
+      "id": "cartilagini_biofibre",
+      "label": "Cartilagini Biofibre",
+      "mutation": "forgia condotti muscolari che accumulano energia di impatto.",
+      "selective_drive": "Garantire pressione costante sulle difese avversarie.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "tier": "T1",
+      "usage": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Rischio di sovraccarico se scaricato senza controllo."
+    },
+    "cartilagini_desertiche": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "pianura_salina_iperarida"
+      ],
+      "families": [
+        "Strategico",
+        "Tattico"
+      ],
+      "glossary_ok": true,
+      "id": "cartilagini_desertiche",
+      "label": "Cartilagini Desertiche",
+      "mutation": "espande gangli pianificatori e nodi logici distribuiti.",
+      "selective_drive": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
+    },
+    "cartilagini_flessoacustiche": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Simbiotico",
+        "Cooperativo"
+      ],
+      "glossary_ok": true,
+      "id": "cartilagini_flessoacustiche",
+      "label": "Cartilagini Flessoacustiche",
+      "mutation": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "selective_drive": "Coltivare ecosistemi interdipendenti resilienti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "tier": "T1",
+      "usage": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
+    },
+    "cartilagini_pseudometalliche": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "abisso_vulcanico"
+      ],
+      "families": [
+        "Strutturale",
+        "Adattivo"
+      ],
+      "glossary_ok": true,
+      "id": "cartilagini_pseudometalliche",
+      "label": "Cartilagini Pseudometalliche",
+      "mutation": "compatta matrici scheletriche con fibre autoreattive.",
+      "selective_drive": "Mantenere integrità strutturale durante stress ciclici.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Risonanze errate possono generare microfratture."
+    },
+    "cavita_risonanti_tundra": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Camere di risonanza statiche)",
+      "environments": [
+        "tundra_risonante"
+      ],
+      "families": [
+        "Sensoriale",
+        "Supporto"
+      ],
+      "glossary_ok": true,
+      "id": "cavita_risonanti_tundra",
+      "label": "Cavità Risonanti della Tundra",
+      "mutation": "Camere toraciche espanse che amplificano vibrazioni subsoniche nel permafrost.",
+      "selective_drive": "Coordinare branchi in lande aperte dove la visibilità è ridotta da bufere di ghiaccio.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "tundra-risonante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "criostasi_adattiva",
+        "eco_interno_riflesso",
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Amplifica segnali acustici per comunicazioni a lungo raggio nel gelo.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "In ambienti temperati l'eco interna produce rumori udibili che rivelano la posizione."
+    },
+    "cervelletto_equilibrio_statico": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "canopia_ionica"
+      ],
+      "families": [
+        "Sensoriale",
+        "Analitico"
+      ],
+      "glossary_ok": true,
+      "id": "cervelletto_equilibrio_statico",
+      "label": "Cervelletto Equilibrio Statico",
+      "mutation": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "selective_drive": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T1",
+      "usage": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
+    },
+    "chemiorecettori_bromuro": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "pianura_salina_iperarida"
+      ],
+      "families": [
+        "Locomotorio",
+        "Mobilità"
+      ],
+      "glossary_ok": true,
+      "id": "chemiorecettori_bromuro",
+      "label": "Chemiorecettori Bromuro",
+      "mutation": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "selective_drive": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "tier": "T1",
+      "usage": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede manutenzione costante delle strutture propulsive."
+    },
+    "chioma_parassita_canopica": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Nutrimento condiviso con l'ospite arboreo)",
+      "environments": [
+        "canopie_sospese"
+      ],
+      "families": [
+        "Simbiotico",
+        "Utility"
+      ],
+      "glossary_ok": true,
+      "id": "chioma_parassita_canopica",
+      "label": "Chioma Parassita Canopica",
+      "mutation": "Filamenti vegetali che si intrecciano con la canopia ospite fornendo punti d'ancoraggio e energia.",
+      "selective_drive": "Stabilizzare piattaforme mobili e reti di trasporto tra gli alberi viventi.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopie-sospese-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "bulbi_radici_permafrost",
+        "nodi_micorrizici_oracolari"
+      ],
+      "tier": "T1",
+      "usage": "Crea passaggi e nodi energetici condivisi nella canopia per movimenti rapidi.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Se la pianta ospite muore la chioma psionica collassa causando shock sistemico."
+    },
+    "circolazione_bifasica": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caldera_glaciale"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "circolazione_bifasica",
+      "label": "Circolazione Bifasica",
+      "mutation": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "selective_drive": "Assorbire shock continui proteggendo unità di supporto.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "tier": "T1",
+      "usage": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
+    },
+    "circolazione_bifasica_palude": {
+      "completion_flags": {},
+      "conflicts": [
+        "sangue_piroforico"
+      ],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Doppio circuito emolinfa/linfa)",
+      "environments": [
+        "paludi_gas_luminescenti"
+      ],
+      "families": [
+        "Metabolico",
+        "Resilienza"
+      ],
+      "glossary_ok": true,
+      "id": "circolazione_bifasica_palude",
+      "label": "Circolazione Bifasica di Palude",
+      "mutation": "Cuori gemelli che pompano separatamente emolinfa ossigenata e linfa detossificante.",
+      "selective_drive": "Resistere a tossine e anossia tipiche delle paludi psioniche.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "paludi-gas-luminescenti-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "mucillagine_simbionte_mangrovie"
+      ],
+      "tier": "T2",
+      "usage": "Gestisce due circuiti circolatori per filtrare veleni e mantenere prestazioni elevate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Zone asciutte e calde causano stagnazione del circuito linfatico portando a tossicosi."
+    },
+    "circolazione_cooling_loop": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "steppe_algoritmiche"
+      ],
+      "families": [
+        "Digestivo",
+        "Metabolico"
+      ],
+      "glossary_ok": true,
+      "id": "circolazione_cooling_loop",
+      "label": "Circolazione Cooling Loop",
+      "mutation": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "selective_drive": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "tier": "T1",
+      "usage": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
+    },
+    "circolazione_doppia": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "dorsale_termale_tropicale"
+      ],
+      "families": [
+        "Supporto",
+        "Logistico"
+      ],
+      "glossary_ok": true,
+      "id": "circolazione_doppia",
+      "label": "Circolazione Doppia",
+      "mutation": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "selective_drive": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
+    },
+    "circolazione_supercritica": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "abisso_vulcanico"
+      ],
+      "families": [
+        "Offensivo",
+        "Assalto"
+      ],
+      "glossary_ok": true,
+      "id": "circolazione_supercritica",
+      "label": "Circolazione Supercritica",
+      "mutation": "forgia condotti muscolari che accumulano energia di impatto.",
+      "selective_drive": "Garantire pressione costante sulle difese avversarie.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "tier": "T1",
+      "usage": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Rischio di sovraccarico se scaricato senza controllo."
+    },
+    "ciste_riduttive": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "laguna_bioreattiva"
+      ],
+      "families": [
+        "Strategico",
+        "Tattico"
+      ],
+      "glossary_ok": true,
+      "id": "ciste_riduttive",
+      "label": "Ciste Riduttive",
+      "mutation": "espande gangli pianificatori e nodi logici distribuiti.",
+      "selective_drive": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
+    },
+    "ciste_salmastre": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "pianura_salina_iperarida"
+      ],
+      "families": [
+        "Simbiotico",
+        "Cooperativo"
+      ],
+      "glossary_ok": true,
+      "id": "ciste_salmastre",
+      "label": "Ciste Salmastre",
+      "mutation": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "selective_drive": "Coltivare ecosistemi interdipendenti resilienti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "tier": "T1",
+      "usage": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
+    },
+    "cisti_iperbariche": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "abisso_vulcanico"
+      ],
+      "families": [
+        "Strutturale",
+        "Adattivo"
+      ],
+      "glossary_ok": true,
+      "id": "cisti_iperbariche",
+      "label": "Cisti Iperbariche",
+      "mutation": "compatta matrici scheletriche con fibre autoreattive.",
+      "selective_drive": "Mantenere integrità strutturale durante stress ciclici.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Risonanze errate possono generare microfratture."
+    },
+    "coda_balanciere": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Sensoriale",
+        "Analitico"
+      ],
+      "glossary_ok": true,
+      "id": "coda_balanciere",
+      "label": "Coda Balanciere",
+      "mutation": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "selective_drive": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T1",
+      "usage": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
+    },
+    "coda_contrappeso": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "mangrovieto_cinetico"
+      ],
+      "families": [
+        "Locomotorio",
+        "Mobilità"
+      ],
+      "glossary_ok": true,
+      "id": "coda_contrappeso",
+      "label": "Coda Contrappeso",
+      "mutation": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "selective_drive": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "tier": "T1",
+      "usage": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede manutenzione costante delle strutture propulsive."
+    },
+    "coda_coppia_retroattiva": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "steppe_algoritmiche"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "coda_coppia_retroattiva",
+      "label": "Coda Coppia Retroattiva",
+      "mutation": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "selective_drive": "Assorbire shock continui proteggendo unità di supporto.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "tier": "T1",
+      "usage": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
+    },
+    "coda_frusta_cinetica": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
       ],
       "energy_profile": "Medio (Mantenimento dell'energia accumulata)",
       "environments": [
-        "caverna_risonante"
+        "falde_magnetiche_psioniche",
+        "orbita_psionica_inversa"
       ],
       "families": [
         "Locomotorio",
         "Difensivo"
       ],
+      "glossary_ok": true,
       "id": "coda_frusta_cinetica",
       "label": "Coda a Frusta Cinetica",
       "mutation": "Muscolatura della coda densa con tendini e fibre che agiscono come molle.",
       "selective_drive": "Necessità di un attacco di \"sfondamento\" dopo movimento preparatorio.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "dune-stalker",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "magneto-ridge-hunter",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "slag-veil-ambusher",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "orbita-psionica-inversa-trait-keeper",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
-        "artigli_sette_vie"
+        "ali_ioniche",
+        "antenne_flusso_mareale",
+        "antenne_wideband",
+        "artigli_induzione",
+        "artigli_sette_vie",
+        "barbigli_sensori_plasma",
+        "biochip_memoria",
+        "branchie_metalloidi",
+        "camere_anticorrosione",
+        "capillari_fotovoltaici",
+        "cartilagini_biofibre",
+        "chemiorecettori_bromuro",
+        "circolazione_supercritica",
+        "coda_contrappeso",
+        "coda_stabilizzatrice_vortex",
+        "cuscinetti_elettrostatici",
+        "denti_chelatanti",
+        "enzimi_antifase_termica",
+        "enzimi_metanoossidanti",
+        "filamenti_termoconduzione",
+        "foliaggio_spugna",
+        "ghiandole_fango_calde",
+        "ghiandole_iodoattive",
+        "ghiandole_ventosa",
+        "gusci_magnesio",
+        "linfa_tampone",
+        "mantelli_geotermici",
+        "mucose_aderenza_sonica"
       ],
       "tier": "T1",
       "usage": "Immagazzinare energia da ogni movimento per un colpo finale potente.",
@@ -213,22 +5733,22 @@
         ],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Richiede un periodo di inattività o movimento preparatorio per massimizzare il danno."
     },
-    "criostasi_adattiva": {
-      "conflicts": [
-        "sangue_piroforico",
-        "sacche_galleggianti_ascensoriali"
-      ],
+    "coda_stabilizzatrice_filo": {
+      "completion_flags": {},
+      "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -253,24 +5773,445 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "canopia_ionica"
+      ],
+      "families": [
+        "Digestivo",
+        "Metabolico"
+      ],
+      "glossary_ok": true,
+      "id": "coda_stabilizzatrice_filo",
+      "label": "Coda Stabilizzatrice Filo",
+      "mutation": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "selective_drive": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "tier": "T1",
+      "usage": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
+    },
+    "coda_stabilizzatrice_geiser": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "dorsale_termale_tropicale"
+      ],
+      "families": [
+        "Supporto",
+        "Logistico"
+      ],
+      "glossary_ok": true,
+      "id": "coda_stabilizzatrice_geiser",
+      "label": "Coda Stabilizzatrice Geiser",
+      "mutation": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "selective_drive": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
+    },
+    "coda_stabilizzatrice_vortex": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "stratosfera_tempestosa"
+      ],
+      "families": [
+        "Offensivo",
+        "Assalto"
+      ],
+      "glossary_ok": true,
+      "id": "coda_stabilizzatrice_vortex",
+      "label": "Coda Stabilizzatrice Vortex",
+      "mutation": "forgia condotti muscolari che accumulano energia di impatto.",
+      "selective_drive": "Garantire pressione costante sulle difese avversarie.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "tier": "T1",
+      "usage": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Rischio di sovraccarico se scaricato senza controllo."
+    },
+    "colonne_vibromagnetiche": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Strategico",
+        "Tattico"
+      ],
+      "glossary_ok": true,
+      "id": "colonne_vibromagnetiche",
+      "label": "Colonne Vibromagnetiche",
+      "mutation": "espande gangli pianificatori e nodi logici distribuiti.",
+      "selective_drive": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
+    },
+    "coralli_partner": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "reef_luminescente"
+      ],
+      "families": [
+        "Simbiotico",
+        "Cooperativo"
+      ],
+      "glossary_ok": true,
+      "id": "coralli_partner",
+      "label": "Coralli Partner",
+      "mutation": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "selective_drive": "Coltivare ecosistemi interdipendenti resilienti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "tier": "T1",
+      "usage": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
+    },
+    "criostasi_adattiva": {
+      "completion_flags": {},
+      "conflicts": [
+        "sangue_piroforico",
+        "sacche_galleggianti_ascensoriali"
+      ],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
       ],
       "energy_profile": "Alto (Fase di risveglio/inizio) / Basso (Fase Criostasi).",
       "environments": [
-        "caverna_risonante"
+        "canopia_psionica_leggera",
+        "orbita_psionica_inversa"
       ],
       "families": [
         "Metabolico",
         "Difensivo"
       ],
+      "glossary_ok": true,
       "id": "criostasi_adattiva",
       "label": "Criostasi",
       "mutation": "Sviluppo di enzimi crioprotettivi e tessuto adiposo isolante.",
       "selective_drive": "Inverni prolungati o lunghi periodi di scarsità di cibo.",
-      "synergies": [],
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "aurora-gull",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "orbita-psionica-inversa-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "orbital-ascendant",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "cavita_risonanti_tundra"
+      ],
       "tier": "T1",
       "usage": "Sopravvivenza a condizioni ambientali estreme.",
       "usage_map": {
@@ -280,19 +6221,22 @@
         ],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Vulnerabilità estrema agli attacchi chimici (veleni) in fase Criostasi."
     },
-    "eco_interno_riflesso": {
+    "cromofori_alert_acido": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -317,27 +6261,997 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "foresta_acida"
+      ],
+      "families": [
+        "Strutturale",
+        "Adattivo"
+      ],
+      "glossary_ok": true,
+      "id": "cromofori_alert_acido",
+      "label": "Cromofori Alert Acido",
+      "mutation": "compatta matrici scheletriche con fibre autoreattive.",
+      "selective_drive": "Mantenere integrità strutturale durante stress ciclici.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Risonanze errate possono generare microfratture."
+    },
+    "cuore_multicamera_bassa_pressione": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "stratosfera_tempestosa"
+      ],
+      "families": [
+        "Sensoriale",
+        "Analitico"
+      ],
+      "glossary_ok": true,
+      "id": "cuore_multicamera_bassa_pressione",
+      "label": "Cuore Multicamera Bassa Pressione",
+      "mutation": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "selective_drive": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T1",
+      "usage": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
+    },
+    "cuscinetti_elettrostatici": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "pianura_salina_iperarida"
+      ],
+      "families": [
+        "Locomotorio",
+        "Mobilità"
+      ],
+      "glossary_ok": true,
+      "id": "cuscinetti_elettrostatici",
+      "label": "Cuscinetti Elettrostatici",
+      "mutation": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "selective_drive": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "tier": "T1",
+      "usage": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede manutenzione costante delle strutture propulsive."
+    },
+    "cute_resistente_sali": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Attivazione situazionale)",
+      "environments": [
+        "badlands"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "cute_resistente_sali",
+      "label": "Cute Resistente Sali",
+      "mutation": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "selective_drive": "Assorbire shock continui proteggendo unità di supporto.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "evento-tempesta-ferrosa",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "badlands-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "tier": "T2",
+      "usage": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "usage_map": {
+        "core": [
+          "evento-tempesta-ferrosa"
+        ],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
+    },
+    "cuticole_cerose": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [],
+      "families": [
+        "Digestivo",
+        "Metabolico"
+      ],
+      "glossary_ok": true,
+      "id": "cuticole_cerose",
+      "label": "Cuticole Cerose",
+      "mutation": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "selective_drive": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cactus-weaver",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-brinastorm",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-ondata-termica",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "noctule-termico",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "silica-bloom",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thermo-raptor",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "tier": "T1",
+      "usage": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "usage_map": {
+        "core": [
+          "aurora-gull",
+          "cactus-weaver",
+          "cryo-lynx",
+          "evento-brinastorm",
+          "evento-ondata-termica",
+          "noctule-termico",
+          "silica-bloom",
+          "steppe-bison-mini",
+          "thaw-rot",
+          "thermo-raptor"
+        ],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
+    },
+    "cuticole_neutralizzanti": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "foresta_acida"
+      ],
+      "families": [
+        "Supporto",
+        "Logistico"
+      ],
+      "glossary_ok": true,
+      "id": "cuticole_neutralizzanti",
+      "label": "Cuticole Neutralizzanti",
+      "mutation": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "selective_drive": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
+    },
+    "denti_chelatanti": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "foresta_acida"
+      ],
+      "families": [
+        "Offensivo",
+        "Assalto"
+      ],
+      "glossary_ok": true,
+      "id": "denti_chelatanti",
+      "label": "Denti Chelatanti",
+      "mutation": "forgia condotti muscolari che accumulano energia di impatto.",
+      "selective_drive": "Garantire pressione costante sulle difese avversarie.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "tier": "T1",
+      "usage": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Rischio di sovraccarico se scaricato senza controllo."
+    },
+    "denti_ossidoferro": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "abisso_vulcanico"
+      ],
+      "families": [
+        "Strategico",
+        "Tattico"
+      ],
+      "glossary_ok": true,
+      "id": "denti_ossidoferro",
+      "label": "Denti Ossidoferro",
+      "mutation": "espande gangli pianificatori e nodi logici distribuiti.",
+      "selective_drive": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
+    },
+    "denti_silice_termici": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "dorsale_termale_tropicale"
+      ],
+      "families": [
+        "Simbiotico",
+        "Cooperativo"
+      ],
+      "glossary_ok": true,
+      "id": "denti_silice_termici",
+      "label": "Denti Silice Termici",
+      "mutation": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "selective_drive": "Coltivare ecosistemi interdipendenti resilienti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "tier": "T1",
+      "usage": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
+    },
+    "denti_tuning_fork": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Strutturale",
+        "Adattivo"
+      ],
+      "glossary_ok": true,
+      "id": "denti_tuning_fork",
+      "label": "Denti Tuning Fork",
+      "mutation": "compatta matrici scheletriche con fibre autoreattive.",
+      "selective_drive": "Mantenere integrità strutturale durante stress ciclici.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Risonanze errate possono generare microfratture."
+    },
+    "echi_risonanti": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Sensoriale",
+        "Analitico"
+      ],
+      "glossary_ok": true,
+      "id": "echi_risonanti",
+      "label": "Echi Risonanti",
+      "mutation": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "selective_drive": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T1",
+      "usage": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
+    },
+    "eco_interno_riflesso": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
       ],
       "energy_profile": "Medio (Emissioni e ricezione continua)",
       "environments": [
-        "caverna_risonante"
+        "canopia_psionica_leggera",
+        "falde_magnetiche_psioniche"
       ],
       "families": [
         "Sensoriale",
         "Nervoso"
       ],
+      "glossary_ok": true,
       "id": "eco_interno_riflesso",
       "label": "Riflesso dell'Eco Interno",
       "mutation": "Organi interni che emettono ultrasuoni e li captano tramite lo scheletro.",
       "selective_drive": "Orientamento in ambienti completamente privi di luce.",
-      "synergies": [
-        "olfatto_risonanza_magnetica"
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "echo-wing",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "aurora-bridge-runner",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "aurora-gull",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "orbital-ascendant",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "zephyr-spore-courier",
+          "weight": 1.0
+        }
       ],
-      "tier": "T1",
+      "synergies": [
+        "cavita_risonanti_tundra",
+        "olfatto_risonanza_magnetica",
+        "sensori_geomagnetici"
+      ],
+      "tier": "T2",
       "usage": "Utilizzo di onde sonore emesse internamente per mappare l'ambiente.",
       "usage_map": {
         "core": [
@@ -348,19 +7262,22 @@
         "optional": [],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Estremamente disorientato da suoni o vibrazioni esterne forti e continue."
     },
     "empatia_coordinativa": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -385,7 +7302,6 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
-        "data/traits/index.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -396,11 +7312,84 @@
         "Supporto",
         "Empatico"
       ],
+      "glossary_ok": true,
       "id": "empatia_coordinativa",
       "label": "Empatia Coordinativa",
       "mutation": "Circuiti sensorio-emotivi collegati al feed HUD PI.",
       "selective_drive": "Turni lunghi con rischio alto in cui serve mitigare tilt e HP critici.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "archon-solare",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "balor-fission",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "glowcap-weaver",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "lupus-temperatus",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "myco-spire-warden",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
+        "antenne_eco_turbina",
+        "artigli_acidofagi",
+        "batteri_termofili_endosimbiosi",
+        "branchie_turbina",
+        "carapaci_ferruginosi",
+        "cavita_risonanti_tundra",
+        "circolazione_doppia",
+        "coda_stabilizzatrice_geiser",
+        "cuticole_neutralizzanti",
+        "enzimi_chelatori_rapidi",
+        "foliage_fotocatodico",
+        "ghiandole_inchiostro_luce",
+        "gusci_criovetro",
+        "luminescenza_hydrotermica",
         "aura_scudo_radianza"
       ],
       "tier": "T1",
@@ -416,19 +7405,22 @@
           "zephyr-spore-courier"
         ]
       },
+      "usage_tags": [],
       "weakness": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende."
     },
-    "filamenti_digestivi_compattanti": {
+    "enzimi_antifase_termica": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -453,27 +7445,649 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
-        "data/traits/index.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
       ],
       "energy_profile": "Basso (Passivo)",
       "environments": [
-        "caverna_risonante"
+        "caldera_glaciale"
+      ],
+      "families": [
+        "Locomotorio",
+        "Mobilità"
+      ],
+      "glossary_ok": true,
+      "id": "enzimi_antifase_termica",
+      "label": "Enzimi Antifase Termica",
+      "mutation": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "selective_drive": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "tier": "T1",
+      "usage": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede manutenzione costante delle strutture propulsive."
+    },
+    "enzimi_antipredatori_algali": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "reef_luminescente"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "enzimi_antipredatori_algali",
+      "label": "Enzimi Antipredatori Algali",
+      "mutation": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "selective_drive": "Assorbire shock continui proteggendo unità di supporto.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "tier": "T1",
+      "usage": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
+    },
+    "enzimi_chelanti": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [],
+      "families": [
+        "Digestivo",
+        "Metabolico"
+      ],
+      "glossary_ok": true,
+      "id": "enzimi_chelanti",
+      "label": "Enzimi Chelanti",
+      "mutation": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "selective_drive": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "evento-tempesta-ferrosa",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "tier": "T1",
+      "usage": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "usage_map": {
+        "core": [
+          "evento-tempesta-ferrosa"
+        ],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
+    },
+    "enzimi_chelatori_rapidi": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "foresta_acida"
+      ],
+      "families": [
+        "Supporto",
+        "Logistico"
+      ],
+      "glossary_ok": true,
+      "id": "enzimi_chelatori_rapidi",
+      "label": "Enzimi Chelatori Rapidi",
+      "mutation": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "selective_drive": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
+    },
+    "enzimi_metanoossidanti": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "abisso_vulcanico"
+      ],
+      "families": [
+        "Offensivo",
+        "Assalto"
+      ],
+      "glossary_ok": true,
+      "id": "enzimi_metanoossidanti",
+      "label": "Enzimi Metanoossidanti",
+      "mutation": "forgia condotti muscolari che accumulano energia di impatto.",
+      "selective_drive": "Garantire pressione costante sulle difese avversarie.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "tier": "T1",
+      "usage": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Rischio di sovraccarico se scaricato senza controllo."
+    },
+    "epidermide_dielettrica": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "stratosfera_tempestosa"
+      ],
+      "families": [
+        "Strategico",
+        "Tattico"
+      ],
+      "glossary_ok": true,
+      "id": "epidermide_dielettrica",
+      "label": "Epidermide Dielettrica",
+      "mutation": "espande gangli pianificatori e nodi logici distribuiti.",
+      "selective_drive": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
+    },
+    "epitelio_fosforescente": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "reef_luminescente"
+      ],
+      "families": [
+        "Simbiotico",
+        "Cooperativo"
+      ],
+      "glossary_ok": true,
+      "id": "epitelio_fosforescente",
+      "label": "Epitelio Fosforescente",
+      "mutation": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "selective_drive": "Coltivare ecosistemi interdipendenti resilienti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "tier": "T1",
+      "usage": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
+    },
+    "filamenti_digestivi_compattanti": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante",
+        "falde_magnetiche_psioniche"
       ],
       "families": [
         "Digestivo",
         "Escretorio"
       ],
+      "glossary_ok": true,
       "id": "filamenti_digestivi_compattanti",
       "label": "Filamento materiali digeriti",
       "mutation": "Muscolatura rettale ipertrofica e organo appendice dedicato.",
       "selective_drive": "Necessità di mantenere la pulizia del territorio/nido.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "magnet-fathom-surveyor",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "nano-rust-bloom",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "rust-scavenger",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "glowcap-weaver",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "myco-spire-warden",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thaw-rot",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
+        "antenne_dustsense",
+        "appendici_thermotattiche",
+        "batteri_endosimbionti_chemio",
+        "branchie_solfatiche",
+        "carapace_segmenti_logici",
+        "circolazione_cooling_loop",
+        "coda_stabilizzatrice_filo",
+        "cuticole_cerose",
+        "enzimi_chelanti",
+        "flagelli_ancoranti",
+        "ghiandole_grafene",
+        "grassi_termici",
+        "luminescenza_aurorale",
         "ventriglio_gastroliti"
       ],
-      "tier": "T1",
+      "tier": "T2",
       "usage": "Espulsione compatta e ordinata di scorie.",
       "usage_map": {
         "core": [
@@ -485,19 +8099,22 @@
         "optional": [],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Blocco intestinale se la dieta è priva di materiale 'legante'."
     },
-    "focus_frazionato": {
+    "filamenti_magnetotrofi": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -522,7 +8139,391 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "abisso_vulcanico"
+      ],
+      "families": [
+        "Strutturale",
+        "Adattivo"
+      ],
+      "glossary_ok": true,
+      "id": "filamenti_magnetotrofi",
+      "label": "Filamenti Magnetotrofi",
+      "mutation": "compatta matrici scheletriche con fibre autoreattive.",
+      "selective_drive": "Mantenere integrità strutturale durante stress ciclici.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Risonanze errate possono generare microfratture."
+    },
+    "filamenti_superconduttivi": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caldera_glaciale"
+      ],
+      "families": [
+        "Sensoriale",
+        "Analitico"
+      ],
+      "glossary_ok": true,
+      "id": "filamenti_superconduttivi",
+      "label": "Filamenti Superconduttivi",
+      "mutation": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "selective_drive": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T1",
+      "usage": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
+    },
+    "filamenti_termoconduzione": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "dorsale_termale_tropicale"
+      ],
+      "families": [
+        "Locomotorio",
+        "Mobilità"
+      ],
+      "glossary_ok": true,
+      "id": "filamenti_termoconduzione",
+      "label": "Filamenti Termoconduzione",
+      "mutation": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "selective_drive": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "tier": "T1",
+      "usage": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede manutenzione costante delle strutture propulsive."
+    },
+    "filtri_planctonici": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "laguna_bioreattiva"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "filtri_planctonici",
+      "label": "Filtri Planctonici",
+      "mutation": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "selective_drive": "Assorbire shock continui proteggendo unità di supporto.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "tier": "T1",
+      "usage": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
+    },
+    "flagelli_ancoranti": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "laguna_bioreattiva"
+      ],
+      "families": [
+        "Digestivo",
+        "Metabolico"
+      ],
+      "glossary_ok": true,
+      "id": "flagelli_ancoranti",
+      "label": "Flagelli Ancoranti",
+      "mutation": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "selective_drive": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "tier": "T1",
+      "usage": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
+    },
+    "focus_frazionato": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -530,14 +8531,90 @@
       "energy_profile": "Medio (Dividere l'attenzione su più canali)",
       "environments": [],
       "families": [
-        "Tattico",
-        "Controllo"
+        "Strategico",
+        "Psionico"
       ],
+      "glossary_ok": true,
       "id": "focus_frazionato",
       "label": "Focus Frazionato",
       "mutation": "Processore di priorità multi-thread per bersagli e obiettivi.",
       "selective_drive": "Comunicazioni piatte dove occorre coprire minacce su più fronti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "orbital-ascendant",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 3.0
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "archon-solare",
+          "weight": 2.0
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "balor-fission",
+          "weight": 2.0
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 2.0
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 2.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sentinella-radice",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
+        "ali_fulminee",
+        "antenne_plasmatiche_tempesta",
+        "antenne_waveguide",
+        "baffi_mareomotori",
+        "branchie_eoliche",
+        "capillari_fluoridici",
+        "cervelletto_equilibrio_statico",
+        "coda_balanciere",
+        "cuore_multicamera_bassa_pressione",
+        "echi_risonanti",
+        "filamenti_superconduttivi",
+        "ghiandole_eco_mappanti",
+        "ghiandole_resina_conduttiva",
+        "lamine_scudo_silice",
+        "midollo_antivibrazione",
         "frusta_fiammeggiante"
       ],
       "tier": "T1",
@@ -552,19 +8629,22 @@
           "dune_stalker"
         ]
       },
+      "usage_tags": [],
       "weakness": "Rischio di overload mentale se tilt e aggro salgono oltre le soglie HUD."
     },
-    "ghiandola_caustica": {
+    "foliage_fotocatodico": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -589,7 +8669,324 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "foresta_acida"
+      ],
+      "families": [
+        "Supporto",
+        "Logistico"
+      ],
+      "glossary_ok": true,
+      "id": "foliage_fotocatodico",
+      "label": "Foliage Fotocatodico",
+      "mutation": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "selective_drive": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
+    },
+    "foliaggio_spugna": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "mangrovieto_cinetico"
+      ],
+      "families": [
+        "Offensivo",
+        "Assalto"
+      ],
+      "glossary_ok": true,
+      "id": "foliaggio_spugna",
+      "label": "Foliaggio Spugna",
+      "mutation": "forgia condotti muscolari che accumulano energia di impatto.",
+      "selective_drive": "Garantire pressione costante sulle difese avversarie.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "tier": "T1",
+      "usage": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Rischio di sovraccarico se scaricato senza controllo."
+    },
+    "frusta_fiammeggiante": {
+      "completion_flags": {},
+      "conflicts": [
+        "armatura_pietra_planare"
+      ],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Filamenti di plasma vincolato)",
+      "environments": [
+        "rovine_planari"
+      ],
+      "families": [
+        "Offensivo",
+        "Controllo"
+      ],
+      "glossary_ok": true,
+      "id": "frusta_fiammeggiante",
+      "label": "Frusta Fiammeggiante",
+      "mutation": "Genera appendici tentacolari avvolte da plasma infernale controllato.",
+      "selective_drive": "Creare distanza di sicurezza contro predatori d'élite nelle zone instabili.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "balor-fission",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 3.0
+        }
+      ],
+      "synergies": [
+        "focus_frazionato",
+        "mantello_meteoritico"
+      ],
+      "tier": "T2",
+      "usage": "Afferra e disarma avversari o sigilla varchi planari con tagli di energia.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Consumante: richiede costante dissipazione termica per non bruciare la matrice portante."
+    },
+    "ghiaccio_piezoelettrico": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caldera_glaciale"
+      ],
+      "families": [
+        "Strategico",
+        "Tattico"
+      ],
+      "glossary_ok": true,
+      "id": "ghiaccio_piezoelettrico",
+      "label": "Ghiaccio Piezoelettrico",
+      "mutation": "espande gangli pianificatori e nodi logici distribuiti.",
+      "selective_drive": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
+    },
+    "ghiandola_caustica": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -600,10 +8997,27 @@
         "Offensivo",
         "Chimico"
       ],
+      "glossary_ok": true,
       "id": "ghiandola_caustica",
       "label": "Ghiandola Caustica",
       "mutation": "Sintesi rapida di composti caustici nei moduli d'attacco.",
       "selective_drive": "Squadre che devono rispondere a guardie situazionali al turno 1-2.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "blight-micotico",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "slag-veil-ambusher",
+          "weight": 1.0
+        }
+      ],
       "synergies": [],
       "tier": "T1",
       "usage": "Sblocco early di danni da acido per rompere armature leggere.",
@@ -614,19 +9028,22 @@
         ],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Gestione accurata delle riserve per non calare sotto i budget PE previsto."
     },
-    "lingua_tattile_trama": {
+    "ghiandole_cambio_salino": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -651,7 +9068,1936 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "laguna_bioreattiva"
+      ],
+      "families": [
+        "Simbiotico",
+        "Cooperativo"
+      ],
+      "glossary_ok": true,
+      "id": "ghiandole_cambio_salino",
+      "label": "Ghiandole Cambio Salino",
+      "mutation": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "selective_drive": "Coltivare ecosistemi interdipendenti resilienti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "tier": "T1",
+      "usage": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
+    },
+    "ghiandole_condensa_ozono": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "stratosfera_tempestosa"
+      ],
+      "families": [
+        "Strutturale",
+        "Adattivo"
+      ],
+      "glossary_ok": true,
+      "id": "ghiandole_condensa_ozono",
+      "label": "Ghiandole Condensa Ozono",
+      "mutation": "compatta matrici scheletriche con fibre autoreattive.",
+      "selective_drive": "Mantenere integrità strutturale durante stress ciclici.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Risonanze errate possono generare microfratture."
+    },
+    "ghiandole_eco_mappanti": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Sensoriale",
+        "Analitico"
+      ],
+      "glossary_ok": true,
+      "id": "ghiandole_eco_mappanti",
+      "label": "Ghiandole Eco Mappanti",
+      "mutation": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "selective_drive": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T1",
+      "usage": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
+    },
+    "ghiandole_fango_calde": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "abisso_vulcanico"
+      ],
+      "families": [
+        "Locomotorio",
+        "Mobilità"
+      ],
+      "glossary_ok": true,
+      "id": "ghiandole_fango_calde",
+      "label": "Ghiandole Fango Calde",
+      "mutation": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "selective_drive": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "tier": "T1",
+      "usage": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede manutenzione costante delle strutture propulsive."
+    },
+    "ghiandole_fango_coesivo": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "mangrovieto_cinetico"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "ghiandole_fango_coesivo",
+      "label": "Ghiandole Fango Coesivo",
+      "mutation": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "selective_drive": "Assorbire shock continui proteggendo unità di supporto.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "tier": "T1",
+      "usage": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
+    },
+    "ghiandole_grafene": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "steppe_algoritmiche"
+      ],
+      "families": [
+        "Digestivo",
+        "Metabolico"
+      ],
+      "glossary_ok": true,
+      "id": "ghiandole_grafene",
+      "label": "Ghiandole Grafene",
+      "mutation": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "selective_drive": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "tier": "T1",
+      "usage": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
+    },
+    "ghiandole_inchiostro_luce": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "reef_luminescente"
+      ],
+      "families": [
+        "Supporto",
+        "Logistico"
+      ],
+      "glossary_ok": true,
+      "id": "ghiandole_inchiostro_luce",
+      "label": "Ghiandole Inchiostro Luce",
+      "mutation": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "selective_drive": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reef-luminescente-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
+    },
+    "ghiandole_iodoattive": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "pianura_salina_iperarida"
+      ],
+      "families": [
+        "Offensivo",
+        "Assalto"
+      ],
+      "glossary_ok": true,
+      "id": "ghiandole_iodoattive",
+      "label": "Ghiandole Iodoattive",
+      "mutation": "forgia condotti muscolari che accumulano energia di impatto.",
+      "selective_drive": "Garantire pressione costante sulle difese avversarie.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "tier": "T1",
+      "usage": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Rischio di sovraccarico se scaricato senza controllo."
+    },
+    "ghiandole_minerali": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "dorsale_termale_tropicale"
+      ],
+      "families": [
+        "Strategico",
+        "Tattico"
+      ],
+      "glossary_ok": true,
+      "id": "ghiandole_minerali",
+      "label": "Ghiandole Minerali",
+      "mutation": "espande gangli pianificatori e nodi logici distribuiti.",
+      "selective_drive": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
+    },
+    "ghiandole_nebbia_acida": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "foresta_acida"
+      ],
+      "families": [
+        "Simbiotico",
+        "Cooperativo"
+      ],
+      "glossary_ok": true,
+      "id": "ghiandole_nebbia_acida",
+      "label": "Ghiandole Nebbia Acida",
+      "mutation": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "selective_drive": "Coltivare ecosistemi interdipendenti resilienti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "tier": "T1",
+      "usage": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
+    },
+    "ghiandole_nebbia_ionica": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "canopia_ionica"
+      ],
+      "families": [
+        "Strutturale",
+        "Adattivo"
+      ],
+      "glossary_ok": true,
+      "id": "ghiandole_nebbia_ionica",
+      "label": "Ghiandole Nebbia Ionica",
+      "mutation": "compatta matrici scheletriche con fibre autoreattive.",
+      "selective_drive": "Mantenere integrità strutturale durante stress ciclici.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Risonanze errate possono generare microfratture."
+    },
+    "ghiandole_resina_conduttiva": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "canopia_ionica"
+      ],
+      "families": [
+        "Sensoriale",
+        "Analitico"
+      ],
+      "glossary_ok": true,
+      "id": "ghiandole_resina_conduttiva",
+      "label": "Ghiandole Resina Conduttiva",
+      "mutation": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "selective_drive": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T1",
+      "usage": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
+    },
+    "ghiandole_ventosa": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caldera_glaciale"
+      ],
+      "families": [
+        "Locomotorio",
+        "Mobilità"
+      ],
+      "glossary_ok": true,
+      "id": "ghiandole_ventosa",
+      "label": "Ghiandole Ventosa",
+      "mutation": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "selective_drive": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "tier": "T1",
+      "usage": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede manutenzione costante delle strutture propulsive."
+    },
+    "giunti_antitorsione": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "mangrovieto_cinetico"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "giunti_antitorsione",
+      "label": "Giunti Antitorsione",
+      "mutation": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "selective_drive": "Assorbire shock continui proteggendo unità di supporto.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "tier": "T1",
+      "usage": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
+    },
+    "grassi_termici": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [],
+      "families": [
+        "Digestivo",
+        "Metabolico"
+      ],
+      "glossary_ok": true,
+      "id": "grassi_termici",
+      "label": "Grassi Termici",
+      "mutation": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "selective_drive": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cactus-weaver",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-brinastorm",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-ondata-termica",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "noctule-termico",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "silica-bloom",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thermo-raptor",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "tier": "T1",
+      "usage": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "usage_map": {
+        "core": [
+          "aurora-gull",
+          "cactus-weaver",
+          "cryo-lynx",
+          "evento-brinastorm",
+          "evento-ondata-termica",
+          "noctule-termico",
+          "silica-bloom",
+          "steppe-bison-mini",
+          "thaw-rot",
+          "thermo-raptor"
+        ],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
+    },
+    "gusci_criovetro": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caldera_glaciale"
+      ],
+      "families": [
+        "Supporto",
+        "Logistico"
+      ],
+      "glossary_ok": true,
+      "id": "gusci_criovetro",
+      "label": "Gusci Criovetro",
+      "mutation": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "selective_drive": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
+    },
+    "gusci_magnesio": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "dorsale_termale_tropicale"
+      ],
+      "families": [
+        "Offensivo",
+        "Assalto"
+      ],
+      "glossary_ok": true,
+      "id": "gusci_magnesio",
+      "label": "Gusci Magnesio",
+      "mutation": "forgia condotti muscolari che accumulano energia di impatto.",
+      "selective_drive": "Garantire pressione costante sulle difese avversarie.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "tier": "T1",
+      "usage": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Rischio di sovraccarico se scaricato senza controllo."
+    },
+    "lamelle_shear": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "stratosfera_tempestosa"
+      ],
+      "families": [
+        "Strategico",
+        "Tattico"
+      ],
+      "glossary_ok": true,
+      "id": "lamelle_shear",
+      "label": "Lamelle Shear",
+      "mutation": "espande gangli pianificatori e nodi logici distribuiti.",
+      "selective_drive": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
+    },
+    "lamelle_sincroniche": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "steppe_algoritmiche"
+      ],
+      "families": [
+        "Simbiotico",
+        "Cooperativo"
+      ],
+      "glossary_ok": true,
+      "id": "lamelle_sincroniche",
+      "label": "Lamelle Sincroniche",
+      "mutation": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "selective_drive": "Coltivare ecosistemi interdipendenti resilienti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "tier": "T1",
+      "usage": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
+    },
+    "lamelle_termoforetiche": {
+      "completion_flags": {},
+      "conflicts": [
+        "criostasi_adattiva"
+      ],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Flusso continuo di fluidi caldi)",
+      "environments": [
+        "sorgenti_geotermiche"
+      ],
+      "families": [
+        "Respiratorio",
+        "Termoregolazione"
+      ],
+      "glossary_ok": true,
+      "id": "lamelle_termoforetiche",
+      "label": "Lamelle Termoforetiche",
+      "mutation": "Canali lamellari mineralizzati che convogliano fluidi caldi tra branchie interne.",
+      "selective_drive": "Sopravvivere a fluidi tossici e temperature estreme nelle fumarole geotermiche.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "magnet-fathom-surveyor",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sorgenti-geotermiche-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "sangue_piroforico"
+      ],
+      "tier": "T2",
+      "usage": "Regola lo scambio gassoso sfruttando gradienti termici controllati.",
+      "usage_map": {
+        "core": [],
+        "optional": [
+          "dune_stalker"
+        ],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Rende instabile la fisiologia in ambienti a gelo improvviso, con rischio di microfratture vascolari."
+    },
+    "lamine_filtranti_aeree": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "mangrovieto_cinetico"
+      ],
+      "families": [
+        "Strutturale",
+        "Adattivo"
+      ],
+      "glossary_ok": true,
+      "id": "lamine_filtranti_aeree",
+      "label": "Lamine Filtranti Aeree",
+      "mutation": "compatta matrici scheletriche con fibre autoreattive.",
+      "selective_drive": "Mantenere integrità strutturale durante stress ciclici.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Risonanze errate possono generare microfratture."
+    },
+    "lamine_scudo_silice": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "dorsale_termale_tropicale"
+      ],
+      "families": [
+        "Sensoriale",
+        "Analitico"
+      ],
+      "glossary_ok": true,
+      "id": "lamine_scudo_silice",
+      "label": "Lamine Scudo Silice",
+      "mutation": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "selective_drive": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T1",
+      "usage": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
+    },
+    "linfa_tampone": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "foresta_acida"
+      ],
+      "families": [
+        "Locomotorio",
+        "Mobilità"
+      ],
+      "glossary_ok": true,
+      "id": "linfa_tampone",
+      "label": "Linfa Tampone",
+      "mutation": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "selective_drive": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foresta-acida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "tier": "T1",
+      "usage": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede manutenzione costante delle strutture propulsive."
+    },
+    "lingua_cristallina": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "pianura_salina_iperarida"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "lingua_cristallina",
+      "label": "Lingua Cristallina",
+      "mutation": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "selective_drive": "Assorbire shock continui proteggendo unità di supporto.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "tier": "T1",
+      "usage": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
+    },
+    "lingua_tattile_trama": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -664,10 +11010,41 @@
         "Sensoriale",
         "Alimentare"
       ],
+      "glossary_ok": true,
       "id": "lingua_tattile_trama",
       "label": "Lingua Tattile Trama-Sensibile",
       "mutation": "Lingua sottile con papille tattili e meccanocettori avanzati.",
       "selective_drive": "Individuare movimenti sismici o cibi sepolti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "blight-micotico",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "echo-wing",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "ferrocolonia-magnetotattica",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
         "olfatto_risonanza_magnetica"
       ],
@@ -684,19 +11061,22 @@
         ],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Estrema vulnerabilità della lingua a contaminanti chimici o acidi."
     },
-    "mimetismo_cromatico_passivo": {
+    "luminescenza_aurorale": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -721,24 +11101,789 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caldera_glaciale"
+      ],
+      "families": [
+        "Digestivo",
+        "Metabolico"
+      ],
+      "glossary_ok": true,
+      "id": "luminescenza_aurorale",
+      "label": "Luminescenza Aurorale",
+      "mutation": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "selective_drive": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "tier": "T1",
+      "usage": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
+    },
+    "luminescenza_hydrotermica": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "abisso_vulcanico"
+      ],
+      "families": [
+        "Supporto",
+        "Logistico"
+      ],
+      "glossary_ok": true,
+      "id": "luminescenza_hydrotermica",
+      "label": "Luminescenza Hydrotermica",
+      "mutation": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "selective_drive": "Aumentare la resilienza coordinativa durante campagne prolungate.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
+    },
+    "mantelli_geotermici": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caldera_glaciale"
+      ],
+      "families": [
+        "Offensivo",
+        "Assalto"
+      ],
+      "glossary_ok": true,
+      "id": "mantelli_geotermici",
+      "label": "Mantelli Geotermici",
+      "mutation": "forgia condotti muscolari che accumulano energia di impatto.",
+      "selective_drive": "Garantire pressione costante sulle difese avversarie.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caldera-glaciale-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "tier": "T1",
+      "usage": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Rischio di sovraccarico se scaricato senza controllo."
+    },
+    "mantello_meteoritico": {
+      "completion_flags": {},
+      "conflicts": [
+        "aura_scudo_radianza"
+      ],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Alto (Rivestimento ablativo rigenerante)",
+      "environments": [
+        "rovine_planari"
+      ],
+      "families": [
+        "Difesa",
+        "Termoregolazione"
+      ],
+      "glossary_ok": true,
+      "id": "mantello_meteoritico",
+      "label": "Mantello Meteoritico",
+      "mutation": "Deposita strati sovrapposti di materiale meteorico che vaporizzano l'impatto e rilasciano radianza.",
+      "selective_drive": "Sopravvivere a bombardamenti planari e piogge di meteore dimensionali.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "balor-fission",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 3.0
+        }
+      ],
+      "synergies": [
+        "frusta_fiammeggiante",
+        "carapace_fase_variabile"
+      ],
+      "tier": "T3",
+      "usage": "Assorbe colpi energetici estremi e converte il surplus in impulsi offensivi.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Vulnerabile a scariche di freddo gravitazionale che irrigidiscono il mantello."
+    },
+    "membrane_captura_rugiada": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "pianura_salina_iperarida"
+      ],
+      "families": [
+        "Strategico",
+        "Tattico"
+      ],
+      "glossary_ok": true,
+      "id": "membrane_captura_rugiada",
+      "label": "Membrane Captura Rugiada",
+      "mutation": "espande gangli pianificatori e nodi logici distribuiti.",
+      "selective_drive": "Allineare tattiche di lungo termine con segnali ambientali.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "tier": "T1",
+      "usage": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
+    },
+    "membrane_eliofiltranti": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Auto-riparazione lenta)",
+      "environments": [
+        "laghi_alcalini"
+      ],
+      "families": [
+        "Respiratorio",
+        "Protezione"
+      ],
+      "glossary_ok": true,
+      "id": "membrane_eliofiltranti",
+      "label": "Membrane Eliofiltranti",
+      "mutation": "Strati di mucopolisaccaridi trasparenti che filtrano radiazioni e microrganismi sospesi.",
+      "selective_drive": "Proteggersi da radiazioni e agenti patogeni in altopiani ipersalini.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "laghi-alcalini-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "piume_solari_fotovoltaiche",
+        "polmoni_cristallini_alta_quota"
+      ],
+      "tier": "T2",
+      "usage": "Filtra l'aria e i flussi luminosi rendendoli sicuri per tessuti delicati.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Atmosfere acide degradano rapidamente il film eliofiltrante."
+    },
+    "membrane_planata_vectored": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "canopia_ionica"
+      ],
+      "families": [
+        "Simbiotico",
+        "Cooperativo"
+      ],
+      "glossary_ok": true,
+      "id": "membrane_planata_vectored",
+      "label": "Membrane Planata Vectored",
+      "mutation": "integra organi ponte che mediano scambi nutrizionali e psionici.",
+      "selective_drive": "Coltivare ecosistemi interdipendenti resilienti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "tier": "T1",
+      "usage": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
+    },
+    "membrane_pneumatofori": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "mangrovieto_cinetico"
+      ],
+      "families": [
+        "Strutturale",
+        "Adattivo"
+      ],
+      "glossary_ok": true,
+      "id": "membrane_pneumatofori",
+      "label": "Membrane Pneumatofori",
+      "mutation": "compatta matrici scheletriche con fibre autoreattive.",
+      "selective_drive": "Mantenere integrità strutturale durante stress ciclici.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "tier": "T1",
+      "usage": "Regola densità e flessibilità per sopportare cambi repentini.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Risonanze errate possono generare microfratture."
+    },
+    "midollo_antivibrazione": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Sensoriale",
+        "Analitico"
+      ],
+      "glossary_ok": true,
+      "id": "midollo_antivibrazione",
+      "label": "Midollo Antivibrazione",
+      "mutation": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "selective_drive": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "tier": "T1",
+      "usage": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
+    },
+    "mimetismo_cromatico_passivo": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
       ],
       "energy_profile": "Basso (Fase passiva)",
       "environments": [
-        "caverna_risonante"
+        "canopia_psionica_leggera",
+        "falde_magnetiche_psioniche"
       ],
       "families": [
         "Tegumentario",
         "Difensivo"
       ],
+      "glossary_ok": true,
       "id": "mimetismo_cromatico_passivo",
       "label": "Ghiandole di Mimetismo Cromatico Passivo",
       "mutation": "Cromatofori che richiedono un input tattile prolungato per la ricarica.",
       "selective_drive": "Ambiente con pattern cromatici molto variabili che cambiano lentamente.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "ferrocolonia-magnetotattica",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "aurora-bridge-runner",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "zephyr-spore-courier",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
+        "ali_membrana_sonica",
+        "appendici_risonanti_marea",
+        "artigli_sette_vie",
+        "barriere_miasma_glaciale",
+        "branchie_microfiltri",
+        "capsule_paracadute",
+        "circolazione_bifasica",
+        "coda_coppia_retroattiva",
+        "cute_resistente_sali",
+        "enzimi_antipredatori_algali",
+        "filtri_planctonici",
+        "ghiandole_fango_coesivo",
+        "giunti_antitorsione",
+        "lingua_cristallina",
+        "mucose_barofile",
         "struttura_elastica_amorfa"
       ],
       "tier": "T1",
@@ -752,21 +11897,24 @@
         "optional": [],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "La colorazione è fissa finché non c'è un nuovo contatto prolungato."
     },
-    "nucleo_ovomotore_rotante": {
+    "mucillagine_simbionte_mangrovie": {
+      "completion_flags": {},
       "conflicts": [
-        "secrezione_rallentante_palmi"
+        "ghiandola_caustica"
       ],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -791,7 +11939,346 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Coltura simbiotica costante)",
+      "environments": [
+        "mangrovie_risonanti"
+      ],
+      "families": [
+        "Simbiotico",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "mucillagine_simbionte_mangrovie",
+      "label": "Mucillagine Simbionte delle Mangrovie",
+      "mutation": "Strati mucosi che ospitano microfauna detossificante proveniente dalle radici di mangrovia.",
+      "selective_drive": "Respinge tossine e predatori microbici tipici dei delta paludosi.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "mangrovie-risonanti-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "antenne_reagenti",
+        "artigli_scivolo_silente",
+        "biofilm_iperarido",
+        "branchie_osmotiche_salmastra",
+        "camere_nutrienti_vent",
+        "cartilagini_flessoacustiche",
+        "circolazione_bifasica_palude",
+        "ciste_salmastre",
+        "coralli_partner",
+        "denti_silice_termici",
+        "epitelio_fosforescente",
+        "ghiandole_cambio_salino",
+        "ghiandole_nebbia_acida",
+        "lamelle_sincroniche",
+        "membrane_planata_vectored",
+        "nodi_micorrizici_oracolari"
+      ],
+      "tier": "T1",
+      "usage": "Forma una barriera viva che neutralizza veleni e sigilla ferite.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Acque eccessivamente pure diluiscono la mucillagine riducendo la protezione."
+    },
+    "mucose_aderenza_sonica": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "caverna_risonante"
+      ],
+      "families": [
+        "Locomotorio",
+        "Mobilità"
+      ],
+      "glossary_ok": true,
+      "id": "mucose_aderenza_sonica",
+      "label": "Mucose Aderenza Sonica",
+      "mutation": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "selective_drive": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "tier": "T1",
+      "usage": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Richiede manutenzione costante delle strutture propulsive."
+    },
+    "mucose_barofile": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Passivo)",
+      "environments": [
+        "abisso_vulcanico"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "mucose_barofile",
+      "label": "Mucose Barofile",
+      "mutation": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "selective_drive": "Assorbire shock continui proteggendo unità di supporto.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "tier": "T1",
+      "usage": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
+    },
+    "nodi_micorrizici_oracolari": {
+      "completion_flags": {},
+      "conflicts": [
+        "spore_psichiche_silenziate"
+      ],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Scambio continuo di segnali con simbionti)",
+      "environments": [
+        "reti_micorriziche"
+      ],
+      "families": [
+        "Simbiotico",
+        "Nervoso"
+      ],
+      "glossary_ok": true,
+      "id": "nodi_micorrizici_oracolari",
+      "label": "Nodi Micorrizici Oracolari",
+      "mutation": "Radici dermiche che intrecciano funghi psionici capaci di predire variazioni ambientali.",
+      "selective_drive": "Anticipare frane psioniche e predatori guidati da reti vegetali senzienti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "reti-micorriziche-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "antenne_reagenti",
+        "artigli_scivolo_silente",
+        "biofilm_iperarido",
+        "bulbi_radici_permafrost",
+        "camere_nutrienti_vent",
+        "cartilagini_flessoacustiche",
+        "chioma_parassita_canopica",
+        "ciste_salmastre",
+        "coralli_partner",
+        "denti_silice_termici",
+        "epitelio_fosforescente",
+        "ghiandole_cambio_salino",
+        "ghiandole_nebbia_acida",
+        "lamelle_sincroniche",
+        "membrane_planata_vectored",
+        "mucillagine_simbionte_mangrovie"
+      ],
+      "tier": "T3",
+      "usage": "Riceve presagi e segnali tattici dalla rete fungina per coordinare manovre di squadra.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Se la rete micorrizica viene recisa, l'organismo soffre crisi percettive e perdita di orientamento."
+    },
+    "nucleo_ovomotore_rotante": {
+      "completion_flags": {},
+      "conflicts": [
+        "secrezione_rallentante_palmi"
+      ],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -804,10 +12291,51 @@
         "Riproduttivo",
         "Locomotorio"
       ],
+      "glossary_ok": true,
       "id": "nucleo_ovomotore_rotante",
       "label": "Uovo rotaia, uovo grande e uova piccole dentro...",
       "mutation": "Massa globulare rigida con giunto sferico al centro del petto.",
       "selective_drive": "Necessità di spostarsi rapidamente su terreni uniformi in assenza di arti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "magnet-fathom-surveyor",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "orbital-ascendant",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "sand-burrower",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "rust-scavenger",
+          "weight": 1.0
+        }
+      ],
       "synergies": [],
       "tier": "T1",
       "usage": "Organo Motorio Rotante: usato come 'ruota' centrale per il rotolamento.",
@@ -820,19 +12348,22 @@
         ],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Impossibilità di muoversi su superfici irregolari o in salita ripida."
     },
     "occhi_infrarosso_composti": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -857,7 +12388,6 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
-        "data/traits/index.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -870,10 +12400,28 @@
         "Sensoriale",
         "Visivo"
       ],
+      "glossary_ok": true,
       "id": "occhi_infrarosso_composti",
       "label": "Occhi Composti ad Infrarosso",
       "mutation": "Sviluppo di un secondo strato retinico sensibile all'infrarosso.",
       "selective_drive": "Caccia notturna o nell'oscurità totale basata sul gradiente termico.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "echo-wing",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
         "sonno_emisferico_alternato"
       ],
@@ -889,19 +12437,22 @@
         ],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Accecamento temporaneo da fonti di calore intenso e concentrato."
     },
     "olfatto_risonanza_magnetica": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -926,27 +12477,97 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
-        "data/traits/index.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
       ],
       "energy_profile": "Medio (Elaborazione sensoriale costante)",
       "environments": [
-        "caverna_risonante"
+        "falde_magnetiche_psioniche",
+        "orbita_psionica_inversa"
       ],
       "families": [
         "Sensoriale",
         "Nervoso"
       ],
+      "glossary_ok": true,
       "id": "olfatto_risonanza_magnetica",
       "label": "Olfatto di Risonanza Magnetica",
       "mutation": "Organi sensoriali elettrorecettori concentrati su muso o antenne.",
       "selective_drive": "Orientamento in ambienti sotterranei senza luce o caccia a prede metallifere.",
-      "synergies": [
-        "eco_interno_riflesso"
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "magnet-fathom-surveyor",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "orbital-ascendant",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "slag-veil-ambusher",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cryo-lynx",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dune-stalker",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "magneto-ridge-hunter",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "orbita-psionica-inversa-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 1.0
+        }
       ],
-      "tier": "T1",
+      "synergies": [
+        "eco_interno_riflesso",
+        "lingua_tattile_trama"
+      ],
+      "tier": "T2",
       "usage": "Percepire la direzione e la composizione di metalli o campi energetici.",
       "usage_map": {
         "core": [
@@ -958,19 +12579,26 @@
         ],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Sensibilità a forti interferenze elettromagnetiche (es. fulmini o minerali magnetici)."
     },
     "pathfinder": {
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -995,7 +12623,6 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
-        "data/traits/index.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -1006,10 +12633,20 @@
         "Esplorazione",
         "Tattico"
       ],
+      "glossary_ok": true,
       "id": "pathfinder",
       "label": "Pathfinder",
       "mutation": "Suite sensoriale orientata a scouting e lettura minacce.",
       "selective_drive": "Missioni con indice explore alto e opzioni opzionali da capitalizzare.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sentinella-radice",
+          "weight": 1.0
+        }
+      ],
       "synergies": [],
       "tier": "T1",
       "usage": "Ottimizza esplorazione e controllo mappe multi-bioma.",
@@ -1021,19 +12658,25 @@
           "myco-spire-warden"
         ]
       },
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
       "weakness": "Valore ridotto in scenari a corridoio o con tilt già stabilizzato."
     },
     "pianificatore": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -1058,7 +12701,6 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
-        "data/traits/index.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -1067,13 +12709,37 @@
       "environments": [],
       "families": [
         "Strategico",
-        "Comando"
+        "Tattico"
       ],
+      "glossary_ok": true,
       "id": "pianificatore",
       "label": "Pianificatore",
       "mutation": "Protocollo decisionale adattivo con buffer informativi dedicati.",
       "selective_drive": "Squadre che devono mantenere priorità multiple su turni lunghi.",
-      "synergies": [],
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sentinella-radice",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "antenne_microonde_cavernose",
+        "artigli_radice",
+        "biofilm_glow",
+        "camere_mirage",
+        "cartilagini_desertiche",
+        "ciste_riduttive",
+        "colonne_vibromagnetiche",
+        "denti_ossidoferro",
+        "epidermide_dielettrica",
+        "ghiaccio_piezoelettrico",
+        "ghiandole_minerali",
+        "lamelle_shear",
+        "membrane_captura_rugiada"
+      ],
       "tier": "T1",
       "usage": "Coordina finestre di danno e difesa, mantenendo la squadra allineata al piano PI.",
       "usage_map": {
@@ -1084,19 +12750,24 @@
           "myco-spire-warden"
         ]
       },
+      "usage_tags": [],
       "weakness": "Rigidità tattica se gli input di telemetria arrivano in ritardo."
     },
-    "random": {
-      "conflicts": [],
+    "piume_solari_fotovoltaiche": {
+      "completion_flags": {},
+      "conflicts": [
+        "criostasi_adattiva"
+      ],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -1121,7 +12792,161 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Alto (Richiede manutenzione delle lamine fotoreattive)",
+      "environments": [
+        "altipiani_solari"
+      ],
+      "families": [
+        "Tegumentario",
+        "Energetico"
+      ],
+      "glossary_ok": true,
+      "id": "piume_solari_fotovoltaiche",
+      "label": "Piume Solari Fotovoltaiche",
+      "mutation": "Piumaggio stratificato con pigmenti piezo-fotovoltaici che immagazzinano luce.",
+      "selective_drive": "Massimizzare l'autonomia energetica per migrazioni aeree sopra deserti e oceani.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "altipiani-solari-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "membrane_eliofiltranti",
+        "sacche_spore_stratosferiche"
+      ],
+      "tier": "T2",
+      "usage": "Convertire la radiazione solare in riserve energetiche per abilità a lungo raggio.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Ombre prolungate o polveri dense riducono drasticamente la produzione energetica."
+    },
+    "polmoni_cristallini_alta_quota": {
+      "completion_flags": {},
+      "conflicts": [
+        "branchie_osmotiche_salmastra"
+      ],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Pulizia periodica dei cristalli)",
+      "environments": [
+        "picchi_cristallini"
+      ],
+      "families": [
+        "Respiratorio",
+        "Aerobico"
+      ],
+      "glossary_ok": true,
+      "id": "polmoni_cristallini_alta_quota",
+      "label": "Polmoni Cristallini d'Alta Quota",
+      "mutation": "Sistemi alveolari irrobustiti da strutture cristalline che catturano ossigeno rarefatto.",
+      "selective_drive": "Operare in missioni d'alta quota senza supporto logistico esterno.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "picchi-cristallini-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "membrane_eliofiltranti"
+      ],
+      "tier": "T2",
+      "usage": "Massimizza l'assorbimento di ossigeno rarefatto e filtra agenti nocivi.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Particolato pesante o sabbia vulcanica graffia i cristalli riducendo l'efficienza respiratoria."
+    },
+    "random": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -1132,10 +12957,12 @@
         "Flessibile",
         "Generico"
       ],
+      "glossary_ok": true,
       "id": "random",
       "label": "Trait Random",
       "mutation": "Selezione casuale da pool controllata per esperimenti di build.",
       "selective_drive": "Draft rapidi o recuperi quando il tavolo necessita sorprese adattive.",
+      "species_affinity": [],
       "synergies": [],
       "tier": "T1",
       "usage": "Slot jolly per testing o pareggiare budget PI quando serve varietà.",
@@ -1144,19 +12971,22 @@
         "optional": [],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Bassa affidabilità: richiede slot aggiuntivi per mitigare risultati sfavorevoli."
     },
     "respiro_a_scoppio": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -1181,7 +13011,6 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
-        "data/traits/index.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -1194,12 +13023,59 @@
         "Respiratorio",
         "Propulsivo"
       ],
+      "glossary_ok": true,
       "id": "respiro_a_scoppio",
       "label": "Respiro a scoppio",
       "mutation": "Polmoni o sacche aeree ad alta pressione con valvole di rilascio rapide.",
       "selective_drive": "Spostamento rapido tramite getto d'aria in ambienti a bassa resistenza.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "rust-scavenger",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dune-stalker",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "magneto-ridge-hunter",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "slag-veil-ambusher",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-bison-mini",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
-        "sacche_galleggianti_ascensoriali"
+        "sacche_galleggianti_ascensoriali",
+        "squame_rifrangenti_deserto"
       ],
       "tier": "T1",
       "usage": "Rilasciare grandi quantità d'aria o energia in un getto potente.",
@@ -1214,19 +13090,22 @@
         ],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Vulnerabilità respiratoria subito dopo l'utilizzo (tempo di ricarica)."
     },
     "risonanza_di_branco": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -1251,7 +13130,6 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
-        "data/traits/index.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -1260,13 +13138,75 @@
       "environments": [],
       "families": [
         "Supporto",
-        "Armonico"
+        "Coordinativo"
       ],
+      "glossary_ok": true,
       "id": "risonanza_di_branco",
       "label": "Risonanza di Branco",
       "mutation": "Reticolo empatico che collega i canali PI cooperativi.",
       "selective_drive": "Forme che eccellono in difesa coordinata e scudi sovrapposti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional",
+            "synergy"
+          ],
+          "species_id": "archon-solare",
+          "weight": 3.0
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 3.0
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 2.0
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 2.0
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "treant-portale",
+          "weight": 2.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "lupus-temperatus",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
+        "antenne_eco_turbina",
+        "antenne_plasmatiche_tempesta",
+        "artigli_acidofagi",
+        "batteri_termofili_endosimbiosi",
+        "branchie_turbina",
+        "carapace_luminiscente_abissale",
+        "carapaci_ferruginosi",
+        "cavita_risonanti_tundra",
+        "circolazione_doppia",
+        "coda_stabilizzatrice_geiser",
+        "cuticole_neutralizzanti",
+        "enzimi_chelatori_rapidi",
+        "foliage_fotocatodico",
+        "ghiandole_inchiostro_luce",
+        "gusci_criovetro",
+        "luminescenza_hydrotermica",
         "aura_scudo_radianza"
       ],
       "tier": "T1",
@@ -1280,19 +13220,22 @@
           "zephyr-spore-courier"
         ]
       },
+      "usage_tags": [],
       "weakness": "Stress elevato se la coesione cala sotto i target di telemetria."
     },
     "sacche_galleggianti_ascensoriali": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -1317,24 +13260,89 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
-        "data/traits/index.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
       ],
       "energy_profile": "Medio (Per il controllo della pressione)",
       "environments": [
-        "caverna_risonante"
+        "canopia_psionica_leggera",
+        "orbita_psionica_inversa"
       ],
       "families": [
         "Idrostatico",
         "Locomotorio"
       ],
+      "glossary_ok": true,
       "id": "sacche_galleggianti_ascensoriali",
       "label": "Sacche galleggianti ascensoriali",
       "mutation": "Sacche ripiene di gas leggeri con pompe muscolari.",
       "selective_drive": "Vivere in un ambiente acquatico con forti correnti verticali.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "orbital-ascendant",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "sand-burrower",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "aurora-bridge-runner",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "echo-wing",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "orbita-psionica-inversa-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "zephyr-spore-courier",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
+        "cartilagine_flessotermica_venti",
+        "respiro_a_scoppio",
+        "scheletro_idro_regolante",
         "struttura_elastica_amorfa"
       ],
       "tier": "T1",
@@ -1351,22 +13359,24 @@
         ],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Rischio di barotrauma se la pressione esterna cambia troppo rapidamente."
     },
-    "sangue_piroforico": {
+    "sacche_spore_stratosferiche": {
+      "completion_flags": {},
       "conflicts": [
-        "criostasi_adattiva",
-        "scheletro_idro_regolante"
+        "respiro_a_scoppio"
       ],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -1391,7 +13401,85 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Alto (Coltura continua di spore portanti)",
+      "environments": [
+        "stratosfera_portante"
+      ],
+      "families": [
+        "Simbiotico",
+        "Supporto"
+      ],
+      "glossary_ok": true,
+      "id": "sacche_spore_stratosferiche",
+      "label": "Sacche di Spore Stratosferiche",
+      "mutation": "Vescicole dermiche che rilasciano spore portatrici capaci di galleggiare per chilometri.",
+      "selective_drive": "Dispersone genetica rapida tra arcipelaghi aerei e piattaforme galleggianti.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-portante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "piume_solari_fotovoltaiche"
+      ],
+      "tier": "T3",
+      "usage": "Distribuisce simbionti di supporto e crea corridoi di movimento per la squadra.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Correnti ionizzate possono incendiare le sacche rendendo l'organismo instabile."
+    },
+    "sangue_piroforico": {
+      "completion_flags": {},
+      "conflicts": [
+        "criostasi_adattiva",
+        "scheletro_idro_regolante"
+      ],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -1401,14 +13489,61 @@
         "caverna_risonante"
       ],
       "families": [
-        "Circolatorio",
-        "Difensivo"
+        "Offensivo",
+        "Cinetico"
       ],
+      "glossary_ok": true,
       "id": "sangue_piroforico",
       "label": "Sangue che prende fuoco a contatto con l'ossigeno",
       "mutation": "Presenza di composti piroforici nel sangue.",
       "selective_drive": "Difesa contro predatori che tentano di estrarre fluidi corporei.",
-      "synergies": [],
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "ferrocolonia-magnetotattica",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "nano-rust-bloom",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thaw-rot",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "antenne_flusso_mareale",
+        "artigli_induzione",
+        "biochip_memoria",
+        "camere_anticorrosione",
+        "cartilagini_biofibre",
+        "circolazione_supercritica",
+        "coda_stabilizzatrice_vortex",
+        "denti_chelatanti",
+        "enzimi_metanoossidanti",
+        "foliaggio_spugna",
+        "ghiandole_iodoattive",
+        "gusci_magnesio",
+        "lamelle_termoforetiche",
+        "mantelli_geotermici"
+      ],
       "tier": "T1",
       "usage": "Meccanismo di difesa termico o chimico che si attiva con l'aria.",
       "usage_map": {
@@ -1420,21 +13555,24 @@
         ],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Rischio di auto-combustione in caso di ferita profonda in atmosfera ricca di ossigeno."
     },
     "scheletro_idro_regolante": {
+      "completion_flags": {},
       "conflicts": [
         "sangue_piroforico"
       ],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -1459,7 +13597,6 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
-        "data/traits/index.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -1472,12 +13609,104 @@
         "Strutturale",
         "Omeostatico"
       ],
+      "glossary_ok": true,
       "id": "scheletro_idro_regolante",
       "label": "Scheletro Idro-Regolante",
       "mutation": "Struttura ossea porosa capace di scambio rapido di fluidi.",
       "selective_drive": "Alternare vita terrestre e vita acquatica/aerea.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "dune-stalker",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "magneto-ridge-hunter",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "nano-rust-bloom",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "sand-burrower",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "slag-veil-ambusher",
+          "weight": 2.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "magnet-fathom-surveyor",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "rust-scavenger",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-bison-mini",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
-        "sacche_galleggianti_ascensoriali"
+        "antenne_tesla",
+        "artigli_vetrificati",
+        "branchie_dual_mode",
+        "branchie_osmotiche_salmastra",
+        "capillari_criogenici",
+        "cartilagini_pseudometalliche",
+        "cisti_iperbariche",
+        "cromofori_alert_acido",
+        "denti_tuning_fork",
+        "filamenti_magnetotrofi",
+        "ghiandole_condensa_ozono",
+        "ghiandole_nebbia_ionica",
+        "lamine_filtranti_aeree",
+        "membrane_pneumatofori",
+        "sacche_galleggianti_ascensoriali",
+        "struttura_elastica_amorfa"
       ],
       "tier": "T1",
       "usage": "Assorbire o espellere rapidamente acqua dai tessuti ossei per modificare il peso.",
@@ -1496,22 +13725,25 @@
           "slag-veil-ambusher"
         ]
       },
+      "usage_tags": [],
       "weakness": "Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio."
     },
     "secrezione_rallentante_palmi": {
+      "completion_flags": {},
       "conflicts": [
         "carapace_fase_variabile",
         "nucleo_ovomotore_rotante"
       ],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -1536,7 +13768,6 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
-        "data/traits/index.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -1549,10 +13780,28 @@
         "Tegumentario",
         "Difensivo"
       ],
+      "glossary_ok": true,
       "id": "secrezione_rallentante_palmi",
       "label": "Mani secernano liquido rallentante",
       "mutation": "Ghiandole mucose modificate sulle superfici prensili.",
       "selective_drive": "Cattura di prede veloci o difesa da aggressori corpo a corpo.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "ferrocolonia-magnetotattica",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
       "synergies": [],
       "tier": "T1",
       "usage": "Neutralizzare o immobilizzare prede/nemici.",
@@ -1563,19 +13812,22 @@
         "optional": [],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Esaurimento rapido delle riserve di liquido con tempo di ricarica prolungato."
     },
-    "sonno_emisferico_alternato": {
+    "sensori_geomagnetici": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -1600,7 +13852,199 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Ricettori passivi)",
+      "environments": [
+        "pianure_magnetiche"
+      ],
+      "families": [
+        "Sensoriale",
+        "Navigazione"
+      ],
+      "glossary_ok": true,
+      "id": "sensori_geomagnetici",
+      "label": "Sensori a Risonanza Geomagnetica",
+      "mutation": "Cristalli ferromagnetici allineati lungo il cranio che fungono da bussola psionica.",
+      "selective_drive": "Orientarsi in steppe polarizzate e tunnel sotterranei privi di riferimenti visivi.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "pianure-magnetiche-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "carapace_fase_variabile",
+        "eco_interno_riflesso"
+      ],
+      "tier": "T1",
+      "usage": "Traccia linee di campo e memorizza corridoi magnetici per la migrazione.",
+      "usage_map": {
+        "core": [
+          "dune_stalker"
+        ],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Tempeste solari possono saturare il segnale magnetico, causando disorientamento prolungato."
+    },
+    "sinapsi_coraline_polifoniche": {
+      "completion_flags": {},
+      "conflicts": [
+        "spore_psichiche_silenziate"
+      ],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Scambio continuo di impulsi corallini)",
+      "environments": [
+        "barriere_coralline_psioniche"
+      ],
+      "families": [
+        "Simbiotico",
+        "Comunicazione"
+      ],
+      "glossary_ok": true,
+      "id": "sinapsi_coraline_polifoniche",
+      "label": "Sinapsi Coraline Polifoniche",
+      "mutation": "Fibre nervose intrecciate con coralli sonori che trasmettono ordini tramite armoniche.",
+      "selective_drive": "Coordinare banchi e alleati in ambienti tridimensionali complessi.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "barriere-coralline-psioniche-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "ali_fulminee",
+        "antenne_plasmatiche_tempesta",
+        "antenne_waveguide",
+        "baffi_mareomotori",
+        "branchie_eoliche",
+        "capillari_fluoridici",
+        "carapace_luminiscente_abissale",
+        "cervelletto_equilibrio_statico",
+        "coda_balanciere",
+        "cuore_multicamera_bassa_pressione",
+        "echi_risonanti",
+        "filamenti_superconduttivi",
+        "ghiandole_eco_mappanti",
+        "ghiandole_resina_conduttiva",
+        "lamine_scudo_silice",
+        "midollo_antivibrazione"
+      ],
+      "tier": "T2",
+      "usage": "Trasmette comandi e pattern tattici sfruttando armoniche subacquee.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Vibrazioni sintonizzate male possono generare feedback dolorosi e perdita di coscienza."
+    },
+    "sonno_emisferico_alternato": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
+        "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -1613,11 +14057,37 @@
         "Nervoso",
         "Omeostatico"
       ],
+      "glossary_ok": true,
       "id": "sonno_emisferico_alternato",
       "label": "Dormire con solo metà cervello alla volta",
       "mutation": "Encefalizzazione asimmetrica o due lobi cerebrali separati.",
       "selective_drive": "Monitoraggio costante dei predatori in ambienti ad alto rischio.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "echo-wing",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "aurora-gull",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
+        "artigli_sghiaccio_glaciale",
         "occhi_infrarosso_composti"
       ],
       "tier": "T1",
@@ -1629,21 +14099,24 @@
         "optional": [],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Vulnerabilità a suoni/stimoli che colpiscono entrambi i lobi contemporaneamente."
     },
     "spore_psichiche_silenziate": {
+      "completion_flags": {},
       "conflicts": [
         "respiro_a_scoppio"
       ],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -1668,7 +14141,6 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
-        "data/traits/index.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -1681,10 +14153,42 @@
         "Escretorio",
         "Psichico"
       ],
+      "glossary_ok": true,
       "id": "spore_psichiche_silenziate",
       "label": "Spora Psichica Silenziosa",
       "mutation": "Pori che rilasciano nano-particelle attive chimicamente o psichicamente.",
       "selective_drive": "Neutralizzare gruppi di prede o predatori senza impegnare in combattimento.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "nano-rust-bloom",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "blight-micotico",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thaw-rot",
+          "weight": 1.0
+        }
+      ],
       "synergies": [],
       "tier": "T1",
       "usage": "Indurre uno stato di confusione o letargia negli individui vicini.",
@@ -1697,19 +14201,24 @@
         ],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Funzionalità ridotta in presenza di vento forte o umidità elevata."
     },
-    "struttura_elastica_amorfa": {
-      "conflicts": [],
+    "squame_rifrangenti_deserto": {
+      "completion_flags": {},
+      "conflicts": [
+        "mimetismo_cromatico_passivo"
+      ],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -1734,24 +14243,186 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Medio (Richiede riallineamento delle placche)",
+      "environments": [
+        "dune_cristalline"
+      ],
+      "families": [
+        "Tegumentario",
+        "Difensivo"
+      ],
+      "glossary_ok": true,
+      "id": "squame_rifrangenti_deserto",
+      "label": "Squame Rifrangenti del Deserto",
+      "mutation": "Placche cristalline sovrapposte che deviano luce e calore lungo superfici multiple.",
+      "selective_drive": "Sopravvivere a intensi flare termici e accecanti miraggi desertici.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "dune-cristalline-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "respiro_a_scoppio"
+      ],
+      "tier": "T2",
+      "usage": "Rifrange la luce generando miraggi e dissipando attacchi energetici.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "Soffre danni da feedback termico se colpito da raggi concentrati o laser."
+    },
+    "struttura_elastica_amorfa": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
       ],
       "energy_profile": "Basso (Passivo)",
       "environments": [
-        "caverna_risonante"
+        "canopia_psionica_leggera",
+        "falde_magnetiche_psioniche"
       ],
       "families": [
         "Strutturale",
         "Locomotorio"
       ],
+      "glossary_ok": true,
       "id": "struttura_elastica_amorfa",
       "label": "Struttura elastica, allungabile, amorfa, retrattile",
       "mutation": "Tessuto con matrice di proteine elastiche iper-modificate.",
       "selective_drive": "Fuga rapida da predatori in spazi confinati.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "dune-stalker",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "magnet-fathom-surveyor",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "slag-veil-ambusher",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "magneto-ridge-hunter",
+          "weight": 2.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "glowcap-weaver",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "myco-spire-warden",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
+        "antenne_tesla",
+        "artigli_sette_vie",
+        "artigli_vetrificati",
+        "branchie_dual_mode",
+        "capillari_criogenici",
+        "cartilagini_pseudometalliche",
+        "cisti_iperbariche",
+        "cromofori_alert_acido",
+        "denti_tuning_fork",
+        "filamenti_magnetotrofi",
+        "ghiandole_condensa_ozono",
+        "ghiandole_nebbia_ionica",
+        "lamine_filtranti_aeree",
+        "membrane_pneumatofori",
+        "mimetismo_cromatico_passivo",
+        "sacche_galleggianti_ascensoriali",
         "scheletro_idro_regolante"
       ],
       "tier": "T1",
@@ -1769,19 +14440,22 @@
           "magneto-ridge-hunter"
         ]
       },
+      "usage_tags": [],
       "weakness": "Vulnerabilità a danni da taglio o perforazione (difficile cauterizzazione)."
     },
     "tattiche_di_branco": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -1806,7 +14480,6 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
-        "data/traits/index.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -1815,13 +14488,52 @@
       "environments": [],
       "families": [
         "Strategico",
-        "Supporto"
+        "Tattico"
       ],
+      "glossary_ok": true,
       "id": "tattiche_di_branco",
       "label": "Tattiche di Branco",
       "mutation": "Canale condiviso per marcature e ingaggi simultanei.",
       "selective_drive": "Squadre che puntano a style bonus tramite assist e controllo spazio.",
-      "synergies": [],
+      "species_affinity": [
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "magneto-ridge-hunter",
+          "weight": 2.0
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "slag-veil-ambusher",
+          "weight": 2.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "lupus-temperatus",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "antenne_microonde_cavernose",
+        "artigli_radice",
+        "artigli_sette_vie",
+        "biofilm_glow",
+        "camere_mirage",
+        "cartilagini_desertiche",
+        "ciste_riduttive",
+        "colonne_vibromagnetiche",
+        "denti_ossidoferro",
+        "epidermide_dielettrica",
+        "ghiaccio_piezoelettrico",
+        "ghiandole_minerali",
+        "lamelle_shear",
+        "membrane_captura_rugiada"
+      ],
       "tier": "T1",
       "usage": "Coordina prese e focus bersaglio condividendo segnali di priorità.",
       "usage_map": {
@@ -1833,19 +14545,22 @@
           "slag-veil-ambusher"
         ]
       },
+      "usage_tags": [],
       "weakness": "Richiede formazione stabile; cala se la coesione precipita sotto il target."
     },
-    "ventriglio_gastroliti": {
+    "vello_condensatore_nebbie": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -1870,7 +14585,82 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
+      ],
+      "energy_profile": "Basso (Strutture passive a microfilo)",
+      "environments": [
+        "foreste_nubose"
+      ],
+      "families": [
+        "Tegumentario",
+        "Idratazione"
+      ],
+      "glossary_ok": true,
+      "id": "vello_condensatore_nebbie",
+      "label": "Vello Condensatore di Nebbie",
+      "mutation": "Peli cavi microstriati che catturano e canalizzano la bruma atmosferica.",
+      "selective_drive": "Garantire idratazione in climi montani dove l'acqua liquida è scarsa ma la nebbia abbondante.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "foreste-nubose-trait-keeper",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "bulbi_radici_permafrost"
+      ],
+      "tier": "T1",
+      "usage": "Condensa acqua atmosferica per supportare abilità metaboliche ad alto consumo.",
+      "usage_map": {
+        "core": [],
+        "optional": [],
+        "synergy": []
+      },
+      "usage_tags": [],
+      "weakness": "In ambienti aridi accumula detriti che riducono la capacità di condensa."
+    },
+    "ventriglio_gastroliti": {
+      "completion_flags": {},
+      "conflicts": [],
+      "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -1883,12 +14673,57 @@
         "Digestivo",
         "Alimentare"
       ],
+      "glossary_ok": true,
       "id": "ventriglio_gastroliti",
       "label": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
       "mutation": "Sviluppo di un organo muscolare (ventriglio) con gastroliti.",
       "selective_drive": "Dieta basata su semi, conchiglie o insetti corazzati.",
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "rust-scavenger",
+          "weight": 4.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "caverna-risonante-trait-keeper",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "ferrocolonia-magnetotattica",
+          "weight": 1.0
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-bison-mini",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
-        "filamenti_digestivi_compattanti"
+        "antenne_dustsense",
+        "appendici_thermotattiche",
+        "batteri_endosimbionti_chemio",
+        "branchie_solfatiche",
+        "carapace_segmenti_logici",
+        "circolazione_cooling_loop",
+        "coda_stabilizzatrice_filo",
+        "cuticole_cerose",
+        "enzimi_chelanti",
+        "filamenti_digestivi_compattanti",
+        "flagelli_ancoranti",
+        "ghiandole_grafene",
+        "grassi_termici",
+        "luminescenza_aurorale"
       ],
       "tier": "T1",
       "usage": "Macinazione di cibo duro all'interno di un ventriglio.",
@@ -1901,19 +14736,22 @@
         ],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Usura e rottura del ventriglio se i gastroliti sono esauriti o troppo lisci."
     },
     "zampe_a_molla": {
+      "completion_flags": {},
       "conflicts": [],
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
+        "data/core/traits/glossary.json",
         "data/derived/analysis/trait_baseline.yaml",
         "data/derived/analysis/trait_coverage_matrix.csv",
         "data/derived/analysis/trait_coverage_report.json",
         "data/derived/analysis/trait_env_mapping.json",
         "data/packs.yaml",
-        "data/core/species.yaml",
-        "data/core/telemetry.yaml",
-        "data/core/traits/glossary.json",
+        "data/traits/index.json",
         "docs/catalog/species_trait_matrix.json",
         "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
@@ -1938,7 +14776,6 @@
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
         "packs/evo_tactics_pack/docs/catalog/env_traits.json",
         "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
-        "data/traits/index.json",
         "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
         "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
         "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
@@ -1949,11 +14786,37 @@
         "Mobilità",
         "Cinetico"
       ],
+      "glossary_ok": true,
       "id": "zampe_a_molla",
       "label": "Zampe a Molla",
       "mutation": "Arti potenziati con ammortizzatori ad alta compressione.",
       "selective_drive": "Metagame con forte pressione di aggro e necessità di riposizionamento.",
-      "synergies": [],
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sand-burrower",
+          "weight": 1.0
+        }
+      ],
+      "synergies": [
+        "ali_ioniche",
+        "antenne_wideband",
+        "artigli_sghiaccio_glaciale",
+        "barbigli_sensori_plasma",
+        "branchie_metalloidi",
+        "capillari_fotovoltaici",
+        "chemiorecettori_bromuro",
+        "coda_contrappeso",
+        "cuscinetti_elettrostatici",
+        "enzimi_antifase_termica",
+        "filamenti_termoconduzione",
+        "ghiandole_fango_calde",
+        "ghiandole_ventosa",
+        "linfa_tampone",
+        "mucose_aderenza_sonica"
+      ],
       "tier": "T1",
       "usage": "Dash esplosivi per mantenere il ritmo di ingaggio o disimpegno.",
       "usage_map": {
@@ -1963,162 +14826,86 @@
         ],
         "synergy": []
       },
+      "usage_tags": [],
       "weakness": "Perdita di valore su mappe con spazi stretti o controllo setup elevato."
     },
-    "aura_scudo_radianza": {
-      "id": "aura_scudo_radianza",
-      "label": "Aura Scudo di Radianza",
-      "tier": "T3",
-      "families": [
-        "Supporto",
-        "Difesa"
-      ],
-      "energy_profile": "Alto (Canalizzazione fotonica continua)",
-      "usage": "Canalizza scudi fotoplasmatici condivisi.",
-      "selective_drive": "Proteggere i punti di ancoraggio durante tempeste planari.",
-      "mutation": "Integra cristalli luminescenti connessi al sistema nervoso.",
-      "synergies": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+    "zoccoli_risonanti_steppe": {
+      "completion_flags": {},
       "conflicts": [
-        "mantello_meteoritico"
+        "zampe_a_molla"
       ],
-      "environments": [
-        "rovine_planari"
-      ],
-      "weakness": "Sovraccarica in presenza di ombre gravitazionali.",
       "dataset_sources": [
+        "data/core/species.yaml",
+        "data/core/telemetry.yaml",
         "data/core/traits/glossary.json",
+        "data/derived/analysis/trait_baseline.yaml",
+        "data/derived/analysis/trait_coverage_matrix.csv",
+        "data/derived/analysis/trait_coverage_report.json",
+        "data/derived/analysis/trait_env_mapping.json",
+        "data/packs.yaml",
         "data/traits/index.json",
-        "packs/evo_tactics_pack/data/species/rovine_planari/archon-solare.yaml"
+        "docs/catalog/species_trait_matrix.json",
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+        "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+        "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+        "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+        "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+        "packs/evo_tactics_pack/docs/catalog/env_traits.json",
+        "packs/evo_tactics_pack/docs/catalog/trait_glossary.json",
+        "packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml",
+        "packs/evo_tactics_pack/tools/py/schema/npg_schema.json",
+        "packs/evo_tactics_pack/tools/py/vtt/npg_pack.json"
       ],
-      "usage_map": {
-        "core": [
-          "archon-solare"
-        ],
-        "optional": [],
-        "synergy": [
-          "balor-fission",
-          "couatl-aurora"
-        ]
-      }
-    },
-    "frusta_fiammeggiante": {
-      "id": "frusta_fiammeggiante",
-      "label": "Frusta Fiammeggiante",
-      "tier": "T2",
+      "energy_profile": "Basso (Vibrazione passiva del suolo)",
+      "environments": [
+        "steppe_risonanti"
+      ],
       "families": [
-        "Offensivo",
-        "Controllo"
+        "Locomotorio",
+        "Supporto"
       ],
-      "energy_profile": "Medio (Filamenti di plasma vincolato)",
-      "usage": "Cattura e trascina bersagli mentre infonde danni termici.",
-      "selective_drive": "Gestire predatori élite nelle fratture planari.",
-      "mutation": "Forma tentacoli plasmatici con nocciolo runico stabilizzante.",
+      "glossary_ok": true,
+      "id": "zoccoli_risonanti_steppe",
+      "label": "Zoccoli Risonanti delle Steppe",
+      "mutation": "Placche cornee cave che emettono onde sismiche ritmiche al contatto con il terreno.",
+      "selective_drive": "Mantenere coesione di branchi su grandi distanze e rilevare predatori sotterranei.",
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "steppe-risonanti-trait-keeper",
+          "weight": 1.0
+        }
+      ],
       "synergies": [
-        "focus_frazionato",
-        "mantello_meteoritico"
+        "cartilagine_flessotermica_venti"
       ],
-      "conflicts": [
-        "armatura_pietra_planare"
-      ],
-      "environments": [
-        "rovine_planari"
-      ],
-      "weakness": "Richiede dissipazione termica continua.",
-      "dataset_sources": [
-        "data/core/traits/glossary.json",
-        "data/traits/index.json",
-        "packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml",
-        "packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml"
-      ],
+      "tier": "T1",
+      "usage": "Propaga segnali ritmici che sincronizzano movimenti e abilità di squadra.",
       "usage_map": {
-        "core": [
-          "balor-fission",
-          "marilith-vault"
-        ],
-        "optional": [],
-        "synergy": []
-      }
-    },
-    "mantello_meteoritico": {
-      "id": "mantello_meteoritico",
-      "label": "Mantello Meteoritico",
-      "tier": "T3",
-      "families": [
-        "Difesa",
-        "Termico"
-      ],
-      "energy_profile": "Alto (Rivestimento ablativo rigenerante)",
-      "usage": "Dissipa impatti estremi e converte l'energia in contropressioni.",
-      "selective_drive": "Sopravvivere a bombardamenti planari prolungati.",
-      "mutation": "Deposita strati di minerali meteoritici autorigeneranti.",
-      "synergies": [
-        "frusta_fiammeggiante",
-        "carapace_fase_variabile"
-      ],
-      "conflicts": [
-        "aura_scudo_radianza"
-      ],
-      "environments": [
-        "rovine_planari"
-      ],
-      "weakness": "Perde efficacia con raffreddamento gravitazionale improvviso.",
-      "dataset_sources": [
-        "data/core/traits/glossary.json",
-        "data/traits/index.json",
-        "packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml",
-        "packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml"
-      ],
-      "usage_map": {
-        "core": [
-          "balor-fission",
-          "marilith-vault"
-        ],
+        "core": [],
         "optional": [],
         "synergy": []
-      }
-    },
-    "armatura_pietra_planare": {
-      "id": "armatura_pietra_planare",
-      "label": "Armatura di Pietra Planare",
-      "tier": "T2",
-      "families": [
-        "Difesa",
-        "Strutturale"
-      ],
-      "energy_profile": "Basso (Risonanza geodetica stabile)",
-      "usage": "Stabilizza il corpo contro onde d'urto e torsioni dimensionali.",
-      "selective_drive": "Ancorare unità difensive durante aperture di portali.",
-      "mutation": "Cristallizza il dermascheletro con nodi runici.",
-      "synergies": [
-        "carapace_fase_variabile"
-      ],
-      "conflicts": [
-        "frusta_fiammeggiante"
-      ],
-      "environments": [
-        "rovine_planari"
-      ],
-      "weakness": "Peso elevato in atmosfera standard.",
-      "dataset_sources": [
-        "data/core/traits/glossary.json",
-        "data/traits/index.json",
-        "packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml",
-        "packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml",
-        "packs/evo_tactics_pack/data/species/rovine_planari/treant-portale.yaml"
-      ],
-      "usage_map": {
-        "core": [
-          "golem-runico"
-        ],
-        "optional": [
-          "bulette-fase",
-          "treant-portale"
-        ],
-        "synergy": []
-      }
+      },
+      "usage_tags": [],
+      "weakness": "Suoli cedevoli come sabbie mobili annullano la vibrazione e riducono la trazione."
     }
   }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Added
-- _Nessuna voce._
+- Trait metadata (`species_affinity`, `usage_tags`, `completion_flags`) now exposed across catalog loaders, generators e servizi API, con test automatici aggiornati.
 
 ### Changed
 - _Nessuna voce._

--- a/server/app.js
+++ b/server/app.js
@@ -12,7 +12,7 @@ const {
   createGenerationSnapshotHandler,
 } = require('./routes/generationSnapshot');
 const { createGenerationSnapshotStore } = require('./services/generationSnapshotStore');
-const { createNebulaRouter } = require('./routes/nebula');
+const { createNebulaRouter, createAtlasV1Router } = require('./routes/nebula');
 const { createNebulaTelemetryAggregator } = require('./services/nebulaTelemetryAggregator');
 const { createReleaseReporter } = require('./services/releaseReporter');
 const ideaTaxonomy = require('../config/idea_engine_taxonomy.json');
@@ -373,6 +373,14 @@ function createApp(options = {}) {
   const nebulaRouter = createNebulaRouter({
     telemetryPath: nebulaOptions.telemetryPath,
     generatorTelemetryPath: nebulaOptions.generatorTelemetryPath,
+    configPath: nebulaOptions.configPath,
+    config: nebulaOptions.config,
+    aggregator: nebulaAggregator,
+  });
+  const atlasV1Router = createAtlasV1Router({
+    telemetryPath: nebulaOptions.telemetryPath,
+    generatorTelemetryPath: nebulaOptions.generatorTelemetryPath,
+    datasetPath: nebulaOptions.datasetPath,
     configPath: nebulaOptions.configPath,
     config: nebulaOptions.config,
     aggregator: nebulaAggregator,

--- a/tests/services/speciesBuilder.test.js
+++ b/tests/services/speciesBuilder.test.js
@@ -1,0 +1,22 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const { createSpeciesBuilder } = require('../../services/generation/speciesBuilder');
+
+const DEFAULT_CATALOG_PATH = path.resolve(__dirname, '..', '..', 'docs', 'catalog', 'catalog_data.json');
+
+test('createSpeciesBuilder exposes metadata for traits', async () => {
+  const builder = createSpeciesBuilder({ catalogPath: DEFAULT_CATALOG_PATH });
+  const profile = await builder.buildProfile(['pathfinder'], { baseName: 'Scout' });
+  assert.ok(profile?.traits?.metadata, 'metadata should be present in trait payload');
+  const metadata = profile.traits.metadata;
+  assert.ok(Array.isArray(metadata.usage_tags), 'usage tags should be aggregated');
+  assert.ok(metadata.usage_tags.includes('scout'), 'aggregated usage tags should include trait tags');
+  assert.ok(metadata.per_trait, 'per-trait metadata should be exposed');
+  const pathfinderMeta = metadata.per_trait?.pathfinder;
+  assert.ok(pathfinderMeta, 'pathfinder trait metadata should be available');
+  assert.ok(Array.isArray(pathfinderMeta.species_affinity), 'species affinity array should exist');
+  assert.ok(pathfinderMeta.species_affinity.length > 0, 'species affinity should include entries');
+  assert.equal(metadata.completion_flags.has_species_link, true, 'aggregated completion flags should be truthy for species link');
+});

--- a/tests/snapshots/species_builder_predatore.json
+++ b/tests/snapshots/species_builder_predatore.json
@@ -2,7 +2,7 @@
   "id": "synthetic-1d37afd07a",
   "display_name": "Predatore / Coda a Frusta Cinetica",
   "summary": "Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante",
-  "description": "Sintesi genetica focalizzata su Artigli a Sette Vie e Coda a Frusta Cinetica con impronta morfologica defensive, locomotor, omeostatico, prehensile, structural; comportamento climber. Ottimizzata per biomi: caverna_risonante.",
+  "description": "Sintesi genetica focalizzata su Artigli a Sette Vie e Coda a Frusta Cinetica con impronta morfologica defensive, locomotor, omeostatico, prehensile, structural; comportamento climber. Ottimizzata per biomi: caverna_risonante, falde_magnetiche_psioniche, orbita_psionica_inversa.",
   "morphology": {
     "families": [
       "defensive",
@@ -20,7 +20,9 @@
       "Precauzione: Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio."
     ],
     "environments": [
-      "caverna_risonante"
+      "caverna_risonante",
+      "falde_magnetiche_psioniche",
+      "orbita_psionica_inversa"
     ]
   },
   "behavior": {
@@ -40,7 +42,7 @@
     "threat_tier": "T1",
     "rarity": "R1",
     "energy_profile": "medio",
-    "synergy_score": 0.167
+    "synergy_score": 0.333
   },
   "traits": {
     "core": [
@@ -49,12 +51,405 @@
       "scheletro_idro_regolante"
     ],
     "derived": [
+      "ali_ioniche",
+      "antenne_flusso_mareale",
+      "antenne_tesla",
+      "antenne_wideband",
+      "artigli_induzione",
       "artigli_sette_vie",
+      "artigli_vetrificati",
+      "barbigli_sensori_plasma",
+      "biochip_memoria",
+      "branchie_dual_mode",
+      "branchie_metalloidi",
+      "branchie_osmotiche_salmastra",
+      "camere_anticorrosione",
+      "capillari_criogenici",
+      "capillari_fotovoltaici",
+      "cartilagini_biofibre",
+      "cartilagini_pseudometalliche",
+      "chemiorecettori_bromuro",
+      "circolazione_supercritica",
+      "cisti_iperbariche",
+      "coda_contrappeso",
+      "coda_frusta_cinetica",
+      "coda_stabilizzatrice_vortex",
+      "cromofori_alert_acido",
+      "cuscinetti_elettrostatici",
+      "denti_chelatanti",
+      "denti_tuning_fork",
+      "enzimi_antifase_termica",
+      "enzimi_metanoossidanti",
+      "filamenti_magnetotrofi",
+      "filamenti_termoconduzione",
+      "foliaggio_spugna",
+      "ghiandole_condensa_ozono",
+      "ghiandole_fango_calde",
+      "ghiandole_iodoattive",
+      "ghiandole_nebbia_ionica",
+      "ghiandole_ventosa",
+      "gusci_magnesio",
+      "lamine_filtranti_aeree",
+      "linfa_tampone",
+      "mantelli_geotermici",
+      "membrane_pneumatofori",
+      "mimetismo_cromatico_passivo",
+      "mucose_aderenza_sonica",
       "sacche_galleggianti_ascensoriali",
-      "struttura_elastica_amorfa"
+      "struttura_elastica_amorfa",
+      "tattiche_di_branco"
     ],
     "conflicts": [
       "sangue_piroforico"
-    ]
+    ],
+    "metadata": {
+      "usage_tags": [],
+      "species_affinity": [
+        {
+          "species_id": "dune-stalker",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 12.0
+        },
+        {
+          "species_id": "magneto-ridge-hunter",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 12.0
+        },
+        {
+          "species_id": "slag-veil-ambusher",
+          "roles": [
+            "core",
+            "optional",
+            "synergy"
+          ],
+          "weight": 6.0
+        },
+        {
+          "species_id": "nano-rust-bloom",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4.0
+        },
+        {
+          "species_id": "sand-burrower",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4.0
+        },
+        {
+          "species_id": "bulette-fase",
+          "roles": [
+            "optional"
+          ],
+          "weight": 2.0
+        },
+        {
+          "species_id": "caverna-risonante-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 2.0
+        },
+        {
+          "species_id": "marilith-vault",
+          "roles": [
+            "optional"
+          ],
+          "weight": 2.0
+        },
+        {
+          "species_id": "balor-fission",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1.0
+        },
+        {
+          "species_id": "couatl-aurora",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1.0
+        },
+        {
+          "species_id": "cryo-lynx",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1.0
+        },
+        {
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1.0
+        },
+        {
+          "species_id": "magnet-fathom-surveyor",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1.0
+        },
+        {
+          "species_id": "orbita-psionica-inversa-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1.0
+        },
+        {
+          "species_id": "otyugh-sentinella",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1.0
+        },
+        {
+          "species_id": "resonant-claw-hunter",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1.0
+        },
+        {
+          "species_id": "rust-scavenger",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1.0
+        },
+        {
+          "species_id": "steppe-bison-mini",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1.0
+        }
+      ],
+      "completion_flags": {},
+      "per_trait": {
+        "artigli_sette_vie": {
+          "usage_tags": [],
+          "species_affinity": [
+            {
+              "species_id": "dune-stalker",
+              "roles": [
+                "core",
+                "optional"
+              ],
+              "weight": 4.0
+            },
+            {
+              "species_id": "magneto-ridge-hunter",
+              "roles": [
+                "core",
+                "optional"
+              ],
+              "weight": 4.0
+            },
+            {
+              "species_id": "balor-fission",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            },
+            {
+              "species_id": "caverna-risonante-trait-keeper",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            },
+            {
+              "species_id": "couatl-aurora",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            },
+            {
+              "species_id": "cryo-lynx",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            },
+            {
+              "species_id": "marilith-vault",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            },
+            {
+              "species_id": "otyugh-sentinella",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            },
+            {
+              "species_id": "resonant-claw-hunter",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            }
+          ],
+          "completion_flags": {}
+        },
+        "coda_frusta_cinetica": {
+          "usage_tags": [],
+          "species_affinity": [
+            {
+              "species_id": "dune-stalker",
+              "roles": [
+                "core",
+                "optional"
+              ],
+              "weight": 4.0
+            },
+            {
+              "species_id": "magneto-ridge-hunter",
+              "roles": [
+                "core",
+                "optional"
+              ],
+              "weight": 4.0
+            },
+            {
+              "species_id": "slag-veil-ambusher",
+              "roles": [
+                "core",
+                "optional"
+              ],
+              "weight": 4.0
+            },
+            {
+              "species_id": "bulette-fase",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            },
+            {
+              "species_id": "falde-magnetiche-psioniche-trait-keeper",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            },
+            {
+              "species_id": "marilith-vault",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            },
+            {
+              "species_id": "orbita-psionica-inversa-trait-keeper",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            }
+          ],
+          "completion_flags": {}
+        },
+        "scheletro_idro_regolante": {
+          "usage_tags": [],
+          "species_affinity": [
+            {
+              "species_id": "dune-stalker",
+              "roles": [
+                "core",
+                "optional"
+              ],
+              "weight": 4.0
+            },
+            {
+              "species_id": "magneto-ridge-hunter",
+              "roles": [
+                "core",
+                "optional"
+              ],
+              "weight": 4.0
+            },
+            {
+              "species_id": "nano-rust-bloom",
+              "roles": [
+                "core",
+                "optional"
+              ],
+              "weight": 4.0
+            },
+            {
+              "species_id": "sand-burrower",
+              "roles": [
+                "core",
+                "optional"
+              ],
+              "weight": 4.0
+            },
+            {
+              "species_id": "slag-veil-ambusher",
+              "roles": [
+                "synergy"
+              ],
+              "weight": 2.0
+            },
+            {
+              "species_id": "bulette-fase",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            },
+            {
+              "species_id": "caverna-risonante-trait-keeper",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            },
+            {
+              "species_id": "magnet-fathom-surveyor",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            },
+            {
+              "species_id": "rust-scavenger",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            },
+            {
+              "species_id": "steppe-bison-mini",
+              "roles": [
+                "optional"
+              ],
+              "weight": 1.0
+            }
+          ],
+          "completion_flags": {}
+        }
+      }
+    }
   }
 }

--- a/tests/test_species_builder.py
+++ b/tests/test_species_builder.py
@@ -21,6 +21,13 @@ class SpeciesBuilderTests(unittest.TestCase):
         self.assertIn("data/core/traits/glossary.json", trait.dataset_sources)
         self.assertIn("caverna_risonante", trait.environments)
 
+    def test_trait_profile_includes_new_metadata(self) -> None:
+        trait = self.catalog.require("pathfinder")
+        self.assertIn("scout", trait.usage_tags)
+        affinity_ids = {entry.species_id for entry in trait.species_affinity}
+        self.assertIn("sentinella-radice", affinity_ids)
+        self.assertTrue(trait.completion_flags.get("has_species_link"))
+
     def test_species_blueprint_matches_snapshot(self) -> None:
         profile = self.builder.build(
             [
@@ -33,6 +40,15 @@ class SpeciesBuilderTests(unittest.TestCase):
         )
         snapshot = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
         self.assertDictEqual(profile, snapshot)
+
+    def test_species_blueprint_includes_trait_metadata(self) -> None:
+        profile = self.builder.build(["pathfinder", "artigli_sette_vie"], seed=7, base_name="Scout")
+        metadata = profile["traits"]["metadata"]
+        self.assertIn("usage_tags", metadata)
+        self.assertIn("scout", metadata["usage_tags"])
+        per_trait = metadata["per_trait"]
+        self.assertIn("pathfinder", per_trait)
+        self.assertTrue(per_trait["pathfinder"]["completion_flags"].get("has_species_link"))
 
     def test_trait_diagnostics_summary(self) -> None:
         diagnostics = build_trait_diagnostics()

--- a/webapp/src/state/useTraitDiagnostics.ts
+++ b/webapp/src/state/useTraitDiagnostics.ts
@@ -131,21 +131,36 @@ export function useTraitDiagnostics(options: TraitDiagnosticsOptions = {}) {
     const traits = Array.isArray(diagnostics.value?.traits)
       ? diagnostics.value.traits
       : [];
-    const labels = {};
-    const synergyMap = {};
-    for (const entry of traits) {
+    const labels: Record<string, string> = {};
+    const synergyMap: Record<string, string[]> = {};
+    const usageTags: Record<string, string[]> = {};
+    const completionFlags: Record<string, Record<string, boolean>> = {};
+    const speciesAffinity: Record<string, unknown[]> = {};
+    for (const entry of traits as Array<Record<string, unknown>>) {
       if (!entry || typeof entry !== 'object') continue;
-      const id = entry.id;
+      const id = (entry.id as string | undefined) || undefined;
       if (!id) continue;
-      labels[id] = entry.label || id;
+      labels[id] = (entry.label as string) || id;
       if (Array.isArray(entry.synergies)) {
-        synergyMap[id] = entry.synergies.filter(Boolean);
+        synergyMap[id] = (entry.synergies as string[]).filter(Boolean);
+      }
+      if (Array.isArray(entry.usage_tags)) {
+        usageTags[id] = (entry.usage_tags as string[]).filter(Boolean);
+      }
+      if (entry.completion_flags && typeof entry.completion_flags === 'object') {
+        completionFlags[id] = entry.completion_flags as Record<string, boolean>;
+      }
+      if (Array.isArray(entry.species_affinity)) {
+        speciesAffinity[id] = entry.species_affinity as unknown[];
       }
     }
     return {
       traits,
       labels,
       synergyMap,
+      usageTags,
+      completionFlags,
+      speciesAffinity,
     };
   });
   const traitCompliance = computed(() => {


### PR DESCRIPTION
## Summary
- normalize and persist species affinity, usage tags, and completion flags in the Python trait catalog, ensuring builders export aggregated metadata
- propagate the new trait metadata through the JS species builder, biome synthesizer, server atlas router, and web diagnostics, updating the generated catalog snapshot
- extend automated coverage with refreshed Python snapshots and a new Node test validating trait metadata wiring

## Testing
- python -m pytest tests/test_species_builder.py
- node --test tests/services/speciesBuilder.test.js
- node --test --test-reporter tap tests/api/biome-generation.test.js

------
https://chatgpt.com/codex/tasks/task_e_690628312ad483328d2929fa4ad771d5