### PR TITLE
Refactor generation API routing to versioned router

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,14 +145,14 @@ node dist/roll_pack.js ENTP invoker --seed demo
   - `POST /api/v1/generation/biomes` (`/api/biomes/generate` legacy) – genera sintesi bioma via `createBiomeSynthesizer`.
   - `POST /api/v1/validators/runtime` (`/api/validators/runtime` legacy) – esegue validator runtime sul payload fornito.
   - `POST /api/v1/quality/suggestions/apply` (`/api/quality/suggestions/apply` legacy) – applica suggerimenti qualità sul dataset ricevuto.
-  - `POST /api/v1/generation/species` e `/api/v1/generation/species/batch` (alias legacy `/api/generation/species[*]`) – orchestrano la generazione specie integrando `SpeciesBuilder`, `TraitCatalog` e validator pack.
+  - `POST /api/v1/generation/species` e `/api/v1/generation/species/batch` (`/api/generation/species[*]` legacy) – orchestrano la generazione specie integrando `SpeciesBuilder`, `TraitCatalog` e validator pack.
   - `GET /api/v1/atlas/dataset`, `/api/v1/atlas/telemetry`, `/api/v1/atlas/generator` – bundle dataset e telemetria Nebula (alias legacy aggregato `/api/nebula/atlas`).
   - `GET /api/v1/qa/status` (`/api/qa/status` legacy) – report QA corrente.
   - `GET /api/ideas/:id/report` – produce report Codex in HTML/JSON usando `server/report.js`.
 - **Orchestrazione**: la pipeline combina normalizzazione slug, fallback automatici per trait non validi e log strutturati (vedi `services/generation/*`).
 
 ### Pipeline generazione orchestrata
-- **Endpoint backend** – `POST /api/generation/species` instrada le richieste
+- **Endpoint backend** – `POST /api/v1/generation/species` (alias legacy `/api/generation/species`) instrada le richieste
   dell'UI verso l'orchestratore Python (`services/generation/orchestrator.py`),
   normalizzando gli input (`trait_ids`, `seed`, `biome_id`).
 - **Orchestratore Python** – carica il `TraitCatalog`, costruisce il blueprint

--- a/docs/adr/ADR-2025-12-07-generation-orchestrator.md
+++ b/docs/adr/ADR-2025-12-07-generation-orchestrator.md
@@ -38,7 +38,7 @@ con responsabilità di:
    `validation_outcome`) così da alimentare alerting e dashboard QA.
 
 Il server Express (`server/app.js`) espone il nuovo endpoint
-`POST /api/generation/species` che delega all’orchestratore via bridge
+`POST /api/v1/generation/species` (alias legacy `/api/generation/species`) che delega all’orchestratore via bridge
 Node↔Python, garantendo un’API omogenea alla UI Vue.
 
 ## Conseguenze

--- a/docs/evo-tactics-pack/generator.js
+++ b/docs/evo-tactics-pack/generator.js
@@ -514,7 +514,7 @@ const TRAIT_CATEGORY_LABELS = {
 };
 
 const API_ENDPOINTS = {
-  biomeGeneration: "/api/biomes/generate",
+  biomeGeneration: "/api/v1/generation/biomes",
 };
 
 const CLIMATE_HINTS = [

--- a/server/routes/generation.js
+++ b/server/routes/generation.js
@@ -1,0 +1,89 @@
+const express = require('express');
+
+function createGenerationHandler(executor, options = {}) {
+  const mapResult = typeof options.mapResult === 'function' ? options.mapResult : (value) => value;
+  const resolveStatus = typeof options.resolveStatus === 'function' ? options.resolveStatus : () => 500;
+  const defaultError = typeof options.defaultError === 'string' ? options.defaultError : 'Errore generazione';
+
+  return async function generationRoute(req, res) {
+    const payload = req.body || {};
+    try {
+      const result = await executor(payload, req, res);
+      const responseBody = mapResult(result, payload, req, res);
+      if (responseBody === undefined) {
+        res.status(204).end();
+        return;
+      }
+      res.json(responseBody);
+    } catch (error) {
+      const status = resolveStatus(error, req, res);
+      const statusCode = Number.isInteger(status) && status >= 100 ? status : 500;
+      const message = error && error.message ? error.message : defaultError;
+      res.status(statusCode).json({ error: message });
+    }
+  };
+}
+
+function createGenerationRoutes({ biomeSynthesizer, generationOrchestrator }) {
+  if (!biomeSynthesizer || typeof biomeSynthesizer.generate !== 'function') {
+    throw new Error('biomeSynthesizer con metodo generate richiesto');
+  }
+  if (!generationOrchestrator) {
+    throw new Error('generationOrchestrator richiesto');
+  }
+
+  const traitErrorStatus = (error) => {
+    const message = error && error.message ? String(error.message) : '';
+    return message.includes('trait_ids') ? 400 : 500;
+  };
+
+  const biomes = createGenerationHandler(
+    async (payload) => {
+      const result = await biomeSynthesizer.generate({
+        count: payload.count,
+        constraints: payload.constraints || {},
+        seed: payload.seed,
+      });
+      return result;
+    },
+    {
+      mapResult: (result) => ({ biomes: result.biomes, meta: result.constraints }),
+      defaultError: 'Errore generazione biomi',
+    },
+  );
+
+  const species = createGenerationHandler(
+    (payload) => generationOrchestrator.generateSpecies(payload),
+    {
+      resolveStatus: traitErrorStatus,
+      defaultError: 'Errore generazione specie',
+    },
+  );
+
+  const speciesBatch = createGenerationHandler(
+    (payload) => generationOrchestrator.generateSpeciesBatch(payload),
+    {
+      resolveStatus: traitErrorStatus,
+      defaultError: 'Errore generazione batch specie',
+    },
+  );
+
+  return { biomes, species, speciesBatch };
+}
+
+function createGenerationRouter(dependencies) {
+  const router = express.Router();
+  const routes = createGenerationRoutes(dependencies);
+
+  router.post('/biomes', routes.biomes);
+  router.post('/species', routes.species);
+  router.post('/species/batch', routes.speciesBatch);
+
+  return router;
+}
+
+module.exports = {
+  createGenerationHandler,
+  createGenerationRoutes,
+  createGenerationRouter,
+};

--- a/tests/api/biome-generation.test.js
+++ b/tests/api/biome-generation.test.js
@@ -11,12 +11,12 @@ function hasRole(species, role) {
   return Boolean(species.flags[role]);
 }
 
-test('POST /api/biomes/generate produce biomi sintetici coerenti con i vincoli', async () => {
+test('POST /api/v1/generation/biomes produce biomi sintetici coerenti con i vincoli', async () => {
   const dataRoot = path.resolve(__dirname, '..', '..', 'data');
   const { app } = createApp({ dataRoot });
 
   const response = await request(app)
-    .post('/api/biomes/generate')
+    .post('/api/v1/generation/biomes')
     .send({
       count: 3,
       constraints: {

--- a/tests/api/species-generation.test.js
+++ b/tests/api/species-generation.test.js
@@ -4,11 +4,11 @@ const request = require('supertest');
 
 const { createApp } = require('../../server/app');
 
-test('POST /api/generation/species restituisce blueprint validato', async () => {
+test('POST /api/v1/generation/species restituisce blueprint validato', async () => {
   const { app } = createApp();
 
   const response = await request(app)
-    .post('/api/generation/species')
+    .post('/api/v1/generation/species')
     .send({
       trait_ids: ['artigli_sette_vie', 'coda_frusta_cinetica', 'scheletro_idro_regolante'],
       seed: 99,
@@ -25,11 +25,11 @@ test('POST /api/generation/species restituisce blueprint validato', async () => 
   assert.equal(meta.fallback_used, false, 'non deve essere necessario il fallback');
 });
 
-test('POST /api/generation/species ritorna 400 senza trait', async () => {
+test('POST /api/v1/generation/species ritorna 400 senza trait', async () => {
   const { app } = createApp();
 
   const response = await request(app)
-    .post('/api/generation/species')
+    .post('/api/v1/generation/species')
     .send({ trait_ids: [] })
     .expect(400);
 

--- a/webapp/src/config/dataSources.ts
+++ b/webapp/src/config/dataSources.ts
@@ -70,7 +70,7 @@ const defaults: Record<DataSourceId, DataSourceDefaults> = {
     },
   },
   generationSpecies: {
-    endpoint: '/api/generation/species',
+    endpoint: '/api/v1/generation/species',
     fallback: 'data/flow/generation/species.json',
     env: {
       endpoint: 'VITE_GENERATION_SPECIES_URL',
@@ -78,7 +78,7 @@ const defaults: Record<DataSourceId, DataSourceDefaults> = {
     },
   },
   generationSpeciesBatch: {
-    endpoint: '/api/generation/species/batch',
+    endpoint: '/api/v1/generation/species/batch',
     fallback: 'data/flow/generation/species-batch.json',
     env: {
       endpoint: 'VITE_GENERATION_SPECIES_BATCH_URL',
@@ -86,7 +86,7 @@ const defaults: Record<DataSourceId, DataSourceDefaults> = {
     },
   },
   generationSpeciesPreview: {
-    endpoint: '/api/generation/species/batch',
+    endpoint: '/api/v1/generation/species/batch',
     fallback: 'data/flow/generation/species-preview.json',
     env: {
       endpoint: 'VITE_GENERATION_SPECIES_PREVIEW_URL',

--- a/webapp/tests/state/flowStores.spec.ts
+++ b/webapp/tests/state/flowStores.spec.ts
@@ -13,9 +13,9 @@ const dataSourceMock = vi.hoisted(() => {
       'flowSnapshot',
       { endpoint: '/api/generation/snapshot', fallback: 'data/flow/snapshots/flow-shell-snapshot.json', mock: null },
     ],
-    ['generationSpecies', { endpoint: '/api/generation/species', fallback: null, mock: null }],
-    ['generationSpeciesBatch', { endpoint: '/api/generation/species/batch', fallback: null, mock: null }],
-    ['generationSpeciesPreview', { endpoint: '/api/generation/species/batch', fallback: null, mock: null }],
+    ['generationSpecies', { endpoint: '/api/v1/generation/species', fallback: null, mock: null }],
+    ['generationSpeciesBatch', { endpoint: '/api/v1/generation/species/batch', fallback: null, mock: null }],
+    ['generationSpeciesPreview', { endpoint: '/api/v1/generation/species/batch', fallback: null, mock: null }],
     [
       'traitDiagnostics',
       { endpoint: '/api/traits/diagnostics', fallback: 'data/flow/traits/diagnostics.json', mock: null },


### PR DESCRIPTION
## Summary
- add a dedicated generation router with shared middleware for biome and species generation endpoints
- mount the router under /api/v1/generation while keeping legacy aliases and update docs, configs, and tests to use the versioned paths

## Testing
- ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/species-generation.test.js tests/api/biome-generation.test.js

------
https://chatgpt.com/codex/tasks/task_e_69062d12d4dc8332935b7d8b8d455f52