### PR TITLE
Restore trait text values and update localization sync

### DIFF
--- a/data/traits/_drafts/artigli_a_sette_vie.json
+++ b/data/traits/_drafts/artigli_a_sette_vie.json
@@ -1,8 +1,8 @@
 {
   "id": "artigli_a_sette_vie",
-  "label": "i18n:traits.artigli_a_sette_vie.label",
+  "label": "Artigli a Sette Vie",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_a_sette_vie.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.artigli_a_sette_vie.mutazione_indotta",
-  "uso_funzione": "i18n:traits.artigli_a_sette_vie.uso_funzione",
-  "spinta_selettiva": "i18n:traits.artigli_a_sette_vie.spinta_selettiva",
+  "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Core Tier 1.",
+  "uso_funzione": "Bozza generata automaticamente dalla fonte A-CANVAS_ORIGINALE.txt. Controllare requisiti e slot per 'Artigli a Sette Vie'.",
+  "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/balance_reflex.json
+++ b/data/traits/_drafts/balance_reflex.json
@@ -1,8 +1,8 @@
 {
   "id": "balance_reflex",
-  "label": "i18n:traits.balance_reflex.label",
+  "label": "Balance Reflex",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.balance_reflex.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T2",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.balance_reflex.mutazione_indotta",
-  "uso_funzione": "i18n:traits.balance_reflex.uso_funzione",
-  "spinta_selettiva": "i18n:traits.balance_reflex.spinta_selettiva",
+  "mutazione_indotta": "Riduce penalità in piedi; sinergia con WA 03, WA 05.",
+  "uso_funzione": "Tier Pre‑Sociale (T2). Richiede neuroni: WA 02, DE 01, DO 01",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/coda_a_frusta_cinetica.json
+++ b/data/traits/_drafts/coda_a_frusta_cinetica.json
@@ -1,8 +1,8 @@
 {
   "id": "coda_a_frusta_cinetica",
-  "label": "i18n:traits.coda_a_frusta_cinetica.label",
+  "label": "Coda a Frusta Cinetica",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_a_frusta_cinetica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.coda_a_frusta_cinetica.mutazione_indotta",
-  "uso_funzione": "i18n:traits.coda_a_frusta_cinetica.uso_funzione",
-  "spinta_selettiva": "i18n:traits.coda_a_frusta_cinetica.spinta_selettiva",
+  "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Opzionali Tier 1.",
+  "uso_funzione": "Bozza generata automaticamente dalla fonte A-CANVAS_ORIGINALE.txt. Controllare requisiti e slot per 'Coda a Frusta Cinetica'.",
+  "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/craft_loop.json
+++ b/data/traits/_drafts/craft_loop.json
@@ -1,8 +1,8 @@
 {
   "id": "craft_loop",
-  "label": "i18n:traits.craft_loop.label",
+  "label": "Craft Loop",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.craft_loop.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T5",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.craft_loop.mutazione_indotta",
-  "uso_funzione": "i18n:traits.craft_loop.uso_funzione",
-  "spinta_selettiva": "i18n:traits.craft_loop.spinta_selettiva",
+  "mutazione_indotta": "Riduce di 1 i colpi richiesti con strumenti; si cumula con BB AL 01.",
+  "uso_funzione": "Tier Culturale (T5). Richiede neuroni: NE 01, IN 02, AL 07",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/criostasi.json
+++ b/data/traits/_drafts/criostasi.json
@@ -1,8 +1,8 @@
 {
   "id": "criostasi",
-  "label": "i18n:traits.criostasi.label",
+  "label": "Criostasi",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.criostasi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.criostasi.mutazione_indotta",
-  "uso_funzione": "i18n:traits.criostasi.uso_funzione",
-  "spinta_selettiva": "i18n:traits.criostasi.spinta_selettiva",
+  "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Opzionali Tier 1.",
+  "uso_funzione": "Bozza generata automaticamente dalla fonte A-CANVAS_ORIGINALE.txt. Controllare requisiti e slot per 'Criostasi'.",
+  "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/echoic_trace.json
+++ b/data/traits/_drafts/echoic_trace.json
@@ -1,8 +1,8 @@
 {
   "id": "echoic_trace",
-  "label": "i18n:traits.echoic_trace.label",
+  "label": "Echoic Trace",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.echoic_trace.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T3",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.echoic_trace.mutazione_indotta",
-  "uso_funzione": "i18n:traits.echoic_trace.uso_funzione",
-  "spinta_selettiva": "i18n:traits.echoic_trace.spinta_selettiva",
+  "mutazione_indotta": "Memorizza 1 target uditivo addizionale (sinergia BB SS 01).",
+  "uso_funzione": "Tier Senziente Emergente (T3). Richiede neuroni: WA 03, DE 05, SS 04, SO 06",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/executive_loop.json
+++ b/data/traits/_drafts/executive_loop.json
@@ -1,8 +1,8 @@
 {
   "id": "executive_loop",
-  "label": "i18n:traits.executive_loop.label",
+  "label": "Executive Loop",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.executive_loop.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T6",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.executive_loop.mutazione_indotta",
-  "uso_funzione": "i18n:traits.executive_loop.uso_funzione",
-  "spinta_selettiva": "i18n:traits.executive_loop.spinta_selettiva",
+  "mutazione_indotta": "Concatena 1 azione gratuita di 'focus' o 'memorizza' tra due compiti.",
+  "uso_funzione": "Tier Proto‑Umano (T6). Richiede neuroni: WA 05, WH 06, Intelligence_Core",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/focus_frazionato_2.json
+++ b/data/traits/_drafts/focus_frazionato_2.json
@@ -1,8 +1,8 @@
 {
   "id": "focus_frazionato_2",
-  "label": "i18n:traits.focus_frazionato_2.label",
+  "label": "Focus Frazionato",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.focus_frazionato_2.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.focus_frazionato_2.mutazione_indotta",
-  "uso_funzione": "i18n:traits.focus_frazionato_2.uso_funzione",
-  "spinta_selettiva": "i18n:traits.focus_frazionato_2.spinta_selettiva",
+  "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Sinergie Tier 1.",
+  "uso_funzione": "Bozza generata automaticamente dalla fonte A-CANVAS_ORIGINALE.txt. Controllare requisiti e slot per 'Focus Frazionato'.",
+  "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/group_form.json
+++ b/data/traits/_drafts/group_form.json
@@ -1,8 +1,8 @@
 {
   "id": "group_form",
-  "label": "i18n:traits.group_form.label",
+  "label": "Group Form",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.group_form.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T4",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.group_form.mutazione_indotta",
-  "uso_funzione": "i18n:traits.group_form.uso_funzione",
-  "spinta_selettiva": "i18n:traits.group_form.spinta_selettiva",
+  "mutazione_indotta": "Bonus posizionale con 2+ alleati adiacenti.",
+  "uso_funzione": "Tier Sociale (T4). Richiede neuroni: CM 06, DO 07, CO 1",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/interoception_seed.json
+++ b/data/traits/_drafts/interoception_seed.json
@@ -1,8 +1,8 @@
 {
   "id": "interoception_seed",
-  "label": "i18n:traits.interoception_seed.label",
+  "label": "Interoception Seed",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.interoception_seed.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.interoception_seed.mutazione_indotta",
-  "uso_funzione": "i18n:traits.interoception_seed.uso_funzione",
-  "spinta_selettiva": "i18n:traits.interoception_seed.spinta_selettiva",
+  "mutazione_indotta": "+1 ai tiri di Consapevolezza Corporea; segnali anticipati di fame/sete.",
+  "uso_funzione": "Tier Proto‑Senziente (T1). Richiede neuroni: SO 01, SS 01, MS 01",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/mimicry_basic.json
+++ b/data/traits/_drafts/mimicry_basic.json
@@ -1,8 +1,8 @@
 {
   "id": "mimicry_basic",
-  "label": "i18n:traits.mimicry_basic.label",
+  "label": "Mimicry Basic",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.mimicry_basic.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T2",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.mimicry_basic.mutazione_indotta",
-  "uso_funzione": "i18n:traits.mimicry_basic.uso_funzione",
-  "spinta_selettiva": "i18n:traits.mimicry_basic.spinta_selettiva",
+  "mutazione_indotta": "Il clan imita switch/alterazioni semplici (pieno con CM 06).",
+  "uso_funzione": "Tier Pre‑Sociale (T2). Richiede neuroni: WA 02, DE 01, DO 01",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/postural_endurance.json
+++ b/data/traits/_drafts/postural_endurance.json
@@ -1,8 +1,8 @@
 {
   "id": "postural_endurance",
-  "label": "i18n:traits.postural_endurance.label",
+  "label": "Postural Endurance",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.postural_endurance.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T6",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.postural_endurance.mutazione_indotta",
-  "uso_funzione": "i18n:traits.postural_endurance.uso_funzione",
-  "spinta_selettiva": "i18n:traits.postural_endurance.spinta_selettiva",
+  "mutazione_indotta": "Riduce consumo energia in piedi/corsa.",
+  "uso_funzione": "Tier Proto‑Umano (T6). Richiede neuroni: WA 05, WH 06, Intelligence_Core",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/risonanza_di_branco_2.json
+++ b/data/traits/_drafts/risonanza_di_branco_2.json
@@ -1,8 +1,8 @@
 {
   "id": "risonanza_di_branco_2",
-  "label": "i18n:traits.risonanza_di_branco_2.label",
+  "label": "Risonanza di Branco",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.risonanza_di_branco_2.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.risonanza_di_branco_2.mutazione_indotta",
-  "uso_funzione": "i18n:traits.risonanza_di_branco_2.uso_funzione",
-  "spinta_selettiva": "i18n:traits.risonanza_di_branco_2.spinta_selettiva",
+  "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Sinergie Tier 1.",
+  "uso_funzione": "Bozza generata automaticamente dalla fonte A-CANVAS_ORIGINALE.txt. Controllare requisiti e slot per 'Risonanza di Branco'.",
+  "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/sacche_galleggianti_ascensoriali_2.json
+++ b/data/traits/_drafts/sacche_galleggianti_ascensoriali_2.json
@@ -1,8 +1,8 @@
 {
   "id": "sacche_galleggianti_ascensoriali_2",
-  "label": "i18n:traits.sacche_galleggianti_ascensoriali_2.label",
+  "label": "Sacche Galleggianti Ascensoriali",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.sacche_galleggianti_ascensoriali_2.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.sacche_galleggianti_ascensoriali_2.mutazione_indotta",
-  "uso_funzione": "i18n:traits.sacche_galleggianti_ascensoriali_2.uso_funzione",
-  "spinta_selettiva": "i18n:traits.sacche_galleggianti_ascensoriali_2.spinta_selettiva",
+  "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Opzionali Tier 1.",
+  "uso_funzione": "Bozza generata automaticamente dalla fonte A-CANVAS_ORIGINALE.txt. Controllare requisiti e slot per 'Sacche Galleggianti Ascensoriali'.",
+  "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/scheletro_idro_regolante_2.json
+++ b/data/traits/_drafts/scheletro_idro_regolante_2.json
@@ -1,8 +1,8 @@
 {
   "id": "scheletro_idro_regolante_2",
-  "label": "i18n:traits.scheletro_idro_regolante_2.label",
+  "label": "Scheletro Idro-Regolante",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.scheletro_idro_regolante_2.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.scheletro_idro_regolante_2.mutazione_indotta",
-  "uso_funzione": "i18n:traits.scheletro_idro_regolante_2.uso_funzione",
-  "spinta_selettiva": "i18n:traits.scheletro_idro_regolante_2.spinta_selettiva",
+  "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Core Tier 1.",
+  "uso_funzione": "Bozza generata automaticamente dalla fonte A-CANVAS_ORIGINALE.txt. Controllare requisiti e slot per 'Scheletro Idro-Regolante'.",
+  "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/sheltering.json
+++ b/data/traits/_drafts/sheltering.json
@@ -1,8 +1,8 @@
 {
   "id": "sheltering",
-  "label": "i18n:traits.sheltering.label",
+  "label": "Sheltering",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.sheltering.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T5",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.sheltering.mutazione_indotta",
-  "uso_funzione": "i18n:traits.sheltering.uso_funzione",
-  "spinta_selettiva": "i18n:traits.sheltering.spinta_selettiva",
+  "mutazione_indotta": "Riduce stress in pericolo vicino a costruzioni.",
+  "uso_funzione": "Tier Culturale (T5). Richiede neuroni: NE 01, IN 02, AL 07",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/startle_reflex.json
+++ b/data/traits/_drafts/startle_reflex.json
@@ -1,8 +1,8 @@
 {
   "id": "startle_reflex",
-  "label": "i18n:traits.startle_reflex.label",
+  "label": "Startle Reflex",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.startle_reflex.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.startle_reflex.mutazione_indotta",
-  "uso_funzione": "i18n:traits.startle_reflex.uso_funzione",
-  "spinta_selettiva": "i18n:traits.startle_reflex.spinta_selettiva",
+  "mutazione_indotta": "Reazioni di fuga più rapide (sinergia con MS 02 se presente).",
+  "uso_funzione": "Tier Proto‑Senziente (T1). Richiede neuroni: SO 01, SS 01, MS 01",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/struttura_elastica_amorfa_2.json
+++ b/data/traits/_drafts/struttura_elastica_amorfa_2.json
@@ -1,8 +1,8 @@
 {
   "id": "struttura_elastica_amorfa_2",
-  "label": "i18n:traits.struttura_elastica_amorfa_2.label",
+  "label": "Struttura Elastica Amorfa",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.struttura_elastica_amorfa_2.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.struttura_elastica_amorfa_2.mutazione_indotta",
-  "uso_funzione": "i18n:traits.struttura_elastica_amorfa_2.uso_funzione",
-  "spinta_selettiva": "i18n:traits.struttura_elastica_amorfa_2.spinta_selettiva",
+  "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Core Tier 1.",
+  "uso_funzione": "Bozza generata automaticamente dalla fonte A-CANVAS_ORIGINALE.txt. Controllare requisiti e slot per 'Struttura Elastica Amorfa'.",
+  "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/tattiche_di_branco_2.json
+++ b/data/traits/_drafts/tattiche_di_branco_2.json
@@ -1,8 +1,8 @@
 {
   "id": "tattiche_di_branco_2",
-  "label": "i18n:traits.tattiche_di_branco_2.label",
+  "label": "Tattiche di Branco",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.tattiche_di_branco_2.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.tattiche_di_branco_2.mutazione_indotta",
-  "uso_funzione": "i18n:traits.tattiche_di_branco_2.uso_funzione",
-  "spinta_selettiva": "i18n:traits.tattiche_di_branco_2.spinta_selettiva",
+  "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Sinergie Tier 1.",
+  "uso_funzione": "Bozza generata automaticamente dalla fonte A-CANVAS_ORIGINALE.txt. Controllare requisiti e slot per 'Tattiche di Branco'.",
+  "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/teach_action.json
+++ b/data/traits/_drafts/teach_action.json
@@ -1,8 +1,8 @@
 {
   "id": "teach_action",
-  "label": "i18n:traits.teach_action.label",
+  "label": "Teach Action",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.teach_action.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T4",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.teach_action.mutazione_indotta",
-  "uso_funzione": "i18n:traits.teach_action.uso_funzione",
-  "spinta_selettiva": "i18n:traits.teach_action.spinta_selettiva",
+  "mutazione_indotta": "Insegna 1 azione pratica al clan (switch/alter/transport).",
+  "uso_funzione": "Tier Sociale (T4). Richiede neuroni: CM 06, DO 07, CO 1",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/toolseed.json
+++ b/data/traits/_drafts/toolseed.json
@@ -1,8 +1,8 @@
 {
   "id": "toolseed",
-  "label": "i18n:traits.toolseed.label",
+  "label": "Toolseed",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.toolseed.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T3",
   "slot": [],
   "slot_profile": {
@@ -11,9 +11,9 @@
   },
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "i18n:traits.toolseed.mutazione_indotta",
-  "uso_funzione": "i18n:traits.toolseed.uso_funzione",
-  "spinta_selettiva": "i18n:traits.toolseed.spinta_selettiva",
+  "mutazione_indotta": "Progetti Rozzi: +5% successo alterazioni; si cumula con AL 01–03.",
+  "uso_funzione": "Tier Senziente Emergente (T3). Richiede neuroni: WA 03, DE 05, SS 04, SO 06",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/difensivo/ali_membrana_sonica.json
+++ b/data/traits/difensivo/ali_membrana_sonica.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ali_membrana_sonica.debolezza",
+  "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.ali_membrana_sonica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ali_membrana_sonica",
-  "label": "i18n:traits.ali_membrana_sonica.label",
-  "mutazione_indotta": "i18n:traits.ali_membrana_sonica.mutazione_indotta",
+  "label": "Ali Membrana Sonica",
+  "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "protezione",
     "core": "difensivo"
   },
-  "spinta_selettiva": "i18n:traits.ali_membrana_sonica.spinta_selettiva",
+  "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ali_membrana_sonica.uso_funzione"
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
 }

--- a/data/traits/difensivo/appendici_risonanti_marea.json
+++ b/data/traits/difensivo/appendici_risonanti_marea.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.appendici_risonanti_marea.debolezza",
+  "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.appendici_risonanti_marea.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "appendici_risonanti_marea",
-  "label": "i18n:traits.appendici_risonanti_marea.label",
-  "mutazione_indotta": "i18n:traits.appendici_risonanti_marea.mutazione_indotta",
+  "label": "Appendici Risonanti Marea",
+  "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "protezione",
     "core": "difensivo"
   },
-  "spinta_selettiva": "i18n:traits.appendici_risonanti_marea.spinta_selettiva",
+  "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.appendici_risonanti_marea.uso_funzione"
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
 }

--- a/data/traits/difensivo/barriere_miasma_glaciale.json
+++ b/data/traits/difensivo/barriere_miasma_glaciale.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.barriere_miasma_glaciale.debolezza",
+  "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.barriere_miasma_glaciale.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "barriere_miasma_glaciale",
-  "label": "i18n:traits.barriere_miasma_glaciale.label",
-  "mutazione_indotta": "i18n:traits.barriere_miasma_glaciale.mutazione_indotta",
+  "label": "Barriere Miasma Glaciale",
+  "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "protezione",
     "core": "difensivo"
   },
-  "spinta_selettiva": "i18n:traits.barriere_miasma_glaciale.spinta_selettiva",
+  "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.barriere_miasma_glaciale.uso_funzione"
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
 }

--- a/data/traits/difensivo/branchie_microfiltri.json
+++ b/data/traits/difensivo/branchie_microfiltri.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.branchie_microfiltri.debolezza",
+  "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.branchie_microfiltri.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "branchie_microfiltri",
-  "label": "i18n:traits.branchie_microfiltri.label",
-  "mutazione_indotta": "i18n:traits.branchie_microfiltri.mutazione_indotta",
+  "label": "Branchie Microfiltri",
+  "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "protezione",
     "core": "difensivo"
   },
-  "spinta_selettiva": "i18n:traits.branchie_microfiltri.spinta_selettiva",
+  "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.branchie_microfiltri.uso_funzione"
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
 }

--- a/data/traits/difensivo/capsule_paracadute.json
+++ b/data/traits/difensivo/capsule_paracadute.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.capsule_paracadute.debolezza",
+  "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.capsule_paracadute.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "capsule_paracadute",
-  "label": "i18n:traits.capsule_paracadute.label",
-  "mutazione_indotta": "i18n:traits.capsule_paracadute.mutazione_indotta",
+  "label": "Capsule Paracadute",
+  "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "protezione",
     "core": "difensivo"
   },
-  "spinta_selettiva": "i18n:traits.capsule_paracadute.spinta_selettiva",
+  "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.capsule_paracadute.uso_funzione"
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
 }

--- a/data/traits/difensivo/circolazione_bifasica.json
+++ b/data/traits/difensivo/circolazione_bifasica.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.circolazione_bifasica.debolezza",
+  "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.circolazione_bifasica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "circolazione_bifasica",
-  "label": "i18n:traits.circolazione_bifasica.label",
-  "mutazione_indotta": "i18n:traits.circolazione_bifasica.mutazione_indotta",
+  "label": "Circolazione Bifasica",
+  "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "protezione",
     "core": "difensivo"
   },
-  "spinta_selettiva": "i18n:traits.circolazione_bifasica.spinta_selettiva",
+  "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.circolazione_bifasica.uso_funzione"
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
 }

--- a/data/traits/difensivo/coda_coppia_retroattiva.json
+++ b/data/traits/difensivo/coda_coppia_retroattiva.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.coda_coppia_retroattiva.debolezza",
+  "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_coppia_retroattiva.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "coda_coppia_retroattiva",
-  "label": "i18n:traits.coda_coppia_retroattiva.label",
-  "mutazione_indotta": "i18n:traits.coda_coppia_retroattiva.mutazione_indotta",
+  "label": "Coda Coppia Retroattiva",
+  "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "protezione",
     "core": "difensivo"
   },
-  "spinta_selettiva": "i18n:traits.coda_coppia_retroattiva.spinta_selettiva",
+  "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.coda_coppia_retroattiva.uso_funzione"
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
 }

--- a/data/traits/difensivo/cute_resistente_sali.json
+++ b/data/traits/difensivo/cute_resistente_sali.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.cute_resistente_sali.debolezza",
+  "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.cute_resistente_sali.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Attivazione situazionale)",
   "id": "cute_resistente_sali",
-  "label": "i18n:traits.cute_resistente_sali.label",
-  "mutazione_indotta": "i18n:traits.cute_resistente_sali.mutazione_indotta",
+  "label": "Cute Resistente Sali",
+  "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "protezione",
     "core": "difensivo"
   },
-  "spinta_selettiva": "i18n:traits.cute_resistente_sali.spinta_selettiva",
+  "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.cute_resistente_sali.uso_funzione"
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
 }

--- a/data/traits/difensivo/enzimi_antipredatori_algali.json
+++ b/data/traits/difensivo/enzimi_antipredatori_algali.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.enzimi_antipredatori_algali.debolezza",
+  "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.enzimi_antipredatori_algali.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "enzimi_antipredatori_algali",
-  "label": "i18n:traits.enzimi_antipredatori_algali.label",
-  "mutazione_indotta": "i18n:traits.enzimi_antipredatori_algali.mutazione_indotta",
+  "label": "Enzimi Antipredatori Algali",
+  "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "protezione",
     "core": "difensivo"
   },
-  "spinta_selettiva": "i18n:traits.enzimi_antipredatori_algali.spinta_selettiva",
+  "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.enzimi_antipredatori_algali.uso_funzione"
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
 }

--- a/data/traits/difensivo/filtri_planctonici.json
+++ b/data/traits/difensivo/filtri_planctonici.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.filtri_planctonici.debolezza",
+  "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.filtri_planctonici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "filtri_planctonici",
-  "label": "i18n:traits.filtri_planctonici.label",
-  "mutazione_indotta": "i18n:traits.filtri_planctonici.mutazione_indotta",
+  "label": "Filtri Planctonici",
+  "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "protezione",
     "core": "difensivo"
   },
-  "spinta_selettiva": "i18n:traits.filtri_planctonici.spinta_selettiva",
+  "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.filtri_planctonici.uso_funzione"
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
 }

--- a/data/traits/difensivo/ghiandole_fango_coesivo.json
+++ b/data/traits/difensivo/ghiandole_fango_coesivo.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ghiandole_fango_coesivo.debolezza",
+  "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_fango_coesivo.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_fango_coesivo",
-  "label": "i18n:traits.ghiandole_fango_coesivo.label",
-  "mutazione_indotta": "i18n:traits.ghiandole_fango_coesivo.mutazione_indotta",
+  "label": "Ghiandole Fango Coesivo",
+  "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "protezione",
     "core": "difensivo"
   },
-  "spinta_selettiva": "i18n:traits.ghiandole_fango_coesivo.spinta_selettiva",
+  "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ghiandole_fango_coesivo.uso_funzione"
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
 }

--- a/data/traits/difensivo/giunti_antitorsione.json
+++ b/data/traits/difensivo/giunti_antitorsione.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.giunti_antitorsione.debolezza",
+  "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.giunti_antitorsione.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "giunti_antitorsione",
-  "label": "i18n:traits.giunti_antitorsione.label",
-  "mutazione_indotta": "i18n:traits.giunti_antitorsione.mutazione_indotta",
+  "label": "Giunti Antitorsione",
+  "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "protezione",
     "core": "difensivo"
   },
-  "spinta_selettiva": "i18n:traits.giunti_antitorsione.spinta_selettiva",
+  "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.giunti_antitorsione.uso_funzione"
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
 }

--- a/data/traits/difensivo/lingua_cristallina.json
+++ b/data/traits/difensivo/lingua_cristallina.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.lingua_cristallina.debolezza",
+  "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.lingua_cristallina.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "lingua_cristallina",
-  "label": "i18n:traits.lingua_cristallina.label",
-  "mutazione_indotta": "i18n:traits.lingua_cristallina.mutazione_indotta",
+  "label": "Lingua Cristallina",
+  "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "protezione",
     "core": "difensivo"
   },
-  "spinta_selettiva": "i18n:traits.lingua_cristallina.spinta_selettiva",
+  "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.lingua_cristallina.uso_funzione"
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
 }

--- a/data/traits/difensivo/mucose_barofile.json
+++ b/data/traits/difensivo/mucose_barofile.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.mucose_barofile.debolezza",
+  "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.mucose_barofile.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "mucose_barofile",
-  "label": "i18n:traits.mucose_barofile.label",
-  "mutazione_indotta": "i18n:traits.mucose_barofile.mutazione_indotta",
+  "label": "Mucose Barofile",
+  "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "protezione",
     "core": "difensivo"
   },
-  "spinta_selettiva": "i18n:traits.mucose_barofile.spinta_selettiva",
+  "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.mucose_barofile.uso_funzione"
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
 }

--- a/data/traits/difesa/armatura_pietra_planare.json
+++ b/data/traits/difesa/armatura_pietra_planare.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "frusta_fiammeggiante"
   ],
-  "debolezza": "i18n:traits.armatura_pietra_planare.debolezza",
+  "debolezza": "Pesante: riduce mobilità in ambienti non supportati o a bassa gravità.",
   "famiglia_tipologia": "Difesa/Strutturale",
-  "fattore_mantenimento_energetico": "i18n:traits.armatura_pietra_planare.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Risonanza geodetica stabile)",
   "id": "armatura_pietra_planare",
-  "label": "i18n:traits.armatura_pietra_planare.label",
-  "mutazione_indotta": "i18n:traits.armatura_pietra_planare.mutazione_indotta",
+  "label": "Armatura di Pietra Planare",
+  "mutazione_indotta": "Cristallizza il dermascheletro con nodi rune che deviano energia.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [
@@ -38,7 +38,7 @@
     "complementare": "strutturale",
     "core": "difesa"
   },
-  "spinta_selettiva": "i18n:traits.armatura_pietra_planare.spinta_selettiva",
+  "spinta_selettiva": "Stabilizzare varchi e proteggere infrastrutture dalle onde d'urto.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.armatura_pietra_planare.uso_funzione"
+  "uso_funzione": "Offre schermatura massiva e ancoraggio durante le aperture dimensionali."
 }

--- a/data/traits/difesa/mantello_meteoritico.json
+++ b/data/traits/difesa/mantello_meteoritico.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "aura_scudo_radianza"
   ],
-  "debolezza": "i18n:traits.mantello_meteoritico.debolezza",
+  "debolezza": "Vulnerabile a scariche di freddo gravitazionale che irrigidiscono il mantello.",
   "famiglia_tipologia": "Difesa/Termoregolazione",
-  "fattore_mantenimento_energetico": "i18n:traits.mantello_meteoritico.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Rivestimento ablativo rigenerante)",
   "id": "mantello_meteoritico",
-  "label": "i18n:traits.mantello_meteoritico.label",
-  "mutazione_indotta": "i18n:traits.mantello_meteoritico.mutazione_indotta",
+  "label": "Mantello Meteoritico",
+  "mutazione_indotta": "Deposita strati sovrapposti di materiale meteorico che vaporizzano l'impatto e rilasciano radianza.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [
@@ -39,7 +39,7 @@
     "complementare": "termico",
     "core": "difesa"
   },
-  "spinta_selettiva": "i18n:traits.mantello_meteoritico.spinta_selettiva",
+  "spinta_selettiva": "Sopravvivere a bombardamenti planari e piogge di meteore dimensionali.",
   "tier": "T3",
-  "uso_funzione": "i18n:traits.mantello_meteoritico.uso_funzione"
+  "uso_funzione": "Assorbe colpi energetici estremi e converte il surplus in impulsi offensivi."
 }

--- a/data/traits/digestivo/filamenti_digestivi_compattanti.json
+++ b/data/traits/digestivo/filamenti_digestivi_compattanti.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.filamenti_digestivi_compattanti.debolezza",
+  "debolezza": "Blocco intestinale se la dieta è priva di materiale 'legante'.",
   "famiglia_tipologia": "Digestivo/Escretorio",
-  "fattore_mantenimento_energetico": "i18n:traits.filamenti_digestivi_compattanti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "filamenti_digestivi_compattanti",
-  "label": "i18n:traits.filamenti_digestivi_compattanti.label",
-  "mutazione_indotta": "i18n:traits.filamenti_digestivi_compattanti.mutazione_indotta",
+  "label": "Filamento materiali digeriti",
+  "mutazione_indotta": "Muscolatura rettale ipertrofica e organo appendice dedicato.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -59,7 +59,7 @@
     "complementare": "escretorio",
     "core": "digestivo"
   },
-  "spinta_selettiva": "i18n:traits.filamenti_digestivi_compattanti.spinta_selettiva",
+  "spinta_selettiva": "Necessità di mantenere la pulizia del territorio/nido.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.filamenti_digestivi_compattanti.uso_funzione"
+  "uso_funzione": "Espulsione compatta e ordinata di scorie."
 }

--- a/data/traits/digestivo/ventriglio_gastroliti.json
+++ b/data/traits/digestivo/ventriglio_gastroliti.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ventriglio_gastroliti.debolezza",
+  "debolezza": "Usura e rottura del ventriglio se i gastroliti sono esauriti o troppo lisci.",
   "famiglia_tipologia": "Digestivo/Alimentare",
-  "fattore_mantenimento_energetico": "i18n:traits.ventriglio_gastroliti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Contrazione muscolare costante)",
   "id": "ventriglio_gastroliti",
-  "label": "i18n:traits.ventriglio_gastroliti.label",
-  "mutazione_indotta": "i18n:traits.ventriglio_gastroliti.mutazione_indotta",
+  "label": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
+  "mutazione_indotta": "Sviluppo di un organo muscolare (ventriglio) con gastroliti.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -46,7 +46,7 @@
     "complementare": "alimentare",
     "core": "digestivo"
   },
-  "spinta_selettiva": "i18n:traits.ventriglio_gastroliti.spinta_selettiva",
+  "spinta_selettiva": "Dieta basata su semi, conchiglie o insetti corazzati.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ventriglio_gastroliti.uso_funzione"
+  "uso_funzione": "Macinazione di cibo duro all'interno di un ventriglio."
 }

--- a/data/traits/escretorio/spore_psichiche_silenziate.json
+++ b/data/traits/escretorio/spore_psichiche_silenziate.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "respiro_a_scoppio"
   ],
-  "debolezza": "i18n:traits.spore_psichiche_silenziate.debolezza",
+  "debolezza": "Funzionalità ridotta in presenza di vento forte o umidità elevata.",
   "famiglia_tipologia": "Escretorio/Psichico",
-  "fattore_mantenimento_energetico": "i18n:traits.spore_psichiche_silenziate.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Produzione e rilascio)",
   "id": "spore_psichiche_silenziate",
-  "label": "i18n:traits.spore_psichiche_silenziate.label",
-  "mutazione_indotta": "i18n:traits.spore_psichiche_silenziate.mutazione_indotta",
+  "label": "Spora Psichica Silenziosa",
+  "mutazione_indotta": "Pori che rilasciano nano-particelle attive chimicamente o psichicamente.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -33,7 +33,7 @@
     "complementare": "psichico",
     "core": "escretorio"
   },
-  "spinta_selettiva": "i18n:traits.spore_psichiche_silenziate.spinta_selettiva",
+  "spinta_selettiva": "Neutralizzare gruppi di prede o predatori senza impegnare in combattimento.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.spore_psichiche_silenziate.uso_funzione"
+  "uso_funzione": "Indurre uno stato di confusione o letargia negli individui vicini."
 }

--- a/data/traits/idrostatico/sacche_galleggianti_ascensoriali.json
+++ b/data/traits/idrostatico/sacche_galleggianti_ascensoriali.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.sacche_galleggianti_ascensoriali.debolezza",
+  "debolezza": "Rischio di barotrauma se la pressione esterna cambia troppo rapidamente.",
   "famiglia_tipologia": "Idrostatico/Locomotorio",
-  "fattore_mantenimento_energetico": "i18n:traits.sacche_galleggianti_ascensoriali.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Per il controllo della pressione)",
   "id": "sacche_galleggianti_ascensoriali",
-  "label": "i18n:traits.sacche_galleggianti_ascensoriali.label",
-  "mutazione_indotta": "i18n:traits.sacche_galleggianti_ascensoriali.mutazione_indotta",
+  "label": "Sacche galleggianti ascensoriali",
+  "mutazione_indotta": "Sacche ripiene di gas leggeri con pompe muscolari.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -49,7 +49,7 @@
     "complementare": "locomotorio",
     "core": "idrostatico"
   },
-  "spinta_selettiva": "i18n:traits.sacche_galleggianti_ascensoriali.spinta_selettiva",
+  "spinta_selettiva": "Vivere in un ambiente acquatico con forti correnti verticali.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.sacche_galleggianti_ascensoriali.uso_funzione"
+  "uso_funzione": "Controllo preciso della profondità e del movimento verticale."
 }

--- a/data/traits/locomotorio/ali_ioniche.json
+++ b/data/traits/locomotorio/ali_ioniche.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ali_ioniche.debolezza",
+  "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.ali_ioniche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ali_ioniche",
-  "label": "i18n:traits.ali_ioniche.label",
-  "mutazione_indotta": "i18n:traits.ali_ioniche.mutazione_indotta",
+  "label": "Ali Ioniche",
+  "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "mobilita",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.ali_ioniche.spinta_selettiva",
+  "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ali_ioniche.uso_funzione"
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
 }

--- a/data/traits/locomotorio/antenne_wideband.json
+++ b/data/traits/locomotorio/antenne_wideband.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.antenne_wideband.debolezza",
+  "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_wideband.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_wideband",
-  "label": "i18n:traits.antenne_wideband.label",
-  "mutazione_indotta": "i18n:traits.antenne_wideband.mutazione_indotta",
+  "label": "Antenne Wideband",
+  "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "mobilita",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.antenne_wideband.spinta_selettiva",
+  "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.antenne_wideband.uso_funzione"
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
 }

--- a/data/traits/locomotorio/artigli_sette_vie.json
+++ b/data/traits/locomotorio/artigli_sette_vie.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.artigli_sette_vie.debolezza",
+  "debolezza": "Angoli di presa limitati se la superficie è perfettamente liscia.",
   "famiglia_tipologia": "Locomotorio/Prensile",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_sette_vie.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "artigli_sette_vie",
-  "label": "i18n:traits.artigli_sette_vie.label",
-  "mutazione_indotta": "i18n:traits.artigli_sette_vie.mutazione_indotta",
+  "label": "Artigli a Sette Vie",
+  "mutazione_indotta": "Dita lunghe e segmentate con punte a uncino multiplo.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -45,7 +45,7 @@
     "complementare": "prensile",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.artigli_sette_vie.spinta_selettiva",
+  "spinta_selettiva": "Arrampicarsi su pareti rocciose o vegetazione densa.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.artigli_sette_vie.uso_funzione"
+  "uso_funzione": "Afferrare superfici irregolari o oggetti multipli."
 }

--- a/data/traits/locomotorio/artigli_sghiaccio_glaciale.json
+++ b/data/traits/locomotorio/artigli_sghiaccio_glaciale.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.artigli_sghiaccio_glaciale.debolezza",
+  "debolezza": "In ambienti temperati i tessuti subiscono microfratture e richiedono continue riparazioni.",
   "famiglia_tipologia": "Locomotorio/Predatorio",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_sghiaccio_glaciale.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Raffreddamento endogeno controllato)",
   "id": "artigli_sghiaccio_glaciale",
-  "label": "i18n:traits.artigli_sghiaccio_glaciale.label",
-  "mutazione_indotta": "i18n:traits.artigli_sghiaccio_glaciale.mutazione_indotta",
+  "label": "Artigli Sghiaccio Glaciale",
+  "mutazione_indotta": "Falangi rivestite da ghiaccio strutturale che si espande creando lame traslucide.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -43,7 +43,7 @@
     "complementare": "predatorio",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.artigli_sghiaccio_glaciale.spinta_selettiva",
+  "spinta_selettiva": "Cacciare su superfici gelate e pareti verticali di ghiaccio vivo.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.artigli_sghiaccio_glaciale.uso_funzione"
+  "uso_funzione": "Scalza e immobilizza i bersagli congelandoli al contatto."
 }

--- a/data/traits/locomotorio/barbigli_sensori_plasma.json
+++ b/data/traits/locomotorio/barbigli_sensori_plasma.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.barbigli_sensori_plasma.debolezza",
+  "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.barbigli_sensori_plasma.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "barbigli_sensori_plasma",
-  "label": "i18n:traits.barbigli_sensori_plasma.label",
-  "mutazione_indotta": "i18n:traits.barbigli_sensori_plasma.mutazione_indotta",
+  "label": "Barbigli Sensori Plasma",
+  "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "mobilita",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.barbigli_sensori_plasma.spinta_selettiva",
+  "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.barbigli_sensori_plasma.uso_funzione"
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
 }

--- a/data/traits/locomotorio/branchie_metalloidi.json
+++ b/data/traits/locomotorio/branchie_metalloidi.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.branchie_metalloidi.debolezza",
+  "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.branchie_metalloidi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "branchie_metalloidi",
-  "label": "i18n:traits.branchie_metalloidi.label",
-  "mutazione_indotta": "i18n:traits.branchie_metalloidi.mutazione_indotta",
+  "label": "Branchie Metalloidi",
+  "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "mobilita",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.branchie_metalloidi.spinta_selettiva",
+  "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.branchie_metalloidi.uso_funzione"
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
 }

--- a/data/traits/locomotorio/capillari_fotovoltaici.json
+++ b/data/traits/locomotorio/capillari_fotovoltaici.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.capillari_fotovoltaici.debolezza",
+  "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.capillari_fotovoltaici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "capillari_fotovoltaici",
-  "label": "i18n:traits.capillari_fotovoltaici.label",
-  "mutazione_indotta": "i18n:traits.capillari_fotovoltaici.mutazione_indotta",
+  "label": "Capillari Fotovoltaici",
+  "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "mobilita",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.capillari_fotovoltaici.spinta_selettiva",
+  "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.capillari_fotovoltaici.uso_funzione"
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
 }

--- a/data/traits/locomotorio/cartilagine_flessotermica_venti.json
+++ b/data/traits/locomotorio/cartilagine_flessotermica_venti.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "scheletro_idro_regolante"
   ],
-  "debolezza": "i18n:traits.cartilagine_flessotermica_venti.debolezza",
+  "debolezza": "Temperature stabili riducono la reattività della cartilagine rendendo l'organismo lento.",
   "famiglia_tipologia": "Locomotorio/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.cartilagine_flessotermica_venti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Richiede frequenti riallineamenti fibrosi)",
   "id": "cartilagine_flessotermica_venti",
-  "label": "i18n:traits.cartilagine_flessotermica_venti.label",
-  "mutazione_indotta": "i18n:traits.cartilagine_flessotermica_venti.mutazione_indotta",
+  "label": "Cartilagine Flessotermica dei Venti",
+  "mutazione_indotta": "Giunzioni cartilaginee che cambiano rigidità in risposta a gradienti termici e eolici.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -46,7 +46,7 @@
     "complementare": "adattivo",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.cartilagine_flessotermica_venti.spinta_selettiva",
+  "spinta_selettiva": "Scalare falesie e planare tra correnti ascensionali turbolente.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.cartilagine_flessotermica_venti.uso_funzione"
+  "uso_funzione": "Modula elasticità e rigidità muscolo-scheletrica per manovre evasive rapide."
 }

--- a/data/traits/locomotorio/chemiorecettori_bromuro.json
+++ b/data/traits/locomotorio/chemiorecettori_bromuro.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.chemiorecettori_bromuro.debolezza",
+  "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.chemiorecettori_bromuro.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "chemiorecettori_bromuro",
-  "label": "i18n:traits.chemiorecettori_bromuro.label",
-  "mutazione_indotta": "i18n:traits.chemiorecettori_bromuro.mutazione_indotta",
+  "label": "Chemiorecettori Bromuro",
+  "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "mobilita",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.chemiorecettori_bromuro.spinta_selettiva",
+  "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.chemiorecettori_bromuro.uso_funzione"
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
 }

--- a/data/traits/locomotorio/coda_contrappeso.json
+++ b/data/traits/locomotorio/coda_contrappeso.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.coda_contrappeso.debolezza",
+  "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_contrappeso.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "coda_contrappeso",
-  "label": "i18n:traits.coda_contrappeso.label",
-  "mutazione_indotta": "i18n:traits.coda_contrappeso.mutazione_indotta",
+  "label": "Coda Contrappeso",
+  "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "mobilita",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.coda_contrappeso.spinta_selettiva",
+  "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.coda_contrappeso.uso_funzione"
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
 }

--- a/data/traits/locomotorio/coda_frusta_cinetica.json
+++ b/data/traits/locomotorio/coda_frusta_cinetica.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.coda_frusta_cinetica.debolezza",
+  "debolezza": "Richiede un periodo di inattività o movimento preparatorio per massimizzare il danno.",
   "famiglia_tipologia": "Locomotorio/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_frusta_cinetica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Mantenimento dell'energia accumulata)",
   "id": "coda_frusta_cinetica",
-  "label": "i18n:traits.coda_frusta_cinetica.label",
-  "mutazione_indotta": "i18n:traits.coda_frusta_cinetica.mutazione_indotta",
+  "label": "Coda a Frusta Cinetica",
+  "mutazione_indotta": "Muscolatura della coda densa con tendini e fibre che agiscono come molle.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -73,7 +73,7 @@
     "complementare": "difensivo",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.coda_frusta_cinetica.spinta_selettiva",
+  "spinta_selettiva": "Necessità di un attacco di \"sfondamento\" dopo movimento preparatorio.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.coda_frusta_cinetica.uso_funzione"
+  "uso_funzione": "Immagazzinare energia da ogni movimento per un colpo finale potente."
 }

--- a/data/traits/locomotorio/cuscinetti_elettrostatici.json
+++ b/data/traits/locomotorio/cuscinetti_elettrostatici.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.cuscinetti_elettrostatici.debolezza",
+  "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.cuscinetti_elettrostatici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cuscinetti_elettrostatici",
-  "label": "i18n:traits.cuscinetti_elettrostatici.label",
-  "mutazione_indotta": "i18n:traits.cuscinetti_elettrostatici.mutazione_indotta",
+  "label": "Cuscinetti Elettrostatici",
+  "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "mobilita",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.cuscinetti_elettrostatici.spinta_selettiva",
+  "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.cuscinetti_elettrostatici.uso_funzione"
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
 }

--- a/data/traits/locomotorio/enzimi_antifase_termica.json
+++ b/data/traits/locomotorio/enzimi_antifase_termica.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.enzimi_antifase_termica.debolezza",
+  "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.enzimi_antifase_termica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "enzimi_antifase_termica",
-  "label": "i18n:traits.enzimi_antifase_termica.label",
-  "mutazione_indotta": "i18n:traits.enzimi_antifase_termica.mutazione_indotta",
+  "label": "Enzimi Antifase Termica",
+  "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "mobilita",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.enzimi_antifase_termica.spinta_selettiva",
+  "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.enzimi_antifase_termica.uso_funzione"
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
 }

--- a/data/traits/locomotorio/filamenti_termoconduzione.json
+++ b/data/traits/locomotorio/filamenti_termoconduzione.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.filamenti_termoconduzione.debolezza",
+  "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.filamenti_termoconduzione.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "filamenti_termoconduzione",
-  "label": "i18n:traits.filamenti_termoconduzione.label",
-  "mutazione_indotta": "i18n:traits.filamenti_termoconduzione.mutazione_indotta",
+  "label": "Filamenti Termoconduzione",
+  "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "mobilita",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.filamenti_termoconduzione.spinta_selettiva",
+  "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.filamenti_termoconduzione.uso_funzione"
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
 }

--- a/data/traits/locomotorio/ghiandole_fango_calde.json
+++ b/data/traits/locomotorio/ghiandole_fango_calde.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ghiandole_fango_calde.debolezza",
+  "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_fango_calde.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_fango_calde",
-  "label": "i18n:traits.ghiandole_fango_calde.label",
-  "mutazione_indotta": "i18n:traits.ghiandole_fango_calde.mutazione_indotta",
+  "label": "Ghiandole Fango Calde",
+  "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "mobilita",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.ghiandole_fango_calde.spinta_selettiva",
+  "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ghiandole_fango_calde.uso_funzione"
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
 }

--- a/data/traits/locomotorio/ghiandole_ventosa.json
+++ b/data/traits/locomotorio/ghiandole_ventosa.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ghiandole_ventosa.debolezza",
+  "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_ventosa.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_ventosa",
-  "label": "i18n:traits.ghiandole_ventosa.label",
-  "mutazione_indotta": "i18n:traits.ghiandole_ventosa.mutazione_indotta",
+  "label": "Ghiandole Ventosa",
+  "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "mobilita",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.ghiandole_ventosa.spinta_selettiva",
+  "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ghiandole_ventosa.uso_funzione"
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
 }

--- a/data/traits/locomotorio/linfa_tampone.json
+++ b/data/traits/locomotorio/linfa_tampone.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.linfa_tampone.debolezza",
+  "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.linfa_tampone.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "linfa_tampone",
-  "label": "i18n:traits.linfa_tampone.label",
-  "mutazione_indotta": "i18n:traits.linfa_tampone.mutazione_indotta",
+  "label": "Linfa Tampone",
+  "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "mobilita",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.linfa_tampone.spinta_selettiva",
+  "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.linfa_tampone.uso_funzione"
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
 }

--- a/data/traits/locomotorio/mucose_aderenza_sonica.json
+++ b/data/traits/locomotorio/mucose_aderenza_sonica.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.mucose_aderenza_sonica.debolezza",
+  "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.mucose_aderenza_sonica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "mucose_aderenza_sonica",
-  "label": "i18n:traits.mucose_aderenza_sonica.label",
-  "mutazione_indotta": "i18n:traits.mucose_aderenza_sonica.mutazione_indotta",
+  "label": "Mucose Aderenza Sonica",
+  "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "mobilita",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.mucose_aderenza_sonica.spinta_selettiva",
+  "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.mucose_aderenza_sonica.uso_funzione"
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
 }

--- a/data/traits/locomotorio/zampe_a_molla.json
+++ b/data/traits/locomotorio/zampe_a_molla.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.zampe_a_molla.debolezza",
+  "debolezza": "Perdita di valore su mappe con spazi stretti o controllo setup elevato.",
   "famiglia_tipologia": "Mobilità/Cinetico",
-  "fattore_mantenimento_energetico": "i18n:traits.zampe_a_molla.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Carica elastica a turni alterni)",
   "id": "zampe_a_molla",
-  "label": "i18n:traits.zampe_a_molla.label",
-  "mutazione_indotta": "i18n:traits.zampe_a_molla.mutazione_indotta",
+  "label": "Zampe a Molla",
+  "mutazione_indotta": "Arti potenziati con ammortizzatori ad alta compressione.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -56,7 +56,7 @@
     "complementare": "propulsione",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.zampe_a_molla.spinta_selettiva",
+  "spinta_selettiva": "Metagame con forte pressione di aggro e necessità di riposizionamento.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.zampe_a_molla.uso_funzione"
+  "uso_funzione": "Dash esplosivi per mantenere il ritmo di ingaggio o disimpegno."
 }

--- a/data/traits/locomotorio/zoccoli_risonanti_steppe.json
+++ b/data/traits/locomotorio/zoccoli_risonanti_steppe.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "zampe_a_molla"
   ],
-  "debolezza": "i18n:traits.zoccoli_risonanti_steppe.debolezza",
+  "debolezza": "Suoli cedevoli come sabbie mobili annullano la vibrazione e riducono la trazione.",
   "famiglia_tipologia": "Locomotorio/Supporto",
-  "fattore_mantenimento_energetico": "i18n:traits.zoccoli_risonanti_steppe.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Vibrazione passiva del suolo)",
   "id": "zoccoli_risonanti_steppe",
-  "label": "i18n:traits.zoccoli_risonanti_steppe.label",
-  "mutazione_indotta": "i18n:traits.zoccoli_risonanti_steppe.mutazione_indotta",
+  "label": "Zoccoli Risonanti delle Steppe",
+  "mutazione_indotta": "Placche cornee cave che emettono onde sismiche ritmiche al contatto con il terreno.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "supporto",
     "core": "locomotorio"
   },
-  "spinta_selettiva": "i18n:traits.zoccoli_risonanti_steppe.spinta_selettiva",
+  "spinta_selettiva": "Mantenere coesione di branchi su grandi distanze e rilevare predatori sotterranei.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.zoccoli_risonanti_steppe.uso_funzione"
+  "uso_funzione": "Propaga segnali ritmici che sincronizzano movimenti e abilità di squadra."
 }

--- a/data/traits/metabolico/antenne_dustsense.json
+++ b/data/traits/metabolico/antenne_dustsense.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.antenne_dustsense.debolezza",
+  "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_dustsense.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_dustsense",
-  "label": "i18n:traits.antenne_dustsense.label",
-  "mutazione_indotta": "i18n:traits.antenne_dustsense.mutazione_indotta",
+  "label": "Antenne Dustsense",
+  "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "energia",
     "core": "metabolico"
   },
-  "spinta_selettiva": "i18n:traits.antenne_dustsense.spinta_selettiva",
+  "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.antenne_dustsense.uso_funzione"
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
 }

--- a/data/traits/metabolico/appendici_thermotattiche.json
+++ b/data/traits/metabolico/appendici_thermotattiche.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.appendici_thermotattiche.debolezza",
+  "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.appendici_thermotattiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "appendici_thermotattiche",
-  "label": "i18n:traits.appendici_thermotattiche.label",
-  "mutazione_indotta": "i18n:traits.appendici_thermotattiche.mutazione_indotta",
+  "label": "Appendici Thermotattiche",
+  "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "energia",
     "core": "metabolico"
   },
-  "spinta_selettiva": "i18n:traits.appendici_thermotattiche.spinta_selettiva",
+  "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.appendici_thermotattiche.uso_funzione"
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
 }

--- a/data/traits/metabolico/batteri_endosimbionti_chemio.json
+++ b/data/traits/metabolico/batteri_endosimbionti_chemio.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.batteri_endosimbionti_chemio.debolezza",
+  "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.batteri_endosimbionti_chemio.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "batteri_endosimbionti_chemio",
-  "label": "i18n:traits.batteri_endosimbionti_chemio.label",
-  "mutazione_indotta": "i18n:traits.batteri_endosimbionti_chemio.mutazione_indotta",
+  "label": "Batteri Endosimbionti Chemio",
+  "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "energia",
     "core": "metabolico"
   },
-  "spinta_selettiva": "i18n:traits.batteri_endosimbionti_chemio.spinta_selettiva",
+  "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.batteri_endosimbionti_chemio.uso_funzione"
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
 }

--- a/data/traits/metabolico/branchie_solfatiche.json
+++ b/data/traits/metabolico/branchie_solfatiche.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.branchie_solfatiche.debolezza",
+  "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.branchie_solfatiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "branchie_solfatiche",
-  "label": "i18n:traits.branchie_solfatiche.label",
-  "mutazione_indotta": "i18n:traits.branchie_solfatiche.mutazione_indotta",
+  "label": "Branchie Solfatiche",
+  "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "energia",
     "core": "metabolico"
   },
-  "spinta_selettiva": "i18n:traits.branchie_solfatiche.spinta_selettiva",
+  "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.branchie_solfatiche.uso_funzione"
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
 }

--- a/data/traits/metabolico/carapace_segmenti_logici.json
+++ b/data/traits/metabolico/carapace_segmenti_logici.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.carapace_segmenti_logici.debolezza",
+  "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.carapace_segmenti_logici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "carapace_segmenti_logici",
-  "label": "i18n:traits.carapace_segmenti_logici.label",
-  "mutazione_indotta": "i18n:traits.carapace_segmenti_logici.mutazione_indotta",
+  "label": "Carapace Segmenti Logici",
+  "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "energia",
     "core": "metabolico"
   },
-  "spinta_selettiva": "i18n:traits.carapace_segmenti_logici.spinta_selettiva",
+  "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.carapace_segmenti_logici.uso_funzione"
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
 }

--- a/data/traits/metabolico/circolazione_bifasica_palude.json
+++ b/data/traits/metabolico/circolazione_bifasica_palude.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "sangue_piroforico"
   ],
-  "debolezza": "i18n:traits.circolazione_bifasica_palude.debolezza",
+  "debolezza": "Zone asciutte e calde causano stagnazione del circuito linfatico portando a tossicosi.",
   "famiglia_tipologia": "Metabolico/Resilienza",
-  "fattore_mantenimento_energetico": "i18n:traits.circolazione_bifasica_palude.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Doppio circuito emolinfa/linfa)",
   "id": "circolazione_bifasica_palude",
-  "label": "i18n:traits.circolazione_bifasica_palude.label",
-  "mutazione_indotta": "i18n:traits.circolazione_bifasica_palude.mutazione_indotta",
+  "label": "Circolazione Bifasica di Palude",
+  "mutazione_indotta": "Cuori gemelli che pompano separatamente emolinfa ossigenata e linfa detossificante.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "resilienza",
     "core": "metabolico"
   },
-  "spinta_selettiva": "i18n:traits.circolazione_bifasica_palude.spinta_selettiva",
+  "spinta_selettiva": "Resistere a tossine e anossia tipiche delle paludi psioniche.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.circolazione_bifasica_palude.uso_funzione"
+  "uso_funzione": "Gestisce due circuiti circolatori per filtrare veleni e mantenere prestazioni elevate."
 }

--- a/data/traits/metabolico/circolazione_cooling_loop.json
+++ b/data/traits/metabolico/circolazione_cooling_loop.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.circolazione_cooling_loop.debolezza",
+  "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.circolazione_cooling_loop.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "circolazione_cooling_loop",
-  "label": "i18n:traits.circolazione_cooling_loop.label",
-  "mutazione_indotta": "i18n:traits.circolazione_cooling_loop.mutazione_indotta",
+  "label": "Circolazione Cooling Loop",
+  "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "energia",
     "core": "metabolico"
   },
-  "spinta_selettiva": "i18n:traits.circolazione_cooling_loop.spinta_selettiva",
+  "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.circolazione_cooling_loop.uso_funzione"
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
 }

--- a/data/traits/metabolico/coda_stabilizzatrice_filo.json
+++ b/data/traits/metabolico/coda_stabilizzatrice_filo.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.coda_stabilizzatrice_filo.debolezza",
+  "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_stabilizzatrice_filo.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "coda_stabilizzatrice_filo",
-  "label": "i18n:traits.coda_stabilizzatrice_filo.label",
-  "mutazione_indotta": "i18n:traits.coda_stabilizzatrice_filo.mutazione_indotta",
+  "label": "Coda Stabilizzatrice Filo",
+  "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "energia",
     "core": "metabolico"
   },
-  "spinta_selettiva": "i18n:traits.coda_stabilizzatrice_filo.spinta_selettiva",
+  "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.coda_stabilizzatrice_filo.uso_funzione"
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
 }

--- a/data/traits/metabolico/criostasi_adattiva.json
+++ b/data/traits/metabolico/criostasi_adattiva.json
@@ -3,12 +3,12 @@
     "sangue_piroforico",
     "sacche_galleggianti_ascensoriali"
   ],
-  "debolezza": "i18n:traits.criostasi_adattiva.debolezza",
+  "debolezza": "Vulnerabilità estrema agli attacchi chimici (veleni) in fase Criostasi.",
   "famiglia_tipologia": "Metabolico/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.criostasi_adattiva.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Fase di risveglio/inizio) / Basso (Fase Criostasi).",
   "id": "criostasi_adattiva",
-  "label": "i18n:traits.criostasi_adattiva.label",
-  "mutazione_indotta": "i18n:traits.criostasi_adattiva.mutazione_indotta",
+  "label": "Criostasi",
+  "mutazione_indotta": "Sviluppo di enzimi crioprotettivi e tessuto adiposo isolante.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -49,7 +49,7 @@
     "complementare": "difensivo",
     "core": "metabolico"
   },
-  "spinta_selettiva": "i18n:traits.criostasi_adattiva.spinta_selettiva",
+  "spinta_selettiva": "Inverni prolungati o lunghi periodi di scarsità di cibo.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.criostasi_adattiva.uso_funzione"
+  "uso_funzione": "Sopravvivenza a condizioni ambientali estreme."
 }

--- a/data/traits/metabolico/cuticole_cerose.json
+++ b/data/traits/metabolico/cuticole_cerose.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.cuticole_cerose.debolezza",
+  "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.cuticole_cerose.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cuticole_cerose",
-  "label": "i18n:traits.cuticole_cerose.label",
-  "mutazione_indotta": "i18n:traits.cuticole_cerose.mutazione_indotta",
+  "label": "Cuticole Cerose",
+  "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -33,7 +33,7 @@
     "complementare": "energia",
     "core": "metabolico"
   },
-  "spinta_selettiva": "i18n:traits.cuticole_cerose.spinta_selettiva",
+  "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.cuticole_cerose.uso_funzione"
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
 }

--- a/data/traits/metabolico/enzimi_chelanti.json
+++ b/data/traits/metabolico/enzimi_chelanti.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.enzimi_chelanti.debolezza",
+  "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.enzimi_chelanti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "enzimi_chelanti",
-  "label": "i18n:traits.enzimi_chelanti.label",
-  "mutazione_indotta": "i18n:traits.enzimi_chelanti.mutazione_indotta",
+  "label": "Enzimi Chelanti",
+  "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -33,7 +33,7 @@
     "complementare": "energia",
     "core": "metabolico"
   },
-  "spinta_selettiva": "i18n:traits.enzimi_chelanti.spinta_selettiva",
+  "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.enzimi_chelanti.uso_funzione"
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
 }

--- a/data/traits/metabolico/flagelli_ancoranti.json
+++ b/data/traits/metabolico/flagelli_ancoranti.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.flagelli_ancoranti.debolezza",
+  "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.flagelli_ancoranti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "flagelli_ancoranti",
-  "label": "i18n:traits.flagelli_ancoranti.label",
-  "mutazione_indotta": "i18n:traits.flagelli_ancoranti.mutazione_indotta",
+  "label": "Flagelli Ancoranti",
+  "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "energia",
     "core": "metabolico"
   },
-  "spinta_selettiva": "i18n:traits.flagelli_ancoranti.spinta_selettiva",
+  "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.flagelli_ancoranti.uso_funzione"
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
 }

--- a/data/traits/metabolico/ghiandole_grafene.json
+++ b/data/traits/metabolico/ghiandole_grafene.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ghiandole_grafene.debolezza",
+  "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_grafene.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_grafene",
-  "label": "i18n:traits.ghiandole_grafene.label",
-  "mutazione_indotta": "i18n:traits.ghiandole_grafene.mutazione_indotta",
+  "label": "Ghiandole Grafene",
+  "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "energia",
     "core": "metabolico"
   },
-  "spinta_selettiva": "i18n:traits.ghiandole_grafene.spinta_selettiva",
+  "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ghiandole_grafene.uso_funzione"
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
 }

--- a/data/traits/metabolico/grassi_termici.json
+++ b/data/traits/metabolico/grassi_termici.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.grassi_termici.debolezza",
+  "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.grassi_termici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "grassi_termici",
-  "label": "i18n:traits.grassi_termici.label",
-  "mutazione_indotta": "i18n:traits.grassi_termici.mutazione_indotta",
+  "label": "Grassi Termici",
+  "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -33,7 +33,7 @@
     "complementare": "energia",
     "core": "metabolico"
   },
-  "spinta_selettiva": "i18n:traits.grassi_termici.spinta_selettiva",
+  "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.grassi_termici.uso_funzione"
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
 }

--- a/data/traits/metabolico/luminescenza_aurorale.json
+++ b/data/traits/metabolico/luminescenza_aurorale.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.luminescenza_aurorale.debolezza",
+  "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.luminescenza_aurorale.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "luminescenza_aurorale",
-  "label": "i18n:traits.luminescenza_aurorale.label",
-  "mutazione_indotta": "i18n:traits.luminescenza_aurorale.mutazione_indotta",
+  "label": "Luminescenza Aurorale",
+  "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "energia",
     "core": "metabolico"
   },
-  "spinta_selettiva": "i18n:traits.luminescenza_aurorale.spinta_selettiva",
+  "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.luminescenza_aurorale.uso_funzione"
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
 }

--- a/data/traits/nervoso/sonno_emisferico_alternato.json
+++ b/data/traits/nervoso/sonno_emisferico_alternato.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.sonno_emisferico_alternato.debolezza",
+  "debolezza": "Vulnerabilità a suoni/stimoli che colpiscono entrambi i lobi contemporaneamente.",
   "famiglia_tipologia": "Nervoso/Omeostatico",
-  "fattore_mantenimento_energetico": "i18n:traits.sonno_emisferico_alternato.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Mantenimento attivo di metà cervello)",
   "id": "sonno_emisferico_alternato",
-  "label": "i18n:traits.sonno_emisferico_alternato.label",
-  "mutazione_indotta": "i18n:traits.sonno_emisferico_alternato.mutazione_indotta",
+  "label": "Dormire con solo metà cervello alla volta",
+  "mutazione_indotta": "Encefalizzazione asimmetrica o due lobi cerebrali separati.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -34,7 +34,7 @@
     "complementare": "omeostatico",
     "core": "nervoso"
   },
-  "spinta_selettiva": "i18n:traits.sonno_emisferico_alternato.spinta_selettiva",
+  "spinta_selettiva": "Monitoraggio costante dei predatori in ambienti ad alto rischio.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.sonno_emisferico_alternato.uso_funzione"
+  "uso_funzione": "Vigilanza continua pur garantendo riposo."
 }

--- a/data/traits/offensivo/antenne_flusso_mareale.json
+++ b/data/traits/offensivo/antenne_flusso_mareale.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.antenne_flusso_mareale.debolezza",
+  "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_flusso_mareale.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_flusso_mareale",
-  "label": "i18n:traits.antenne_flusso_mareale.label",
-  "mutazione_indotta": "i18n:traits.antenne_flusso_mareale.mutazione_indotta",
+  "label": "Antenne Flusso Mareale",
+  "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "assalto",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.antenne_flusso_mareale.spinta_selettiva",
+  "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.antenne_flusso_mareale.uso_funzione"
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
 }

--- a/data/traits/offensivo/artigli_induzione.json
+++ b/data/traits/offensivo/artigli_induzione.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.artigli_induzione.debolezza",
+  "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_induzione.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "artigli_induzione",
-  "label": "i18n:traits.artigli_induzione.label",
-  "mutazione_indotta": "i18n:traits.artigli_induzione.mutazione_indotta",
+  "label": "Artigli Induzione",
+  "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "assalto",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.artigli_induzione.spinta_selettiva",
+  "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.artigli_induzione.uso_funzione"
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
 }

--- a/data/traits/offensivo/biochip_memoria.json
+++ b/data/traits/offensivo/biochip_memoria.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.biochip_memoria.debolezza",
+  "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.biochip_memoria.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "biochip_memoria",
-  "label": "i18n:traits.biochip_memoria.label",
-  "mutazione_indotta": "i18n:traits.biochip_memoria.mutazione_indotta",
+  "label": "Biochip Memoria",
+  "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "assalto",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.biochip_memoria.spinta_selettiva",
+  "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.biochip_memoria.uso_funzione"
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
 }

--- a/data/traits/offensivo/camere_anticorrosione.json
+++ b/data/traits/offensivo/camere_anticorrosione.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.camere_anticorrosione.debolezza",
+  "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.camere_anticorrosione.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "camere_anticorrosione",
-  "label": "i18n:traits.camere_anticorrosione.label",
-  "mutazione_indotta": "i18n:traits.camere_anticorrosione.mutazione_indotta",
+  "label": "Camere Anticorrosione",
+  "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "assalto",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.camere_anticorrosione.spinta_selettiva",
+  "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.camere_anticorrosione.uso_funzione"
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
 }

--- a/data/traits/offensivo/cartilagini_biofibre.json
+++ b/data/traits/offensivo/cartilagini_biofibre.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.cartilagini_biofibre.debolezza",
+  "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.cartilagini_biofibre.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cartilagini_biofibre",
-  "label": "i18n:traits.cartilagini_biofibre.label",
-  "mutazione_indotta": "i18n:traits.cartilagini_biofibre.mutazione_indotta",
+  "label": "Cartilagini Biofibre",
+  "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "assalto",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.cartilagini_biofibre.spinta_selettiva",
+  "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.cartilagini_biofibre.uso_funzione"
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
 }

--- a/data/traits/offensivo/circolazione_supercritica.json
+++ b/data/traits/offensivo/circolazione_supercritica.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.circolazione_supercritica.debolezza",
+  "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.circolazione_supercritica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "circolazione_supercritica",
-  "label": "i18n:traits.circolazione_supercritica.label",
-  "mutazione_indotta": "i18n:traits.circolazione_supercritica.mutazione_indotta",
+  "label": "Circolazione Supercritica",
+  "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "assalto",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.circolazione_supercritica.spinta_selettiva",
+  "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.circolazione_supercritica.uso_funzione"
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
 }

--- a/data/traits/offensivo/coda_stabilizzatrice_vortex.json
+++ b/data/traits/offensivo/coda_stabilizzatrice_vortex.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.coda_stabilizzatrice_vortex.debolezza",
+  "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_stabilizzatrice_vortex.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "coda_stabilizzatrice_vortex",
-  "label": "i18n:traits.coda_stabilizzatrice_vortex.label",
-  "mutazione_indotta": "i18n:traits.coda_stabilizzatrice_vortex.mutazione_indotta",
+  "label": "Coda Stabilizzatrice Vortex",
+  "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "assalto",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.coda_stabilizzatrice_vortex.spinta_selettiva",
+  "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.coda_stabilizzatrice_vortex.uso_funzione"
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
 }

--- a/data/traits/offensivo/denti_chelatanti.json
+++ b/data/traits/offensivo/denti_chelatanti.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.denti_chelatanti.debolezza",
+  "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.denti_chelatanti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "denti_chelatanti",
-  "label": "i18n:traits.denti_chelatanti.label",
-  "mutazione_indotta": "i18n:traits.denti_chelatanti.mutazione_indotta",
+  "label": "Denti Chelatanti",
+  "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "assalto",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.denti_chelatanti.spinta_selettiva",
+  "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.denti_chelatanti.uso_funzione"
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
 }

--- a/data/traits/offensivo/enzimi_metanoossidanti.json
+++ b/data/traits/offensivo/enzimi_metanoossidanti.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.enzimi_metanoossidanti.debolezza",
+  "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.enzimi_metanoossidanti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "enzimi_metanoossidanti",
-  "label": "i18n:traits.enzimi_metanoossidanti.label",
-  "mutazione_indotta": "i18n:traits.enzimi_metanoossidanti.mutazione_indotta",
+  "label": "Enzimi Metanoossidanti",
+  "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "assalto",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.enzimi_metanoossidanti.spinta_selettiva",
+  "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.enzimi_metanoossidanti.uso_funzione"
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
 }

--- a/data/traits/offensivo/foliaggio_spugna.json
+++ b/data/traits/offensivo/foliaggio_spugna.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.foliaggio_spugna.debolezza",
+  "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.foliaggio_spugna.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "foliaggio_spugna",
-  "label": "i18n:traits.foliaggio_spugna.label",
-  "mutazione_indotta": "i18n:traits.foliaggio_spugna.mutazione_indotta",
+  "label": "Foliaggio Spugna",
+  "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "assalto",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.foliaggio_spugna.spinta_selettiva",
+  "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.foliaggio_spugna.uso_funzione"
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
 }

--- a/data/traits/offensivo/frusta_fiammeggiante.json
+++ b/data/traits/offensivo/frusta_fiammeggiante.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "armatura_pietra_planare"
   ],
-  "debolezza": "i18n:traits.frusta_fiammeggiante.debolezza",
+  "debolezza": "Consumante: richiede costante dissipazione termica per non bruciare la matrice portante.",
   "famiglia_tipologia": "Offensivo/Controllo",
-  "fattore_mantenimento_energetico": "i18n:traits.frusta_fiammeggiante.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Filamenti di plasma vincolato)",
   "id": "frusta_fiammeggiante",
-  "label": "i18n:traits.frusta_fiammeggiante.label",
-  "mutazione_indotta": "i18n:traits.frusta_fiammeggiante.mutazione_indotta",
+  "label": "Frusta Fiammeggiante",
+  "mutazione_indotta": "Genera appendici tentacolari avvolte da plasma infernale controllato.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [
@@ -39,7 +39,7 @@
     "complementare": "controllo",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.frusta_fiammeggiante.spinta_selettiva",
+  "spinta_selettiva": "Creare distanza di sicurezza contro predatori d'élite nelle zone instabili.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.frusta_fiammeggiante.uso_funzione"
+  "uso_funzione": "Afferra e disarma avversari o sigilla varchi planari con tagli di energia."
 }

--- a/data/traits/offensivo/ghiandola_caustica.json
+++ b/data/traits/offensivo/ghiandola_caustica.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ghiandola_caustica.debolezza",
+  "debolezza": "Gestione accurata delle riserve per non calare sotto i budget PE previsto.",
   "famiglia_tipologia": "Offensivo/Chimico",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandola_caustica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Produzione reagenti)",
   "id": "ghiandola_caustica",
-  "label": "i18n:traits.ghiandola_caustica.label",
-  "mutazione_indotta": "i18n:traits.ghiandola_caustica.mutazione_indotta",
+  "label": "Ghiandola Caustica",
+  "mutazione_indotta": "Sintesi rapida di composti caustici nei moduli d'attacco.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -37,7 +37,7 @@
     "complementare": "assalto",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.ghiandola_caustica.spinta_selettiva",
+  "spinta_selettiva": "Squadre che devono rispondere a guardie situazionali al turno 1-2.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ghiandola_caustica.uso_funzione"
+  "uso_funzione": "Sblocco early di danni da acido per rompere armature leggere."
 }

--- a/data/traits/offensivo/ghiandole_iodoattive.json
+++ b/data/traits/offensivo/ghiandole_iodoattive.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ghiandole_iodoattive.debolezza",
+  "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_iodoattive.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_iodoattive",
-  "label": "i18n:traits.ghiandole_iodoattive.label",
-  "mutazione_indotta": "i18n:traits.ghiandole_iodoattive.mutazione_indotta",
+  "label": "Ghiandole Iodoattive",
+  "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "assalto",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.ghiandole_iodoattive.spinta_selettiva",
+  "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ghiandole_iodoattive.uso_funzione"
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
 }

--- a/data/traits/offensivo/gusci_magnesio.json
+++ b/data/traits/offensivo/gusci_magnesio.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.gusci_magnesio.debolezza",
+  "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.gusci_magnesio.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "gusci_magnesio",
-  "label": "i18n:traits.gusci_magnesio.label",
-  "mutazione_indotta": "i18n:traits.gusci_magnesio.mutazione_indotta",
+  "label": "Gusci Magnesio",
+  "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "assalto",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.gusci_magnesio.spinta_selettiva",
+  "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.gusci_magnesio.uso_funzione"
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
 }

--- a/data/traits/offensivo/mantelli_geotermici.json
+++ b/data/traits/offensivo/mantelli_geotermici.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.mantelli_geotermici.debolezza",
+  "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.mantelli_geotermici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "mantelli_geotermici",
-  "label": "i18n:traits.mantelli_geotermici.label",
-  "mutazione_indotta": "i18n:traits.mantelli_geotermici.mutazione_indotta",
+  "label": "Mantelli Geotermici",
+  "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "assalto",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.mantelli_geotermici.spinta_selettiva",
+  "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.mantelli_geotermici.uso_funzione"
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
 }

--- a/data/traits/offensivo/sangue_piroforico.json
+++ b/data/traits/offensivo/sangue_piroforico.json
@@ -3,12 +3,12 @@
     "criostasi_adattiva",
     "scheletro_idro_regolante"
   ],
-  "debolezza": "i18n:traits.sangue_piroforico.debolezza",
+  "debolezza": "Rischio di auto-combustione in caso di ferita profonda in atmosfera ricca di ossigeno.",
   "famiglia_tipologia": "Offensivo/Cinetico",
-  "fattore_mantenimento_energetico": "i18n:traits.sangue_piroforico.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Sintesi dei composti)",
   "id": "sangue_piroforico",
-  "label": "i18n:traits.sangue_piroforico.label",
-  "mutazione_indotta": "i18n:traits.sangue_piroforico.mutazione_indotta",
+  "label": "Sangue che prende fuoco a contatto con l'ossigeno",
+  "mutazione_indotta": "Presenza di composti piroforici nel sangue.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -49,7 +49,7 @@
     "complementare": "impatto",
     "core": "offensivo"
   },
-  "spinta_selettiva": "i18n:traits.sangue_piroforico.spinta_selettiva",
+  "spinta_selettiva": "Difesa contro predatori che tentano di estrarre fluidi corporei.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.sangue_piroforico.uso_funzione"
+  "uso_funzione": "Meccanismo di difesa termico o chimico che si attiva con l'aria."
 }

--- a/data/traits/respiratorio/branchie_osmotiche_salmastra.json
+++ b/data/traits/respiratorio/branchie_osmotiche_salmastra.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "polmoni_cristallini_alta_quota"
   ],
-  "debolezza": "i18n:traits.branchie_osmotiche_salmastra.debolezza",
+  "debolezza": "Richiede accesso costante ad acqua salmastra; ambienti d'acqua dolce provocano stress ionico.",
   "famiglia_tipologia": "Respiratorio/Osmoregolazione",
-  "fattore_mantenimento_energetico": "i18n:traits.branchie_osmotiche_salmastra.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Pompe ioniche attive)",
   "id": "branchie_osmotiche_salmastra",
-  "label": "i18n:traits.branchie_osmotiche_salmastra.label",
-  "mutazione_indotta": "i18n:traits.branchie_osmotiche_salmastra.mutazione_indotta",
+  "label": "Branchie Osmotiche Salmastre",
+  "mutazione_indotta": "Lamelle branchiali multilivello con valvole che separano sali e tossine.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -44,7 +44,7 @@
     "complementare": "osmoregolazione",
     "core": "respiratorio"
   },
-  "spinta_selettiva": "i18n:traits.branchie_osmotiche_salmastra.spinta_selettiva",
+  "spinta_selettiva": "Colonizzare mangrovie psioniche e barriere di estuario soggette a maree estreme.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.branchie_osmotiche_salmastra.uso_funzione"
+  "uso_funzione": "Bilancia sali e tossine sfruttando microvalvole controllate psionicamente."
 }

--- a/data/traits/respiratorio/lamelle_termoforetiche.json
+++ b/data/traits/respiratorio/lamelle_termoforetiche.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "criostasi_adattiva"
   ],
-  "debolezza": "i18n:traits.lamelle_termoforetiche.debolezza",
+  "debolezza": "Rende instabile la fisiologia in ambienti a gelo improvviso, con rischio di microfratture vascolari.",
   "famiglia_tipologia": "Respiratorio/Termoregolazione",
-  "fattore_mantenimento_energetico": "i18n:traits.lamelle_termoforetiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Flusso continuo di fluidi caldi)",
   "id": "lamelle_termoforetiche",
-  "label": "i18n:traits.lamelle_termoforetiche.label",
-  "mutazione_indotta": "i18n:traits.lamelle_termoforetiche.mutazione_indotta",
+  "label": "Lamelle Termoforetiche",
+  "mutazione_indotta": "Canali lamellari mineralizzati che convogliano fluidi caldi tra branchie interne.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "termoregolazione",
     "core": "respiratorio"
   },
-  "spinta_selettiva": "i18n:traits.lamelle_termoforetiche.spinta_selettiva",
+  "spinta_selettiva": "Sopravvivere a fluidi tossici e temperature estreme nelle fumarole geotermiche.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.lamelle_termoforetiche.uso_funzione"
+  "uso_funzione": "Regola lo scambio gassoso sfruttando gradienti termici controllati."
 }

--- a/data/traits/respiratorio/membrane_eliofiltranti.json
+++ b/data/traits/respiratorio/membrane_eliofiltranti.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.membrane_eliofiltranti.debolezza",
+  "debolezza": "Atmosfere acide degradano rapidamente il film eliofiltrante.",
   "famiglia_tipologia": "Respiratorio/Protezione",
-  "fattore_mantenimento_energetico": "i18n:traits.membrane_eliofiltranti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Auto-riparazione lenta)",
   "id": "membrane_eliofiltranti",
-  "label": "i18n:traits.membrane_eliofiltranti.label",
-  "mutazione_indotta": "i18n:traits.membrane_eliofiltranti.mutazione_indotta",
+  "label": "Membrane Eliofiltranti",
+  "mutazione_indotta": "Strati di mucopolisaccaridi trasparenti che filtrano radiazioni e microrganismi sospesi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -34,7 +34,7 @@
     "complementare": "protezione",
     "core": "respiratorio"
   },
-  "spinta_selettiva": "i18n:traits.membrane_eliofiltranti.spinta_selettiva",
+  "spinta_selettiva": "Proteggersi da radiazioni e agenti patogeni in altopiani ipersalini.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.membrane_eliofiltranti.uso_funzione"
+  "uso_funzione": "Filtra l'aria e i flussi luminosi rendendoli sicuri per tessuti delicati."
 }

--- a/data/traits/respiratorio/polmoni_cristallini_alta_quota.json
+++ b/data/traits/respiratorio/polmoni_cristallini_alta_quota.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "branchie_osmotiche_salmastra"
   ],
-  "debolezza": "i18n:traits.polmoni_cristallini_alta_quota.debolezza",
+  "debolezza": "Particolato pesante o sabbia vulcanica graffia i cristalli riducendo l'efficienza respiratoria.",
   "famiglia_tipologia": "Respiratorio/Aerobico",
-  "fattore_mantenimento_energetico": "i18n:traits.polmoni_cristallini_alta_quota.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Pulizia periodica dei cristalli)",
   "id": "polmoni_cristallini_alta_quota",
-  "label": "i18n:traits.polmoni_cristallini_alta_quota.label",
-  "mutazione_indotta": "i18n:traits.polmoni_cristallini_alta_quota.mutazione_indotta",
+  "label": "Polmoni Cristallini d'Alta Quota",
+  "mutazione_indotta": "Sistemi alveolari irrobustiti da strutture cristalline che catturano ossigeno rarefatto.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "aerobico",
     "core": "respiratorio"
   },
-  "spinta_selettiva": "i18n:traits.polmoni_cristallini_alta_quota.spinta_selettiva",
+  "spinta_selettiva": "Operare in missioni d'alta quota senza supporto logistico esterno.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.polmoni_cristallini_alta_quota.uso_funzione"
+  "uso_funzione": "Massimizza l'assorbimento di ossigeno rarefatto e filtra agenti nocivi."
 }

--- a/data/traits/respiratorio/respiro_a_scoppio.json
+++ b/data/traits/respiratorio/respiro_a_scoppio.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.respiro_a_scoppio.debolezza",
+  "debolezza": "Vulnerabilità respiratoria subito dopo l'utilizzo (tempo di ricarica).",
   "famiglia_tipologia": "Respiratorio/Propulsivo",
-  "fattore_mantenimento_energetico": "i18n:traits.respiro_a_scoppio.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Richiede ricarica polmonare)",
   "id": "respiro_a_scoppio",
-  "label": "i18n:traits.respiro_a_scoppio.label",
-  "mutazione_indotta": "i18n:traits.respiro_a_scoppio.mutazione_indotta",
+  "label": "Respiro a scoppio",
+  "mutazione_indotta": "Polmoni o sacche aeree ad alta pressione con valvole di rilascio rapide.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -34,7 +34,7 @@
     "complementare": "propulsivo",
     "core": "respiratorio"
   },
-  "spinta_selettiva": "i18n:traits.respiro_a_scoppio.spinta_selettiva",
+  "spinta_selettiva": "Spostamento rapido tramite getto d'aria in ambienti a bassa resistenza.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.respiro_a_scoppio.uso_funzione"
+  "uso_funzione": "Rilasciare grandi quantità d'aria o energia in un getto potente."
 }

--- a/data/traits/riproduttivo/nucleo_ovomotore_rotante.json
+++ b/data/traits/riproduttivo/nucleo_ovomotore_rotante.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "secrezione_rallentante_palmi"
   ],
-  "debolezza": "i18n:traits.nucleo_ovomotore_rotante.debolezza",
+  "debolezza": "Impossibilità di muoversi su superfici irregolari o in salita ripida.",
   "famiglia_tipologia": "Riproduttivo/Locomotorio",
-  "fattore_mantenimento_energetico": "i18n:traits.nucleo_ovomotore_rotante.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Rotolamento)",
   "id": "nucleo_ovomotore_rotante",
-  "label": "i18n:traits.nucleo_ovomotore_rotante.label",
-  "mutazione_indotta": "i18n:traits.nucleo_ovomotore_rotante.mutazione_indotta",
+  "label": "Uovo rotaia, uovo grande e uova piccole dentro...",
+  "mutazione_indotta": "Massa globulare rigida con giunto sferico al centro del petto.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -33,7 +33,7 @@
     "complementare": "locomotorio",
     "core": "riproduttivo"
   },
-  "spinta_selettiva": "i18n:traits.nucleo_ovomotore_rotante.spinta_selettiva",
+  "spinta_selettiva": "Necessità di spostarsi rapidamente su terreni uniformi in assenza di arti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.nucleo_ovomotore_rotante.uso_funzione"
+  "uso_funzione": "Organo Motorio Rotante: usato come 'ruota' centrale per il rotolamento."
 }

--- a/data/traits/sensoriale/ali_fulminee.json
+++ b/data/traits/sensoriale/ali_fulminee.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ali_fulminee.debolezza",
+  "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.ali_fulminee.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ali_fulminee",
-  "label": "i18n:traits.ali_fulminee.label",
-  "mutazione_indotta": "i18n:traits.ali_fulminee.mutazione_indotta",
+  "label": "Ali Fulminee",
+  "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "analitico",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.ali_fulminee.spinta_selettiva",
+  "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ali_fulminee.uso_funzione"
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
 }

--- a/data/traits/sensoriale/antenne_plasmatiche_tempesta.json
+++ b/data/traits/sensoriale/antenne_plasmatiche_tempesta.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.antenne_plasmatiche_tempesta.debolezza",
+  "debolezza": "Scariche elettriche massicce possono bruciare i recettori e compromettere la coordinazione.",
   "famiglia_tipologia": "Sensoriale/Offensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_plasmatiche_tempesta.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Canalizzazione costante di plasma atmosferico)",
   "id": "antenne_plasmatiche_tempesta",
-  "label": "i18n:traits.antenne_plasmatiche_tempesta.label",
-  "mutazione_indotta": "i18n:traits.antenne_plasmatiche_tempesta.mutazione_indotta",
+  "label": "Antenne Plasmatiche di Tempesta",
+  "mutazione_indotta": "Flagelli coronati da nodi plasma-sensibili che captano e deviano fulmini.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -45,7 +45,7 @@
     "complementare": "offensivo",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.antenne_plasmatiche_tempesta.spinta_selettiva",
+  "spinta_selettiva": "Comandare fulmini e navigare in cieli turbolenti durante campagne aeree.",
   "tier": "T3",
-  "uso_funzione": "i18n:traits.antenne_plasmatiche_tempesta.uso_funzione"
+  "uso_funzione": "Canalizza scariche atmosferiche in attacchi direzionati o scudi ionici."
 }

--- a/data/traits/sensoriale/antenne_waveguide.json
+++ b/data/traits/sensoriale/antenne_waveguide.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.antenne_waveguide.debolezza",
+  "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_waveguide.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_waveguide",
-  "label": "i18n:traits.antenne_waveguide.label",
-  "mutazione_indotta": "i18n:traits.antenne_waveguide.mutazione_indotta",
+  "label": "Antenne Waveguide",
+  "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "analitico",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.antenne_waveguide.spinta_selettiva",
+  "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.antenne_waveguide.uso_funzione"
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
 }

--- a/data/traits/sensoriale/baffi_mareomotori.json
+++ b/data/traits/sensoriale/baffi_mareomotori.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.baffi_mareomotori.debolezza",
+  "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.baffi_mareomotori.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "baffi_mareomotori",
-  "label": "i18n:traits.baffi_mareomotori.label",
-  "mutazione_indotta": "i18n:traits.baffi_mareomotori.mutazione_indotta",
+  "label": "Baffi Mareomotori",
+  "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "analitico",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.baffi_mareomotori.spinta_selettiva",
+  "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.baffi_mareomotori.uso_funzione"
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
 }

--- a/data/traits/sensoriale/branchie_eoliche.json
+++ b/data/traits/sensoriale/branchie_eoliche.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.branchie_eoliche.debolezza",
+  "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.branchie_eoliche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "branchie_eoliche",
-  "label": "i18n:traits.branchie_eoliche.label",
-  "mutazione_indotta": "i18n:traits.branchie_eoliche.mutazione_indotta",
+  "label": "Branchie Eoliche",
+  "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "analitico",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.branchie_eoliche.spinta_selettiva",
+  "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.branchie_eoliche.uso_funzione"
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
 }

--- a/data/traits/sensoriale/capillari_fluoridici.json
+++ b/data/traits/sensoriale/capillari_fluoridici.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.capillari_fluoridici.debolezza",
+  "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.capillari_fluoridici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "capillari_fluoridici",
-  "label": "i18n:traits.capillari_fluoridici.label",
-  "mutazione_indotta": "i18n:traits.capillari_fluoridici.mutazione_indotta",
+  "label": "Capillari Fluoridici",
+  "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "analitico",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.capillari_fluoridici.spinta_selettiva",
+  "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.capillari_fluoridici.uso_funzione"
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
 }

--- a/data/traits/sensoriale/cavita_risonanti_tundra.json
+++ b/data/traits/sensoriale/cavita_risonanti_tundra.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.cavita_risonanti_tundra.debolezza",
+  "debolezza": "In ambienti temperati l'eco interna produce rumori udibili che rivelano la posizione.",
   "famiglia_tipologia": "Sensoriale/Supporto",
-  "fattore_mantenimento_energetico": "i18n:traits.cavita_risonanti_tundra.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Camere di risonanza statiche)",
   "id": "cavita_risonanti_tundra",
-  "label": "i18n:traits.cavita_risonanti_tundra.label",
-  "mutazione_indotta": "i18n:traits.cavita_risonanti_tundra.mutazione_indotta",
+  "label": "Cavità Risonanti della Tundra",
+  "mutazione_indotta": "Camere toraciche espanse che amplificano vibrazioni subsoniche nel permafrost.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -45,7 +45,7 @@
     "complementare": "supporto",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.cavita_risonanti_tundra.spinta_selettiva",
+  "spinta_selettiva": "Coordinare branchi in lande aperte dove la visibilità è ridotta da bufere di ghiaccio.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.cavita_risonanti_tundra.uso_funzione"
+  "uso_funzione": "Amplifica segnali acustici per comunicazioni a lungo raggio nel gelo."
 }

--- a/data/traits/sensoriale/cervelletto_equilibrio_statico.json
+++ b/data/traits/sensoriale/cervelletto_equilibrio_statico.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.cervelletto_equilibrio_statico.debolezza",
+  "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.cervelletto_equilibrio_statico.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cervelletto_equilibrio_statico",
-  "label": "i18n:traits.cervelletto_equilibrio_statico.label",
-  "mutazione_indotta": "i18n:traits.cervelletto_equilibrio_statico.mutazione_indotta",
+  "label": "Cervelletto Equilibrio Statico",
+  "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "analitico",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.cervelletto_equilibrio_statico.spinta_selettiva",
+  "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.cervelletto_equilibrio_statico.uso_funzione"
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
 }

--- a/data/traits/sensoriale/coda_balanciere.json
+++ b/data/traits/sensoriale/coda_balanciere.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.coda_balanciere.debolezza",
+  "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_balanciere.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "coda_balanciere",
-  "label": "i18n:traits.coda_balanciere.label",
-  "mutazione_indotta": "i18n:traits.coda_balanciere.mutazione_indotta",
+  "label": "Coda Balanciere",
+  "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "analitico",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.coda_balanciere.spinta_selettiva",
+  "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.coda_balanciere.uso_funzione"
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
 }

--- a/data/traits/sensoriale/cuore_multicamera_bassa_pressione.json
+++ b/data/traits/sensoriale/cuore_multicamera_bassa_pressione.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.cuore_multicamera_bassa_pressione.debolezza",
+  "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.cuore_multicamera_bassa_pressione.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cuore_multicamera_bassa_pressione",
-  "label": "i18n:traits.cuore_multicamera_bassa_pressione.label",
-  "mutazione_indotta": "i18n:traits.cuore_multicamera_bassa_pressione.mutazione_indotta",
+  "label": "Cuore Multicamera Bassa Pressione",
+  "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "analitico",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.cuore_multicamera_bassa_pressione.spinta_selettiva",
+  "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.cuore_multicamera_bassa_pressione.uso_funzione"
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
 }

--- a/data/traits/sensoriale/echi_risonanti.json
+++ b/data/traits/sensoriale/echi_risonanti.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.echi_risonanti.debolezza",
+  "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.echi_risonanti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "echi_risonanti",
-  "label": "i18n:traits.echi_risonanti.label",
-  "mutazione_indotta": "i18n:traits.echi_risonanti.mutazione_indotta",
+  "label": "Echi Risonanti",
+  "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "analitico",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.echi_risonanti.spinta_selettiva",
+  "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.echi_risonanti.uso_funzione"
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
 }

--- a/data/traits/sensoriale/eco_interno_riflesso.json
+++ b/data/traits/sensoriale/eco_interno_riflesso.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.eco_interno_riflesso.debolezza",
+  "debolezza": "Estremamente disorientato da suoni o vibrazioni esterne forti e continue.",
   "famiglia_tipologia": "Sensoriale/Nervoso",
-  "fattore_mantenimento_energetico": "i18n:traits.eco_interno_riflesso.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Emissioni e ricezione continua)",
   "id": "eco_interno_riflesso",
-  "label": "i18n:traits.eco_interno_riflesso.label",
-  "mutazione_indotta": "i18n:traits.eco_interno_riflesso.mutazione_indotta",
+  "label": "Riflesso dell'Eco Interno",
+  "mutazione_indotta": "Organi interni che emettono ultrasuoni e li captano tramite lo scheletro.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -48,7 +48,7 @@
     "complementare": "nervoso",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.eco_interno_riflesso.spinta_selettiva",
+  "spinta_selettiva": "Orientamento in ambienti completamente privi di luce.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.eco_interno_riflesso.uso_funzione"
+  "uso_funzione": "Utilizzo di onde sonore emesse internamente per mappare l'ambiente."
 }

--- a/data/traits/sensoriale/filamenti_superconduttivi.json
+++ b/data/traits/sensoriale/filamenti_superconduttivi.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.filamenti_superconduttivi.debolezza",
+  "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.filamenti_superconduttivi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "filamenti_superconduttivi",
-  "label": "i18n:traits.filamenti_superconduttivi.label",
-  "mutazione_indotta": "i18n:traits.filamenti_superconduttivi.mutazione_indotta",
+  "label": "Filamenti Superconduttivi",
+  "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "analitico",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.filamenti_superconduttivi.spinta_selettiva",
+  "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.filamenti_superconduttivi.uso_funzione"
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
 }

--- a/data/traits/sensoriale/ghiandole_eco_mappanti.json
+++ b/data/traits/sensoriale/ghiandole_eco_mappanti.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ghiandole_eco_mappanti.debolezza",
+  "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_eco_mappanti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_eco_mappanti",
-  "label": "i18n:traits.ghiandole_eco_mappanti.label",
-  "mutazione_indotta": "i18n:traits.ghiandole_eco_mappanti.mutazione_indotta",
+  "label": "Ghiandole Eco Mappanti",
+  "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "analitico",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.ghiandole_eco_mappanti.spinta_selettiva",
+  "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ghiandole_eco_mappanti.uso_funzione"
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
 }

--- a/data/traits/sensoriale/ghiandole_resina_conduttiva.json
+++ b/data/traits/sensoriale/ghiandole_resina_conduttiva.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ghiandole_resina_conduttiva.debolezza",
+  "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_resina_conduttiva.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_resina_conduttiva",
-  "label": "i18n:traits.ghiandole_resina_conduttiva.label",
-  "mutazione_indotta": "i18n:traits.ghiandole_resina_conduttiva.mutazione_indotta",
+  "label": "Ghiandole Resina Conduttiva",
+  "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "analitico",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.ghiandole_resina_conduttiva.spinta_selettiva",
+  "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ghiandole_resina_conduttiva.uso_funzione"
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
 }

--- a/data/traits/sensoriale/lamine_scudo_silice.json
+++ b/data/traits/sensoriale/lamine_scudo_silice.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.lamine_scudo_silice.debolezza",
+  "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.lamine_scudo_silice.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "lamine_scudo_silice",
-  "label": "i18n:traits.lamine_scudo_silice.label",
-  "mutazione_indotta": "i18n:traits.lamine_scudo_silice.mutazione_indotta",
+  "label": "Lamine Scudo Silice",
+  "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "analitico",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.lamine_scudo_silice.spinta_selettiva",
+  "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.lamine_scudo_silice.uso_funzione"
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
 }

--- a/data/traits/sensoriale/lingua_tattile_trama.json
+++ b/data/traits/sensoriale/lingua_tattile_trama.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.lingua_tattile_trama.debolezza",
+  "debolezza": "Estrema vulnerabilità della lingua a contaminanti chimici o acidi.",
   "famiglia_tipologia": "Sensoriale/Alimentare",
-  "fattore_mantenimento_energetico": "i18n:traits.lingua_tattile_trama.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "lingua_tattile_trama",
-  "label": "i18n:traits.lingua_tattile_trama.label",
-  "mutazione_indotta": "i18n:traits.lingua_tattile_trama.mutazione_indotta",
+  "label": "Lingua Tattile Trama-Sensibile",
+  "mutazione_indotta": "Lingua sottile con papille tattili e meccanocettori avanzati.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -33,7 +33,7 @@
     "complementare": "alimentare",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.lingua_tattile_trama.spinta_selettiva",
+  "spinta_selettiva": "Individuare movimenti sismici o cibi sepolti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.lingua_tattile_trama.uso_funzione"
+  "uso_funzione": "\"Leggere\" la tessitura delle superfici per vibrazioni o micro-fratture."
 }

--- a/data/traits/sensoriale/midollo_antivibrazione.json
+++ b/data/traits/sensoriale/midollo_antivibrazione.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.midollo_antivibrazione.debolezza",
+  "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.midollo_antivibrazione.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "midollo_antivibrazione",
-  "label": "i18n:traits.midollo_antivibrazione.label",
-  "mutazione_indotta": "i18n:traits.midollo_antivibrazione.mutazione_indotta",
+  "label": "Midollo Antivibrazione",
+  "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "analitico",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.midollo_antivibrazione.spinta_selettiva",
+  "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.midollo_antivibrazione.uso_funzione"
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
 }

--- a/data/traits/sensoriale/occhi_infrarosso_composti.json
+++ b/data/traits/sensoriale/occhi_infrarosso_composti.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.occhi_infrarosso_composti.debolezza",
+  "debolezza": "Accecamento temporaneo da fonti di calore intenso e concentrato.",
   "famiglia_tipologia": "Sensoriale/Visivo",
-  "fattore_mantenimento_energetico": "i18n:traits.occhi_infrarosso_composti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "occhi_infrarosso_composti",
-  "label": "i18n:traits.occhi_infrarosso_composti.label",
-  "mutazione_indotta": "i18n:traits.occhi_infrarosso_composti.mutazione_indotta",
+  "label": "Occhi Composti ad Infrarosso",
+  "mutazione_indotta": "Sviluppo di un secondo strato retinico sensibile all'infrarosso.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -33,7 +33,7 @@
     "complementare": "visivo",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.occhi_infrarosso_composti.spinta_selettiva",
+  "spinta_selettiva": "Caccia notturna o nell'oscurità totale basata sul gradiente termico.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.occhi_infrarosso_composti.uso_funzione"
+  "uso_funzione": "Vista specializzata che percepisce il calore corporeo."
 }

--- a/data/traits/sensoriale/olfatto_risonanza_magnetica.json
+++ b/data/traits/sensoriale/olfatto_risonanza_magnetica.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.olfatto_risonanza_magnetica.debolezza",
+  "debolezza": "Sensibilità a forti interferenze elettromagnetiche (es. fulmini o minerali magnetici).",
   "famiglia_tipologia": "Sensoriale/Nervoso",
-  "fattore_mantenimento_energetico": "i18n:traits.olfatto_risonanza_magnetica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Elaborazione sensoriale costante)",
   "id": "olfatto_risonanza_magnetica",
-  "label": "i18n:traits.olfatto_risonanza_magnetica.label",
-  "mutazione_indotta": "i18n:traits.olfatto_risonanza_magnetica.mutazione_indotta",
+  "label": "Olfatto di Risonanza Magnetica",
+  "mutazione_indotta": "Organi sensoriali elettrorecettori concentrati su muso o antenne.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -47,7 +47,7 @@
     "complementare": "nervoso",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.olfatto_risonanza_magnetica.spinta_selettiva",
+  "spinta_selettiva": "Orientamento in ambienti sotterranei senza luce o caccia a prede metallifere.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.olfatto_risonanza_magnetica.uso_funzione"
+  "uso_funzione": "Percepire la direzione e la composizione di metalli o campi energetici."
 }

--- a/data/traits/sensoriale/sensori_geomagnetici.json
+++ b/data/traits/sensoriale/sensori_geomagnetici.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.sensori_geomagnetici.debolezza",
+  "debolezza": "Tempeste solari possono saturare il segnale magnetico, causando disorientamento prolungato.",
   "famiglia_tipologia": "Sensoriale/Navigazione",
-  "fattore_mantenimento_energetico": "i18n:traits.sensori_geomagnetici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Ricettori passivi)",
   "id": "sensori_geomagnetici",
-  "label": "i18n:traits.sensori_geomagnetici.label",
-  "mutazione_indotta": "i18n:traits.sensori_geomagnetici.mutazione_indotta",
+  "label": "Sensori Geomagnetici",
+  "mutazione_indotta": "Cristalli ferromagnetici allineati lungo il cranio che fungono da bussola psionica.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -34,7 +34,7 @@
     "complementare": "navigazione",
     "core": "sensoriale"
   },
-  "spinta_selettiva": "i18n:traits.sensori_geomagnetici.spinta_selettiva",
+  "spinta_selettiva": "Orientarsi in steppe polarizzate e tunnel sotterranei privi di riferimenti visivi.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.sensori_geomagnetici.uso_funzione"
+  "uso_funzione": "Traccia linee di campo e memorizza corridoi magnetici per la migrazione."
 }

--- a/data/traits/simbiotico/antenne_reagenti.json
+++ b/data/traits/simbiotico/antenne_reagenti.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.antenne_reagenti.debolezza",
+  "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_reagenti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_reagenti",
-  "label": "i18n:traits.antenne_reagenti.label",
-  "mutazione_indotta": "i18n:traits.antenne_reagenti.mutazione_indotta",
+  "label": "Antenne Reagenti",
+  "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "cooperazione",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.antenne_reagenti.spinta_selettiva",
+  "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.antenne_reagenti.uso_funzione"
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
 }

--- a/data/traits/simbiotico/artigli_scivolo_silente.json
+++ b/data/traits/simbiotico/artigli_scivolo_silente.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.artigli_scivolo_silente.debolezza",
+  "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_scivolo_silente.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "artigli_scivolo_silente",
-  "label": "i18n:traits.artigli_scivolo_silente.label",
-  "mutazione_indotta": "i18n:traits.artigli_scivolo_silente.mutazione_indotta",
+  "label": "Artigli Scivolo Silente",
+  "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "cooperazione",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.artigli_scivolo_silente.spinta_selettiva",
+  "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.artigli_scivolo_silente.uso_funzione"
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
 }

--- a/data/traits/simbiotico/biofilm_iperarido.json
+++ b/data/traits/simbiotico/biofilm_iperarido.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.biofilm_iperarido.debolezza",
+  "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.biofilm_iperarido.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "biofilm_iperarido",
-  "label": "i18n:traits.biofilm_iperarido.label",
-  "mutazione_indotta": "i18n:traits.biofilm_iperarido.mutazione_indotta",
+  "label": "Biofilm Iperarido",
+  "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "cooperazione",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.biofilm_iperarido.spinta_selettiva",
+  "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.biofilm_iperarido.uso_funzione"
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
 }

--- a/data/traits/simbiotico/bulbi_radici_permafrost.json
+++ b/data/traits/simbiotico/bulbi_radici_permafrost.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.bulbi_radici_permafrost.debolezza",
+  "debolezza": "Disgeli improvvisi trasformano i bulbi in masse gelatinose che rallentano i movimenti.",
   "famiglia_tipologia": "Simbiotico/Nutrizione",
-  "fattore_mantenimento_energetico": "i18n:traits.bulbi_radici_permafrost.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Accumulo e rilascio lento di nutrienti)",
   "id": "bulbi_radici_permafrost",
-  "label": "i18n:traits.bulbi_radici_permafrost.label",
-  "mutazione_indotta": "i18n:traits.bulbi_radici_permafrost.mutazione_indotta",
+  "label": "Bulbi Radici del Permafrost",
+  "mutazione_indotta": "Bulbi radicali multipli che immagazzinano energia nelle stagioni fredde per rilasciarla durante le missioni.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -44,7 +44,7 @@
     "complementare": "nutrizione",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.bulbi_radici_permafrost.spinta_selettiva",
+  "spinta_selettiva": "Sostenere campagne lunghe in climi artici con riserve nutrizionali concentrate.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.bulbi_radici_permafrost.uso_funzione"
+  "uso_funzione": "Rilascia energia e calore agli alleati radicati nella stessa rete subglaciale."
 }

--- a/data/traits/simbiotico/camere_nutrienti_vent.json
+++ b/data/traits/simbiotico/camere_nutrienti_vent.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.camere_nutrienti_vent.debolezza",
+  "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.camere_nutrienti_vent.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "camere_nutrienti_vent",
-  "label": "i18n:traits.camere_nutrienti_vent.label",
-  "mutazione_indotta": "i18n:traits.camere_nutrienti_vent.mutazione_indotta",
+  "label": "Camere Nutrienti Vent",
+  "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "cooperazione",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.camere_nutrienti_vent.spinta_selettiva",
+  "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.camere_nutrienti_vent.uso_funzione"
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
 }

--- a/data/traits/simbiotico/cartilagini_flessoacustiche.json
+++ b/data/traits/simbiotico/cartilagini_flessoacustiche.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.cartilagini_flessoacustiche.debolezza",
+  "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.cartilagini_flessoacustiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cartilagini_flessoacustiche",
-  "label": "i18n:traits.cartilagini_flessoacustiche.label",
-  "mutazione_indotta": "i18n:traits.cartilagini_flessoacustiche.mutazione_indotta",
+  "label": "Cartilagini Flessoacustiche",
+  "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "cooperazione",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.cartilagini_flessoacustiche.spinta_selettiva",
+  "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.cartilagini_flessoacustiche.uso_funzione"
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
 }

--- a/data/traits/simbiotico/chioma_parassita_canopica.json
+++ b/data/traits/simbiotico/chioma_parassita_canopica.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.chioma_parassita_canopica.debolezza",
+  "debolezza": "Se la pianta ospite muore la chioma psionica collassa causando shock sistemico.",
   "famiglia_tipologia": "Simbiotico/Utility",
-  "fattore_mantenimento_energetico": "i18n:traits.chioma_parassita_canopica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Nutrimento condiviso con l'ospite arboreo)",
   "id": "chioma_parassita_canopica",
-  "label": "i18n:traits.chioma_parassita_canopica.label",
-  "mutazione_indotta": "i18n:traits.chioma_parassita_canopica.mutazione_indotta",
+  "label": "Chioma Parassita Canopica",
+  "mutazione_indotta": "Filamenti vegetali che si intrecciano con la canopia ospite fornendo punti d'ancoraggio e energia.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -34,7 +34,7 @@
     "complementare": "utility",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.chioma_parassita_canopica.spinta_selettiva",
+  "spinta_selettiva": "Stabilizzare piattaforme mobili e reti di trasporto tra gli alberi viventi.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.chioma_parassita_canopica.uso_funzione"
+  "uso_funzione": "Crea passaggi e nodi energetici condivisi nella canopia per movimenti rapidi."
 }

--- a/data/traits/simbiotico/ciste_salmastre.json
+++ b/data/traits/simbiotico/ciste_salmastre.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ciste_salmastre.debolezza",
+  "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.ciste_salmastre.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ciste_salmastre",
-  "label": "i18n:traits.ciste_salmastre.label",
-  "mutazione_indotta": "i18n:traits.ciste_salmastre.mutazione_indotta",
+  "label": "Ciste Salmastre",
+  "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "cooperazione",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.ciste_salmastre.spinta_selettiva",
+  "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ciste_salmastre.uso_funzione"
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
 }

--- a/data/traits/simbiotico/coralli_partner.json
+++ b/data/traits/simbiotico/coralli_partner.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.coralli_partner.debolezza",
+  "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.coralli_partner.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "coralli_partner",
-  "label": "i18n:traits.coralli_partner.label",
-  "mutazione_indotta": "i18n:traits.coralli_partner.mutazione_indotta",
+  "label": "Coralli Partner",
+  "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "cooperazione",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.coralli_partner.spinta_selettiva",
+  "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.coralli_partner.uso_funzione"
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
 }

--- a/data/traits/simbiotico/denti_silice_termici.json
+++ b/data/traits/simbiotico/denti_silice_termici.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.denti_silice_termici.debolezza",
+  "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.denti_silice_termici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "denti_silice_termici",
-  "label": "i18n:traits.denti_silice_termici.label",
-  "mutazione_indotta": "i18n:traits.denti_silice_termici.mutazione_indotta",
+  "label": "Denti Silice Termici",
+  "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "cooperazione",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.denti_silice_termici.spinta_selettiva",
+  "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.denti_silice_termici.uso_funzione"
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
 }

--- a/data/traits/simbiotico/epitelio_fosforescente.json
+++ b/data/traits/simbiotico/epitelio_fosforescente.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.epitelio_fosforescente.debolezza",
+  "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.epitelio_fosforescente.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "epitelio_fosforescente",
-  "label": "i18n:traits.epitelio_fosforescente.label",
-  "mutazione_indotta": "i18n:traits.epitelio_fosforescente.mutazione_indotta",
+  "label": "Epitelio Fosforescente",
+  "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "cooperazione",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.epitelio_fosforescente.spinta_selettiva",
+  "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.epitelio_fosforescente.uso_funzione"
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
 }

--- a/data/traits/simbiotico/ghiandole_cambio_salino.json
+++ b/data/traits/simbiotico/ghiandole_cambio_salino.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ghiandole_cambio_salino.debolezza",
+  "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_cambio_salino.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_cambio_salino",
-  "label": "i18n:traits.ghiandole_cambio_salino.label",
-  "mutazione_indotta": "i18n:traits.ghiandole_cambio_salino.mutazione_indotta",
+  "label": "Ghiandole Cambio Salino",
+  "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "cooperazione",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.ghiandole_cambio_salino.spinta_selettiva",
+  "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ghiandole_cambio_salino.uso_funzione"
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
 }

--- a/data/traits/simbiotico/ghiandole_nebbia_acida.json
+++ b/data/traits/simbiotico/ghiandole_nebbia_acida.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ghiandole_nebbia_acida.debolezza",
+  "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_nebbia_acida.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_nebbia_acida",
-  "label": "i18n:traits.ghiandole_nebbia_acida.label",
-  "mutazione_indotta": "i18n:traits.ghiandole_nebbia_acida.mutazione_indotta",
+  "label": "Ghiandole Nebbia Acida",
+  "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "cooperazione",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.ghiandole_nebbia_acida.spinta_selettiva",
+  "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ghiandole_nebbia_acida.uso_funzione"
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
 }

--- a/data/traits/simbiotico/lamelle_sincroniche.json
+++ b/data/traits/simbiotico/lamelle_sincroniche.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.lamelle_sincroniche.debolezza",
+  "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.lamelle_sincroniche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "lamelle_sincroniche",
-  "label": "i18n:traits.lamelle_sincroniche.label",
-  "mutazione_indotta": "i18n:traits.lamelle_sincroniche.mutazione_indotta",
+  "label": "Lamelle Sincroniche",
+  "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "cooperazione",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.lamelle_sincroniche.spinta_selettiva",
+  "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.lamelle_sincroniche.uso_funzione"
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
 }

--- a/data/traits/simbiotico/membrane_planata_vectored.json
+++ b/data/traits/simbiotico/membrane_planata_vectored.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.membrane_planata_vectored.debolezza",
+  "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.membrane_planata_vectored.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "membrane_planata_vectored",
-  "label": "i18n:traits.membrane_planata_vectored.label",
-  "mutazione_indotta": "i18n:traits.membrane_planata_vectored.mutazione_indotta",
+  "label": "Membrane Planata Vectored",
+  "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "cooperazione",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.membrane_planata_vectored.spinta_selettiva",
+  "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.membrane_planata_vectored.uso_funzione"
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
 }

--- a/data/traits/simbiotico/mucillagine_simbionte_mangrovie.json
+++ b/data/traits/simbiotico/mucillagine_simbionte_mangrovie.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "ghiandola_caustica"
   ],
-  "debolezza": "i18n:traits.mucillagine_simbionte_mangrovie.debolezza",
+  "debolezza": "Acque eccessivamente pure diluiscono la mucillagine riducendo la protezione.",
   "famiglia_tipologia": "Simbiotico/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.mucillagine_simbionte_mangrovie.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Coltura simbiotica costante)",
   "id": "mucillagine_simbionte_mangrovie",
-  "label": "i18n:traits.mucillagine_simbionte_mangrovie.label",
-  "mutazione_indotta": "i18n:traits.mucillagine_simbionte_mangrovie.mutazione_indotta",
+  "label": "Mucillagine Simbionte delle Mangrovie",
+  "mutazione_indotta": "Strati mucosi che ospitano microfauna detossificante proveniente dalle radici di mangrovia.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -50,7 +50,7 @@
     "complementare": "difensivo",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.mucillagine_simbionte_mangrovie.spinta_selettiva",
+  "spinta_selettiva": "Respinge tossine e predatori microbici tipici dei delta paludosi.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.mucillagine_simbionte_mangrovie.uso_funzione"
+  "uso_funzione": "Forma una barriera viva che neutralizza veleni e sigilla ferite."
 }

--- a/data/traits/simbiotico/nodi_micorrizici_oracolari.json
+++ b/data/traits/simbiotico/nodi_micorrizici_oracolari.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "spore_psichiche_silenziate"
   ],
-  "debolezza": "i18n:traits.nodi_micorrizici_oracolari.debolezza",
+  "debolezza": "Se la rete micorrizica viene recisa, l'organismo soffre crisi percettive e perdita di orientamento.",
   "famiglia_tipologia": "Simbiotico/Nervoso",
-  "fattore_mantenimento_energetico": "i18n:traits.nodi_micorrizici_oracolari.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Scambio continuo di segnali con simbionti)",
   "id": "nodi_micorrizici_oracolari",
-  "label": "i18n:traits.nodi_micorrizici_oracolari.label",
-  "mutazione_indotta": "i18n:traits.nodi_micorrizici_oracolari.mutazione_indotta",
+  "label": "Nodi Micorrizici Oracolari",
+  "mutazione_indotta": "Radici dermiche che intrecciano funghi psionici capaci di predire variazioni ambientali.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -50,7 +50,7 @@
     "complementare": "nervoso",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.nodi_micorrizici_oracolari.spinta_selettiva",
+  "spinta_selettiva": "Anticipare frane psioniche e predatori guidati da reti vegetali senzienti.",
   "tier": "T3",
-  "uso_funzione": "i18n:traits.nodi_micorrizici_oracolari.uso_funzione"
+  "uso_funzione": "Riceve presagi e segnali tattici dalla rete fungina per coordinare manovre di squadra."
 }

--- a/data/traits/simbiotico/sacche_spore_stratosferiche.json
+++ b/data/traits/simbiotico/sacche_spore_stratosferiche.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "respiro_a_scoppio"
   ],
-  "debolezza": "i18n:traits.sacche_spore_stratosferiche.debolezza",
+  "debolezza": "Correnti ionizzate possono incendiare le sacche rendendo l'organismo instabile.",
   "famiglia_tipologia": "Simbiotico/Supporto",
-  "fattore_mantenimento_energetico": "i18n:traits.sacche_spore_stratosferiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Coltura continua di spore portanti)",
   "id": "sacche_spore_stratosferiche",
-  "label": "i18n:traits.sacche_spore_stratosferiche.label",
-  "mutazione_indotta": "i18n:traits.sacche_spore_stratosferiche.mutazione_indotta",
+  "label": "Sacche di Spore Stratosferiche",
+  "mutazione_indotta": "Vescicole dermiche che rilasciano spore portatrici capaci di galleggiare per chilometri.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "supporto",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.sacche_spore_stratosferiche.spinta_selettiva",
+  "spinta_selettiva": "Dispersone genetica rapida tra arcipelaghi aerei e piattaforme galleggianti.",
   "tier": "T3",
-  "uso_funzione": "i18n:traits.sacche_spore_stratosferiche.uso_funzione"
+  "uso_funzione": "Distribuisce simbionti di supporto e crea corridoi di movimento per la squadra."
 }

--- a/data/traits/simbiotico/sinapsi_coraline_polifoniche.json
+++ b/data/traits/simbiotico/sinapsi_coraline_polifoniche.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "spore_psichiche_silenziate"
   ],
-  "debolezza": "i18n:traits.sinapsi_coraline_polifoniche.debolezza",
+  "debolezza": "Vibrazioni sintonizzate male possono generare feedback dolorosi e perdita di coscienza.",
   "famiglia_tipologia": "Simbiotico/Comunicazione",
-  "fattore_mantenimento_energetico": "i18n:traits.sinapsi_coraline_polifoniche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Scambio continuo di impulsi corallini)",
   "id": "sinapsi_coraline_polifoniche",
-  "label": "i18n:traits.sinapsi_coraline_polifoniche.label",
-  "mutazione_indotta": "i18n:traits.sinapsi_coraline_polifoniche.mutazione_indotta",
+  "label": "Sinapsi Coraline Polifoniche",
+  "mutazione_indotta": "Fibre nervose intrecciate con coralli sonori che trasmettono ordini tramite armoniche.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -50,7 +50,7 @@
     "complementare": "comunicazione",
     "core": "simbiotico"
   },
-  "spinta_selettiva": "i18n:traits.sinapsi_coraline_polifoniche.spinta_selettiva",
+  "spinta_selettiva": "Coordinare banchi e alleati in ambienti tridimensionali complessi.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.sinapsi_coraline_polifoniche.uso_funzione"
+  "uso_funzione": "Trasmette comandi e pattern tattici sfruttando armoniche subacquee."
 }

--- a/data/traits/strategia/antenne_microonde_cavernose.json
+++ b/data/traits/strategia/antenne_microonde_cavernose.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.antenne_microonde_cavernose.debolezza",
+  "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_microonde_cavernose.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_microonde_cavernose",
-  "label": "i18n:traits.antenne_microonde_cavernose.label",
-  "mutazione_indotta": "i18n:traits.antenne_microonde_cavernose.mutazione_indotta",
+  "label": "Antenne Microonde Cavernose",
+  "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "tattico",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.antenne_microonde_cavernose.spinta_selettiva",
+  "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.antenne_microonde_cavernose.uso_funzione"
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
 }

--- a/data/traits/strategia/artigli_radice.json
+++ b/data/traits/strategia/artigli_radice.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.artigli_radice.debolezza",
+  "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_radice.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "artigli_radice",
-  "label": "i18n:traits.artigli_radice.label",
-  "mutazione_indotta": "i18n:traits.artigli_radice.mutazione_indotta",
+  "label": "Artigli Radice",
+  "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "tattico",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.artigli_radice.spinta_selettiva",
+  "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.artigli_radice.uso_funzione"
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
 }

--- a/data/traits/strategia/biofilm_glow.json
+++ b/data/traits/strategia/biofilm_glow.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.biofilm_glow.debolezza",
+  "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.biofilm_glow.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "biofilm_glow",
-  "label": "i18n:traits.biofilm_glow.label",
-  "mutazione_indotta": "i18n:traits.biofilm_glow.mutazione_indotta",
+  "label": "Biofilm Glow",
+  "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "tattico",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.biofilm_glow.spinta_selettiva",
+  "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.biofilm_glow.uso_funzione"
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
 }

--- a/data/traits/strategia/camere_mirage.json
+++ b/data/traits/strategia/camere_mirage.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.camere_mirage.debolezza",
+  "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.camere_mirage.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "camere_mirage",
-  "label": "i18n:traits.camere_mirage.label",
-  "mutazione_indotta": "i18n:traits.camere_mirage.mutazione_indotta",
+  "label": "Camere Mirage",
+  "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "tattico",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.camere_mirage.spinta_selettiva",
+  "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.camere_mirage.uso_funzione"
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
 }

--- a/data/traits/strategia/cartilagini_desertiche.json
+++ b/data/traits/strategia/cartilagini_desertiche.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.cartilagini_desertiche.debolezza",
+  "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.cartilagini_desertiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cartilagini_desertiche",
-  "label": "i18n:traits.cartilagini_desertiche.label",
-  "mutazione_indotta": "i18n:traits.cartilagini_desertiche.mutazione_indotta",
+  "label": "Cartilagini Desertiche",
+  "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "tattico",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.cartilagini_desertiche.spinta_selettiva",
+  "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.cartilagini_desertiche.uso_funzione"
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
 }

--- a/data/traits/strategia/ciste_riduttive.json
+++ b/data/traits/strategia/ciste_riduttive.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ciste_riduttive.debolezza",
+  "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.ciste_riduttive.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ciste_riduttive",
-  "label": "i18n:traits.ciste_riduttive.label",
-  "mutazione_indotta": "i18n:traits.ciste_riduttive.mutazione_indotta",
+  "label": "Ciste Riduttive",
+  "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "tattico",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.ciste_riduttive.spinta_selettiva",
+  "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ciste_riduttive.uso_funzione"
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
 }

--- a/data/traits/strategia/colonne_vibromagnetiche.json
+++ b/data/traits/strategia/colonne_vibromagnetiche.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.colonne_vibromagnetiche.debolezza",
+  "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.colonne_vibromagnetiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "colonne_vibromagnetiche",
-  "label": "i18n:traits.colonne_vibromagnetiche.label",
-  "mutazione_indotta": "i18n:traits.colonne_vibromagnetiche.mutazione_indotta",
+  "label": "Colonne Vibromagnetiche",
+  "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "tattico",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.colonne_vibromagnetiche.spinta_selettiva",
+  "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.colonne_vibromagnetiche.uso_funzione"
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
 }

--- a/data/traits/strategia/denti_ossidoferro.json
+++ b/data/traits/strategia/denti_ossidoferro.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.denti_ossidoferro.debolezza",
+  "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.denti_ossidoferro.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "denti_ossidoferro",
-  "label": "i18n:traits.denti_ossidoferro.label",
-  "mutazione_indotta": "i18n:traits.denti_ossidoferro.mutazione_indotta",
+  "label": "Denti Ossidoferro",
+  "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "tattico",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.denti_ossidoferro.spinta_selettiva",
+  "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.denti_ossidoferro.uso_funzione"
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
 }

--- a/data/traits/strategia/epidermide_dielettrica.json
+++ b/data/traits/strategia/epidermide_dielettrica.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.epidermide_dielettrica.debolezza",
+  "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.epidermide_dielettrica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "epidermide_dielettrica",
-  "label": "i18n:traits.epidermide_dielettrica.label",
-  "mutazione_indotta": "i18n:traits.epidermide_dielettrica.mutazione_indotta",
+  "label": "Epidermide Dielettrica",
+  "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "tattico",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.epidermide_dielettrica.spinta_selettiva",
+  "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.epidermide_dielettrica.uso_funzione"
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
 }

--- a/data/traits/strategia/focus_frazionato.json
+++ b/data/traits/strategia/focus_frazionato.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.focus_frazionato.debolezza",
+  "debolezza": "Rischio di overload mentale se tilt e aggro salgono oltre le soglie HUD.",
   "famiglia_tipologia": "Strategico/Psionico",
-  "fattore_mantenimento_energetico": "i18n:traits.focus_frazionato.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Dividere l'attenzione su più canali)",
   "id": "focus_frazionato",
-  "label": "i18n:traits.focus_frazionato.label",
-  "mutazione_indotta": "i18n:traits.focus_frazionato.mutazione_indotta",
+  "label": "Focus Frazionato",
+  "mutazione_indotta": "Processore di priorità multi-thread per bersagli e obiettivi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -60,7 +60,7 @@
     "complementare": "psionico",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.focus_frazionato.spinta_selettiva",
+  "spinta_selettiva": "Comunicazioni piatte dove occorre coprire minacce su più fronti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.focus_frazionato.uso_funzione"
+  "uso_funzione": "Permette di gestire due ingaggi paralleli senza perdere efficienza."
 }

--- a/data/traits/strategia/ghiaccio_piezoelettrico.json
+++ b/data/traits/strategia/ghiaccio_piezoelettrico.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ghiaccio_piezoelettrico.debolezza",
+  "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiaccio_piezoelettrico.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiaccio_piezoelettrico",
-  "label": "i18n:traits.ghiaccio_piezoelettrico.label",
-  "mutazione_indotta": "i18n:traits.ghiaccio_piezoelettrico.mutazione_indotta",
+  "label": "Ghiaccio Piezoelettrico",
+  "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "tattico",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.ghiaccio_piezoelettrico.spinta_selettiva",
+  "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ghiaccio_piezoelettrico.uso_funzione"
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
 }

--- a/data/traits/strategia/ghiandole_minerali.json
+++ b/data/traits/strategia/ghiandole_minerali.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ghiandole_minerali.debolezza",
+  "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_minerali.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_minerali",
-  "label": "i18n:traits.ghiandole_minerali.label",
-  "mutazione_indotta": "i18n:traits.ghiandole_minerali.mutazione_indotta",
+  "label": "Ghiandole Minerali",
+  "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "tattico",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.ghiandole_minerali.spinta_selettiva",
+  "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ghiandole_minerali.uso_funzione"
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
 }

--- a/data/traits/strategia/lamelle_shear.json
+++ b/data/traits/strategia/lamelle_shear.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.lamelle_shear.debolezza",
+  "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.lamelle_shear.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "lamelle_shear",
-  "label": "i18n:traits.lamelle_shear.label",
-  "mutazione_indotta": "i18n:traits.lamelle_shear.mutazione_indotta",
+  "label": "Lamelle Shear",
+  "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "tattico",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.lamelle_shear.spinta_selettiva",
+  "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.lamelle_shear.uso_funzione"
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
 }

--- a/data/traits/strategia/membrane_captura_rugiada.json
+++ b/data/traits/strategia/membrane_captura_rugiada.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.membrane_captura_rugiada.debolezza",
+  "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.membrane_captura_rugiada.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "membrane_captura_rugiada",
-  "label": "i18n:traits.membrane_captura_rugiada.label",
-  "mutazione_indotta": "i18n:traits.membrane_captura_rugiada.mutazione_indotta",
+  "label": "Membrane Captura Rugiada",
+  "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "tattico",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.membrane_captura_rugiada.spinta_selettiva",
+  "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.membrane_captura_rugiada.uso_funzione"
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
 }

--- a/data/traits/strategia/pathfinder.json
+++ b/data/traits/strategia/pathfinder.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.pathfinder.debolezza",
+  "debolezza": "Valore ridotto in scenari a corridoio o con tilt già stabilizzato.",
   "famiglia_tipologia": "Esplorazione/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.pathfinder.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Sincronizzazione con HUD di esplorazione)",
   "id": "pathfinder",
-  "label": "i18n:traits.pathfinder.label",
-  "mutazione_indotta": "i18n:traits.pathfinder.mutazione_indotta",
+  "label": "Pathfinder",
+  "mutazione_indotta": "Suite sensoriale orientata a scouting e lettura minacce.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -52,7 +52,7 @@
     "has_species_link": true,
     "has_usage_tags": true
   },
-  "spinta_selettiva": "i18n:traits.pathfinder.spinta_selettiva",
+  "spinta_selettiva": "Missioni con indice explore alto e opzioni opzionali da capitalizzare.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.pathfinder.uso_funzione"
+  "uso_funzione": "Ottimizza esplorazione e controllo mappe multi-bioma."
 }

--- a/data/traits/strategia/pianificatore.json
+++ b/data/traits/strategia/pianificatore.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.pianificatore.debolezza",
+  "debolezza": "Rigidità tattica se gli input di telemetria arrivano in ritardo.",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.pianificatore.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Analisi continua di stato squadre)",
   "id": "pianificatore",
-  "label": "i18n:traits.pianificatore.label",
-  "mutazione_indotta": "i18n:traits.pianificatore.mutazione_indotta",
+  "label": "Pianificatore",
+  "mutazione_indotta": "Protocollo decisionale adattivo con buffer informativi dedicati.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -59,7 +59,7 @@
     "complementare": "tattico",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.pianificatore.spinta_selettiva",
+  "spinta_selettiva": "Squadre che devono mantenere priorità multiple su turni lunghi.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.pianificatore.uso_funzione"
+  "uso_funzione": "Coordina finestre di danno e difesa, mantenendo la squadra allineata al piano PI."
 }

--- a/data/traits/strategia/random.json
+++ b/data/traits/strategia/random.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.random.debolezza",
+  "debolezza": "Bassa affidabilità: richiede slot aggiuntivi per mitigare risultati sfavorevoli.",
   "famiglia_tipologia": "Flessibile/Generico",
-  "fattore_mantenimento_energetico": "i18n:traits.random.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Variabile (Dipende dal tratto estratto)",
   "id": "random",
-  "label": "i18n:traits.random.label",
-  "mutazione_indotta": "i18n:traits.random.mutazione_indotta",
+  "label": "Trait Random",
+  "mutazione_indotta": "Selezione casuale da pool controllata per esperimenti di build.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -39,7 +39,7 @@
     "complementare": "adattivo",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.random.spinta_selettiva",
+  "spinta_selettiva": "Draft rapidi o recuperi quando il tavolo necessita sorprese adattive.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.random.uso_funzione"
+  "uso_funzione": "Slot jolly per testing o pareggiare budget PI quando serve varietà."
 }

--- a/data/traits/strategia/tattiche_di_branco.json
+++ b/data/traits/strategia/tattiche_di_branco.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.tattiche_di_branco.debolezza",
+  "debolezza": "Richiede formazione stabile; cala se la coesione precipita sotto il target.",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.tattiche_di_branco.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Broadcast continuo di segnali)",
   "id": "tattiche_di_branco",
-  "label": "i18n:traits.tattiche_di_branco.label",
-  "mutazione_indotta": "i18n:traits.tattiche_di_branco.mutazione_indotta",
+  "label": "Tattiche di Branco",
+  "mutazione_indotta": "Canale condiviso per marcature e ingaggi simultanei.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -56,7 +56,7 @@
     "complementare": "coordinazione",
     "core": "strategia"
   },
-  "spinta_selettiva": "i18n:traits.tattiche_di_branco.spinta_selettiva",
+  "spinta_selettiva": "Squadre che puntano a style bonus tramite assist e controllo spazio.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.tattiche_di_branco.uso_funzione"
+  "uso_funzione": "Coordina prese e focus bersaglio condividendo segnali di priorità."
 }

--- a/data/traits/strutturale/antenne_tesla.json
+++ b/data/traits/strutturale/antenne_tesla.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.antenne_tesla.debolezza",
+  "debolezza": "Risonanze errate possono generare microfratture.",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_tesla.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_tesla",
-  "label": "i18n:traits.antenne_tesla.label",
-  "mutazione_indotta": "i18n:traits.antenne_tesla.mutazione_indotta",
+  "label": "Antenne Tesla",
+  "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "resilienza",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.antenne_tesla.spinta_selettiva",
+  "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.antenne_tesla.uso_funzione"
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
 }

--- a/data/traits/strutturale/artigli_vetrificati.json
+++ b/data/traits/strutturale/artigli_vetrificati.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.artigli_vetrificati.debolezza",
+  "debolezza": "Risonanze errate possono generare microfratture.",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_vetrificati.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "artigli_vetrificati",
-  "label": "i18n:traits.artigli_vetrificati.label",
-  "mutazione_indotta": "i18n:traits.artigli_vetrificati.mutazione_indotta",
+  "label": "Artigli Vetrificati",
+  "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "resilienza",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.artigli_vetrificati.spinta_selettiva",
+  "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.artigli_vetrificati.uso_funzione"
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
 }

--- a/data/traits/strutturale/branchie_dual_mode.json
+++ b/data/traits/strutturale/branchie_dual_mode.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.branchie_dual_mode.debolezza",
+  "debolezza": "Risonanze errate possono generare microfratture.",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.branchie_dual_mode.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "branchie_dual_mode",
-  "label": "i18n:traits.branchie_dual_mode.label",
-  "mutazione_indotta": "i18n:traits.branchie_dual_mode.mutazione_indotta",
+  "label": "Branchie Dual Mode",
+  "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "resilienza",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.branchie_dual_mode.spinta_selettiva",
+  "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.branchie_dual_mode.uso_funzione"
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
 }

--- a/data/traits/strutturale/capillari_criogenici.json
+++ b/data/traits/strutturale/capillari_criogenici.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.capillari_criogenici.debolezza",
+  "debolezza": "Risonanze errate possono generare microfratture.",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.capillari_criogenici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "capillari_criogenici",
-  "label": "i18n:traits.capillari_criogenici.label",
-  "mutazione_indotta": "i18n:traits.capillari_criogenici.mutazione_indotta",
+  "label": "Capillari Criogenici",
+  "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "resilienza",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.capillari_criogenici.spinta_selettiva",
+  "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.capillari_criogenici.uso_funzione"
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
 }

--- a/data/traits/strutturale/carapace_fase_variabile.json
+++ b/data/traits/strutturale/carapace_fase_variabile.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "struttura_elastica_amorfa"
   ],
-  "debolezza": "i18n:traits.carapace_fase_variabile.debolezza",
+  "debolezza": "Debolezza strutturale durante la transizione tra le fasi di durezza.",
   "famiglia_tipologia": "Strutturale/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.carapace_fase_variabile.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Richiede energia per il cambio di fase)",
   "id": "carapace_fase_variabile",
-  "label": "i18n:traits.carapace_fase_variabile.label",
-  "mutazione_indotta": "i18n:traits.carapace_fase_variabile.mutazione_indotta",
+  "label": "Carapace a Variazione di Fase",
+  "mutazione_indotta": "Strutture minerali a legame reversibile o micro-strutture a rigidità controllata.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -74,7 +74,7 @@
     "complementare": "difensivo",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.carapace_fase_variabile.spinta_selettiva",
+  "spinta_selettiva": "Alternanza tra ambienti con attacchi cinetici pesanti e ambienti che richiedono velocità.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.carapace_fase_variabile.uso_funzione"
+  "uso_funzione": "Durezza/densità del guscio modificabile rapidamente."
 }

--- a/data/traits/strutturale/carapace_luminiscente_abissale.json
+++ b/data/traits/strutturale/carapace_luminiscente_abissale.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "carapace_fase_variabile"
   ],
-  "debolezza": "i18n:traits.carapace_luminiscente_abissale.debolezza",
+  "debolezza": "Luce intensa di superficie sovraccarica i biofotoni rendendo la corazza fragile.",
   "famiglia_tipologia": "Strutturale/Sensoriale",
-  "fattore_mantenimento_energetico": "i18n:traits.carapace_luminiscente_abissale.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Bioluminescenza controllata)",
   "id": "carapace_luminiscente_abissale",
-  "label": "i18n:traits.carapace_luminiscente_abissale.label",
-  "mutazione_indotta": "i18n:traits.carapace_luminiscente_abissale.mutazione_indotta",
+  "label": "Carapace Luminiscente Abissale",
+  "mutazione_indotta": "Placche chitino-minerali con microrganismi luminescenti che comunicano in pattern.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -46,7 +46,7 @@
     "complementare": "sensoriale",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.carapace_luminiscente_abissale.spinta_selettiva",
+  "spinta_selettiva": "Comunicare e mimetizzarsi nelle profondità prive di luce naturale.",
   "tier": "T3",
-  "uso_funzione": "i18n:traits.carapace_luminiscente_abissale.uso_funzione"
+  "uso_funzione": "Emette segnali di branco e devia attacchi grazie a pattern luminosi cangianti."
 }

--- a/data/traits/strutturale/cartilagini_pseudometalliche.json
+++ b/data/traits/strutturale/cartilagini_pseudometalliche.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.cartilagini_pseudometalliche.debolezza",
+  "debolezza": "Risonanze errate possono generare microfratture.",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.cartilagini_pseudometalliche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cartilagini_pseudometalliche",
-  "label": "i18n:traits.cartilagini_pseudometalliche.label",
-  "mutazione_indotta": "i18n:traits.cartilagini_pseudometalliche.mutazione_indotta",
+  "label": "Cartilagini Pseudometalliche",
+  "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "resilienza",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.cartilagini_pseudometalliche.spinta_selettiva",
+  "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.cartilagini_pseudometalliche.uso_funzione"
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
 }

--- a/data/traits/strutturale/cisti_iperbariche.json
+++ b/data/traits/strutturale/cisti_iperbariche.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.cisti_iperbariche.debolezza",
+  "debolezza": "Risonanze errate possono generare microfratture.",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.cisti_iperbariche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cisti_iperbariche",
-  "label": "i18n:traits.cisti_iperbariche.label",
-  "mutazione_indotta": "i18n:traits.cisti_iperbariche.mutazione_indotta",
+  "label": "Cisti Iperbariche",
+  "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "resilienza",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.cisti_iperbariche.spinta_selettiva",
+  "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.cisti_iperbariche.uso_funzione"
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
 }

--- a/data/traits/strutturale/cromofori_alert_acido.json
+++ b/data/traits/strutturale/cromofori_alert_acido.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.cromofori_alert_acido.debolezza",
+  "debolezza": "Risonanze errate possono generare microfratture.",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.cromofori_alert_acido.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cromofori_alert_acido",
-  "label": "i18n:traits.cromofori_alert_acido.label",
-  "mutazione_indotta": "i18n:traits.cromofori_alert_acido.mutazione_indotta",
+  "label": "Cromofori Alert Acido",
+  "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "resilienza",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.cromofori_alert_acido.spinta_selettiva",
+  "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.cromofori_alert_acido.uso_funzione"
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
 }

--- a/data/traits/strutturale/denti_tuning_fork.json
+++ b/data/traits/strutturale/denti_tuning_fork.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.denti_tuning_fork.debolezza",
+  "debolezza": "Risonanze errate possono generare microfratture.",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.denti_tuning_fork.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "denti_tuning_fork",
-  "label": "i18n:traits.denti_tuning_fork.label",
-  "mutazione_indotta": "i18n:traits.denti_tuning_fork.mutazione_indotta",
+  "label": "Denti Tuning Fork",
+  "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "resilienza",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.denti_tuning_fork.spinta_selettiva",
+  "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.denti_tuning_fork.uso_funzione"
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
 }

--- a/data/traits/strutturale/filamenti_magnetotrofi.json
+++ b/data/traits/strutturale/filamenti_magnetotrofi.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.filamenti_magnetotrofi.debolezza",
+  "debolezza": "Risonanze errate possono generare microfratture.",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.filamenti_magnetotrofi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "filamenti_magnetotrofi",
-  "label": "i18n:traits.filamenti_magnetotrofi.label",
-  "mutazione_indotta": "i18n:traits.filamenti_magnetotrofi.mutazione_indotta",
+  "label": "Filamenti Magnetotrofi",
+  "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "resilienza",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.filamenti_magnetotrofi.spinta_selettiva",
+  "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.filamenti_magnetotrofi.uso_funzione"
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
 }

--- a/data/traits/strutturale/ghiandole_condensa_ozono.json
+++ b/data/traits/strutturale/ghiandole_condensa_ozono.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ghiandole_condensa_ozono.debolezza",
+  "debolezza": "Risonanze errate possono generare microfratture.",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_condensa_ozono.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_condensa_ozono",
-  "label": "i18n:traits.ghiandole_condensa_ozono.label",
-  "mutazione_indotta": "i18n:traits.ghiandole_condensa_ozono.mutazione_indotta",
+  "label": "Ghiandole Condensa Ozono",
+  "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "resilienza",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.ghiandole_condensa_ozono.spinta_selettiva",
+  "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ghiandole_condensa_ozono.uso_funzione"
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
 }

--- a/data/traits/strutturale/ghiandole_nebbia_ionica.json
+++ b/data/traits/strutturale/ghiandole_nebbia_ionica.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ghiandole_nebbia_ionica.debolezza",
+  "debolezza": "Risonanze errate possono generare microfratture.",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_nebbia_ionica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_nebbia_ionica",
-  "label": "i18n:traits.ghiandole_nebbia_ionica.label",
-  "mutazione_indotta": "i18n:traits.ghiandole_nebbia_ionica.mutazione_indotta",
+  "label": "Ghiandole Nebbia Ionica",
+  "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "resilienza",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.ghiandole_nebbia_ionica.spinta_selettiva",
+  "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ghiandole_nebbia_ionica.uso_funzione"
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
 }

--- a/data/traits/strutturale/lamine_filtranti_aeree.json
+++ b/data/traits/strutturale/lamine_filtranti_aeree.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.lamine_filtranti_aeree.debolezza",
+  "debolezza": "Risonanze errate possono generare microfratture.",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.lamine_filtranti_aeree.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "lamine_filtranti_aeree",
-  "label": "i18n:traits.lamine_filtranti_aeree.label",
-  "mutazione_indotta": "i18n:traits.lamine_filtranti_aeree.mutazione_indotta",
+  "label": "Lamine Filtranti Aeree",
+  "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "resilienza",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.lamine_filtranti_aeree.spinta_selettiva",
+  "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.lamine_filtranti_aeree.uso_funzione"
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
 }

--- a/data/traits/strutturale/membrane_pneumatofori.json
+++ b/data/traits/strutturale/membrane_pneumatofori.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.membrane_pneumatofori.debolezza",
+  "debolezza": "Risonanze errate possono generare microfratture.",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.membrane_pneumatofori.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "membrane_pneumatofori",
-  "label": "i18n:traits.membrane_pneumatofori.label",
-  "mutazione_indotta": "i18n:traits.membrane_pneumatofori.mutazione_indotta",
+  "label": "Membrane Pneumatofori",
+  "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "resilienza",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.membrane_pneumatofori.spinta_selettiva",
+  "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.membrane_pneumatofori.uso_funzione"
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
 }

--- a/data/traits/strutturale/scheletro_idro_regolante.json
+++ b/data/traits/strutturale/scheletro_idro_regolante.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "sangue_piroforico"
   ],
-  "debolezza": "i18n:traits.scheletro_idro_regolante.debolezza",
+  "debolezza": "Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio.",
   "famiglia_tipologia": "Strutturale/Omeostatico",
-  "fattore_mantenimento_energetico": "i18n:traits.scheletro_idro_regolante.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Scambio rapido di fluidi)",
   "id": "scheletro_idro_regolante",
-  "label": "i18n:traits.scheletro_idro_regolante.label",
-  "mutazione_indotta": "i18n:traits.scheletro_idro_regolante.mutazione_indotta",
+  "label": "Scheletro Idro-Regolante",
+  "mutazione_indotta": "Struttura ossea porosa capace di scambio rapido di fluidi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -50,7 +50,7 @@
     "complementare": "omeostatico",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.scheletro_idro_regolante.spinta_selettiva",
+  "spinta_selettiva": "Alternare vita terrestre e vita acquatica/aerea.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.scheletro_idro_regolante.uso_funzione"
+  "uso_funzione": "Assorbire o espellere rapidamente acqua dai tessuti ossei per modificare il peso."
 }

--- a/data/traits/strutturale/struttura_elastica_amorfa.json
+++ b/data/traits/strutturale/struttura_elastica_amorfa.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.struttura_elastica_amorfa.debolezza",
+  "debolezza": "Vulnerabilità a danni da taglio o perforazione (difficile cauterizzazione).",
   "famiglia_tipologia": "Strutturale/Locomotorio",
-  "fattore_mantenimento_energetico": "i18n:traits.struttura_elastica_amorfa.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "struttura_elastica_amorfa",
-  "label": "i18n:traits.struttura_elastica_amorfa.label",
-  "mutazione_indotta": "i18n:traits.struttura_elastica_amorfa.mutazione_indotta",
+  "label": "Struttura elastica, allungabile, amorfa, retrattile",
+  "mutazione_indotta": "Tessuto con matrice di proteine elastiche iper-modificate.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -62,7 +62,7 @@
     "complementare": "locomotorio",
     "core": "strutturale"
   },
-  "spinta_selettiva": "i18n:traits.struttura_elastica_amorfa.spinta_selettiva",
+  "spinta_selettiva": "Fuga rapida da predatori in spazi confinati.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.struttura_elastica_amorfa.uso_funzione"
+  "uso_funzione": "Flessibilità estrema e capacità di assumere forme diverse."
 }

--- a/data/traits/supporto/antenne_eco_turbina.json
+++ b/data/traits/supporto/antenne_eco_turbina.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.antenne_eco_turbina.debolezza",
+  "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_eco_turbina.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_eco_turbina",
-  "label": "i18n:traits.antenne_eco_turbina.label",
-  "mutazione_indotta": "i18n:traits.antenne_eco_turbina.mutazione_indotta",
+  "label": "Antenne Eco Turbina",
+  "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "logistico",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.antenne_eco_turbina.spinta_selettiva",
+  "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.antenne_eco_turbina.uso_funzione"
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
 }

--- a/data/traits/supporto/artigli_acidofagi.json
+++ b/data/traits/supporto/artigli_acidofagi.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.artigli_acidofagi.debolezza",
+  "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_acidofagi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "artigli_acidofagi",
-  "label": "i18n:traits.artigli_acidofagi.label",
-  "mutazione_indotta": "i18n:traits.artigli_acidofagi.mutazione_indotta",
+  "label": "Artigli Acidofagi",
+  "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "logistico",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.artigli_acidofagi.spinta_selettiva",
+  "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.artigli_acidofagi.uso_funzione"
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
 }

--- a/data/traits/supporto/aura_scudo_radianza.json
+++ b/data/traits/supporto/aura_scudo_radianza.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "mantello_meteoritico"
   ],
-  "debolezza": "i18n:traits.aura_scudo_radianza.debolezza",
+  "debolezza": "Soffre saturazione se esposta a ombre gravitazionali o zone di antimagia.",
   "famiglia_tipologia": "Supporto/Difesa",
-  "fattore_mantenimento_energetico": "i18n:traits.aura_scudo_radianza.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Canalizzazione fotonica continua)",
   "id": "aura_scudo_radianza",
-  "label": "i18n:traits.aura_scudo_radianza.label",
-  "mutazione_indotta": "i18n:traits.aura_scudo_radianza.mutazione_indotta",
+  "label": "Aura Scudo di Radianza",
+  "mutazione_indotta": "Innesta organi fotoplasmatici che diffondono uno scudo radiante sugli alleati vicini.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [
@@ -39,7 +39,7 @@
     "complementare": "difesa",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.aura_scudo_radianza.spinta_selettiva",
+  "spinta_selettiva": "Proteggere gli hub di evacuazione durante tempeste di energia planare.",
   "tier": "T3",
-  "uso_funzione": "i18n:traits.aura_scudo_radianza.uso_funzione"
+  "uso_funzione": "Proietta schermature luminose sincronizzate con i segnali tattici della squadra."
 }

--- a/data/traits/supporto/batteri_termofili_endosimbiosi.json
+++ b/data/traits/supporto/batteri_termofili_endosimbiosi.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.batteri_termofili_endosimbiosi.debolezza",
+  "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.batteri_termofili_endosimbiosi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "batteri_termofili_endosimbiosi",
-  "label": "i18n:traits.batteri_termofili_endosimbiosi.label",
-  "mutazione_indotta": "i18n:traits.batteri_termofili_endosimbiosi.mutazione_indotta",
+  "label": "Batteri Termofili Endosimbiosi",
+  "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "logistico",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.batteri_termofili_endosimbiosi.spinta_selettiva",
+  "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.batteri_termofili_endosimbiosi.uso_funzione"
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
 }

--- a/data/traits/supporto/branchie_turbina.json
+++ b/data/traits/supporto/branchie_turbina.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.branchie_turbina.debolezza",
+  "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.branchie_turbina.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "branchie_turbina",
-  "label": "i18n:traits.branchie_turbina.label",
-  "mutazione_indotta": "i18n:traits.branchie_turbina.mutazione_indotta",
+  "label": "Branchie Turbina",
+  "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "logistico",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.branchie_turbina.spinta_selettiva",
+  "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.branchie_turbina.uso_funzione"
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
 }

--- a/data/traits/supporto/carapaci_ferruginosi.json
+++ b/data/traits/supporto/carapaci_ferruginosi.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.carapaci_ferruginosi.debolezza",
+  "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.carapaci_ferruginosi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "carapaci_ferruginosi",
-  "label": "i18n:traits.carapaci_ferruginosi.label",
-  "mutazione_indotta": "i18n:traits.carapaci_ferruginosi.mutazione_indotta",
+  "label": "Carapaci Ferruginosi",
+  "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "logistico",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.carapaci_ferruginosi.spinta_selettiva",
+  "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.carapaci_ferruginosi.uso_funzione"
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
 }

--- a/data/traits/supporto/circolazione_doppia.json
+++ b/data/traits/supporto/circolazione_doppia.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.circolazione_doppia.debolezza",
+  "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.circolazione_doppia.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "circolazione_doppia",
-  "label": "i18n:traits.circolazione_doppia.label",
-  "mutazione_indotta": "i18n:traits.circolazione_doppia.mutazione_indotta",
+  "label": "Circolazione Doppia",
+  "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "logistico",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.circolazione_doppia.spinta_selettiva",
+  "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.circolazione_doppia.uso_funzione"
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
 }

--- a/data/traits/supporto/coda_stabilizzatrice_geiser.json
+++ b/data/traits/supporto/coda_stabilizzatrice_geiser.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.coda_stabilizzatrice_geiser.debolezza",
+  "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_stabilizzatrice_geiser.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "coda_stabilizzatrice_geiser",
-  "label": "i18n:traits.coda_stabilizzatrice_geiser.label",
-  "mutazione_indotta": "i18n:traits.coda_stabilizzatrice_geiser.mutazione_indotta",
+  "label": "Coda Stabilizzatrice Geiser",
+  "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "logistico",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.coda_stabilizzatrice_geiser.spinta_selettiva",
+  "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.coda_stabilizzatrice_geiser.uso_funzione"
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
 }

--- a/data/traits/supporto/cuticole_neutralizzanti.json
+++ b/data/traits/supporto/cuticole_neutralizzanti.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.cuticole_neutralizzanti.debolezza",
+  "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.cuticole_neutralizzanti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cuticole_neutralizzanti",
-  "label": "i18n:traits.cuticole_neutralizzanti.label",
-  "mutazione_indotta": "i18n:traits.cuticole_neutralizzanti.mutazione_indotta",
+  "label": "Cuticole Neutralizzanti",
+  "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "logistico",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.cuticole_neutralizzanti.spinta_selettiva",
+  "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.cuticole_neutralizzanti.uso_funzione"
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
 }

--- a/data/traits/supporto/empatia_coordinativa.json
+++ b/data/traits/supporto/empatia_coordinativa.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.empatia_coordinativa.debolezza",
+  "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
   "famiglia_tipologia": "Supporto/Empatico",
-  "fattore_mantenimento_energetico": "i18n:traits.empatia_coordinativa.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
   "id": "empatia_coordinativa",
-  "label": "i18n:traits.empatia_coordinativa.label",
-  "mutazione_indotta": "i18n:traits.empatia_coordinativa.mutazione_indotta",
+  "label": "Empatia Coordinativa",
+  "mutazione_indotta": "Circuiti sensorio-emotivi collegati al feed HUD PI.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -52,7 +52,7 @@
     "complementare": "coordinazione",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.empatia_coordinativa.spinta_selettiva",
+  "spinta_selettiva": "Turni lunghi con rischio alto in cui serve mitigare tilt e HP critici.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.empatia_coordinativa.uso_funzione"
+  "uso_funzione": "Collega cooldown difensivi e cura quando la squadra entra in finestra rischio."
 }

--- a/data/traits/supporto/enzimi_chelatori_rapidi.json
+++ b/data/traits/supporto/enzimi_chelatori_rapidi.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.enzimi_chelatori_rapidi.debolezza",
+  "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.enzimi_chelatori_rapidi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "enzimi_chelatori_rapidi",
-  "label": "i18n:traits.enzimi_chelatori_rapidi.label",
-  "mutazione_indotta": "i18n:traits.enzimi_chelatori_rapidi.mutazione_indotta",
+  "label": "Enzimi Chelatori Rapidi",
+  "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "logistico",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.enzimi_chelatori_rapidi.spinta_selettiva",
+  "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.enzimi_chelatori_rapidi.uso_funzione"
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
 }

--- a/data/traits/supporto/foliage_fotocatodico.json
+++ b/data/traits/supporto/foliage_fotocatodico.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.foliage_fotocatodico.debolezza",
+  "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.foliage_fotocatodico.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "foliage_fotocatodico",
-  "label": "i18n:traits.foliage_fotocatodico.label",
-  "mutazione_indotta": "i18n:traits.foliage_fotocatodico.mutazione_indotta",
+  "label": "Foliage Fotocatodico",
+  "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "logistico",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.foliage_fotocatodico.spinta_selettiva",
+  "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.foliage_fotocatodico.uso_funzione"
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
 }

--- a/data/traits/supporto/ghiandole_inchiostro_luce.json
+++ b/data/traits/supporto/ghiandole_inchiostro_luce.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.ghiandole_inchiostro_luce.debolezza",
+  "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_inchiostro_luce.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_inchiostro_luce",
-  "label": "i18n:traits.ghiandole_inchiostro_luce.label",
-  "mutazione_indotta": "i18n:traits.ghiandole_inchiostro_luce.mutazione_indotta",
+  "label": "Ghiandole Inchiostro Luce",
+  "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "logistico",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.ghiandole_inchiostro_luce.spinta_selettiva",
+  "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.ghiandole_inchiostro_luce.uso_funzione"
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
 }

--- a/data/traits/supporto/gusci_criovetro.json
+++ b/data/traits/supporto/gusci_criovetro.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.gusci_criovetro.debolezza",
+  "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.gusci_criovetro.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "gusci_criovetro",
-  "label": "i18n:traits.gusci_criovetro.label",
-  "mutazione_indotta": "i18n:traits.gusci_criovetro.mutazione_indotta",
+  "label": "Gusci Criovetro",
+  "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "logistico",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.gusci_criovetro.spinta_selettiva",
+  "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.gusci_criovetro.uso_funzione"
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
 }

--- a/data/traits/supporto/luminescenza_hydrotermica.json
+++ b/data/traits/supporto/luminescenza_hydrotermica.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.luminescenza_hydrotermica.debolezza",
+  "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.luminescenza_hydrotermica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "luminescenza_hydrotermica",
-  "label": "i18n:traits.luminescenza_hydrotermica.label",
-  "mutazione_indotta": "i18n:traits.luminescenza_hydrotermica.mutazione_indotta",
+  "label": "Luminescenza Hydrotermica",
+  "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "logistico",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.luminescenza_hydrotermica.spinta_selettiva",
+  "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.luminescenza_hydrotermica.uso_funzione"
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
 }

--- a/data/traits/supporto/risonanza_di_branco.json
+++ b/data/traits/supporto/risonanza_di_branco.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.risonanza_di_branco.debolezza",
+  "debolezza": "Stress elevato se la coesione cala sotto i target di telemetria.",
   "famiglia_tipologia": "Supporto/Coordinativo",
-  "fattore_mantenimento_energetico": "i18n:traits.risonanza_di_branco.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Richiede mantenimento empatico)",
   "id": "risonanza_di_branco",
-  "label": "i18n:traits.risonanza_di_branco.label",
-  "mutazione_indotta": "i18n:traits.risonanza_di_branco.mutazione_indotta",
+  "label": "Risonanza di Branco",
+  "mutazione_indotta": "Reticolo empatico che collega i canali PI cooperativi.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -61,7 +61,7 @@
     "complementare": "coordinazione",
     "core": "supporto"
   },
-  "spinta_selettiva": "i18n:traits.risonanza_di_branco.spinta_selettiva",
+  "spinta_selettiva": "Forme che eccellono in difesa coordinata e scudi sovrapposti.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.risonanza_di_branco.uso_funzione"
+  "uso_funzione": "Amplifica buff condivisi sincronizzando i timer di squadra."
 }

--- a/data/traits/tegumentario/mimetismo_cromatico_passivo.json
+++ b/data/traits/tegumentario/mimetismo_cromatico_passivo.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.mimetismo_cromatico_passivo.debolezza",
+  "debolezza": "La colorazione è fissa finché non c'è un nuovo contatto prolungato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.mimetismo_cromatico_passivo.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Fase passiva)",
   "id": "mimetismo_cromatico_passivo",
-  "label": "i18n:traits.mimetismo_cromatico_passivo.label",
-  "mutazione_indotta": "i18n:traits.mimetismo_cromatico_passivo.mutazione_indotta",
+  "label": "Ghiandole di Mimetismo Cromatico Passivo",
+  "mutazione_indotta": "Cromatofori che richiedono un input tattile prolungato per la ricarica.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -61,7 +61,7 @@
     "complementare": "difensivo",
     "core": "tegumentario"
   },
-  "spinta_selettiva": "i18n:traits.mimetismo_cromatico_passivo.spinta_selettiva",
+  "spinta_selettiva": "Ambiente con pattern cromatici molto variabili che cambiano lentamente.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.mimetismo_cromatico_passivo.uso_funzione"
+  "uso_funzione": "Assorbire e replicare il colore dell'ambiente circostante dopo contatto."
 }

--- a/data/traits/tegumentario/piume_solari_fotovoltaiche.json
+++ b/data/traits/tegumentario/piume_solari_fotovoltaiche.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "criostasi_adattiva"
   ],
-  "debolezza": "i18n:traits.piume_solari_fotovoltaiche.debolezza",
+  "debolezza": "Ombre prolungate o polveri dense riducono drasticamente la produzione energetica.",
   "famiglia_tipologia": "Tegumentario/Energetico",
-  "fattore_mantenimento_energetico": "i18n:traits.piume_solari_fotovoltaiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Richiede manutenzione delle lamine fotoreattive)",
   "id": "piume_solari_fotovoltaiche",
-  "label": "i18n:traits.piume_solari_fotovoltaiche.label",
-  "mutazione_indotta": "i18n:traits.piume_solari_fotovoltaiche.mutazione_indotta",
+  "label": "Piume Solari Fotovoltaiche",
+  "mutazione_indotta": "Piumaggio stratificato con pigmenti piezo-fotovoltaici che immagazzinano luce.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -36,7 +36,7 @@
     "complementare": "energetico",
     "core": "tegumentario"
   },
-  "spinta_selettiva": "i18n:traits.piume_solari_fotovoltaiche.spinta_selettiva",
+  "spinta_selettiva": "Massimizzare l'autonomia energetica per migrazioni aeree sopra deserti e oceani.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.piume_solari_fotovoltaiche.uso_funzione"
+  "uso_funzione": "Convertire la radiazione solare in riserve energetiche per abilità a lungo raggio."
 }

--- a/data/traits/tegumentario/secrezione_rallentante_palmi.json
+++ b/data/traits/tegumentario/secrezione_rallentante_palmi.json
@@ -3,12 +3,12 @@
     "carapace_fase_variabile",
     "nucleo_ovomotore_rotante"
   ],
-  "debolezza": "i18n:traits.secrezione_rallentante_palmi.debolezza",
+  "debolezza": "Esaurimento rapido delle riserve di liquido con tempo di ricarica prolungato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.secrezione_rallentante_palmi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Produzione del liquido)",
   "id": "secrezione_rallentante_palmi",
-  "label": "i18n:traits.secrezione_rallentante_palmi.label",
-  "mutazione_indotta": "i18n:traits.secrezione_rallentante_palmi.mutazione_indotta",
+  "label": "Mani secernano liquido rallentante",
+  "mutazione_indotta": "Ghiandole mucose modificate sulle superfici prensili.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -34,7 +34,7 @@
     "complementare": "difensivo",
     "core": "tegumentario"
   },
-  "spinta_selettiva": "i18n:traits.secrezione_rallentante_palmi.spinta_selettiva",
+  "spinta_selettiva": "Cattura di prede veloci o difesa da aggressori corpo a corpo.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.secrezione_rallentante_palmi.uso_funzione"
+  "uso_funzione": "Neutralizzare o immobilizzare prede/nemici."
 }

--- a/data/traits/tegumentario/squame_rifrangenti_deserto.json
+++ b/data/traits/tegumentario/squame_rifrangenti_deserto.json
@@ -2,12 +2,12 @@
   "conflitti": [
     "mimetismo_cromatico_passivo"
   ],
-  "debolezza": "i18n:traits.squame_rifrangenti_deserto.debolezza",
+  "debolezza": "Soffre danni da feedback termico se colpito da raggi concentrati o laser.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.squame_rifrangenti_deserto.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Richiede riallineamento delle placche)",
   "id": "squame_rifrangenti_deserto",
-  "label": "i18n:traits.squame_rifrangenti_deserto.label",
-  "mutazione_indotta": "i18n:traits.squame_rifrangenti_deserto.mutazione_indotta",
+  "label": "Squame Rifrangenti del Deserto",
+  "mutazione_indotta": "Placche cristalline sovrapposte che deviano luce e calore lungo superfici multiple.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -35,7 +35,7 @@
     "complementare": "difensivo",
     "core": "tegumentario"
   },
-  "spinta_selettiva": "i18n:traits.squame_rifrangenti_deserto.spinta_selettiva",
+  "spinta_selettiva": "Sopravvivere a intensi flare termici e accecanti miraggi desertici.",
   "tier": "T2",
-  "uso_funzione": "i18n:traits.squame_rifrangenti_deserto.uso_funzione"
+  "uso_funzione": "Rifrange la luce generando miraggi e dissipando attacchi energetici."
 }

--- a/data/traits/tegumentario/vello_condensatore_nebbie.json
+++ b/data/traits/tegumentario/vello_condensatore_nebbie.json
@@ -1,11 +1,11 @@
 {
   "conflitti": [],
-  "debolezza": "i18n:traits.vello_condensatore_nebbie.debolezza",
+  "debolezza": "In ambienti aridi accumula detriti che riducono la capacità di condensa.",
   "famiglia_tipologia": "Tegumentario/Idratazione",
-  "fattore_mantenimento_energetico": "i18n:traits.vello_condensatore_nebbie.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Strutture passive a microfilo)",
   "id": "vello_condensatore_nebbie",
-  "label": "i18n:traits.vello_condensatore_nebbie.label",
-  "mutazione_indotta": "i18n:traits.vello_condensatore_nebbie.mutazione_indotta",
+  "label": "Vello Condensatore di Nebbie",
+  "mutazione_indotta": "Peli cavi microstriati che catturano e canalizzano la bruma atmosferica.",
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -33,7 +33,7 @@
     "complementare": "idratazione",
     "core": "tegumentario"
   },
-  "spinta_selettiva": "i18n:traits.vello_condensatore_nebbie.spinta_selettiva",
+  "spinta_selettiva": "Garantire idratazione in climi montani dove l'acqua liquida è scarsa ma la nebbia abbondante.",
   "tier": "T1",
-  "uso_funzione": "i18n:traits.vello_condensatore_nebbie.uso_funzione"
+  "uso_funzione": "Condensa acqua atmosferica per supportare abilità metaboliche ad alto consumo."
 }

--- a/docs/process/localization.md
+++ b/docs/process/localization.md
@@ -51,8 +51,9 @@ Lo script esegue tre operazioni:
 1. Esplora tutti i trait (`*.json`, esclusi gli indici) e raccoglie i valori dei
    campi testuali.
 2. Popola `locales/<lingua>/traits.json` con i testi normalizzati e ordinati.
-3. Sostituisce i valori testuali nei trait con chiavi `i18n:traits.<id>.<campo>`
-   che puntano alla voce nel bundle.
+3. Aggiorna (o crea) le voci del bundle lasciando invariati i testi nei file
+   dei trait; le traduzioni vengono quindi gestite tramite i bundle senza
+   impattare gli strumenti esistenti.
 
 Usare `--dry-run` per verificare le modifiche senza applicarle. Lo script è
 idempotente: eseguendolo più volte non produce diff aggiuntivi se i contenuti non


### PR DESCRIPTION
## Summary
- restore the Italian text fields across the trait JSON files so existing tooling no longer sees i18n placeholders
- update `scripts/sync_trait_locales.py` to populate locale bundles without overwriting the source texts and adjust the localization guide accordingly

## Testing
- python scripts/sync_trait_locales.py --dry-run

------
https://chatgpt.com/codex/tasks/task_e_69063ffbfb488332859470fab513df37