### PR TITLE
Add TAP rollout gates for HUD overlay and adaptive engine

### DIFF
--- a/.github/workflows/deploy-test-interface.yml
+++ b/.github/workflows/deploy-test-interface.yml
@@ -38,6 +38,10 @@ jobs:
         working-directory: tools/ts
         run: npm run build --if-present
 
+      - name: Run adaptive engine TAP tests
+        working-directory: tools/ts
+        run: npx tsx ../tests/analytics/squadsync_responses.test.ts
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -47,6 +51,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r tools/py/requirements.txt
+
+      - name: Validate HUD smart alert logs (TAP overlay)
+        run: |
+          python3 scripts/qa/hud_smart_alerts.py \
+            logs/playtests \
+            --json-report "$RUNNER_TEMP/hud_smart_alerts.json"
 
       - name: Run CLI smoke suite
         run: ./scripts/cli_smoke.sh

--- a/config/feature_flags.yaml
+++ b/config/feature_flags.yaml
@@ -15,6 +15,28 @@ feature_flags:
       metrics:
         - "Engagement medio > 0.58 nelle squadre canary"
         - "Tempo medio stand-up < 11 minuti"
+    adaptive_engine_tap:
+      description: "Attiva il motore adaptive per SquadSync con programma TAP dedicato."
+      default: false
+      rollout:
+        phase: limited_availability
+        program: tap
+        stage_gate: squadsync-tap-go
+        cohorts:
+          - squadsync-tap-alpha
+          - squadsync-tap-bravo
+          - qa-insights
+        start: 2025-11-18
+        target: 2025-12-02
+      owner: analytics
+      controls:
+        contact: analytics-duty@gamestudio.local
+        slack: "#analytics-squadsync"
+        playbook: docs/process/telemetry_ingestion_pipeline.md
+      metrics:
+        - "Ack rate adaptive ≥ 82% su finestre 24h"
+        - "Tempo medio risposta adaptive ≤ 5m"
+        - "Tilt medio post-risposta < 0.48"
   idea_engine:
     feedback_enhancements:
       description: "Attiva il modulo feedback con fallback Slack #feedback-enhancements."
@@ -29,3 +51,26 @@ feature_flags:
       metrics:
         - "Tempo medio risposta feedback < 24h"
         - "Numero escalation Slack gestite per sprint >= 3"
+  hud:
+    smart_overlay_tap:
+      description: "Abilita l'overlay telemetrico Smart HUD per il programma TAP."
+      default: false
+      rollout:
+        phase: limited_availability
+        program: tap
+        stage_gate: hud-tap-go
+        cohorts:
+          - hud-tap-alpha
+          - hud-tap-bravo
+          - ops-foxtrot
+        start: 2025-11-14
+        target: 2025-11-28
+      owner: ui_systems
+      controls:
+        contact: ui-systems@gamestudio.local
+        slack: "#hud-alerts"
+        playbook: docs/process/qa_hud.md
+      metrics:
+        - "Durata alert P95 ≤ 2 turni"
+        - "Ack rate ≥ 85% sulle coorti TAP"
+        - "Tilt medio < 0.50 dopo l'overlay"

--- a/docs/qa/rollout_checklist.md
+++ b/docs/qa/rollout_checklist.md
@@ -21,6 +21,17 @@ Questa checklist coordina QA, Ops e Analytics durante il rollout canary di Missi
   - `hud_action_latency_p95` ≤ 3800 ms (6h) → apri ticket nel board QA rollout.
   - `playtest_squad_engagement` ≥ 0.62 (7d) → sync con Analytics Duty.
 
+## Scenari overlay & adaptive response
+- [ ] Simula alert risk > 0.60 su coorti TAP e verifica che l'overlay HUD mostri soglie risk/cohesion aggiornate.
+- [ ] Conferma ack entro 2 turni medi e registra recipient in `hud_alert_log.json` per ogni overlay mostrato.
+- [ ] Valida che l'Adaptive Engine generi risposte `critical` e `warning` per squadre TAP con delta engagement coerente.
+- [ ] Riesegui `npx tsx tests/analytics/squadsync_responses.test.ts` per garantire compatibilità REST/GraphQL delle risposte adaptive.
+
+## Criteri di rollback
+- [ ] Ack rate < 0.82 su finestra 24h o durata alert P95 > 2 turni → rollback immediato dell'overlay TAP.
+- [ ] Tilt medio > 0.50 dopo 3 cicli consecutivi → disattiva flag `hud.smart_overlay_tap` e notifica `#hud-alerts`.
+- [ ] Adaptive Engine con delta engagement negativo > 12% per due squadre TAP → ripristina configurazione precedente e avvia post-mortem.
+
 ## Gate di avanzamento
 - [ ] Approvazione QA Insights dopo 24h di stabilità.
 - [ ] Validazione Ops per uptime costante.

--- a/tools/monitoring/rollout/dashboard.yaml
+++ b/tools/monitoring/rollout/dashboard.yaml
@@ -84,11 +84,53 @@ panels:
             value: 1
         annotations:
           - text: "Rollback massimo 1 per giorno"
+  - id: hud-tap-overlay
+    title: "HUD TAP Overlay - Stabilità"
+    description: "Durata alert, ack rate e tilt per il programma Smart HUD TAP."
+    layout:
+      row: 9
+      column: 1
+      width: 12
+      height: 8
+    queries:
+      - metric: hud_alert_duration_turns_p95
+        visualization: timeseries
+        thresholds:
+          - level: warning
+            condition: above
+            value: 1.8
+          - level: critical
+            condition: above
+            value: 2.0
+        annotations:
+          - text: "Durata alert target ≤2 turni"
+      - metric: hud_ack_rate
+        visualization: timeseries
+        thresholds:
+          - level: warning
+            condition: below
+            value: 0.85
+          - level: critical
+            condition: below
+            value: 0.82
+        annotations:
+          - text: "Ack rate minimo TAP 82%"
+      - metric: hud_tilt_index
+        visualization: timeseries
+        thresholds:
+          - level: warning
+            condition: above
+            value: 0.48
+          - level: critical
+            condition: above
+            value: 0.5
+        annotations:
+          - text: "Tilt medio deve restare <0.50"
   - id: moderazione-assistita
     title: "Moderazione Assistita - Efficienza"
     description: "Tassi di adozione e tempi di risposta per il pannello assistito."
     layout:
-      row: 9
+      row: 17
       column: 1
       width: 12
       height: 8
@@ -154,3 +196,21 @@ alerts:
     channels:
       - slack:#moderation-ops
       - pagerduty:moderation-oncall
+  - id: hud-tap-ack-drop
+    panel: hud-tap-overlay
+    metric: hud_ack_rate
+    condition: below
+    value: 0.82
+    for: 30m
+    channels:
+      - slack:#hud-alerts
+      - pagerduty:ui-systems
+  - id: hud-tap-tilt-spike
+    panel: hud-tap-overlay
+    metric: hud_tilt_index
+    condition: above
+    value: 0.5
+    for: 45m
+    channels:
+      - slack:#hud-alerts
+      - jira:HUD-TAP


### PR DESCRIPTION
## Summary
- add TAP-specific feature flag entries for the HUD overlay and SquadSync adaptive engine
- extend the deploy workflow with adaptive engine tests and HUD overlay validation
- document TAP overlay/adaptive rollout steps and expose monitoring panels and alerts for duration, ack rate, and tilt

## Testing
- npx tsx tests/analytics/squadsync_responses.test.ts
- python3 scripts/qa/hud_smart_alerts.py logs/playtests --json-report /tmp/hud_report.json

------
https://chatgpt.com/codex/tasks/task_e_69063c53f124833286429223b94c88ed