### PR TITLE
Add trait style guide validation workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/trait_contribution.md
+++ b/.github/ISSUE_TEMPLATE/trait_contribution.md
@@ -33,6 +33,13 @@ assignees: []
 - Dati PI/species coinvolti:
 - Check QA richiesti (baseline, coverage, audit, CLI smoke, ecc.):
 
+## Conformità guida stile
+
+- [ ] Label e descrizioni mappate su chiavi i18n `i18n:traits.<id>.campo`
+- [ ] Tier, slot e `slot_profile` allineati con la nomenclatura condivisa
+- [ ] Requisiti ambientali con `meta.tier`/`meta.notes` aggiornati e coerenti
+- [ ] Eseguito `scripts/trait_style_check.js` e allegati i report rilevanti
+
 ## Allegati
 
 - [ ] Mockup o reference visivi allegati

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -270,6 +275,24 @@ jobs:
             --trait-reference data/traits/index.json \
             --out-markdown reports/trait_progress.md \
             --history-file logs/trait_audit/trait_progress_history.json
+
+      - name: Run trait style guide check
+        run: |
+          mkdir -p reports/trait_style
+          node scripts/trait_style_check.js \
+            --output-json reports/trait_style/ci_trait_style_report.json \
+            --output-markdown reports/trait_style/ci_trait_style_report.md \
+            --fail-on error
+
+      - name: Upload trait style guide report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trait-style-report-${{ github.run_id }}
+          path: |
+            reports/trait_style/ci_trait_style_report.json
+            reports/trait_style/ci_trait_style_report.md
+          if-no-files-found: warn
 
   deployment-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/traits-monthly-maintenance.yml
+++ b/.github/workflows/traits-monthly-maintenance.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/validate_traits.yml
+++ b/.github/workflows/validate_traits.yml
@@ -45,6 +45,13 @@ jobs:
         run: node scripts/build_trait_index.js
       - name: Generate strict trait coverage report
         run: python tools/py/report_trait_coverage.py --strict
+      - name: Run trait style guide check
+        run: |
+          mkdir -p reports/trait_style
+          node scripts/trait_style_check.js \
+            --output-json reports/trait_style/trait_style_report.json \
+            --output-markdown reports/trait_style/trait_style_report.md \
+            --fail-on error
       - name: Upload trait reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ logs/tooling/*.png
 
 # Generated analytics outputs
 reports/trait_balance/*.png
+# Generated trait style reports
+reports/trait_style/
+logs/monthly_trait_maintenance/trait_style_*.json
+logs/monthly_trait_maintenance/trait_style_*.md

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Descrizione
+
+<!-- Riassunto conciso delle modifiche proposte. -->
+
+## Checklist guida stile & QA
+
+- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
+- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
+- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
+- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
+- [ ] Documentazione/processi aggiornati ove necessario
+
+## Testing
+
+- [ ] `npm run style:check`
+- [ ] Altro: <!-- specificare -->
+
+## Note
+
+<!-- Link a report, artefatti o follow-up da pianificare. -->

--- a/docs/00-INDEX.md
+++ b/docs/00-INDEX.md
@@ -58,6 +58,7 @@
 | [qa_reporting_schema.md](docs/process/qa_reporting_schema.md) | QA Telemetry & Segnalazioni — Schema condiviso | Panorama fonti dati QA, campi disponibili e gap di reporting. | N/D | 2025-10-27 | `docs/process/qa_reporting_schema.md` |
 | [telemetry_ingestion_pipeline.md](docs/process/telemetry_ingestion_pipeline.md) | Pipeline Dati Telemetria → Tabella QA/Design | Flusso di ingestione telemetria, snapshot visuali e modulo QA manuale. | N/D | 2025-10-27 | `docs/process/telemetry_ingestion_pipeline.md` |
 | [traits_checklist.md](docs/process/traits_checklist.md) | Checklist iterativa tratti | Step incrementali per aggiungere/revisionare tratti con controlli dati. | N/D | 2025-10-28 | `docs/process/traits_checklist.md` |
+| [training/trait_style_session.md](docs/process/training/trait_style_session.md) | Trait Style Session & Review | Agenda formazione e processo per nomenclatura/descrizioni trait. | N/D | 2025-10-29 | `docs/process/training/trait_style_session.md` |
 | [web_handoff.md](docs/process/web_handoff.md) | Web Handoff · Foodweb Archetypes 2025-11-05 | Nota di consegna verso team web/UI con archetipi ruolo×bioma aggiornati. | N/D | 2025-10-29 | `docs/process/web_handoff.md` |
 | [web_pipeline.md](docs/process/web_pipeline.md) | Pipeline web · Procedura di rilascio | Processo end-to-end per promuovere la web experience su GitHub Pages. | N/D | 2025-10-28 | `docs/process/web_pipeline.md` |
 

--- a/docs/process/training/trait_style_session.md
+++ b/docs/process/training/trait_style_session.md
@@ -1,0 +1,72 @@
+# Trait Style Session
+
+Sessione formativa dedicata alla guida di stile dei trait: nomenclatura,
+descrizioni editorali e requisiti ambientali. La sessione combina teoria e
+laboratorio pratico con l'editor interno aggiornato e i nuovi report automatici.
+
+## Obiettivi
+
+- Allineare designer, QA e data steward sulla struttura delle chiavi i18n e sui
+  pattern di descrizione (`label`, `uso_funzione`, `spinta_selettiva`, ecc.).
+- Rafforzare la coerenza tra `tier`, slot (`slot`, `slot_profile`) e note
+  strategiche (`meta.notes`) nei requisiti ambientali.
+- Introdurre il flusso di validazione in tempo reale dell'editor trait e il
+  comando `scripts/trait_style_check.js` come gate obbligatorio.
+- Definire responsabilità e tempistiche del nuovo processo di review
+  nomenclatura/descrizioni.
+
+## Preparazione
+
+1. Rivedere la guida stile trait aggiornata nel repository (schemi + esempi
+   recenti).
+2. Installare le dipendenze (Node 20 + `npm install`) per poter usare
+   l'editor interno e gli script di lint.
+3. Portare un tratto reale da revisionare (ideale una bozza in `_drafts/`).
+4. Creare una cartella condivisa per archiviare i report generati (`logs/trait_style/`).
+
+## Agenda consigliata (90 minuti)
+
+1. **Kickoff e recap (10')** – Obiettivi della sessione, novità rispetto alle
+   procedure precedenti, overview dei materiali.
+2. **Demo strumenti (20')** – Navigazione dell'editor con validazione live,
+   spiegazione delle sezioni "Guida stile" e come interpretare badge/suggerimenti.
+3. **Laboratorio (35')** – Lavoro a gruppi: ciascuno corregge un tratto reale
+   utilizzando i suggerimenti dell'editor e lo script CLI. Condivisione rapida
+   dei fix trovati.
+4. **Review process (15')** – Formalizzazione del flusso di approvazione
+   nomenclatura/descrizioni (vedi sezione successiva). Definizione dei punti di
+   controllo con QA e design.
+5. **Chiusura (10')** – Q&A, raccolta feedback, assegnazione dei follow-up.
+
+## Processo di review nomenclatura & descrizioni
+
+1. **Check locale** – L'autore esegue `npm run style:check` (alias dello script
+   `scripts/trait_style_check.js`) e allega i report JSON/Markdown al branch.
+2. **Revisione editoriale** – Il reviewer controlla che ogni campo testuale
+   utilizzi il namespace i18n corretto (`i18n:traits.<id>.*`) e che `tier`/slot
+   rispettino la guida (maiuscole, cluster condivisi, `slot_profile` completo).
+3. **Requisiti ambientali** – Verificare che ogni voce abbia `meta.tier`
+   allineato al tratto, note esplicative e `fonte` valorizzata; aggiornare
+   `completion_flags` (`has_biome`, `has_species_link`) di conseguenza.
+4. **Validazione automatica** – Se il report stile riporta errori, il PR viene
+   bloccato finché `STYLE_ERRORS` = 0. I warning richiedono conferma esplicita
+   nel commento di review.
+5. **Documentazione** – Aggiornare il template PR (sezione "Checklist guida
+   stile") e annotare l'esito nel log di manutenzione mensile.
+
+## Output attesi
+
+- Report JSON/Markdown della lint (archiviati in `reports/trait_style/` o nei
+  log di manutenzione) con riferimento nel PR/issue.
+- Note di review che indicano chi ha firmato la nomenclatura e le descrizioni.
+- Eventuali follow-up (es. nuove chiavi i18n da localizzare) tracciati nel
+  backlog di design o localization.
+
+## Risorse
+
+- Editor interno (`webapp` → Trait Editor) con suggerimenti in tempo reale.
+- Script CLI: `scripts/trait_style_check.js` e shortcut `npm run style:check`.
+- Cron job mensile `scripts/cron/traits_monthly_maintenance.sh` per monitorare
+  regressioni e allegare i report QA.
+- Template aggiornati (`.github/ISSUE_TEMPLATE/trait_contribution.md`,
+  `PULL_REQUEST_TEMPLATE.md`).

--- a/docs/process/trait_review.md
+++ b/docs/process/trait_review.md
@@ -29,6 +29,20 @@ Eseguire questi passaggi prima di promuovere definitivamente un tratto:
 - [ ] Aggiornare `data/traits/index.json` dopo la promozione (manuale o tramite
       strumenti dedicati) se il nuovo tratto deve comparire nell'indice.
 
+### Review stile trait
+
+Il processo completo è documentato in
+[`docs/process/training/trait_style_session.md`](training/trait_style_session.md).
+Prima di promuovere un tratto:
+
+- [ ] Eseguire `npm run style:check` e allegare i report generati al branch.
+- [ ] Verificare che tutte le chiavi testuali usino il namespace
+      `i18n:traits.<id>.campo` e che `tier`/slot rispettino la nomenclatura.
+- [ ] Controllare che `requisiti_ambientali` abbia `meta.tier` e `meta.notes`
+      coerenti e aggiornare i `completion_flags` (es. `has_biome`).
+- [ ] Annotare nel PR l'esito della guida stile (sezione "Checklist guida
+      stile & QA").
+
 ## Comandi utili
 
 Visualizzare l'esito della revisione senza modificare file:

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "webapp:analyze": "npm run analyze --workspace webapp",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "style:check": "node scripts/trait_style_check.js",
     "prepare": "node scripts/husky-install.cjs"
   },
   "dependencies": {

--- a/scripts/trait_style_check.js
+++ b/scripts/trait_style_check.js
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const { evaluateTraitStyle, SEVERITY_ORDER } = require('../server/services/traitStyleGuide');
+
+const DEFAULT_DATA_ROOT = path.resolve(__dirname, '..', 'data', 'traits');
+
+async function main(argv) {
+  const options = parseArgs(argv);
+  const traitFiles = await collectTraitFiles(options.traitsRoot);
+  const issues = [];
+  for (const filePath of traitFiles) {
+    const payload = await readJson(filePath);
+    const traitId = payload && typeof payload === 'object' ? payload.id : null;
+    const { suggestions, summary } = evaluateTraitStyle(payload, { traitId });
+    if (!suggestions.length) {
+      continue;
+    }
+    suggestions.forEach((suggestion) => {
+      issues.push({
+        file: filePath,
+        traitId: traitId || '<unknown>',
+        path: suggestion.path || '',
+        message: suggestion.message,
+        severity: suggestion.severity || 'warning',
+        fix: suggestion.fix || null,
+      });
+    });
+  }
+
+  issues.sort((a, b) => {
+    const severityDiff = (SEVERITY_ORDER[b.severity] ?? 0) - (SEVERITY_ORDER[a.severity] ?? 0);
+    if (severityDiff !== 0) {
+      return severityDiff;
+    }
+    if (a.traitId !== b.traitId) {
+      return a.traitId.localeCompare(b.traitId, 'it');
+    }
+    return a.path.localeCompare(b.path, 'it');
+  });
+
+  const summary = summariseIssues(issues, traitFiles.length);
+
+  if (options.outputJson) {
+    await writeJson(options.outputJson, summary);
+  }
+
+  if (options.outputMarkdown) {
+    await writeMarkdown(options.outputMarkdown, summary, issues);
+  }
+
+  if (!options.quiet) {
+    printSummary(summary, issues, options);
+  }
+
+  const failThreshold = SEVERITY_ORDER[options.failOn] ?? SEVERITY_ORDER.error;
+  const maxSeverity = issues.reduce((acc, issue) => Math.max(acc, SEVERITY_ORDER[issue.severity] ?? 0), 0);
+  if (maxSeverity >= failThreshold && issues.length > 0) {
+    return 1;
+  }
+  return 0;
+}
+
+function parseArgs(argv) {
+  const args = Array.from(argv);
+  const options = {
+    traitsRoot: DEFAULT_DATA_ROOT,
+    outputJson: null,
+    outputMarkdown: null,
+    failOn: 'error',
+    quiet: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case '--traits-root':
+        options.traitsRoot = resolvePath(args[++index]);
+        break;
+      case '--output-json':
+        options.outputJson = resolvePath(args[++index]);
+        break;
+      case '--output-markdown':
+        options.outputMarkdown = resolvePath(args[++index]);
+        break;
+      case '--fail-on':
+        options.failOn = String(args[++index] || 'error');
+        break;
+      case '--quiet':
+        options.quiet = true;
+        break;
+      case '--help':
+      case '-h':
+        printUsage();
+        process.exit(0);
+        break;
+      default:
+        // ignore unknown flags to stay flexible
+        break;
+    }
+  }
+
+  return options;
+}
+
+function printUsage() {
+  process.stdout.write(`Trait style guide check\n\n`);
+  process.stdout.write(`Usage: node scripts/trait_style_check.js [options]\n\n`);
+  process.stdout.write(`Options:\n`);
+  process.stdout.write(`  --traits-root <path>       Directory radice dei file trait (default data/traits)\n`);
+  process.stdout.write(`  --output-json <path>       Percorso di output per il report JSON\n`);
+  process.stdout.write(`  --output-markdown <path>   Percorso di output per il report Markdown\n`);
+  process.stdout.write(`  --fail-on <severity>       Soglia di errore (info|warning|error), default error\n`);
+  process.stdout.write(`  --quiet                    Non stampare il riepilogo a console\n`);
+  process.stdout.write(`  -h, --help                 Mostra questo messaggio\n`);
+}
+
+async function collectTraitFiles(root) {
+  const output = [];
+  async function walk(directory) {
+    const entries = await fs.readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) {
+        continue;
+      }
+      if (entry.isDirectory()) {
+        if (entry.name === '_versions' || entry.name === '_drafts') {
+          continue;
+        }
+        await walk(path.join(directory, entry.name));
+      } else if (entry.isFile() && entry.name.endsWith('.json')) {
+        if (['index.json', 'index.csv', 'species_affinity.json'].includes(entry.name)) {
+          continue;
+        }
+        output.push(path.join(directory, entry.name));
+      }
+    }
+  }
+  await walk(root);
+  return output;
+}
+
+async function readJson(filePath) {
+  const content = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(content);
+}
+
+function summariseIssues(issues, totalTraits) {
+  const counts = { info: 0, warning: 0, error: 0 };
+  issues.forEach((issue) => {
+    const severity = issue.severity || 'warning';
+    counts[severity] = (counts[severity] || 0) + 1;
+  });
+  return {
+    generatedAt: new Date().toISOString(),
+    totalTraits,
+    totalIssues: issues.length,
+    counts,
+    traitsWithIssues: new Set(issues.map((issue) => issue.traitId)).size,
+  };
+}
+
+async function writeJson(targetPath, payload) {
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  await fs.writeFile(targetPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+async function writeMarkdown(targetPath, summary, issues) {
+  const lines = [];
+  lines.push(`# Trait style guide report`, '');
+  lines.push(`Generato: ${summary.generatedAt}`);
+  lines.push(`Totale trait analizzati: ${summary.totalTraits}`);
+  lines.push(`Totale suggerimenti: ${summary.totalIssues}`);
+  lines.push(
+    `Breakdown: error=${summary.counts.error}, warning=${summary.counts.warning}, info=${summary.counts.info}`,
+  );
+  lines.push(`Trait con suggerimenti: ${summary.traitsWithIssues}`, '');
+  if (!issues.length) {
+    lines.push('_Nessuna anomalia rilevata._');
+  } else {
+    const grouped = new Map();
+    issues.forEach((issue) => {
+      const key = issue.traitId;
+      const bucket = grouped.get(key) || [];
+      bucket.push(issue);
+      grouped.set(key, bucket);
+    });
+    for (const [traitId, traitIssues] of grouped.entries()) {
+      lines.push(`## ${traitId}`, '');
+      traitIssues.forEach((issue) => {
+        lines.push(
+          `- **${issue.severity.toUpperCase()}** — ${issue.message} (_${path.relative(
+            process.cwd(),
+            issue.file,
+          )}${issue.path ? ` → ${issue.path}` : ''}_ )`,
+        );
+      });
+      lines.push('');
+    }
+  }
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  await fs.writeFile(targetPath, `${lines.join('\n')}\n`, 'utf8');
+}
+
+function printSummary(summary, issues, options) {
+  const line = `Trait style: ${summary.totalIssues} suggerimenti (error=${summary.counts.error}, warning=${summary.counts.warning}, info=${summary.counts.info}) su ${summary.totalTraits} file`;
+  if (summary.totalIssues === 0) {
+    console.log(`${line} ✅`);
+    return;
+  }
+  console.log(line);
+  issues.slice(0, 5).forEach((issue) => {
+    console.log(
+      `  - [${issue.severity.toUpperCase()}] ${issue.traitId} ${issue.path || '/'} :: ${issue.message}`,
+    );
+  });
+  if (issues.length > 5 && !options.quiet) {
+    console.log(`  … altri ${issues.length - 5} suggerimenti`);
+  }
+}
+
+function resolvePath(candidate) {
+  if (!candidate) {
+    return null;
+  }
+  return path.resolve(process.cwd(), candidate);
+}
+
+if (require.main === module) {
+  main(process.argv.slice(2))
+    .then((code) => {
+      process.exit(code);
+    })
+    .catch((error) => {
+      console.error('[trait-style-check] errore non gestito', error);
+      process.exit(1);
+    });
+}

--- a/server/services/traitStyleGuide.js
+++ b/server/services/traitStyleGuide.js
@@ -1,0 +1,342 @@
+'use strict';
+
+const SLUG_PATTERN = /^[a-z0-9_]+$/;
+const TIER_PATTERN = /^T[0-9]$/;
+
+const I18N_FIELDS = [
+  'label',
+  'mutazione_indotta',
+  'uso_funzione',
+  'spinta_selettiva',
+  'debolezza',
+  'fattore_mantenimento_energetico',
+];
+
+const SEVERITY_ORDER = {
+  info: 0,
+  warning: 1,
+  error: 2,
+};
+
+function clone(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function normalisePath(pathSegments) {
+  if (!Array.isArray(pathSegments) || pathSegments.length === 0) {
+    return '';
+  }
+  return `/${pathSegments.map((segment) => String(segment)).join('/')}`;
+}
+
+function ensureArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function addSuggestion(bucket, suggestion) {
+  const severity = suggestion.severity || 'warning';
+  const normalised = {
+    ...suggestion,
+    severity,
+    path: suggestion.path || '',
+  };
+  bucket.push(normalised);
+}
+
+function checkI18nFields(trait, suggestions, traitId) {
+  I18N_FIELDS.forEach((field) => {
+    const pointer = normalisePath([field]);
+    const value = trait[field];
+    if (typeof value !== 'string' || !value.trim()) {
+      addSuggestion(suggestions, {
+        path: pointer,
+        severity: 'error',
+        message: `Il campo \`${field}\` deve usare una chiave i18n dedicata (i18n:traits.${traitId || 'trait'}.${field}).`,
+        fix: traitId
+          ? { type: 'set', value: `i18n:traits.${traitId}.${field}` }
+          : { type: 'set', note: 'Imposta una chiave i18n per questo campo.' },
+      });
+      return;
+    }
+    const expectedPrefix = traitId ? `i18n:traits.${traitId}.` : 'i18n:traits.';
+    if (!value.startsWith(expectedPrefix)) {
+      addSuggestion(suggestions, {
+        path: pointer,
+        severity: 'error',
+        message: `Allinea \`${field}\` al namespace i18n del tratto (${expectedPrefix}...).`,
+        fix: traitId ? { type: 'set', value: `${expectedPrefix}${field}` } : undefined,
+      });
+    }
+  });
+}
+
+function checkTier(trait, suggestions) {
+  const pointer = normalisePath(['tier']);
+  const tier = trait.tier;
+  if (typeof tier !== 'string' || !tier.trim()) {
+    addSuggestion(suggestions, {
+      path: pointer,
+      severity: 'error',
+      message: 'Imposta il tier del tratto utilizzando il formato T1/T2/T3.',
+      fix: { type: 'set', note: 'Scegliere il tier coerente con la matrice di bilanciamento (es. "T1").' },
+    });
+    return;
+  }
+  const upper = tier.toUpperCase();
+  if (!TIER_PATTERN.test(upper)) {
+    addSuggestion(suggestions, {
+      path: pointer,
+      severity: 'error',
+      message: `Il valore \`${tier}\` non rispetta il formato T{numero}.`,
+      fix: { type: 'set', value: upper.replace(/[^0-9]/g, '') ? upper : 'T1' },
+    });
+    return;
+  }
+  if (tier !== upper) {
+    addSuggestion(suggestions, {
+      path: pointer,
+      severity: 'info',
+      message: 'Utilizza il formato maiuscolo per il tier (es. T1).',
+      fix: { type: 'set', value: upper },
+    });
+  }
+}
+
+function checkId(trait, suggestions, traitId) {
+  const pointer = normalisePath(['id']);
+  const currentId = trait.id;
+  if (!currentId && traitId) {
+    addSuggestion(suggestions, {
+      path: pointer,
+      severity: 'error',
+      message: `Il payload deve includere l'id \`${traitId}\`.`,
+      fix: { type: 'set', value: traitId },
+    });
+    return;
+  }
+  if (typeof currentId !== 'string' || !currentId.trim()) {
+    addSuggestion(suggestions, {
+      path: pointer,
+      severity: 'error',
+      message: 'Specificare un id in formato snake_case.',
+      fix: { type: 'set', note: 'Usa solo caratteri a-z, numeri e underscore.' },
+    });
+    return;
+  }
+  if (!SLUG_PATTERN.test(currentId)) {
+    addSuggestion(suggestions, {
+      path: pointer,
+      severity: 'error',
+      message: `L'id \`${currentId}\` non è uno slug valido (consentiti a-z0-9_).`,
+      fix: { type: 'set', value: currentId.toLowerCase().replace(/[^a-z0-9_]/g, '_') },
+    });
+  }
+  if (traitId && currentId !== traitId) {
+    addSuggestion(suggestions, {
+      path: pointer,
+      severity: 'warning',
+      message: `Allinea l'id del payload all'elemento selezionato (${traitId}).`,
+      fix: { type: 'set', value: traitId },
+    });
+  }
+}
+
+function checkSlugArray(trait, suggestions, field) {
+  const pointer = normalisePath([field]);
+  const value = trait[field];
+  if (value === undefined) {
+    return;
+  }
+  if (!Array.isArray(value)) {
+    addSuggestion(suggestions, {
+      path: pointer,
+      severity: 'error',
+      message: `\`${field}\` deve essere un array di id in snake_case.`,
+      fix: { type: 'set', note: 'Converti il valore in lista di slug.' },
+    });
+    return;
+  }
+  const seen = new Set();
+  value.forEach((entry, index) => {
+    const entryPath = normalisePath([field, index]);
+    if (typeof entry !== 'string') {
+      addSuggestion(suggestions, {
+        path: entryPath,
+        severity: 'error',
+        message: 'Usa slug in formato snake_case.',
+        fix: { type: 'set', note: 'Rimuovi valori non testuali.' },
+      });
+      return;
+    }
+    const trimmed = entry.trim();
+    if (!SLUG_PATTERN.test(trimmed)) {
+      addSuggestion(suggestions, {
+        path: entryPath,
+        severity: 'error',
+        message: `\`${entry}\` non rispetta lo slug richiesto (a-z0-9_).`,
+        fix: { type: 'set', value: trimmed.toLowerCase().replace(/[^a-z0-9_]/g, '_') },
+      });
+    }
+    if (seen.has(trimmed)) {
+      addSuggestion(suggestions, {
+        path: entryPath,
+        severity: 'warning',
+        message: `Valore duplicato \`${trimmed}\` in \`${field}\`.`,
+        fix: { type: 'remove' },
+      });
+    }
+    seen.add(trimmed);
+  });
+}
+
+function checkSlotProfile(trait, suggestions) {
+  const pointer = normalisePath(['slot_profile']);
+  const slotProfile = trait.slot_profile;
+  if (slotProfile === undefined) {
+    return;
+  }
+  if (typeof slotProfile !== 'object' || slotProfile === null || Array.isArray(slotProfile)) {
+    addSuggestion(suggestions, {
+      path: pointer,
+      severity: 'error',
+      message: 'La sezione `slot_profile` deve essere un oggetto con `core` e `complementare`.',
+      fix: { type: 'set', note: 'Converti il valore in oggetto { core, complementare }.' },
+    });
+    return;
+  }
+  ['core', 'complementare'].forEach((field) => {
+    const value = slotProfile[field];
+    const fieldPath = normalisePath(['slot_profile', field]);
+    if (typeof value !== 'string' || !value.trim()) {
+      addSuggestion(suggestions, {
+        path: fieldPath,
+        severity: 'warning',
+        message: `Compila il campo \`${field}\` in slot_profile (es. "metabolico").`,
+        fix: { type: 'set', note: 'Allinea il valore ai cluster slot condivisi.' },
+      });
+    } else if (value !== value.toLowerCase()) {
+      addSuggestion(suggestions, {
+        path: fieldPath,
+        severity: 'info',
+        message: 'Usa lettere minuscole per le etichette slot.',
+        fix: { type: 'set', value: value.toLowerCase() },
+      });
+    }
+  });
+}
+
+function checkEnvironmentalRequirements(trait, suggestions) {
+  const requirements = ensureArray(trait.requisiti_ambientali);
+  if (!requirements.length) {
+    return;
+  }
+  const traitTier = typeof trait.tier === 'string' ? trait.tier.toUpperCase() : null;
+  requirements.forEach((entry, index) => {
+    const basePath = ['requisiti_ambientali', index];
+    if (typeof entry !== 'object' || entry === null) {
+      addSuggestion(suggestions, {
+        path: normalisePath(basePath),
+        severity: 'error',
+        message: 'Ogni requisito ambientale deve essere un oggetto con condizioni/meta.',
+        fix: { type: 'set', note: "Trasforma l'elemento in un oggetto strutturato." },
+      });
+      return;
+    }
+    const fonte = entry.fonte;
+    if (!fonte || typeof fonte !== 'string') {
+      addSuggestion(suggestions, {
+        path: normalisePath([...basePath, 'fonte']),
+        severity: 'warning',
+        message: "Specifica la fonte (es. env_to_traits) per tracciare l'origine della regola.",
+        fix: { type: 'set', value: 'env_to_traits' },
+      });
+    }
+    const meta = entry.meta;
+    if (typeof meta !== 'object' || meta === null) {
+      addSuggestion(suggestions, {
+        path: normalisePath([...basePath, 'meta']),
+        severity: 'warning',
+        message: 'Aggiungi la sezione meta con tier, notes e expansion.',
+        fix: { type: 'set', note: 'Inserire { "tier": "T1", "notes": "..." }.' },
+      });
+    } else {
+      const tier = meta.tier;
+      if (traitTier && tier !== traitTier) {
+        addSuggestion(suggestions, {
+          path: normalisePath([...basePath, 'meta', 'tier']),
+          severity: 'warning',
+          message: `Allinea meta.tier (${tier || '—'}) al tier del tratto (${traitTier}).`,
+          fix: { type: 'set', value: traitTier },
+        });
+      }
+      if (!meta.notes || typeof meta.notes !== 'string') {
+        addSuggestion(suggestions, {
+          path: normalisePath([...basePath, 'meta', 'notes']),
+          severity: 'info',
+          message: 'Compila le note descrivendo perché il tratto si attiva in questo bioma.',
+          fix: { type: 'set', note: 'Riassumi il contesto narrativo/tattico.' },
+        });
+      }
+    }
+    const condizioni = entry.condizioni;
+    if (typeof condizioni !== 'object' || condizioni === null) {
+      addSuggestion(suggestions, {
+        path: normalisePath([...basePath, 'condizioni']),
+        severity: 'error',
+        message: 'Ogni requisito deve definire condizioni (es. biome_class, salinita_in).',
+        fix: { type: 'set', note: 'Imposta un oggetto condizioni con chiavi specifiche.' },
+      });
+    }
+  });
+}
+
+function checkCompletionFlags(trait, suggestions) {
+  const flags = trait.completion_flags;
+  if (typeof flags !== 'object' || flags === null || Array.isArray(flags)) {
+    return;
+  }
+  const requirements = ensureArray(trait.requisiti_ambientali);
+  if (requirements.length && flags.has_biome === false) {
+    addSuggestion(suggestions, {
+      path: normalisePath(['completion_flags', 'has_biome']),
+      severity: 'warning',
+      message: 'Segna `has_biome` a true dopo aver mappato i requisiti ambientali.',
+      fix: { type: 'set', value: true },
+    });
+  }
+}
+
+function evaluateTraitStyle(traitInput, options = {}) {
+  const trait = clone(traitInput) || {};
+  const suggestions = [];
+  const traitId = options.traitId || trait.id;
+
+  checkId(trait, suggestions, traitId);
+  if (traitId) {
+    checkI18nFields(trait, suggestions, traitId);
+  }
+  checkTier(trait, suggestions);
+  checkSlugArray(trait, suggestions, 'sinergie');
+  checkSlugArray(trait, suggestions, 'conflitti');
+  checkSlotProfile(trait, suggestions);
+  checkEnvironmentalRequirements(trait, suggestions);
+  checkCompletionFlags(trait, suggestions);
+
+  const summary = suggestions.reduce(
+    (acc, suggestion) => {
+      const severity = suggestion.severity || 'warning';
+      acc.total += 1;
+      acc.bySeverity[severity] = (acc.bySeverity[severity] || 0) + 1;
+      return acc;
+    },
+    { total: 0, bySeverity: { info: 0, warning: 0, error: 0 } },
+  );
+
+  return { suggestions, summary };
+}
+
+module.exports = {
+  evaluateTraitStyle,
+  I18N_FIELDS,
+  SEVERITY_ORDER,
+};

--- a/tests/api/traits.validate.test.js
+++ b/tests/api/traits.validate.test.js
@@ -1,0 +1,61 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs/promises');
+const request = require('supertest');
+
+const { createApp } = require('../../server/app');
+
+const SAMPLE_TRAIT = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'data',
+  'traits',
+  'metabolico',
+  'circolazione_cooling_loop.json',
+);
+
+test('POST /api/traits/validate restituisce suggerimenti stile', async () => {
+  const payload = JSON.parse(await fs.readFile(SAMPLE_TRAIT, 'utf8'));
+  payload.label = 'Circolazione Cooling Loop';
+  payload.tier = 't1';
+
+  const { app } = createApp({ traits: { token: null } });
+
+  const response = await request(app)
+    .post('/api/traits/validate')
+    .send({ payload })
+    .expect(200);
+
+  assert.equal(response.body.valid, true);
+  assert.equal(Array.isArray(response.body.errors) ? response.body.errors.length : 0, 0);
+
+  const suggestions = response.body.suggestions || [];
+  assert.ok(suggestions.length >= 1, 'attesi suggerimenti dallo stile');
+
+  const labelSuggestion = suggestions.find((item) => item.path === '/label');
+  assert.ok(labelSuggestion, 'atteso suggerimento per label');
+  assert.equal(labelSuggestion.severity, 'error');
+  assert.match(labelSuggestion.message, /i18n/i);
+
+  const tierSuggestion = suggestions.find((item) => item.path === '/tier');
+  assert.ok(tierSuggestion, 'atteso suggerimento per tier');
+  assert.match(tierSuggestion.message, /T1/);
+});
+
+test('POST /api/traits/validate segnala errori schema quando il payload è incompleto', async () => {
+  const { app } = createApp({ traits: { token: null } });
+
+  const response = await request(app)
+    .post('/api/traits/validate')
+    .send({ payload: { label: 'Trait incompleto' } })
+    .expect(200);
+
+  assert.equal(response.body.valid, false);
+  assert.ok(Array.isArray(response.body.errors));
+  assert.ok(response.body.errors.length > 0, 'attesi errori di validazione schema');
+  assert.ok(Array.isArray(response.body.suggestions));
+  const idSuggestion = response.body.suggestions.find((item) => item.path === '/id');
+  assert.ok(idSuggestion, 'atteso suggerimento per id mancante');
+});

--- a/webapp/src/features/traits/editor.css
+++ b/webapp/src/features/traits/editor.css
@@ -337,6 +337,141 @@
   overflow: auto;
 }
 
+.trait-editor__style-panel {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.85rem;
+  padding: 0.75rem 0.85rem;
+  background: rgba(15, 23, 42, 0.65);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.trait-editor__style-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #cbd5f5;
+}
+
+.trait-editor__style-header h3 {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.trait-editor__style-badge {
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.trait-editor__style-badge--pending {
+  background: rgba(59, 130, 246, 0.2);
+  color: #bfdbfe;
+}
+
+.trait-editor__style-badge--issues {
+  background: rgba(239, 68, 68, 0.22);
+  color: #fecaca;
+}
+
+.trait-editor__style-badge--ok {
+  background: rgba(16, 185, 129, 0.2);
+  color: #bbf7d0;
+}
+
+.trait-editor__style-counters {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.75rem;
+}
+
+.trait-editor__style-counter {
+  padding: 0.2rem 0.5rem;
+  border-radius: 0.55rem;
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.trait-editor__style-counter--error {
+  background: rgba(239, 68, 68, 0.25);
+  color: #fecaca;
+}
+
+.trait-editor__style-counter--warning {
+  background: rgba(234, 179, 8, 0.25);
+  color: #fde68a;
+}
+
+.trait-editor__style-counter--info {
+  background: rgba(59, 130, 246, 0.25);
+  color: #bfdbfe;
+}
+
+.trait-editor__suggestions {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.78rem;
+}
+
+.trait-editor__suggestions--panel {
+  max-height: 14rem;
+  overflow: auto;
+}
+
+.trait-editor__suggestions--inline {
+  margin-top: 0.35rem;
+}
+
+.trait-editor__suggestion {
+  list-style: disc;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.trait-editor__suggestion--error {
+  color: #fca5a5;
+}
+
+.trait-editor__suggestion--warning {
+  color: #fde68a;
+}
+
+.trait-editor__suggestion--info {
+  color: #bae6fd;
+}
+
+.trait-editor__suggestion-text {
+  font-weight: 500;
+}
+
+.trait-editor__suggestion-fix {
+  display: block;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.trait-editor__suggestion-fix code {
+  background: rgba(148, 163, 184, 0.18);
+  padding: 0.05rem 0.4rem;
+  border-radius: 0.45rem;
+}
+
+.trait-editor__suggestion-note {
+  display: block;
+  color: rgba(226, 232, 240, 0.65);
+  font-size: 0.72rem;
+}
+
 .trait-editor__message {
   margin: 0;
 }

--- a/webapp/src/services/traitsService.ts
+++ b/webapp/src/services/traitsService.ts
@@ -1,3 +1,5 @@
+import type { ErrorObject } from 'ajv';
+
 import { resolveApiUrl } from './apiEndpoints';
 
 export interface TraitSummary {
@@ -30,6 +32,38 @@ export interface TraitRequestOptions {
 }
 
 export interface TraitSaveOptions extends TraitRequestOptions {
+  payload: Record<string, unknown>;
+}
+
+export interface TraitValidationSuggestion {
+  path: string;
+  message: string;
+  severity?: 'info' | 'warning' | 'error';
+  fix?: {
+    type?: 'set' | 'append' | 'remove';
+    value?: unknown;
+    note?: string;
+  } | null;
+}
+
+export interface TraitValidationSummary {
+  schemaErrors?: number;
+  style?: {
+    total?: number;
+    bySeverity?: Record<string, number>;
+  };
+  [key: string]: unknown;
+}
+
+export interface TraitValidationResponse {
+  valid: boolean;
+  errors?: ErrorObject[];
+  suggestions?: TraitValidationSuggestion[];
+  summary?: TraitValidationSummary;
+}
+
+export interface TraitValidationRequest extends TraitRequestOptions {
+  traitId?: string;
   payload: Record<string, unknown>;
 }
 
@@ -122,6 +156,14 @@ export async function saveTraitEntry(
     ...options,
     method: 'PUT',
     body: payload,
+  });
+}
+
+export async function validateTraitDraft({ traitId, payload, ...options }: TraitValidationRequest): Promise<TraitValidationResponse> {
+  return requestJson<TraitValidationResponse>('/api/traits/validate', {
+    ...options,
+    method: 'POST',
+    body: { traitId, payload },
   });
 }
 


### PR DESCRIPTION
## Summary
- add a trait validation API using Ajv 2020 with style guide diagnostics and regression tests
- surface real-time validation and suggestions in the trait editor UI and expose a CLI style checker
- wire the style checker into CI/cron workflows and update documentation plus PR/issue templates

## Testing
- npm run test:api

------
https://chatgpt.com/codex/tasks/task_e_6906b1e9a1a88332952245548dd68978