### PR TITLE
Update generation API clients to v1 endpoints

### DIFF
--- a/tests/api/quality-release.test.js
+++ b/tests/api/quality-release.test.js
@@ -15,11 +15,11 @@ const speciesEntry = {
   balance: {},
 };
 
-test('POST /api/quality/suggestions/apply esegue fix specie via runtime validator', async () => {
+test('POST /api/v1/quality/suggestions/apply esegue fix specie via runtime validator', async () => {
   const { app } = createApp();
 
   const response = await request(app)
-    .post('/api/quality/suggestions/apply')
+    .post('/api/v1/quality/suggestions/apply')
     .send({
       suggestion: {
         id: 'spec-fix',
@@ -39,11 +39,11 @@ test('POST /api/quality/suggestions/apply esegue fix specie via runtime validato
   assert.ok(logs.every((log) => log.scope === 'species'), 'i log devono essere marcati come specie');
 });
 
-test('POST /api/quality/suggestions/apply rigenera batch tramite orchestrator', async () => {
+test('POST /api/v1/quality/suggestions/apply rigenera batch tramite orchestrator', async () => {
   const { app } = createApp();
 
   const response = await request(app)
-    .post('/api/quality/suggestions/apply')
+    .post('/api/v1/quality/suggestions/apply')
     .send({
       suggestion: {
         id: 'spec-regenerate',

--- a/tests/generation/flow-shell.spec.ts
+++ b/tests/generation/flow-shell.spec.ts
@@ -33,7 +33,7 @@ function createStubDiagnostics(summary = {}) {
   };
 }
 
-test('GET /api/generation/snapshot aggrega dataset, diagnostics e orchestrator', async () => {
+test('GET /api/v1/generation/snapshot aggrega dataset, diagnostics e orchestrator', async () => {
   const diagnosticsSummary = {
     total_traits: 12,
     glossary_ok: 10,
@@ -65,7 +65,7 @@ test('GET /api/generation/snapshot aggrega dataset, diagnostics e orchestrator',
     repo: {},
   });
 
-  const response = await request(app).get('/api/generation/snapshot').expect(200);
+  const response = await request(app).get('/api/v1/generation/snapshot').expect(200);
   const snapshot = response.body;
 
   assert.ok(Array.isArray(snapshot?.overview?.objectives), 'overview deve essere presente');
@@ -83,7 +83,7 @@ test('GET /api/generation/snapshot aggrega dataset, diagnostics e orchestrator',
   );
 });
 
-test('GET /api/generation/snapshot?refresh=1 ricarica il dataset da disco', async (t) => {
+test('GET /api/v1/generation/snapshot?refresh=1 ricarica il dataset da disco', async (t) => {
   const tempDir = await mkdtemp(path.join(tmpdir(), 'flow-shell-'));
   t.after(async () => {
     await rm(tempDir, { recursive: true, force: true });
@@ -126,7 +126,7 @@ test('GET /api/generation/snapshot?refresh=1 ricarica il dataset da disco', asyn
     repo: {},
   });
 
-  const responseV1 = await request(app).get('/api/generation/snapshot').expect(200);
+  const responseV1 = await request(app).get('/api/v1/generation/snapshot').expect(200);
   assert.equal(responseV1.body.overview.title, 'Versione 1');
   assert.equal(responseV1.body.runtime.lastBlueprintId, 'blueprint-req-v1');
   assert.equal(orchestratorCalls.length, 1);
@@ -147,14 +147,14 @@ test('GET /api/generation/snapshot?refresh=1 ricarica il dataset da disco', asyn
   };
   await writeFile(datasetPath, JSON.stringify(datasetV2, null, 2));
 
-  const cachedResponse = await request(app).get('/api/generation/snapshot').expect(200);
+  const cachedResponse = await request(app).get('/api/v1/generation/snapshot').expect(200);
   assert.equal(cachedResponse.body.overview.title, 'Versione 1');
   assert.equal(cachedResponse.body.runtime.lastBlueprintId, 'blueprint-req-v1');
   assert.equal(orchestratorCalls.length, 2);
   assert.deepEqual(orchestratorCalls[1].trait_ids, datasetV1.initialSpeciesRequest.trait_ids);
 
   const refreshedResponse = await request(app)
-    .get('/api/generation/snapshot?refresh=1')
+    .get('/api/v1/generation/snapshot?refresh=1')
     .expect(200);
   assert.equal(refreshedResponse.body.overview.title, 'Versione 2');
   assert.equal(refreshedResponse.body.runtime.lastBlueprintId, 'blueprint-req-v2');

--- a/tools/recap/generateRecap.js
+++ b/tools/recap/generateRecap.js
@@ -4,7 +4,7 @@ const fs = require('node:fs/promises');
 const path = require('node:path');
 
 const SNAPSHOT_ENDPOINT =
-  process.env.RECAP_SNAPSHOT_ENDPOINT || 'http://localhost:3000/api/generation/snapshot';
+  process.env.RECAP_SNAPSHOT_ENDPOINT || 'http://localhost:3000/api/v1/generation/snapshot';
 const NEBULA_BASE = process.env.RECAP_NEBULA_BASE || 'http://localhost:3000/api/v1/atlas';
 const NEBULA_DATASET_ENDPOINT =
   process.env.RECAP_NEBULA_DATASET_ENDPOINT || `${NEBULA_BASE.replace(/\/$/, '')}/dataset`;

--- a/webapp/src/config/dataSources.ts
+++ b/webapp/src/config/dataSources.ts
@@ -62,7 +62,7 @@ function buildEntry(id: DataSourceId, defaults: DataSourceDefaults): DataSourceE
 
 const defaults: Record<DataSourceId, DataSourceDefaults> = {
   flowSnapshot: {
-    endpoint: '/api/generation/snapshot',
+    endpoint: '/api/v1/generation/snapshot',
     fallback: 'data/flow/snapshots/flow-shell-snapshot.json',
     env: {
       endpoint: 'VITE_FLOW_SNAPSHOT_URL',
@@ -94,7 +94,7 @@ const defaults: Record<DataSourceId, DataSourceDefaults> = {
     },
   },
   runtimeValidatorSpecies: {
-    endpoint: '/api/validators/runtime',
+    endpoint: '/api/v1/validators/runtime',
     fallback: 'data/flow/validators/species.json',
     env: {
       endpoint: 'VITE_RUNTIME_VALIDATION_URL',
@@ -102,7 +102,7 @@ const defaults: Record<DataSourceId, DataSourceDefaults> = {
     },
   },
   runtimeValidatorBiome: {
-    endpoint: '/api/validators/runtime',
+    endpoint: '/api/v1/validators/runtime',
     fallback: 'data/flow/validators/biome.json',
     env: {
       endpoint: 'VITE_RUNTIME_VALIDATION_URL',
@@ -110,7 +110,7 @@ const defaults: Record<DataSourceId, DataSourceDefaults> = {
     },
   },
   runtimeValidatorFoodweb: {
-    endpoint: '/api/validators/runtime',
+    endpoint: '/api/v1/validators/runtime',
     fallback: 'data/flow/validators/foodweb.json',
     env: {
       endpoint: 'VITE_RUNTIME_VALIDATION_URL',
@@ -118,7 +118,7 @@ const defaults: Record<DataSourceId, DataSourceDefaults> = {
     },
   },
   qualitySuggestionsApply: {
-    endpoint: '/api/quality/suggestions/apply',
+    endpoint: '/api/v1/quality/suggestions/apply',
     fallback: 'data/flow/quality/suggestions/apply.json',
     env: {
       endpoint: 'VITE_QUALITY_SUGGESTIONS_URL',

--- a/webapp/src/state/useSnapshotLoader.ts
+++ b/webapp/src/state/useSnapshotLoader.ts
@@ -96,7 +96,7 @@ export function useSnapshotLoader(options: SnapshotLoaderOptions = {}) {
       ? normaliseOverride(options.fallbackSnapshotUrl)
       : undefined,
   }) as { endpoint?: string | null; fallback?: string | null };
-  const snapshotEndpoint = source.endpoint || '/api/generation/snapshot';
+  const snapshotEndpoint = source.endpoint || '/api/v1/generation/snapshot';
   const snapshotUrl = resolveApiUrl(snapshotEndpoint);
   const fallbackSnapshotUrl = source.fallback ? resolveAssetUrl(source.fallback) : null;
   const fetchImpl = resolveFetchImplementation(options.fetch);

--- a/webapp/tests/config/dataSources.spec.ts
+++ b/webapp/tests/config/dataSources.spec.ts
@@ -27,7 +27,7 @@ describe('data sources registry', () => {
     const flowSnapshot = getDataSource('flowSnapshot');
     expect(flowSnapshot).toEqual({
       id: 'flowSnapshot',
-      endpoint: '/api/generation/snapshot',
+      endpoint: '/api/v1/generation/snapshot',
       fallback: 'data/flow/snapshots/flow-shell-snapshot.json',
       mock: null,
     });

--- a/webapp/tests/state/flowStores.spec.ts
+++ b/webapp/tests/state/flowStores.spec.ts
@@ -11,7 +11,7 @@ const dataSourceMock = vi.hoisted(() => {
   const defaults = new Map<string, { endpoint: string | null; fallback: string | null; mock: string | null }>([
     [
       'flowSnapshot',
-      { endpoint: '/api/generation/snapshot', fallback: 'data/flow/snapshots/flow-shell-snapshot.json', mock: null },
+      { endpoint: '/api/v1/generation/snapshot', fallback: 'data/flow/snapshots/flow-shell-snapshot.json', mock: null },
     ],
     ['generationSpecies', { endpoint: '/api/v1/generation/species', fallback: null, mock: null }],
     ['generationSpeciesBatch', { endpoint: '/api/v1/generation/species/batch', fallback: null, mock: null }],
@@ -108,7 +108,7 @@ describe('flow stores', () => {
   describe('useSnapshotLoader', () => {
     it('carica lo snapshot da endpoint remoto', async () => {
       const fetchMock = vi.fn(async (url: string) => {
-        if (url === '/api/generation/snapshot') {
+        if (url === '/api/v1/generation/snapshot') {
           return {
             ok: true,
             status: 200,
@@ -121,11 +121,11 @@ describe('flow stores', () => {
       const store = useSnapshotLoader({
         logger,
         fetch: fetchMock as unknown as typeof fetch,
-        snapshotUrl: '/api/generation/snapshot',
+        snapshotUrl: '/api/v1/generation/snapshot',
         fallbackSnapshotUrl: null,
       });
       await store.fetchSnapshot();
-      expect(fetchMock).toHaveBeenCalledWith('/api/generation/snapshot', { cache: 'no-store' });
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/generation/snapshot', { cache: 'no-store' });
       expect(store.source.value).toBe('remote');
       expect(store.overview.value.completion.total).toBe(10);
       expect(logger.log).toHaveBeenCalledWith('snapshot.load.success', expect.any(Object));
@@ -133,7 +133,7 @@ describe('flow stores', () => {
 
     it('applica il fallback locale se la richiesta remota fallisce', async () => {
       const fetchMock = vi.fn(async (url: string) => {
-        if (url === '/api/generation/snapshot') {
+        if (url === '/api/v1/generation/snapshot') {
           return { ok: false, status: 503, json: async () => ({}) };
         }
         if (url === 'data/flow/snapshots/flow-shell-snapshot.json') {
@@ -149,7 +149,7 @@ describe('flow stores', () => {
       const store = useSnapshotLoader({
         logger,
         fetch: fetchMock as unknown as typeof fetch,
-        snapshotUrl: '/api/generation/snapshot',
+        snapshotUrl: '/api/v1/generation/snapshot',
         fallbackSnapshotUrl: 'data/flow/snapshots/flow-shell-snapshot.json',
       });
       await store.fetchSnapshot();


### PR DESCRIPTION
## Summary
- point flow snapshot, runtime validation, and quality suggestion data sources to the `/api/v1` endpoints
- update backend tests and recap CLI defaults to exercise the v1 generation and quality routes
- refresh webapp state/tests to consume the new snapshot URL shape

## Testing
- npm run test:api *(fails: server/app.js expects global buildSlugConfig helper in this environment)*
- npm --prefix webapp run test -- ../tests/webapp/flow-shell-refresh.spec.ts *(fails: ProgressTracker.vue import missing in repo)*
- npm --prefix webapp run test -- tests/config/dataSources.spec.ts tests/state/flowStores.spec.ts
- npm --prefix tools/ts run test


------
https://chatgpt.com/codex/tasks/task_e_69063a396a148332af70a1b292185218