### PR TITLE
refactor: introduce shared insight cards for species and biomes

### DIFF
--- a/tests/webapp/BiomesView.spec.ts
+++ b/tests/webapp/BiomesView.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import BiomesView from '../../webapp/src/views/BiomesView.vue';
+
+const NebulaShellStub = {
+  props: ['tabs', 'modelValue', 'statusIndicators'],
+  emits: ['update:modelValue'],
+  template: `
+    <div class="nebula-shell-stub">
+      <div class="nebula-shell-stub__cards"><slot name="cards" /></div>
+      <div class="nebula-shell-stub__default"><slot :activeTab="modelValue"></slot></div>
+    </div>
+  `,
+};
+
+const PokedexBiomeCardStub = {
+  props: ['biome'],
+  template: `
+    <article class="pokedex-biome-card-stub">
+      <header>{{ biome.name }}</header>
+      <slot name="footer"></slot>
+    </article>
+  `,
+};
+
+const TraitChipStub = {
+  props: ['label'],
+  template: '<span class="trait-chip-stub">{{ label }}</span>',
+};
+
+const PokedexTelemetryBadgeStub = {
+  props: ['label', 'value'],
+  template: '<span class="telemetry-badge-stub">{{ label }}: {{ value }}</span>',
+};
+
+describe('BiomesView', () => {
+  const biomes = [
+    {
+      id: 'frost',
+      name: 'Frost Valley',
+      readiness: 6,
+      total: 10,
+      risk: 3,
+      hazard: 'Tempeste criogeniche',
+      traits: ['fungi', { id: 'lumen', label: 'Lumen', description: 'Favorisce la luminescenza' }],
+      affinities: [{ id: 'bio', label: 'Bio-simbiosi', description: 'Affinità biologica', roles: ['Healer'] }],
+      validators: [{ id: 'val-1', status: 'warning', label: 'Energia instabile', message: 'Richiede bilanciamento' }],
+    },
+    {
+      id: 'ember',
+      name: 'Ember Dunes',
+      readiness: 4,
+      total: 8,
+      risk: 2,
+      hazard: 'Tempeste di cenere',
+      traits: ['pyro'],
+      affinities: ['Bio-simbiosi'],
+      validators: [],
+    },
+  ];
+
+  const mountView = () =>
+    mount(BiomesView, {
+      props: { biomes },
+      global: {
+        stubs: {
+          NebulaShell: NebulaShellStub,
+          PokedexBiomeCard: PokedexBiomeCardStub,
+          TraitChip: TraitChipStub,
+          PokedexTelemetryBadge: PokedexTelemetryBadgeStub,
+        },
+      },
+    });
+
+  it('mostra card di telemetria e chip filtrabili', () => {
+    const wrapper = mountView();
+
+    expect(wrapper.findAll('.telemetry-badge-stub').length).toBeGreaterThan(0);
+    expect(wrapper.findAll('.biomes-view__filter').length).toBeGreaterThanOrEqual(3);
+    expect(wrapper.findAll('.biomes-view__hazards .trait-chip-stub').length).toBeGreaterThan(0);
+  });
+
+  it('filtra i biomi in base ai tratti selezionati e consente il reset', async () => {
+    const wrapper = mountView();
+
+    expect(wrapper.findAll('.pokedex-biome-card-stub').length).toBe(2);
+
+    const filters = wrapper.findAll('.biomes-view__filter');
+    await filters[0].trigger('click');
+
+    expect(wrapper.findAll('.pokedex-biome-card-stub').length).toBe(1);
+    expect(wrapper.text()).toContain('Filtri attivi');
+
+    await wrapper.find('.biomes-view__reset').trigger('click');
+    expect(wrapper.findAll('.pokedex-biome-card-stub').length).toBe(2);
+  });
+});

--- a/tests/webapp/SpeciesView.spec.ts
+++ b/tests/webapp/SpeciesView.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import SpeciesView from '../../webapp/src/views/SpeciesView.vue';
+
+const createWrapper = () => {
+  const status = {
+    curated: 6,
+    total: 10,
+    shortlist: ['Draconis', 'Lycanis'],
+  };
+
+  const meta = {
+    biomeId: 'glacier-01',
+    telemetry: {
+      coverage: 72,
+      phases: [
+        { id: 'draft', label: 'Draft', percent: 60, summary: 'Assemblaggio blueprint' },
+        { id: 'qa', label: 'QA', percent: 40 },
+      ],
+    },
+  };
+
+  const validation = {
+    messages: [
+      { message: 'Controllo habitat completato', level: 'info' },
+      { message: 'Bilanciamento da rivedere', level: 'warning' },
+      { message: 'Errore adattamento', level: 'error' },
+    ],
+    discarded: ['mutation-A'],
+    corrected: { id: 'adj-01' },
+  };
+
+  const traitCatalog = {
+    labels: {
+      apex: 'Predatore apex',
+      stealth: 'Mimetismo',
+      pack: 'Predazione di branco',
+    },
+    synergyMap: {
+      apex: ['stealth', 'pack'],
+    },
+  };
+
+  const traitCompliance = {
+    badges: [
+      { id: 'coverage', label: 'Coverage', value: '85%', tone: 'success' },
+    ],
+    generatedAt: '2035-04-01T12:00:00Z',
+  };
+
+  return mount(SpeciesView, {
+    props: {
+      species: { id: 'specimen-01' },
+      status,
+      meta,
+      validation,
+      requestId: 'orchestrator-77',
+      error: 'Errore orchestrator test',
+      traitCatalog,
+      traitCompliance,
+      traitDiagnosticsLoading: false,
+      traitDiagnosticsError: 'Errore QA sincronia',
+      traitDiagnosticsMeta: { fetched_at: '2035-04-01T12:05:00Z' },
+    },
+    global: {
+      stubs: {
+        SpeciesPanel: {
+          template: '<div class="species-panel-stub" />',
+        },
+      },
+    },
+  });
+};
+
+describe('SpeciesView', () => {
+  it('mostra progress bar di telemetria e metadati orchestrator', () => {
+    const wrapper = createWrapper();
+
+    const progressBars = wrapper.findAll('.telemetry-progress');
+    expect(progressBars.length).toBeGreaterThanOrEqual(3);
+    expect(wrapper.text()).toContain('Specie curate');
+    expect(wrapper.text()).toContain('Copertura shortlist');
+    expect(wrapper.text()).toContain('ID orchestrator');
+    expect(wrapper.text()).toContain('Shortlist');
+    expect(wrapper.text()).toContain('Errore orchestrator test');
+  });
+
+  it('visualizza le sinergie del catalogo nella tab dedicata', async () => {
+    const wrapper = createWrapper();
+
+    const tabs = wrapper.findAll('.insight-card__tab');
+    await tabs[1].trigger('click');
+
+    expect(wrapper.findAll('.species-view__synergy-card').length).toBe(1);
+    expect(wrapper.text()).toContain('Predatore apex');
+    expect(wrapper.text()).toContain('Mimetismo');
+  });
+
+  it('riassume i messaggi di QA nella tab QA', async () => {
+    const wrapper = createWrapper();
+
+    const tabs = wrapper.findAll('.insight-card__tab');
+    await tabs[2].trigger('click');
+
+    expect(wrapper.text()).toContain('Validazione runtime');
+    expect(wrapper.text()).toContain('Errore adattamento');
+    expect(wrapper.text()).toContain('Errore QA sincronia');
+  });
+});

--- a/webapp/src/components/shared/GlossaryTooltip.vue
+++ b/webapp/src/components/shared/GlossaryTooltip.vue
@@ -1,0 +1,47 @@
+<template>
+  <span class="glossary-tooltip">
+    <slot />
+    <span v-if="props.description" class="glossary-tooltip__bubble">{{ props.description }}</span>
+  </span>
+</template>
+
+<script setup>
+const props = defineProps({
+  description: {
+    type: String,
+    default: '',
+  },
+});
+</script>
+
+<style scoped>
+.glossary-tooltip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.glossary-tooltip__bubble {
+  position: absolute;
+  bottom: calc(100% + 0.35rem);
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 220px;
+  padding: 0.45rem 0.6rem;
+  border-radius: 0.6rem;
+  background: rgba(7, 23, 39, 0.95);
+  color: var(--pokedex-text-primary);
+  font-size: 0.75rem;
+  line-height: 1.25;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  border: 1px solid rgba(96, 213, 255, 0.25);
+  z-index: 2;
+}
+
+.glossary-tooltip:hover .glossary-tooltip__bubble,
+.glossary-tooltip:focus-within .glossary-tooltip__bubble {
+  opacity: 1;
+}
+</style>

--- a/webapp/src/components/shared/InsightCard.vue
+++ b/webapp/src/components/shared/InsightCard.vue
@@ -1,0 +1,232 @@
+<template>
+  <section class="insight-card" :data-tone="tone">
+    <header v-if="hasHeader" class="insight-card__header">
+      <div class="insight-card__title">
+        <span v-if="icon" class="insight-card__icon" aria-hidden="true">{{ icon }}</span>
+        <div>
+          <h3 v-if="title">{{ title }}</h3>
+          <p v-if="subtitle" class="insight-card__subtitle">{{ subtitle }}</p>
+          <slot v-else name="subtitle" />
+        </div>
+      </div>
+      <div class="insight-card__actions">
+        <slot name="actions" />
+      </div>
+    </header>
+
+    <div v-if="tabs.length" class="insight-card__tabs" role="tablist">
+      <button
+        v-for="tab in tabs"
+        :key="tab.id"
+        type="button"
+        class="insight-card__tab"
+        :class="{ 'insight-card__tab--active': tab.id === currentTab }"
+        role="tab"
+        :aria-selected="tab.id === currentTab"
+        @click="selectTab(tab.id)"
+      >
+        <span v-if="tab.icon" class="insight-card__tab-icon" aria-hidden="true">{{ tab.icon }}</span>
+        <span>{{ tab.label }}</span>
+      </button>
+    </div>
+
+    <div class="insight-card__body">
+      <template v-if="tabs.length">
+        <div
+          v-for="tab in tabs"
+          :key="`panel-${tab.id}`"
+          v-show="tab.id === currentTab"
+          role="tabpanel"
+          class="insight-card__panel"
+        >
+          <slot :name="`tab-${tab.id}`" :tab="tab" />
+        </div>
+      </template>
+      <slot v-else />
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, onMounted, watch, useSlots } from 'vue';
+
+const props = defineProps({
+  title: {
+    type: String,
+    default: '',
+  },
+  subtitle: {
+    type: String,
+    default: '',
+  },
+  icon: {
+    type: String,
+    default: '',
+  },
+  tone: {
+    type: String,
+    default: 'neutral',
+  },
+  tabs: {
+    type: Array,
+    default: () => [],
+  },
+  modelValue: {
+    type: String,
+    default: '',
+  },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const normalizedTabs = computed(() => (Array.isArray(props.tabs) ? props.tabs.filter(Boolean) : []));
+
+const currentTab = computed({
+  get() {
+    if (!normalizedTabs.value.length) {
+      return '';
+    }
+    const requested = props.modelValue && normalizedTabs.value.find((tab) => tab.id === props.modelValue);
+    return (requested && requested.id) || normalizedTabs.value[0].id;
+  },
+  set(value) {
+    if (value !== props.modelValue) {
+      emit('update:modelValue', value);
+    }
+  },
+});
+
+const slots = useSlots();
+
+const hasHeader = computed(() => Boolean(props.title || props.subtitle || props.icon || !!slots.actions));
+
+const tabs = computed(() => normalizedTabs.value);
+
+function selectTab(id) {
+  if (!tabs.value.some((tab) => tab.id === id)) {
+    return;
+  }
+  currentTab.value = id;
+}
+
+onMounted(() => {
+  if (tabs.value.length && !props.modelValue) {
+    emit('update:modelValue', tabs.value[0].id);
+  }
+});
+
+watch(
+  () => props.tabs,
+  (next) => {
+    const list = Array.isArray(next) ? next : [];
+    if (!list.some((tab) => tab.id === currentTab.value)) {
+      const first = list[0]?.id || '';
+      if (first) {
+        emit('update:modelValue', first);
+      }
+    }
+  },
+);
+</script>
+
+<style scoped>
+.insight-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 18px;
+  background: rgba(7, 16, 28, 0.78);
+  border: 1px solid rgba(96, 213, 255, 0.18);
+  color: var(--pokedex-text-primary);
+}
+
+.insight-card[data-tone='critical'] {
+  border-color: rgba(255, 99, 132, 0.32);
+}
+
+.insight-card[data-tone='warning'] {
+  border-color: rgba(255, 200, 87, 0.28);
+}
+
+.insight-card[data-tone='success'] {
+  border-color: rgba(129, 255, 199, 0.3);
+}
+
+.insight-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.insight-card__title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.insight-card__icon {
+  font-size: 1.5rem;
+  display: inline-flex;
+}
+
+.insight-card__title h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.insight-card__subtitle {
+  margin: 0.2rem 0 0;
+  color: var(--pokedex-text-secondary);
+  font-size: 0.85rem;
+}
+
+.insight-card__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.insight-card__tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.insight-card__tab {
+  border: 1px solid rgba(96, 213, 255, 0.24);
+  background: rgba(10, 24, 38, 0.9);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.insight-card__tab:hover,
+.insight-card__tab:focus-visible {
+  border-color: rgba(146, 255, 230, 0.45);
+}
+
+.insight-card__tab--active {
+  background: rgba(96, 213, 255, 0.18);
+  border-color: rgba(146, 255, 230, 0.6);
+}
+
+.insight-card__tab-icon {
+  font-size: 1.1rem;
+}
+
+.insight-card__body {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.insight-card__panel {
+  display: grid;
+  gap: 0.85rem;
+}
+</style>

--- a/webapp/src/components/shared/TelemetryProgressBar.vue
+++ b/webapp/src/components/shared/TelemetryProgressBar.vue
@@ -1,0 +1,116 @@
+<template>
+  <div
+    class="telemetry-progress"
+    role="progressbar"
+    :aria-valuenow="Math.round(displayPercent)"
+    aria-valuemin="0"
+    aria-valuemax="100"
+  >
+    <div class="telemetry-progress__header">
+      <span class="telemetry-progress__label">{{ label }}</span>
+      <span class="telemetry-progress__value">{{ displayValue }}</span>
+    </div>
+    <div class="telemetry-progress__bar">
+      <div class="telemetry-progress__fill" :style="{ width: `${Math.min(100, Math.max(displayPercent, 0))}%` }" />
+    </div>
+    <p v-if="description" class="telemetry-progress__description">{{ description }}</p>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  label: {
+    type: String,
+    required: true,
+  },
+  current: {
+    type: Number,
+    default: null,
+  },
+  total: {
+    type: Number,
+    default: null,
+  },
+  percent: {
+    type: Number,
+    default: null,
+  },
+  value: {
+    type: String,
+    default: '',
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+});
+
+const displayPercent = computed(() => {
+  if (typeof props.percent === 'number' && Number.isFinite(props.percent)) {
+    return props.percent;
+  }
+  if (typeof props.current === 'number' && typeof props.total === 'number' && props.total > 0) {
+    return (props.current / props.total) * 100;
+  }
+  return 0;
+});
+
+const displayValue = computed(() => {
+  if (props.value) {
+    return props.value;
+  }
+  if (props.current != null && props.total != null) {
+    return `${props.current} / ${props.total}`;
+  }
+  return `${Math.round(displayPercent.value)}%`;
+});
+</script>
+
+<style scoped>
+.telemetry-progress {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.telemetry-progress__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.85rem;
+}
+
+.telemetry-progress__label {
+  color: var(--pokedex-text-secondary);
+}
+
+.telemetry-progress__value {
+  font-weight: 600;
+  color: var(--pokedex-text-primary);
+}
+
+.telemetry-progress__bar {
+  position: relative;
+  height: 0.55rem;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(96, 213, 255, 0.18);
+}
+
+.telemetry-progress__fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  background: linear-gradient(90deg, rgba(96, 213, 255, 0.7), rgba(161, 255, 212, 0.7));
+  border-radius: inherit;
+  transition: width 0.3s ease;
+}
+
+.telemetry-progress__description {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--pokedex-text-muted);
+}
+</style>


### PR DESCRIPTION
## Summary
- add shared insight card, telemetry progress bar, and glossary tooltip components for reusable presentation blocks
- refactor the species view sidebar into tabbed insight cards powered by orchestrator telemetry, synergy, and QA data
- align biomes and biome setup views on the new card layout with filterable trait chips and glossary tooltips, updating rendering tests accordingly

## Testing
- npm --prefix webapp run test -- --run tests/webapp/SpeciesView.spec.ts tests/webapp/BiomesView.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_6906460888ec83328400cf8baf544551