### PR TITLE
Fix TAP adaptive engine test path

### DIFF
--- a/.github/workflows/deploy-test-interface.yml
+++ b/.github/workflows/deploy-test-interface.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run adaptive engine TAP tests
         working-directory: tools/ts
-        run: npx tsx ../tests/analytics/squadsync_responses.test.ts
+        run: npx tsx "$GITHUB_WORKSPACE/tests/analytics/squadsync_responses.test.ts"
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- fix the adaptive engine TAP test step to reference the repository-level test file when run from the tools workspace

## Testing
- not run (CI will cover)

------
https://chatgpt.com/codex/tasks/task_e_69064014c038833281e8e293706a1019