### PR TITLE
Add adaptive responses analytics for SquadSync

### DIFF
--- a/public/analytics/squadsync/index.tsx
+++ b/public/analytics/squadsync/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 
-import type { SquadSyncReport } from '../../../tools/graphql/schema.js';
+import type { SquadSyncAdaptivePayload, SquadSyncReport } from '../../../tools/graphql/schema.js';
 import EngagementSparkline from '../components/EngagementSparkline';
 import SquadSummaryGrid from '../components/SquadSummaryGrid';
 import RangePicker, { type RangeValue } from '../components/RangePicker';
@@ -38,6 +38,46 @@ const SQUADSYNC_QUERY = `
           deployments
           incidents
           engagement
+        }
+      }
+      adaptive {
+        summary {
+          total
+          critical
+          warning
+          info
+          variants {
+            key
+            total
+          }
+          squads {
+            squad
+            total
+            critical
+            warning
+            info
+            latestResponseAt
+          }
+        }
+        responses {
+          id
+          squad
+          priority
+          metric
+          title
+          message
+          value
+          baseline
+          delta
+          createdAt
+          expiresAt
+          tags
+          source
+          variant
+          range {
+            start
+            end
+          }
         }
       }
     }
@@ -100,6 +140,75 @@ const FALLBACK_REPORT: SquadSyncReport = {
       ],
     },
   ],
+  adaptive: {
+    summary: {
+      total: 3,
+      critical: 1,
+      warning: 1,
+      info: 1,
+      variants: [
+        { key: 'adaptive', total: 2 },
+        { key: 'control', total: 1 },
+      ],
+      squads: [
+        { squad: 'Delta', total: 2, critical: 1, warning: 0, info: 1, latestResponseAt: '2025-11-05T09:30:00Z' },
+        { squad: 'Bravo', total: 1, critical: 0, warning: 1, info: 0, latestResponseAt: '2025-11-01T10:00:00Z' },
+      ],
+    },
+    responses: [
+      {
+        id: 'bravo-engagement',
+        squad: 'Bravo',
+        priority: 'WARNING',
+        metric: 'engagement',
+        title: 'Potenziamento engagement squadra Bravo',
+        message: 'Coordina mentoring tra veterani e nuove reclute; calibra i briefing giornalieri sulle esigenze della squadra.',
+        value: 0.589,
+        baseline: 0.645,
+        delta: -0.056,
+        createdAt: '2025-11-05T08:00:00Z',
+        expiresAt: '2025-11-06T20:00:00Z',
+        tags: ['engagement', 'warning', 'adaptive'],
+        source: 'etl',
+        variant: 'adaptive',
+        range: { start: '2025-11-01', end: '2025-11-05' },
+      },
+      {
+        id: 'delta-incidents',
+        squad: 'Delta',
+        priority: 'CRITICAL',
+        metric: 'incidents',
+        title: 'Riduci incidenti operativi per Delta',
+        message: 'Assegna un supporto tattico dedicato e rivedi i protocolli di escalation; programma un dry-run con focus su crowd-control.',
+        value: 8,
+        baseline: 4.5,
+        delta: 3.5,
+        createdAt: '2025-11-05T09:30:00Z',
+        expiresAt: '2025-11-06T21:00:00Z',
+        tags: ['incidents', 'critical', 'adaptive'],
+        source: 'etl',
+        variant: 'adaptive',
+        range: { start: '2025-11-01', end: '2025-11-05' },
+      },
+      {
+        id: 'delta-deployments',
+        squad: 'Delta',
+        priority: 'INFO',
+        metric: 'deployments',
+        title: 'Celebra l\'efficienza operativa di Delta',
+        message: 'Mantieni il ritmo attuale con retrospettive brevi post-deployment; condividi le best practice nel canale cross-squad.',
+        value: 14,
+        baseline: 10,
+        delta: 4,
+        createdAt: '2025-11-05T09:30:00Z',
+        expiresAt: '2025-11-06T21:00:00Z',
+        tags: ['deployments', 'info', 'adaptive'],
+        source: 'etl',
+        variant: 'control',
+        range: { start: '2025-11-01', end: '2025-11-05' },
+      },
+    ],
+  },
 };
 
 function useFeatureFlag(flag: string, fallback = false): boolean {
@@ -168,12 +277,90 @@ function computeEngagementTrend(report: SquadSyncReport) {
 
 const DEFAULT_RANGE: RangeValue = { start: FALLBACK_REPORT.range.start, end: FALLBACK_REPORT.range.end };
 
+const AdaptiveResponsesPanel: React.FC<{ payload: SquadSyncAdaptivePayload }> = ({ payload }) => {
+  const { summary, responses } = payload;
+  if (summary.total === 0) {
+    return <p className="squadsync__placeholder">Nessuna risposta adattiva disponibile.</p>;
+  }
+
+  const variantBadges = summary.variants.length > 0 ? summary.variants : [{ key: 'adaptive', total: summary.total }];
+  const maxTotal = summary.squads.reduce((acc, squad) => Math.max(acc, squad.total), 0) || summary.total;
+
+  return (
+    <>
+      <div className="squadsync__adaptive-summary" aria-label="Riepilogo priorità">
+        <span className="squadsync__adaptive-chip" data-priority="CRITICAL">
+          Criticità <strong>{summary.critical}</strong>
+        </span>
+        <span className="squadsync__adaptive-chip" data-priority="WARNING">
+          Attenzioni <strong>{summary.warning}</strong>
+        </span>
+        <span className="squadsync__adaptive-chip" data-priority="INFO">
+          Informative <strong>{summary.info}</strong>
+        </span>
+      </div>
+      <div className="squadsync__adaptive-summary" aria-label="Varianti A/B">
+        {variantBadges.map((variant) => (
+          <span key={variant.key} className="squadsync__adaptive-chip" data-priority="INFO">
+            Variant {variant.key} <strong>{variant.total}</strong>
+          </span>
+        ))}
+      </div>
+      <div className="squadsync__adaptive-chart" aria-label="Distribuzione risposte per squadra">
+        {summary.squads.length === 0 ? (
+          <p className="squadsync__placeholder">Nessuna squadra con risposte attive.</p>
+        ) : (
+          summary.squads.map((squad) => (
+            <div key={squad.squad} className="squadsync__adaptive-bar">
+              <strong>{squad.squad}</strong>
+              <div className="squadsync__adaptive-bar-track" aria-hidden="true">
+                <span
+                  className="squadsync__adaptive-bar-fill"
+                  style={{
+                    width: `${Math.max(10, (squad.total / Math.max(maxTotal, 1)) * 100)}%`,
+                    background: '#6366f1',
+                  }}
+                />
+              </div>
+              <span>{squad.total}</span>
+            </div>
+          ))
+        )}
+      </div>
+      <div className="squadsync__adaptive-list" aria-label="Dettaglio risposte adattive">
+        {responses.map((response) => (
+          <article key={response.id} className="squadsync__adaptive-item" data-priority={response.priority}>
+            <h3>
+              {response.title} — <span>{response.squad}</span>
+            </h3>
+            <p>{response.message}</p>
+            <div className="squadsync__adaptive-meta">
+              <span>Metric: {response.metric}</span>
+              {typeof response.delta === 'number' && response.delta !== 0 && (
+                <span>
+                  Delta: {response.delta > 0 ? '+' : ''}
+                  {response.delta.toFixed(2)}
+                </span>
+              )}
+              {typeof response.baseline === 'number' && <span>Baseline: {response.baseline.toFixed(2)}</span>}
+              <span>Creato il: {new Date(response.createdAt).toLocaleString()}</span>
+              {response.expiresAt && <span>Scade il: {new Date(response.expiresAt).toLocaleString()}</span>}
+              <span>Variant: {response.variant}</span>
+            </div>
+          </article>
+        ))}
+      </div>
+    </>
+  );
+};
+
 const SquadSyncPage: React.FC = () => {
   const featureEnabled = useFeatureFlag('analytics.squadsync_view', false);
   const [range, setRange] = useState<RangeValue>(DEFAULT_RANGE);
   const [report, setReport] = useState<SquadSyncReport>(FALLBACK_REPORT);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<'overview' | 'adaptive'>('overview');
 
   useEffect(() => {
     if (!featureEnabled) {
@@ -234,6 +421,27 @@ const SquadSyncPage: React.FC = () => {
         .squadsync__totals-item { display: flex; flex-direction: column; }
         .squadsync__totals-item span { font-size: 0.75rem; color: #6b7280; }
         .squadsync__totals-item strong { font-size: 1.25rem; color: #111827; }
+        .squadsync__tabs { display: inline-flex; border: 1px solid #cbd5f5; border-radius: 0.5rem; overflow: hidden; margin-bottom: 1.5rem; }
+        .squadsync__tabs button { padding: 0.5rem 1rem; background: white; border: none; font-size: 0.875rem; cursor: pointer; color: #1f2937; }
+        .squadsync__tabs button[data-active="true"] { background: #4f46e5; color: white; }
+        .squadsync__adaptive-summary { display: flex; flex-wrap: wrap; gap: 1rem; margin-bottom: 1.5rem; }
+        .squadsync__adaptive-chip { padding: 0.5rem 0.75rem; border-radius: 999px; font-size: 0.75rem; font-weight: 600; display: inline-flex; align-items: center; gap: 0.35rem; }
+        .squadsync__adaptive-chip[data-priority="CRITICAL"] { background: rgba(239, 68, 68, 0.12); color: #b91c1c; }
+        .squadsync__adaptive-chip[data-priority="WARNING"] { background: rgba(249, 115, 22, 0.12); color: #c2410c; }
+        .squadsync__adaptive-chip[data-priority="INFO"] { background: rgba(16, 185, 129, 0.12); color: #047857; }
+        .squadsync__adaptive-chart { display: grid; gap: 0.75rem; margin-bottom: 1.5rem; }
+        .squadsync__adaptive-bar { display: grid; grid-template-columns: 140px 1fr 40px; align-items: center; gap: 0.75rem; font-size: 0.85rem; }
+        .squadsync__adaptive-bar strong { font-weight: 600; }
+        .squadsync__adaptive-bar-track { position: relative; height: 0.5rem; background: #e0e7ff; border-radius: 999px; overflow: hidden; }
+        .squadsync__adaptive-bar-fill { position: absolute; inset: 0; border-radius: 999px; }
+        .squadsync__adaptive-list { display: grid; gap: 1rem; }
+        .squadsync__adaptive-item { border: 1px solid #e5e7eb; border-left-width: 4px; border-radius: 0.5rem; padding: 0.85rem 1rem; background: #ffffff; box-shadow: 0 2px 6px rgba(15, 23, 42, 0.05); }
+        .squadsync__adaptive-item[data-priority="CRITICAL"] { border-left-color: #ef4444; }
+        .squadsync__adaptive-item[data-priority="WARNING"] { border-left-color: #f97316; }
+        .squadsync__adaptive-item[data-priority="INFO"] { border-left-color: #10b981; }
+        .squadsync__adaptive-item h3 { margin: 0 0 0.35rem; font-size: 1rem; }
+        .squadsync__adaptive-item p { margin: 0.35rem 0; font-size: 0.875rem; color: #374151; }
+        .squadsync__adaptive-meta { display: flex; flex-wrap: wrap; gap: 0.5rem 1rem; font-size: 0.75rem; color: #6b7280; }
       `}</style>
       <header>
         <h1>SquadSync — Engagement & Deployments</h1>
@@ -245,32 +453,46 @@ const SquadSyncPage: React.FC = () => {
         </div>
       )}
       {error && featureEnabled && <div className="squadsync__banner">Errore API: {error}</div>}
-      <RangePicker value={range} min="2023-10-01" max="2023-12-31" onChange={setRange} />
-      <EngagementSparkline title="Engagement medio giornaliero" points={trendPoints} highlightIndex={highlightIndex} />
-      <section className="squadsync__totals" aria-label="Totali periodo">
-        <div className="squadsync__totals-item">
-          <span>Deployments</span>
-          <strong>{report.totals.deployments}</strong>
-        </div>
-        <div className="squadsync__totals-item">
-          <span>Stand-up</span>
-          <strong>{report.totals.standups}</strong>
-        </div>
-        <div className="squadsync__totals-item">
-          <span>Incidenti</span>
-          <strong>{report.totals.incidents}</strong>
-        </div>
-        <div className="squadsync__totals-item">
-          <span>Engagement medio</span>
-          <strong>{report.totals.averageEngagement.toFixed(3)}</strong>
-        </div>
-        <div className="squadsync__totals-item">
-          <span>Active members medi</span>
-          <strong>{report.totals.averageActiveMembers.toFixed(1)}</strong>
-        </div>
-      </section>
-      {loading && featureEnabled && <p className="squadsync__placeholder">Aggiornamento in corso…</p>}
-      <SquadSummaryGrid squads={report.squads} />
+      <div className="squadsync__tabs" role="tablist">
+        <button type="button" data-active={activeTab === 'overview'} onClick={() => setActiveTab('overview')}>
+          Overview
+        </button>
+        <button type="button" data-active={activeTab === 'adaptive'} onClick={() => setActiveTab('adaptive')}>
+          Adaptive responses
+        </button>
+      </div>
+      {activeTab === 'overview' ? (
+        <>
+          <RangePicker value={range} min="2023-10-01" max="2023-12-31" onChange={setRange} />
+          <EngagementSparkline title="Engagement medio giornaliero" points={trendPoints} highlightIndex={highlightIndex} />
+          <section className="squadsync__totals" aria-label="Totali periodo">
+            <div className="squadsync__totals-item">
+              <span>Deployments</span>
+              <strong>{report.totals.deployments}</strong>
+            </div>
+            <div className="squadsync__totals-item">
+              <span>Stand-up</span>
+              <strong>{report.totals.standups}</strong>
+            </div>
+            <div className="squadsync__totals-item">
+              <span>Incidenti</span>
+              <strong>{report.totals.incidents}</strong>
+            </div>
+            <div className="squadsync__totals-item">
+              <span>Engagement medio</span>
+              <strong>{report.totals.averageEngagement.toFixed(3)}</strong>
+            </div>
+            <div className="squadsync__totals-item">
+              <span>Active members medi</span>
+              <strong>{report.totals.averageActiveMembers.toFixed(1)}</strong>
+            </div>
+          </section>
+          {loading && featureEnabled && <p className="squadsync__placeholder">Aggiornamento in corso…</p>}
+          <SquadSummaryGrid squads={report.squads} />
+        </>
+      ) : (
+        <AdaptiveResponsesPanel payload={report.adaptive} />
+      )}
     </main>
   );
 };

--- a/services/squadsync/adaptiveEngine.ts
+++ b/services/squadsync/adaptiveEngine.ts
@@ -1,0 +1,337 @@
+import { randomUUID } from 'node:crypto';
+
+export type AdaptivePriority = 'critical' | 'warning' | 'info';
+
+export interface AdaptiveRange {
+  start: string;
+  end: string;
+}
+
+export interface AdaptiveResponseInput {
+  id?: string;
+  squad: string;
+  priority: AdaptivePriority;
+  metric: string;
+  title: string;
+  message: string;
+  value: number;
+  baseline?: number | null;
+  delta?: number | null;
+  createdAt?: string | Date;
+  expiresAt?: string | Date | null;
+  ttlMs?: number;
+  tags?: string[];
+  source?: string;
+  variant?: string;
+  range?: AdaptiveRange | null;
+}
+
+export interface AdaptiveResponse {
+  id: string;
+  squad: string;
+  priority: AdaptivePriority;
+  metric: string;
+  title: string;
+  message: string;
+  value: number;
+  baseline: number | null;
+  delta: number | null;
+  createdAt: string;
+  expiresAt: string | null;
+  tags: string[];
+  source: string;
+  variant: string;
+  range: AdaptiveRange | null;
+}
+
+export interface AdaptiveSquadSummary {
+  squad: string;
+  total: number;
+  critical: number;
+  warning: number;
+  info: number;
+  latestResponseAt: string | null;
+}
+
+export interface AdaptiveVariantSummary {
+  [variant: string]: number;
+}
+
+export interface AdaptiveSummary {
+  total: number;
+  critical: number;
+  warning: number;
+  info: number;
+  variant: AdaptiveVariantSummary;
+  squads: AdaptiveSquadSummary[];
+}
+
+export interface AdaptiveSnapshot {
+  responses: AdaptiveResponse[];
+  summary: AdaptiveSummary;
+}
+
+export interface AdaptiveEngineOptions {
+  ttlMs?: number;
+  now?: () => Date;
+  maxTotal?: number;
+  maxPerSquad?: number;
+}
+
+const PRIORITY_ORDER: Record<AdaptivePriority, number> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+};
+
+function normaliseDate(value: string | Date | undefined | null, fallback: () => Date): Date {
+  if (!value) {
+    return fallback();
+  }
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) {
+      return fallback();
+    }
+    return value;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return fallback();
+  }
+  return parsed;
+}
+
+function sortResponses(a: AdaptiveResponse, b: AdaptiveResponse): number {
+  const priorityDiff = PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority];
+  if (priorityDiff !== 0) {
+    return priorityDiff;
+  }
+  const aDate = new Date(a.createdAt).getTime();
+  const bDate = new Date(b.createdAt).getTime();
+  if (aDate !== bDate) {
+    return bDate - aDate;
+  }
+  return a.id.localeCompare(b.id);
+}
+
+export class AdaptiveEngine {
+  private readonly ttlMs: number;
+
+  private readonly now: () => Date;
+
+  private readonly maxTotal: number;
+
+  private readonly maxPerSquad: number;
+
+  private readonly store: Map<string, AdaptiveResponse>;
+
+  constructor(options: AdaptiveEngineOptions = {}) {
+    this.ttlMs = typeof options.ttlMs === 'number' && Number.isFinite(options.ttlMs) ? Math.max(0, options.ttlMs) : 6 * 60 * 60 * 1000;
+    this.now = typeof options.now === 'function' ? options.now : () => new Date();
+    this.maxTotal = typeof options.maxTotal === 'number' && Number.isFinite(options.maxTotal) ? Math.max(1, Math.floor(options.maxTotal)) : 200;
+    this.maxPerSquad = typeof options.maxPerSquad === 'number' && Number.isFinite(options.maxPerSquad) ? Math.max(1, Math.floor(options.maxPerSquad)) : 20;
+    this.store = new Map();
+  }
+
+  seed(responses: AdaptiveResponseInput[]): void {
+    this.store.clear();
+    this.ingestMany(responses);
+  }
+
+  ingest(input: AdaptiveResponseInput): AdaptiveResponse {
+    const createdAt = normaliseDate(input.createdAt, this.now);
+    const ttl = typeof input.ttlMs === 'number' && Number.isFinite(input.ttlMs) ? Math.max(0, input.ttlMs) : this.ttlMs;
+    const expiresAtDate = input.expiresAt
+      ? normaliseDate(input.expiresAt, () => new Date(createdAt.getTime() + ttl))
+      : new Date(createdAt.getTime() + ttl);
+    const expiresAt = ttl === 0 && !input.expiresAt ? null : expiresAtDate.toISOString();
+    const baseline =
+      typeof input.baseline === 'number' && Number.isFinite(input.baseline)
+        ? Number(input.baseline)
+        : input.baseline === null
+          ? null
+          : null;
+    const inferredDelta =
+      typeof input.delta === 'number' && Number.isFinite(input.delta)
+        ? Number(input.delta)
+        : baseline === null
+          ? null
+          : Number((Number(input.value) - baseline).toFixed(3));
+    const response: AdaptiveResponse = {
+      id: input.id && input.id.trim() ? input.id : randomUUID(),
+      squad: input.squad,
+      priority: input.priority,
+      metric: input.metric,
+      title: input.title,
+      message: input.message,
+      value: Number.isFinite(input.value) ? Number(input.value) : 0,
+      baseline,
+      delta: inferredDelta,
+      createdAt: createdAt.toISOString(),
+      expiresAt,
+      tags: Array.isArray(input.tags) ? [...new Set(input.tags.map(String))] : [],
+      source: input.source || 'stream',
+      variant: input.variant || 'adaptive',
+      range: input.range ?? null,
+    };
+    this.store.set(response.id, response);
+    this.purgeExpired();
+    this.enforceLimits();
+    return response;
+  }
+
+  ingestMany(inputs: AdaptiveResponseInput[]): AdaptiveResponse[] {
+    return inputs.map((item) => this.ingest(item));
+  }
+
+  private enforceLimits(): void {
+    if (this.store.size <= this.maxTotal) {
+      this.trimPerSquad();
+      return;
+    }
+    const ordered = this.getResponses();
+    const allowedIds = new Set(ordered.slice(0, this.maxTotal).map((item) => item.id));
+    for (const id of this.store.keys()) {
+      if (!allowedIds.has(id)) {
+        this.store.delete(id);
+      }
+    }
+    this.trimPerSquad();
+  }
+
+  private trimPerSquad(): void {
+    const grouped = new Map<string, AdaptiveResponse[]>();
+    for (const response of this.store.values()) {
+      const list = grouped.get(response.squad) ?? [];
+      list.push(response);
+      grouped.set(response.squad, list);
+    }
+    for (const [squad, responses] of grouped) {
+      if (responses.length <= this.maxPerSquad) {
+        continue;
+      }
+      const ordered = responses.sort(sortResponses);
+      const allowed = new Set(ordered.slice(0, this.maxPerSquad).map((item) => item.id));
+      for (const response of responses) {
+        if (!allowed.has(response.id)) {
+          this.store.delete(response.id);
+        }
+      }
+    }
+  }
+
+  purgeExpired(reference?: Date): void {
+    const now = reference ?? this.now();
+    for (const [id, response] of this.store.entries()) {
+      if (!response.expiresAt) {
+        continue;
+      }
+      const expires = new Date(response.expiresAt);
+      if (!Number.isNaN(expires.getTime()) && expires.getTime() <= now.getTime()) {
+        this.store.delete(id);
+      }
+    }
+  }
+
+  getResponses(options: {
+    squad?: string;
+    variant?: string;
+    range?: AdaptiveRange;
+    limit?: number;
+  } = {}): AdaptiveResponse[] {
+    this.purgeExpired();
+    const { squad, variant, range } = options;
+    const limit = typeof options.limit === 'number' && Number.isFinite(options.limit) ? Math.max(1, options.limit) : null;
+    const filtered = Array.from(this.store.values()).filter((response) => {
+      if (squad && response.squad !== squad) {
+        return false;
+      }
+      if (variant && response.variant !== variant) {
+        return false;
+      }
+      if (range && response.range) {
+        const overlaps = response.range.start <= range.end && response.range.end >= range.start;
+        if (!overlaps) {
+          return false;
+        }
+      }
+      return true;
+    });
+    const ordered = filtered.sort(sortResponses);
+    if (limit && ordered.length > limit) {
+      return ordered.slice(0, limit);
+    }
+    return ordered;
+  }
+
+  snapshot(options: {
+    squad?: string;
+    variant?: string;
+    range?: AdaptiveRange;
+    limit?: number;
+  } = {}): AdaptiveSnapshot {
+    const responses = this.getResponses(options);
+    const summary = this.buildSummary(responses);
+    return { responses, summary };
+  }
+
+  private buildSummary(responses: AdaptiveResponse[]): AdaptiveSummary {
+    const summary: AdaptiveSummary = {
+      total: responses.length,
+      critical: 0,
+      warning: 0,
+      info: 0,
+      variant: {},
+      squads: [],
+    };
+    const perSquad = new Map<string, AdaptiveResponse[]>();
+
+    for (const response of responses) {
+      summary.variant[response.variant] = (summary.variant[response.variant] ?? 0) + 1;
+      if (response.priority === 'critical') {
+        summary.critical += 1;
+      } else if (response.priority === 'warning') {
+        summary.warning += 1;
+      } else {
+        summary.info += 1;
+      }
+      const bucket = perSquad.get(response.squad) ?? [];
+      bucket.push(response);
+      perSquad.set(response.squad, bucket);
+    }
+
+    const squads: AdaptiveSquadSummary[] = [];
+    for (const [squad, bucket] of perSquad.entries()) {
+      const ordered = bucket.sort(sortResponses);
+      squads.push({
+        squad,
+        total: bucket.length,
+        critical: bucket.filter((item) => item.priority === 'critical').length,
+        warning: bucket.filter((item) => item.priority === 'warning').length,
+        info: bucket.filter((item) => item.priority === 'info').length,
+        latestResponseAt: ordered.length > 0 ? ordered[0].createdAt : null,
+      });
+    }
+    squads.sort((a, b) => {
+      if (a.total !== b.total) {
+        return b.total - a.total;
+      }
+      if (a.latestResponseAt && b.latestResponseAt) {
+        return new Date(b.latestResponseAt).getTime() - new Date(a.latestResponseAt).getTime();
+      }
+      if (a.latestResponseAt) return -1;
+      if (b.latestResponseAt) return 1;
+      return a.squad.localeCompare(b.squad);
+    });
+    summary.squads = squads;
+    return summary;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+export function createAdaptiveEngine(options?: AdaptiveEngineOptions): AdaptiveEngine {
+  return new AdaptiveEngine(options);
+}

--- a/tests/analytics/squadsync_responses.test.ts
+++ b/tests/analytics/squadsync_responses.test.ts
@@ -1,0 +1,212 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createAdaptiveEngine } from '../../services/squadsync/adaptiveEngine.js';
+import type { AdaptiveResponseInput } from '../../services/squadsync/adaptiveEngine.js';
+import {
+  createSquadSyncAdaptiveRestHandler,
+  filterReportByRange,
+  type SquadSyncResolverOptions,
+} from '../../tools/graphql/resolvers/squadsync.js';
+import type {
+  SquadSyncReport,
+  SquadSyncSquad,
+  SquadSyncAdaptivePayload,
+} from '../../tools/graphql/schema.js';
+
+const makeSquad = (name: string, engagements: number[]): SquadSyncSquad => ({
+  name,
+  summary: {
+    daysCovered: engagements.length,
+    averageActiveMembers: 4,
+    totalDeployments: engagements.length * 3,
+    totalStandups: engagements.length * 4,
+    totalIncidents: Math.max(1, engagements.length - 1),
+    engagementScore: Number((engagements.reduce((acc, value) => acc + value, 0) / engagements.length).toFixed(3)),
+  },
+  daily: engagements.map((value, index) => ({
+    date: `2025-11-0${index + 1}`,
+    activeMembers: 4,
+    standups: 4,
+    deployments: 3,
+    incidents: index % 2 === 0 ? 1 : 2,
+    engagement: value,
+  })),
+});
+
+const baseReport: SquadSyncReport = {
+  range: { start: '2025-11-01', end: '2025-11-05', days: 5 },
+  generatedAt: '2025-11-06T12:00:00Z',
+  totals: {
+    deployments: 30,
+    standups: 40,
+    incidents: 12,
+    averageActiveMembers: 4,
+    averageEngagement: 0.68,
+  },
+  squads: [makeSquad('Bravo', [0.52, 0.55, 0.61]), makeSquad('Delta', [0.72, 0.76, 0.74])],
+  adaptive: {
+    responses: [
+      {
+        id: 'resp-1',
+        squad: 'Bravo',
+        priority: 'CRITICAL',
+        metric: 'engagement',
+        title: 'Boost Bravo',
+        message: 'Mentorship mirato',
+        value: 0.55,
+        baseline: 0.7,
+        delta: -0.15,
+        createdAt: '2025-11-06T12:00:00Z',
+        expiresAt: '2025-11-07T12:00:00Z',
+        tags: ['engagement'],
+        source: 'etl',
+        variant: 'adaptive',
+        range: { start: '2025-11-01', end: '2025-11-05' },
+      },
+      {
+        id: 'resp-2',
+        squad: 'Delta',
+        priority: 'WARNING',
+        metric: 'incidents',
+        title: 'Mitiga incidenti',
+        message: 'Rafforza il supporto',
+        value: 5,
+        baseline: 3,
+        delta: 2,
+        createdAt: '2025-11-06T12:05:00Z',
+        expiresAt: '2025-11-07T12:00:00Z',
+        tags: ['incidents'],
+        source: 'etl',
+        variant: 'adaptive',
+        range: { start: '2025-11-01', end: '2025-11-05' },
+      },
+      {
+        id: 'resp-3',
+        squad: 'Delta',
+        priority: 'INFO',
+        metric: 'deployments',
+        title: 'Celebra Delta',
+        message: 'Condividi best practice',
+        value: 8,
+        baseline: 5,
+        delta: 3,
+        createdAt: '2025-11-06T12:10:00Z',
+        expiresAt: '2025-11-07T12:00:00Z',
+        tags: ['deployments'],
+        source: 'etl',
+        variant: 'control',
+        range: { start: '2025-11-01', end: '2025-11-05' },
+      },
+    ],
+    summary: {
+      total: 3,
+      critical: 1,
+      warning: 1,
+      info: 1,
+      variants: [
+        { key: 'adaptive', total: 2 },
+        { key: 'control', total: 1 },
+      ],
+      squads: [],
+    },
+  },
+};
+
+describe('AdaptiveEngine priority pipeline', () => {
+  it('ordina per priorità e ripulisce le risposte scadute', () => {
+    const engine = createAdaptiveEngine({ ttlMs: 5 * 60_000, now: () => new Date('2025-11-06T12:00:00Z') });
+    const inputs: AdaptiveResponseInput[] = [
+      {
+        squad: 'Alpha',
+        priority: 'info',
+        metric: 'deployments',
+        title: 'Info Alpha',
+        message: 'Ottimo lavoro',
+        value: 5,
+        createdAt: '2025-11-06T11:58:00Z',
+        variant: 'adaptive',
+        range: { start: '2025-11-01', end: '2025-11-05' },
+      },
+      {
+        squad: 'Alpha',
+        priority: 'critical',
+        metric: 'engagement',
+        title: 'Allerta Alpha',
+        message: 'Serve supporto',
+        value: 0.42,
+        createdAt: '2025-11-06T11:59:30Z',
+        variant: 'adaptive',
+        range: { start: '2025-11-01', end: '2025-11-05' },
+      },
+      {
+        squad: 'Alpha',
+        priority: 'warning',
+        metric: 'incidents',
+        title: 'Incidents Alpha',
+        message: 'Riduci gli incidenti',
+        value: 4,
+        createdAt: '2025-11-06T11:58:30Z',
+        variant: 'control',
+        range: { start: '2025-11-01', end: '2025-11-05' },
+      },
+    ];
+    engine.ingestMany(inputs);
+
+    const initial = engine.getResponses();
+    assert.equal(initial[0].priority, 'critical');
+    assert.equal(initial[1].priority, 'warning');
+    assert.equal(initial[2].priority, 'info');
+
+    engine.purgeExpired(new Date('2025-11-06T12:30:00Z'));
+    const afterExpiry = engine.getResponses();
+    assert.equal(afterExpiry.length, 0);
+  });
+
+  it('calcola riepiloghi per variante A/B', () => {
+    const engine = createAdaptiveEngine({ ttlMs: 0, now: () => new Date('2025-11-06T12:00:00Z') });
+    engine.ingestMany([
+      { squad: 'Bravo', priority: 'critical', metric: 'engagement', title: 'A', message: 'A', value: 0.5, variant: 'adaptive' },
+      { squad: 'Bravo', priority: 'warning', metric: 'incidents', title: 'B', message: 'B', value: 3, variant: 'control' },
+      { squad: 'Delta', priority: 'info', metric: 'deployments', title: 'C', message: 'C', value: 9, variant: 'adaptive' },
+    ]);
+
+    const snapshot = engine.snapshot();
+    assert.equal(snapshot.summary.total, 3);
+    assert.equal(snapshot.summary.variant.adaptive, 2);
+    assert.equal(snapshot.summary.variant.control, 1);
+    const bravoSummary = snapshot.summary.squads.find((entry) => entry.squad === 'Bravo');
+    assert.ok(bravoSummary);
+    assert.equal(bravoSummary?.critical, 1);
+    assert.equal(bravoSummary?.warning, 1);
+  });
+});
+
+describe('GraphQL + REST integration', () => {
+  it('propaga le risposte adattive filtrate per range', () => {
+    const filtered = filterReportByRange(baseReport, { start: '2025-11-02', end: '2025-11-03' });
+    assert.equal(filtered.adaptive.summary.total, 3);
+    assert.equal(filtered.adaptive.summary.variants[0].key, 'adaptive');
+    assert.equal(filtered.adaptive.summary.variants[1].key, 'control');
+  });
+
+  it('espone un endpoint REST compatibile', async () => {
+    const handler = createSquadSyncAdaptiveRestHandler({
+      readReport: async () => baseReport,
+    } satisfies SquadSyncResolverOptions);
+
+    const outputs: unknown[] = [];
+    const res = {
+      status: (_code: number) => res,
+      json: (payload: unknown) => {
+        outputs.push(payload);
+      },
+    };
+
+    await handler({ query: { start: '2025-11-02', end: '2025-11-03' } }, res);
+    assert.equal(outputs.length, 1);
+    const payload = outputs[0] as { adaptive: SquadSyncAdaptivePayload };
+    assert.equal(payload.adaptive.summary.total, 3);
+    assert.equal(payload.adaptive.responses[0].priority, 'CRITICAL');
+  });
+});

--- a/tools/graphql/schema.ts
+++ b/tools/graphql/schema.ts
@@ -50,12 +50,70 @@ export const squadSyncTypeDefs = /* GraphQL */ `
     daily: [SquadSyncDailyStat!]!
   }
 
+  enum SquadSyncAdaptivePriority {
+    CRITICAL
+    WARNING
+    INFO
+  }
+
+  type SquadSyncAdaptiveRange {
+    start: String!
+    end: String!
+  }
+
+  type SquadSyncAdaptiveResponse {
+    id: ID!
+    squad: String!
+    priority: SquadSyncAdaptivePriority!
+    metric: String!
+    title: String!
+    message: String!
+    value: Float!
+    baseline: Float
+    delta: Float
+    createdAt: String!
+    expiresAt: String
+    tags: [String!]!
+    source: String!
+    variant: String!
+    range: SquadSyncAdaptiveRange
+  }
+
+  type SquadSyncAdaptiveVariantSummary {
+    key: String!
+    total: Int!
+  }
+
+  type SquadSyncAdaptiveSquadSummary {
+    squad: String!
+    total: Int!
+    critical: Int!
+    warning: Int!
+    info: Int!
+    latestResponseAt: String
+  }
+
+  type SquadSyncAdaptiveSummary {
+    total: Int!
+    critical: Int!
+    warning: Int!
+    info: Int!
+    variants: [SquadSyncAdaptiveVariantSummary!]!
+    squads: [SquadSyncAdaptiveSquadSummary!]!
+  }
+
+  type SquadSyncAdaptivePayload {
+    responses: [SquadSyncAdaptiveResponse!]!
+    summary: SquadSyncAdaptiveSummary!
+  }
+
   """Report completo di SquadSync (range, squadre, totali)."""
   type SquadSyncReport {
     range: SquadSyncRange!
     generatedAt: String!
     squads: [SquadSyncSquad!]!
     totals: SquadSyncAggregate!
+    adaptive: SquadSyncAdaptivePayload!
   }
 
   extend type Query {
@@ -93,6 +151,59 @@ export interface SquadSyncSquad {
   daily: SquadSyncDailyStat[];
 }
 
+export type SquadSyncAdaptivePriority = 'CRITICAL' | 'WARNING' | 'INFO';
+
+export interface SquadSyncAdaptiveRange {
+  start: string;
+  end: string;
+}
+
+export interface SquadSyncAdaptiveResponse {
+  id: string;
+  squad: string;
+  priority: SquadSyncAdaptivePriority;
+  metric: string;
+  title: string;
+  message: string;
+  value: number;
+  baseline: number | null;
+  delta: number | null;
+  createdAt: string;
+  expiresAt: string | null;
+  tags: string[];
+  source: string;
+  variant: string;
+  range: SquadSyncAdaptiveRange | null;
+}
+
+export interface SquadSyncAdaptiveVariantSummary {
+  key: string;
+  total: number;
+}
+
+export interface SquadSyncAdaptiveSquadSummary {
+  squad: string;
+  total: number;
+  critical: number;
+  warning: number;
+  info: number;
+  latestResponseAt: string | null;
+}
+
+export interface SquadSyncAdaptiveSummary {
+  total: number;
+  critical: number;
+  warning: number;
+  info: number;
+  variants: SquadSyncAdaptiveVariantSummary[];
+  squads: SquadSyncAdaptiveSquadSummary[];
+}
+
+export interface SquadSyncAdaptivePayload {
+  responses: SquadSyncAdaptiveResponse[];
+  summary: SquadSyncAdaptiveSummary;
+}
+
 export interface SquadSyncAggregate {
   deployments: number;
   standups: number;
@@ -106,6 +217,7 @@ export interface SquadSyncReport {
   generatedAt: string;
   squads: SquadSyncSquad[];
   totals: SquadSyncAggregate;
+  adaptive: SquadSyncAdaptivePayload;
 }
 
 export interface SquadSyncRangeInput {

--- a/tools/ts/tests/graphql_squadsync.test.ts
+++ b/tools/ts/tests/graphql_squadsync.test.ts
@@ -111,6 +111,17 @@ const MOCK_REPORT: SquadSyncReport = {
     averageActiveMembers: 7,
     averageEngagement: 0.614,
   },
+  adaptive: {
+    responses: [],
+    summary: {
+      total: 0,
+      critical: 0,
+      warning: 0,
+      info: 0,
+      variants: [],
+      squads: [],
+    },
+  },
 };
 
 test('schema contiene il type SquadSyncReport', () => {
@@ -130,6 +141,7 @@ test('resolver restituisce il report completo senza filtro range', async () => {
   assert.equal(result.totals.deployments, 10);
   assert.equal(result.squads[0].summary.engagementScore, 0.744);
   assert.equal(result.squads[1].daily[0].engagement, 0.333);
+  assert.equal(result.adaptive.summary.total, 0);
 });
 
 test('filterReportByRange riduce correttamente le squadre', () => {


### PR DESCRIPTION
## Summary
- add an adaptive response engine with priority queueing and TTL storage for SquadSync
- extend the SquadSync ETL, GraphQL schema/resolver, and analytics UI to surface adaptive insights via REST/GraphQL
- cover the new behaviour with targeted ETL, resolver, and service tests

## Testing
- pytest tests/analytics/test_etl_squadsync.py
- tools/ts/node_modules/.bin/tsx tests/analytics/squadsync_responses.test.ts

------
https://chatgpt.com/codex/tasks/task_e_69062d7facf08332a6e224cbf5c3f919