### PR TITLE
Fix lock acquisition when snapshot directory is missing

### DIFF
--- a/server/services/generationSnapshotStore.js
+++ b/server/services/generationSnapshotStore.js
@@ -49,6 +49,10 @@ function createFileLock(filePath, fsImpl, options = {}) {
 
   async function acquire() {
     const start = Date.now();
+    const lockDir = path.dirname(lockPath);
+    if (lockDir) {
+      await fsImpl.mkdir(lockDir, { recursive: true });
+    }
     while (true) {
       try {
         const handle = await fsImpl.open(lockPath, 'wx');


### PR DESCRIPTION
## Summary
- ensure the lock file directory is created before trying to acquire the snapshot lock

## Testing
- node --test tests/server/generationSnapshot.spec.js

------
https://chatgpt.com/codex/tasks/task_e_6906ae760bcc8332a8079c868e0dbcf5