### PR TITLE
fix: reset lazy view cache after failed import

### DIFF
--- a/webapp/src/router/index.ts
+++ b/webapp/src/router/index.ts
@@ -16,7 +16,17 @@ type AsyncViewFactory<T> = (() => Promise<T>) & { preload: () => Promise<T> };
 
 function createLazyView<T>(loader: () => Promise<T>): AsyncViewFactory<T> {
   let promise: Promise<T> | null = null;
-  const load = () => (promise ??= loader());
+  const load = () => {
+    if (!promise) {
+      promise = loader()
+        .then((value) => value)
+        .catch((error) => {
+          promise = null;
+          throw error;
+        });
+    }
+    return promise;
+  };
   const factory = (() => load()) as AsyncViewFactory<T>;
   factory.preload = () => load();
   return factory;


### PR DESCRIPTION
## Summary
- reset the cached lazy view promise if the initial import fails so subsequent navigations can retry

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6906ae4bf6b48332b2152f17b51ecffe