### PR TITLE
Refactor validator and quality endpoints into service layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "game-monorepo-shim",
       "dependencies": {
+        "ajv": "^8.17.1",
         "cors": "^2.8.5",
         "express": "^4.19.2",
         "js-yaml": "^4.1.0",
@@ -504,6 +505,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -888,10 +905,32 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/finalhandler": {
       "version": "1.3.1",
@@ -1232,6 +1271,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/lie": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
@@ -1422,6 +1467,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "webapp:qa": "npm --prefix webapp run qa"
   },
   "dependencies": {
+    "ajv": "^8.17.1",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "js-yaml": "^4.1.0",

--- a/schemas/quality/suggestion.schema.json
+++ b/schemas/quality/suggestion.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "quality://suggestion",
+  "title": "Quality Suggestion",
+  "type": "object",
+  "required": ["id"],
+  "additionalProperties": true,
+  "properties": {
+    "id": {
+      "oneOf": [
+        { "type": "string", "minLength": 1 },
+        { "type": "number" }
+      ]
+    },
+    "scope": {
+      "type": "string",
+      "enum": ["general", "species", "biome", "biomes", "foodweb"]
+    },
+    "action": {
+      "type": "string",
+      "enum": ["fix", "regenerate"]
+    },
+    "payload": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "entries": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "biomeId": {
+          "type": ["string", "null"]
+        },
+        "biome": {
+          "type": ["object", "null"]
+        },
+        "defaultHazard": {
+          "type": ["string", "null"]
+        },
+        "foodweb": {
+          "type": ["object", "null"]
+        }
+      }
+    }
+  }
+}

--- a/schemas/quality/suggestions-apply-request.schema.json
+++ b/schemas/quality/suggestions-apply-request.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "quality://suggestions/apply/request",
+  "title": "Apply Quality Suggestion Request",
+  "type": "object",
+  "required": ["suggestion"],
+  "additionalProperties": true,
+  "properties": {
+    "suggestion": {
+      "$ref": "quality://suggestion"
+    }
+  }
+}

--- a/server/middleware/schemaValidator.js
+++ b/server/middleware/schemaValidator.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const Ajv = require('ajv');
+
+class SchemaValidationError extends Error {
+  constructor(message, details = []) {
+    super(message);
+    this.name = 'SchemaValidationError';
+    this.statusCode = 400;
+    this.details = details;
+  }
+}
+
+function createSchemaValidator(options = {}) {
+  const ajv = new Ajv({
+    allErrors: true,
+    strict: false,
+    ...options.ajv,
+  });
+  const validators = new Map();
+
+  function registerSchema(id, schema) {
+    const schemaId = id || schema.$id;
+    if (!schemaId) {
+      throw new Error('ID schema richiesto per la registrazione');
+    }
+    ajv.removeSchema(schemaId);
+    ajv.addSchema(schema, schemaId);
+    const validator = ajv.getSchema(schemaId);
+    if (!validator) {
+      throw new Error(`Schema non valido o non registrato: ${schemaId}`);
+    }
+    validators.set(schemaId, validator);
+    return schemaId;
+  }
+
+  function validate(schemaId, payload) {
+    const validator = validators.get(schemaId);
+    if (!validator) {
+      throw new Error(`Validator non registrato per schema: ${schemaId}`);
+    }
+    const valid = validator(payload);
+    if (!valid) {
+      throw new SchemaValidationError('Payload non valido', validator.errors || []);
+    }
+    return true;
+  }
+
+  function createMiddleware(schemaId) {
+    return (req, res, next) => {
+      try {
+        validate(schemaId, req.body);
+        next();
+      } catch (error) {
+        if (error instanceof SchemaValidationError) {
+          res.status(error.statusCode).json({ error: error.message, details: error.details });
+          return;
+        }
+        next(error);
+      }
+    };
+  }
+
+  return {
+    registerSchema,
+    validate,
+    createMiddleware,
+  };
+}
+
+module.exports = {
+  createSchemaValidator,
+  SchemaValidationError,
+};

--- a/server/routes/quality.js
+++ b/server/routes/quality.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const express = require('express');
+const { applyQualitySuggestion, QualityServiceError } = require('../services/quality');
+
+function createQualityRouter({ runtimeValidator, generationOrchestrator, schemaValidator } = {}) {
+  const router = express.Router();
+  if (!schemaValidator) {
+    throw new Error('Schema validator richiesto per le rotte quality');
+  }
+
+  const validateSuggestionPayload = schemaValidator.createMiddleware('quality://suggestions/apply/request');
+
+  router.post('/suggestions/apply', validateSuggestionPayload, async (req, res) => {
+    try {
+      const payload = await applyQualitySuggestion(req.body || {}, {
+        runtimeValidator,
+        generationOrchestrator,
+      });
+      res.json(payload);
+    } catch (error) {
+      if (error instanceof QualityServiceError || error.statusCode) {
+        const status = error.statusCode || 400;
+        res.status(status).json({ error: error.message });
+        return;
+      }
+      res.status(500).json({ error: error.message || 'Errore applicazione suggerimento' });
+    }
+  });
+
+  return router;
+}
+
+module.exports = {
+  createQualityRouter,
+};

--- a/server/routes/validators.js
+++ b/server/routes/validators.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const express = require('express');
+const { validateRuntime, ValidatorServiceError } = require('../services/validator');
+
+function createValidatorsRouter({ runtimeValidator } = {}) {
+  const router = express.Router();
+
+  router.post('/runtime', async (req, res) => {
+    try {
+      const result = await validateRuntime(req.body || {}, { runtimeValidator });
+      res.json({ result });
+    } catch (error) {
+      if (error instanceof ValidatorServiceError || error.statusCode) {
+        const status = error.statusCode || 400;
+        res.status(status).json({ error: error.message });
+        return;
+      }
+      res.status(500).json({ error: error.message || 'Errore validazione runtime' });
+    }
+  });
+
+  return router;
+}
+
+module.exports = {
+  createValidatorsRouter,
+};

--- a/server/services/quality.js
+++ b/server/services/quality.js
@@ -1,0 +1,160 @@
+'use strict';
+
+class QualityServiceError extends Error {
+  constructor(message, statusCode = 400) {
+    super(message);
+    this.name = 'QualityServiceError';
+    this.statusCode = statusCode;
+  }
+}
+
+function createLogEntry(scope, level, message) {
+  return {
+    scope,
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validationLogs(scope, result = {}) {
+  const logs = [];
+  const messages = Array.isArray(result.messages) ? result.messages : [];
+  for (const entry of messages) {
+    if (!entry) continue;
+    if (typeof entry === 'string') {
+      logs.push(createLogEntry(scope, 'info', entry));
+      continue;
+    }
+    const level = entry.level || entry.severity || 'info';
+    const text = entry.message || entry.text || '';
+    if (text) {
+      logs.push(createLogEntry(scope, level, text));
+    }
+  }
+  if (Array.isArray(result.discarded) && result.discarded.length) {
+    logs.push(
+      createLogEntry(
+        scope,
+        'warning',
+        `Elementi scartati: ${result.discarded.length}`,
+      ),
+    );
+  }
+  if (Array.isArray(result.corrected) && result.corrected.length) {
+    logs.push(
+      createLogEntry(
+        scope,
+        'success',
+        `Correzioni applicate: ${result.corrected.length}`,
+      ),
+    );
+  }
+  return logs;
+}
+
+function generationLogs(scope, batch = {}) {
+  const logs = [];
+  const results = Array.isArray(batch.results) ? batch.results : [];
+  for (const result of results) {
+    const meta = result && result.meta ? result.meta : {};
+    const requestId = meta.request_id || meta.requestId || 'entry';
+    logs.push(
+      createLogEntry(
+        scope,
+        'success',
+        `Rigenerazione completata per ${requestId}`,
+      ),
+    );
+    const messages = result && result.validation ? result.validation.messages : [];
+    if (Array.isArray(messages) && messages.length) {
+      logs.push(
+        createLogEntry(
+          scope,
+          'info',
+          `${messages.length} messaggi di validazione disponibili`,
+        ),
+      );
+    }
+  }
+  const errors = Array.isArray(batch.errors) ? batch.errors : [];
+  for (const error of errors) {
+    if (!error) continue;
+    const requestId = error.request_id || error.requestId || error.index;
+    logs.push(
+      createLogEntry(
+        scope,
+        'error',
+        `Rigenerazione fallita (${requestId}): ${error.error || 'errore sconosciuto'}`,
+      ),
+    );
+  }
+  if (!logs.length) {
+    logs.push(createLogEntry(scope, 'info', 'Rigenerazione completata'));
+  }
+  return logs;
+}
+
+async function applyQualitySuggestion({ suggestion } = {}, dependencies = {}) {
+  const { runtimeValidator, generationOrchestrator } = dependencies;
+  if (!suggestion || !suggestion.id) {
+    throw new QualityServiceError("Suggerimento richiesto per l'applicazione", 400);
+  }
+  const scope = suggestion.scope || 'general';
+  const action = suggestion.action || 'fix';
+  const payload = suggestion.payload || {};
+  const logScope = scope === 'biomes' ? 'biome' : scope;
+
+  if (!runtimeValidator) {
+    throw new QualityServiceError('Runtime validator non configurato', 500);
+  }
+
+  let result = {};
+  let logs = [];
+
+  if (action === 'fix') {
+    if (scope === 'species') {
+      const entries = Array.isArray(payload.entries) ? payload.entries : [];
+      result = await runtimeValidator.validateSpeciesBatch(entries, {
+        biomeId: payload.biomeId,
+      });
+    } else if (scope === 'biome' || scope === 'biomes') {
+      result = await runtimeValidator.validateBiome(payload.biome, {
+        defaultHazard: payload.defaultHazard,
+      });
+    } else if (scope === 'foodweb') {
+      result = await runtimeValidator.validateFoodweb(payload.foodweb);
+    } else {
+      throw new QualityServiceError(`Scope non supportato per fix: ${scope}`, 400);
+    }
+    logs = validationLogs(logScope, result);
+  } else if (action === 'regenerate') {
+    if (scope === 'species') {
+      if (!generationOrchestrator || typeof generationOrchestrator.generateSpeciesBatch !== 'function') {
+        throw new QualityServiceError('Orchestrator rigenerazione non disponibile', 500);
+      }
+      const entries = Array.isArray(payload.entries) ? payload.entries : [];
+      result = await generationOrchestrator.generateSpeciesBatch({ batch: entries });
+      logs = generationLogs(logScope, result);
+    } else {
+      result = { status: 'scheduled', scope };
+      logs = [createLogEntry(logScope, 'info', 'Rigenerazione pianificata')];
+    }
+  } else {
+    throw new QualityServiceError(`Azione non supportata: ${action}`, 400);
+  }
+
+  return {
+    suggestion: { id: suggestion.id, scope, action },
+    result,
+    logs,
+  };
+}
+
+module.exports = {
+  applyQualitySuggestion,
+  QualityServiceError,
+  createLogEntry,
+  validationLogs,
+  generationLogs,
+};

--- a/server/services/validator.js
+++ b/server/services/validator.js
@@ -1,0 +1,42 @@
+'use strict';
+
+class ValidatorServiceError extends Error {
+  constructor(message, statusCode = 400) {
+    super(message);
+    this.name = 'ValidatorServiceError';
+    this.statusCode = statusCode;
+  }
+}
+
+async function validateRuntime({ kind, payload = {} } = {}, { runtimeValidator } = {}) {
+  if (!runtimeValidator) {
+    throw new ValidatorServiceError('Runtime validator non configurato', 500);
+  }
+  if (!kind) {
+    throw new ValidatorServiceError("Campo 'kind' richiesto", 400);
+  }
+
+  if (kind === 'species') {
+    const entries = Array.isArray(payload.entries) ? payload.entries : [];
+    return runtimeValidator.validateSpeciesBatch(entries, {
+      biomeId: payload.biomeId,
+    });
+  }
+
+  if (kind === 'biome') {
+    return runtimeValidator.validateBiome(payload.biome, {
+      defaultHazard: payload.defaultHazard,
+    });
+  }
+
+  if (kind === 'foodweb') {
+    return runtimeValidator.validateFoodweb(payload.foodweb);
+  }
+
+  throw new ValidatorServiceError(`kind non supportato: ${kind}`, 400);
+}
+
+module.exports = {
+  validateRuntime,
+  ValidatorServiceError,
+};

--- a/tests/server/quality-service.spec.js
+++ b/tests/server/quality-service.spec.js
@@ -1,0 +1,148 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { applyQualitySuggestion, QualityServiceError } = require('../../server/services/quality');
+
+test('applyQualitySuggestion esegue fix specie e produce log di validazione', async () => {
+  const calls = [];
+  const runtimeValidator = {
+    async validateSpeciesBatch(entries, context) {
+      calls.push({ method: 'species', entries, context });
+      return {
+        corrected: entries,
+        messages: [
+          'Specie corretta',
+          { level: 'warning', message: 'Valore anomalo' },
+        ],
+        discarded: [{}],
+      };
+    },
+  };
+
+  const result = await applyQualitySuggestion(
+    {
+      suggestion: {
+        id: 'fix-1',
+        scope: 'species',
+        action: 'fix',
+        payload: { entries: [{ id: 1 }], biomeId: 'forest' },
+      },
+    },
+    { runtimeValidator },
+  );
+
+  assert.equal(result.suggestion.id, 'fix-1');
+  assert.equal(result.suggestion.scope, 'species');
+  assert.equal(result.suggestion.action, 'fix');
+  assert.equal(result.logs.length, 4);
+  assert.equal(result.logs[0].level, 'info');
+  assert.equal(result.logs[1].level, 'warning');
+  assert.equal(result.logs[2].level, 'warning');
+  assert.equal(result.logs[3].level, 'success');
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], {
+    method: 'species',
+    entries: [{ id: 1 }],
+    context: { biomeId: 'forest' },
+  });
+});
+
+test('applyQualitySuggestion rigenera specie con orchestrator', async () => {
+  const runtimeValidator = {
+    async validateSpeciesBatch() {
+      throw new Error('non dovrebbe essere chiamato');
+    },
+  };
+  const generationOrchestrator = {
+    async generateSpeciesBatch({ batch }) {
+      return {
+        results: [
+          { meta: { request_id: 'req-1' }, validation: { messages: ['ok'] } },
+        ],
+        errors: [
+          { request_id: 'req-2', error: 'fallimento' },
+        ],
+      };
+    },
+  };
+
+  const result = await applyQualitySuggestion(
+    {
+      suggestion: {
+        id: 'regen-1',
+        scope: 'species',
+        action: 'regenerate',
+        payload: { entries: [{ id: 2 }] },
+      },
+    },
+    { runtimeValidator, generationOrchestrator },
+  );
+
+  assert.equal(result.result.results[0].meta.request_id, 'req-1');
+  assert.equal(result.logs.length, 3);
+  assert.equal(result.logs[0].level, 'success');
+  assert.equal(result.logs[1].level, 'info');
+  assert.equal(result.logs[2].level, 'error');
+});
+
+test('applyQualitySuggestion pianifica rigenerazione per scope non specie', async () => {
+  const runtimeValidator = {
+    async validateFoodweb() {
+      throw new Error('non dovrebbe essere chiamato');
+    },
+  };
+
+  const result = await applyQualitySuggestion(
+    {
+      suggestion: {
+        id: 'regen-2',
+        scope: 'biomes',
+        action: 'regenerate',
+        payload: {},
+      },
+    },
+    { runtimeValidator },
+  );
+
+  assert.deepEqual(result.result, { status: 'scheduled', scope: 'biomes' });
+  assert.equal(result.logs.length, 1);
+  assert.equal(result.logs[0].message, 'Rigenerazione pianificata');
+});
+
+test('applyQualitySuggestion segnala scope fix non supportato', async () => {
+  const runtimeValidator = {
+    async validateSpeciesBatch() {
+      return {};
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      applyQualitySuggestion(
+        { suggestion: { id: 'fix-unsupported', scope: 'unknown', action: 'fix', payload: {} } },
+        { runtimeValidator },
+      ),
+    (error) => {
+      assert.ok(error instanceof QualityServiceError);
+      assert.equal(error.statusCode, 400);
+      return true;
+    },
+  );
+});
+
+test('applyQualitySuggestion richiede suggestion con id', async () => {
+  const runtimeValidator = {
+    async validateSpeciesBatch() {
+      return {};
+    },
+  };
+
+  await assert.rejects(
+    () => applyQualitySuggestion({}, { runtimeValidator }),
+    (error) => {
+      assert.ok(error instanceof QualityServiceError);
+      assert.equal(error.message, "Suggerimento richiesto per l'applicazione");
+      return true;
+    },
+  );
+});

--- a/tests/server/schema-validator.spec.js
+++ b/tests/server/schema-validator.spec.js
@@ -1,0 +1,44 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { createSchemaValidator, SchemaValidationError } = require('../../server/middleware/schemaValidator');
+const qualitySuggestionSchema = require('../../schemas/quality/suggestion.schema.json');
+const qualityApplySchema = require('../../schemas/quality/suggestions-apply-request.schema.json');
+
+test('schema validator accetta payload valido per quality suggestion apply', () => {
+  const schemaValidator = createSchemaValidator();
+  schemaValidator.registerSchema('quality://suggestion', qualitySuggestionSchema);
+  schemaValidator.registerSchema('quality://suggestions/apply/request', qualityApplySchema);
+
+  const payload = {
+    suggestion: {
+      id: 'fix-1',
+      scope: 'species',
+      action: 'fix',
+      payload: {
+        entries: [{ id: 1 }],
+        biomeId: 'forest',
+      },
+    },
+  };
+
+  assert.doesNotThrow(() => schemaValidator.validate('quality://suggestions/apply/request', payload));
+});
+
+test('schema validator rifiuta payload senza id suggerimento', () => {
+  const schemaValidator = createSchemaValidator();
+  schemaValidator.registerSchema('quality://suggestion', qualitySuggestionSchema);
+  schemaValidator.registerSchema('quality://suggestions/apply/request', qualityApplySchema);
+
+  assert.throws(
+    () =>
+      schemaValidator.validate('quality://suggestions/apply/request', {
+        suggestion: { scope: 'species', action: 'fix', payload: {} },
+      }),
+    (error) => {
+      assert.ok(error instanceof SchemaValidationError);
+      assert.equal(error.statusCode, 400);
+      return true;
+    },
+  );
+});

--- a/tests/server/validator-service.spec.js
+++ b/tests/server/validator-service.spec.js
@@ -1,0 +1,68 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { validateRuntime, ValidatorServiceError } = require('../../server/services/validator');
+
+test('validateRuntime delega a validateSpeciesBatch', async () => {
+  const calls = [];
+  const runtimeValidator = {
+    async validateSpeciesBatch(entries, context) {
+      calls.push({ entries, context });
+      return { corrected: entries, messages: [] };
+    },
+  };
+
+  const payload = { kind: 'species', payload: { entries: [{ id: 1 }], biomeId: 'forest' } };
+  const result = await validateRuntime(payload, { runtimeValidator });
+
+  assert.deepEqual(result, { corrected: payload.payload.entries, messages: [] });
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], {
+    entries: payload.payload.entries,
+    context: { biomeId: 'forest' },
+  });
+});
+
+test('validateRuntime delega a validateBiome', async () => {
+  let called = false;
+  const runtimeValidator = {
+    async validateBiome(biome, context) {
+      called = true;
+      assert.deepEqual(biome, { id: 'desert' });
+      assert.deepEqual(context, { defaultHazard: 'sandstorm' });
+      return { corrected: biome };
+    },
+  };
+
+  const result = await validateRuntime(
+    { kind: 'biome', payload: { biome: { id: 'desert' }, defaultHazard: 'sandstorm' } },
+    { runtimeValidator },
+  );
+
+  assert.ok(called);
+  assert.deepEqual(result, { corrected: { id: 'desert' } });
+});
+
+test('validateRuntime solleva errore per kind non supportato', async () => {
+  const runtimeValidator = {};
+  await assert.rejects(
+    () => validateRuntime({ kind: 'unknown', payload: {} }, { runtimeValidator }),
+    (error) => {
+      assert.ok(error instanceof ValidatorServiceError);
+      assert.equal(error.message, 'kind non supportato: unknown');
+      assert.equal(error.statusCode, 400);
+      return true;
+    },
+  );
+});
+
+test('validateRuntime richiede runtimeValidator configurato', async () => {
+  await assert.rejects(
+    () => validateRuntime({ kind: 'species' }),
+    (error) => {
+      assert.equal(error.message, 'Runtime validator non configurato');
+      assert.equal(error.statusCode, 500);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- extract runtime validator handling into a dedicated service and router
- move quality suggestion application into a service with schema-backed validation
- add JSON schemas and unit tests covering the new services and schema validation

## Testing
- node --test tests/server/validator-service.spec.js
- node --test tests/server/quality-service.spec.js
- node --test tests/server/schema-validator.spec.js

------
https://chatgpt.com/codex/tasks/task_e_69062fd14c488332a4823ae280c37be6