### PR TITLE
Add generation snapshot locking and deployment sync

### DIFF
--- a/config/dataSources.json
+++ b/config/dataSources.json
@@ -1,0 +1,8 @@
+{
+  "flowSnapshot": {
+    "local": "flow-shell/atlas-snapshot.json",
+    "shared": "s3://game-shared-flow-shell/snapshots/atlas-snapshot.json",
+    "fallback": "webapp/public/data/flow/snapshots/flow-shell-snapshot.json",
+    "description": "Snapshot atlas iniziale per il servizio generation."
+  }
+}

--- a/tests/helpers/mockFs.js
+++ b/tests/helpers/mockFs.js
@@ -1,0 +1,92 @@
+function createMockFs(initialFiles = {}) {
+  const files = new Map();
+
+  function storeFile(filePath, content) {
+    const payload = typeof content === 'string' ? content : JSON.stringify(content);
+    files.set(filePath, {
+      content: payload,
+      mtimeMs: Date.now(),
+    });
+  }
+
+  for (const [filePath, content] of Object.entries(initialFiles)) {
+    storeFile(filePath, content);
+  }
+
+  class MockFileHandle {
+    constructor(file) {
+      this.file = file;
+    }
+
+    async close() {
+      return undefined;
+    }
+  }
+
+  const api = {
+    async readFile(filePath, encoding = 'utf8') {
+      if (!files.has(filePath)) {
+        const error = new Error(`File not found: ${filePath}`);
+        error.code = 'ENOENT';
+        throw error;
+      }
+      const entry = files.get(filePath);
+      if (encoding === 'utf8') {
+        return entry.content;
+      }
+      return Buffer.from(entry.content, 'utf8');
+    },
+    async writeFile(filePath, content) {
+      storeFile(filePath, typeof content === 'string' ? content : content.toString());
+    },
+    async mkdir() {
+      return undefined;
+    },
+    async rename(source, target) {
+      if (!files.has(source)) {
+        const error = new Error(`File not found: ${source}`);
+        error.code = 'ENOENT';
+        throw error;
+      }
+      const entry = files.get(source);
+      files.set(target, {
+        content: entry.content,
+        mtimeMs: Date.now(),
+      });
+      files.delete(source);
+    },
+    async unlink(filePath) {
+      if (!files.delete(filePath)) {
+        const error = new Error(`File not found: ${filePath}`);
+        error.code = 'ENOENT';
+        throw error;
+      }
+    },
+    async stat(filePath) {
+      const entry = files.get(filePath);
+      if (!entry) {
+        const error = new Error(`File not found: ${filePath}`);
+        error.code = 'ENOENT';
+        throw error;
+      }
+      return { mtimeMs: entry.mtimeMs };
+    },
+    async open(filePath, flags) {
+      if (flags.includes('x')) {
+        if (files.has(filePath)) {
+          const error = new Error(`File exists: ${filePath}`);
+          error.code = 'EEXIST';
+          throw error;
+        }
+        storeFile(filePath, '');
+        return new MockFileHandle(filePath);
+      }
+      throw new Error(`Unsupported flag combination: ${flags}`);
+    },
+    __files: files,
+  };
+
+  return api;
+}
+
+module.exports = { createMockFs };

--- a/tests/server/generationSnapshotHandler.e2e.spec.js
+++ b/tests/server/generationSnapshotHandler.e2e.spec.js
@@ -1,0 +1,113 @@
+const assert = require('node:assert/strict');
+const express = require('express');
+const test = require('node:test');
+const request = require('supertest');
+
+const { createGenerationSnapshotHandler } = require('../../server/routes/generationSnapshot');
+const { createGenerationSnapshotStore } = require('../../server/services/generationSnapshotStore');
+const { createMockFs } = require('../helpers/mockFs');
+
+test('generationSnapshotHandler gestisce richieste concorrenti con patch coerenti', async () => {
+  const datasetPath = '/data/flow-shell/atlas-snapshot.json';
+  const staticDataset = {
+    overview: { completion: { completed: 1, total: 5 } },
+    species: { curated: 1, total: 10 },
+    biomeSummary: { validated: 0, pending: 5 },
+    encounterSummary: { variants: 0, seeds: 0, warnings: 0 },
+    initialSpeciesRequest: { trait_ids: ['alpha-trait', 'beta-trait'] },
+  };
+
+  const fsMock = createMockFs();
+  const store = createGenerationSnapshotStore({ datasetPath, fs: fsMock, staticDataset });
+
+  const orchestratorResponses = [
+    {
+      blueprint: { id: 'bp-001' },
+      meta: { request_id: 'req-001', fallback_used: false },
+      validation: { messages: [] },
+    },
+    {
+      blueprint: { id: 'bp-002' },
+      meta: { request_id: 'req-002', fallback_used: false },
+      validation: { messages: ['warn: missing texture'] },
+    },
+    {
+      blueprint: { id: 'bp-003' },
+      meta: { request_id: 'req-003', fallback_used: true },
+      validation: { messages: ['warn: balance'], extra: ['note'] },
+    },
+  ];
+  const responseDelays = [10, 5, 25];
+  let orchestratorCalls = 0;
+
+  const orchestrator = {
+    async generateSpecies() {
+      const callIndex = orchestratorCalls;
+      orchestratorCalls += 1;
+      const delay = responseDelays[callIndex] ?? 0;
+      const payload = orchestratorResponses[callIndex] || orchestratorResponses[orchestratorResponses.length - 1];
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      return payload;
+    },
+  };
+
+  const traitDiagnostics = {
+    async ensureLoaded() {
+      return undefined;
+    },
+    getDiagnostics() {
+      return { summary: { total_traits: 12, glossary_ok: 10, with_conflicts: 1 } };
+    },
+  };
+
+  const handler = createGenerationSnapshotHandler({
+    datasetPath,
+    snapshotStore: store,
+    orchestrator,
+    traitDiagnostics,
+    schemaValidator: null,
+    validationSchemaId: null,
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.get('/api/v1/generation/snapshot', handler);
+
+  const curatedValues = [3, 5, 7];
+  const shortlistValues = [
+    ['alpha', 'beta'],
+    ['gamma', 'delta'],
+    ['epsilon'],
+  ];
+
+  const concurrentRequests = curatedValues.map((curated, index) =>
+    request(app)
+      .get('/api/v1/generation/snapshot')
+      .query({
+        speciesStatus: JSON.stringify({ curated, shortlist: shortlistValues[index] }),
+      })
+      .expect(200),
+  );
+
+  const responses = await Promise.all(concurrentRequests);
+
+  responses.forEach((response, index) => {
+    const expected = orchestratorResponses[index];
+    assert.equal(response.body.species.curated, curatedValues[index]);
+    assert.deepEqual(response.body.species.shortlist, shortlistValues[index]);
+    assert.equal(response.body.runtime.lastBlueprintId, expected.blueprint.id);
+    assert.equal(response.body.runtime.lastRequestId, expected.meta.request_id);
+    assert.equal(response.body.runtime.validationMessages, expected.validation.messages.length);
+    assert.equal(response.body.runtime.fallbackUsed, Boolean(expected.meta.fallback_used));
+  });
+
+  const finalSnapshot = await store.getSnapshot();
+  assert.equal(finalSnapshot.species.curated, curatedValues[curatedValues.length - 1]);
+  assert.deepEqual(finalSnapshot.species.shortlist, shortlistValues[shortlistValues.length - 1]);
+  assert.equal(finalSnapshot.runtime.lastBlueprintId, orchestratorResponses[2].blueprint.id);
+  assert.equal(finalSnapshot.runtime.lastRequestId, orchestratorResponses[2].meta.request_id);
+  assert.equal(finalSnapshot.runtime.validationMessages, orchestratorResponses[2].validation.messages.length);
+
+  assert.ok(fsMock.__files.has(datasetPath));
+  assert.ok(!fsMock.__files.has(`${datasetPath}.lock`));
+});

--- a/tools/deploy/syncSnapshot.js
+++ b/tools/deploy/syncSnapshot.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const http = require('node:http');
+const https = require('node:https');
+
+const ROOT_DIR = path.resolve(__dirname, '..', '..');
+
+function parseArgs(argv) {
+  const options = {
+    id: 'flowSnapshot',
+    configPath: null,
+    targetDir: null,
+    forceFallback: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--id' && argv[index + 1]) {
+      options.id = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--config' && argv[index + 1]) {
+      options.configPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--target' && argv[index + 1]) {
+      options.targetDir = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--force-fallback') {
+      options.forceFallback = true;
+      continue;
+    }
+  }
+  return options;
+}
+
+async function fileExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: 'inherit', ...options });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${command} exited with status ${code}`));
+    });
+  });
+}
+
+async function downloadHttp(url, destination) {
+  const target = new URL(url);
+  const client = target.protocol === 'https:' ? https : http;
+  await new Promise((resolve, reject) => {
+    const request = client.get(target, (response) => {
+      if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+        downloadHttp(response.headers.location, destination).then(resolve).catch(reject);
+        return;
+      }
+      if (!response.statusCode || response.statusCode < 200 || response.statusCode >= 300) {
+        reject(new Error(`HTTP download failed with status ${response.statusCode}`));
+        response.resume();
+        return;
+      }
+      const chunks = [];
+      response.on('data', (chunk) => chunks.push(chunk));
+      response.on('end', async () => {
+        try {
+          await fs.writeFile(destination, Buffer.concat(chunks));
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+    request.on('error', reject);
+  });
+}
+
+async function syncFromShared(sharedUri, targetPath) {
+  if (!sharedUri) {
+    return false;
+  }
+  const tempPath = `${targetPath}.download`;
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  try {
+    if (sharedUri.startsWith('s3://')) {
+      await runCommand('aws', ['s3', 'cp', sharedUri, tempPath]);
+    } else if (sharedUri.startsWith('http://') || sharedUri.startsWith('https://')) {
+      await downloadHttp(sharedUri, tempPath);
+    } else if (sharedUri.startsWith('file://')) {
+      const resolved = sharedUri.slice('file://'.length);
+      await fs.copyFile(resolved, tempPath);
+    } else {
+      const resolved = path.isAbsolute(sharedUri)
+        ? sharedUri
+        : path.resolve(ROOT_DIR, sharedUri);
+      await fs.copyFile(resolved, tempPath);
+    }
+    await fs.rename(tempPath, targetPath);
+    return true;
+  } catch (error) {
+    await fs.rm(tempPath, { force: true }).catch(() => {});
+    console.warn(`[snapshot-sync] sincronizzazione da ${sharedUri} fallita: ${error.message || error}`);
+    return false;
+  }
+}
+
+async function copyFallback(fallbackPath, targetPath) {
+  if (!fallbackPath) {
+    return false;
+  }
+  const absoluteFallback = path.isAbsolute(fallbackPath)
+    ? fallbackPath
+    : path.resolve(ROOT_DIR, fallbackPath);
+  if (!(await fileExists(absoluteFallback))) {
+    console.warn(`[snapshot-sync] fallback non trovato: ${absoluteFallback}`);
+    return false;
+  }
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  await fs.copyFile(absoluteFallback, targetPath);
+  return true;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const configPath = args.configPath
+    ? path.resolve(ROOT_DIR, args.configPath)
+    : path.join(ROOT_DIR, 'config', 'dataSources.json');
+
+  const configRaw = await fs.readFile(configPath, 'utf8');
+  const config = JSON.parse(configRaw);
+  const entry = config[args.id];
+  if (!entry) {
+    console.error(`[snapshot-sync] sorgente non configurata: ${args.id}`);
+    process.exit(1);
+    return;
+  }
+
+  const targetBase = args.targetDir
+    ? path.resolve(ROOT_DIR, args.targetDir)
+    : path.join(ROOT_DIR, 'data');
+  const localRelative = entry.local || entry.localPath || 'flow-shell/atlas-snapshot.json';
+  const targetPath = path.resolve(targetBase, localRelative);
+
+  const sharedUri = args.forceFallback ? null : process.env.DEPLOY_SNAPSHOT_URI || entry.shared;
+
+  let success = false;
+  if (sharedUri) {
+    console.log(`[snapshot-sync] sincronizzo snapshot da ${sharedUri}`);
+    success = await syncFromShared(sharedUri, targetPath);
+  }
+
+  if (!success) {
+    console.log('[snapshot-sync] utilizzo fallback locale per lo snapshot');
+    success = await copyFallback(entry.fallback, targetPath);
+  }
+
+  if (!success) {
+    console.error('[snapshot-sync] impossibile aggiornare lo snapshot iniziale');
+    process.exit(1);
+    return;
+  }
+
+  console.log(`[snapshot-sync] snapshot disponibile in ${targetPath}`);
+}
+
+main().catch((error) => {
+  console.error('[snapshot-sync] errore inatteso', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add file locking and crash recovery to the generation snapshot store, including rotation
- introduce deployment snapshot synchronisation tooling driven by config/dataSources.json
- cover the new behaviour with recovery and concurrent handler tests

## Testing
- node --test tests/server/generationSnapshot.spec.js
- node --test tests/server/generationSnapshotHandler.e2e.spec.js

------
https://chatgpt.com/codex/tasks/task_e_69068359598c8332b9c6b57c60f5b23b