### PR TITLE
Align sentience manifest references and migration plan

### DIFF
--- a/analytics/README.md
+++ b/analytics/README.md
@@ -12,16 +12,19 @@ chiave (specie collegate, tag di bioma, flag di completamento, ecc.).
    pip install -r tools/py/requirements.txt
    ```
 2. Eseguire lo script dedicato:
+
    ```bash
    python tools/py/trait_completion_dashboard.py \
      --trait-reference data/traits/index.json \
      --out-markdown reports/trait_progress.md \
      --history-file logs/trait_audit/trait_progress_history.json
    ```
+
    - Usa `--no-history-update` per generare il report senza aggiornare lo
      storico JSON.
 
 Lo script produce due artefatti:
+
 - `reports/trait_progress.md`: tabella con i KPI aggiornati, elenco dei trait
   ancora privi di informazione e trend storico.
 - `logs/trait_audit/trait_progress_history.json`: snapshot cronologico delle
@@ -29,18 +32,17 @@ Lo script produce due artefatti:
 
 ## Interpretare gli indicatori
 
-| Indicatore | Significato | Azione consigliata |
-| --- | --- | --- |
-| **Specie collegate** | Percentuale di trait che hanno una relazione con il bestiario. | Mappa le abilità mancanti su specie esistenti o pianifica nuove creature. |
-| **Tag bioma** | Copertura dei tag ambientali sperimentali. | Aggiungi i tag per migliorare le query e i filtri del catalogo. |
-| **Tag d'uso** | Classificazione funzionale delle mutazioni. | Allinea nomenclatura con i registri di bilanciamento e con le UI di editing. |
-| **Flag completamento** | Stato di revisione/QA per ciascun trait. | Chiudi i loop di review e aggiorna i flag nei file sorgente. |
-| **Origine dati** | Provenienza editoriale o tecnica del tratto. | Traccia i dataset di origine per audit futuri e responsabilità. |
+| Indicatore             | Significato                                                    | Azione consigliata                                                           |
+| ---------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **Specie collegate**   | Percentuale di trait che hanno una relazione con il bestiario. | Mappa le abilità mancanti su specie esistenti o pianifica nuove creature.    |
+| **Tag bioma**          | Copertura dei tag ambientali sperimentali.                     | Aggiungi i tag per migliorare le query e i filtri del catalogo.              |
+| **Tag d'uso**          | Classificazione funzionale delle mutazioni.                    | Allinea nomenclatura con i registri di bilanciamento e con le UI di editing. |
+| **Flag completamento** | Stato di revisione/QA per ciascun trait.                       | Chiudi i loop di review e aggiorna i flag nei file sorgente.                 |
+| **Origine dati**       | Provenienza editoriale o tecnica del tratto.                   | Traccia i dataset di origine per audit futuri e responsabilità.              |
 
 Il trend storico nel report mostra l'ultima decina di snapshot registrati: una
 linea crescente suggerisce una buona copertura, mentre plateau prolungati
 richiedono follow-up con i team di narrative e bilanciamento.
-
 
 ## Analisi bilanciamento tratti
 
@@ -48,11 +50,20 @@ richiedono follow-up con i team di narrative e bilanciamento.
    ```bash
    pip install pandas matplotlib seaborn
    ```
-2. Lancia l'analisi completa: 
+2. Lancia l'analisi completa:
+
    ```bash
    python analytics/trait_balance_analysis.py
    ```
+
    - Puoi personalizzare le sorgenti con `--index` e `--species-bridge` se stai lavorando su esportazioni alternative.
+
 3. I grafici sono salvati localmente in `reports/trait_balance/` (heatmap biomi/tier, top specie, sinergie per famiglia); la cartella è ignorata dal versionamento così da evitare di tracciare i PNG generati.
 4. Le note interpretative sono aggiornate in `reports/trait_balance_summary.md` e mettono in evidenza i biomi saturi, le specie con più accesso e le famiglie dominanti nelle sinergie.
    - Usa questi punti come base per priorizzare interventi di bilanciamento: ridistribuisci tratti nei biomi poveri, amplia l'accesso delle specie marginali e riequilibra sinergie troppo concentrate.
+
+### Monitor Sentience
+
+- Importare il manifest finale `incoming/sentience_traits_v1.0.yaml` per mantenere coerenti i report dei tier T1…T6.
+- Aggiornare notebook o query che filtrano per `incoming_sensienti_*`: i nuovi slug seguono lo schema `incoming_sentience_traits_v1_0_tX_<label>`.
+- Cross-checkare i grafici T1→T6 dopo ogni rollout e allegare screenshot nel weekly analytics recap.

--- a/data/traits/_drafts/balance_reflex.json
+++ b/data/traits/_drafts/balance_reflex.json
@@ -12,10 +12,10 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.balance_reflex.mutazione_indotta",
-  "uso_funzione": "i18n:traits.balance_reflex.uso_funzione",
-  "spinta_selettiva": "i18n:traits.balance_reflex.spinta_selettiva",
+  "uso_funzione": "Tier Pre‑Sociale (T2). Milestone: Senses mid; AB 01 Endurance.",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },
-  "data_origin": "incoming_sensienti_traits_v0_1_t2_presociale"
+  "data_origin": "incoming_sentience_traits_v1_0_t2_pre_sociale"
 }

--- a/data/traits/_drafts/craft_loop.json
+++ b/data/traits/_drafts/craft_loop.json
@@ -12,10 +12,10 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.craft_loop.mutazione_indotta",
-  "uso_funzione": "i18n:traits.craft_loop.uso_funzione",
-  "spinta_selettiva": "i18n:traits.craft_loop.spinta_selettiva",
+  "uso_funzione": "Tier Avanzato (T5). Milestone: Memorie echoic/iconic multiple; AB 11 pain.",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },
-  "data_origin": "incoming_sensienti_traits_v0_1_t5_culturale"
+  "data_origin": "incoming_sentience_traits_v1_0_t5_avanzato"
 }

--- a/data/traits/_drafts/echoic_trace.json
+++ b/data/traits/_drafts/echoic_trace.json
@@ -12,10 +12,10 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.echoic_trace.mutazione_indotta",
-  "uso_funzione": "i18n:traits.echoic_trace.uso_funzione",
-  "spinta_selettiva": "i18n:traits.echoic_trace.spinta_selettiva",
+  "uso_funzione": "Tier Emergente (T3). Milestone: Senses mid+; AB 02–03 movement/carry.",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },
-  "data_origin": "incoming_sensienti_traits_v0_1_t3_emergente"
+  "data_origin": "incoming_sentience_traits_v1_0_t3_emergente"
 }

--- a/data/traits/_drafts/executive_loop.json
+++ b/data/traits/_drafts/executive_loop.json
@@ -12,10 +12,10 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.executive_loop.mutazione_indotta",
-  "uso_funzione": "i18n:traits.executive_loop.uso_funzione",
-  "spinta_selettiva": "i18n:traits.executive_loop.spinta_selettiva",
+  "uso_funzione": "Tier Sapiente (T6). Milestone: Senses 37/37; Ambulation 26/26.",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },
-  "data_origin": "incoming_sensienti_traits_v0_1_t6_proto_umano"
+  "data_origin": "incoming_sentience_traits_v1_0_t6_sapiente"
 }

--- a/data/traits/_drafts/group_form.json
+++ b/data/traits/_drafts/group_form.json
@@ -12,10 +12,10 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.group_form.mutazione_indotta",
-  "uso_funzione": "i18n:traits.group_form.uso_funzione",
-  "spinta_selettiva": "i18n:traits.group_form.spinta_selettiva",
+  "uso_funzione": "Tier Civico (T4). Milestone: Sound Awareness/Chemotopy full; AB 05–09 climb/carry.",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },
-  "data_origin": "incoming_sensienti_traits_v0_1_t4_sociale"
+  "data_origin": "incoming_sentience_traits_v1_0_t4_civico"
 }

--- a/data/traits/_drafts/interoception_seed.json
+++ b/data/traits/_drafts/interoception_seed.json
@@ -12,10 +12,10 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.interoception_seed.mutazione_indotta",
-  "uso_funzione": "i18n:traits.interoception_seed.uso_funzione",
-  "spinta_selettiva": "i18n:traits.interoception_seed.spinta_selettiva",
+  "uso_funzione": "Tier Proto‑Sentiente (T1). Milestone: Senses (core).",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },
-  "data_origin": "incoming_sensienti_traits_v0_1_t1_protosentiente"
+  "data_origin": "incoming_sentience_traits_v1_0_t1_proto_sentiente"
 }

--- a/data/traits/_drafts/mimicry_basic.json
+++ b/data/traits/_drafts/mimicry_basic.json
@@ -12,10 +12,10 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.mimicry_basic.mutazione_indotta",
-  "uso_funzione": "i18n:traits.mimicry_basic.uso_funzione",
-  "spinta_selettiva": "i18n:traits.mimicry_basic.spinta_selettiva",
+  "uso_funzione": "Tier Pre‑Sociale (T2). Milestone: Senses mid; AB 01 Endurance.",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },
-  "data_origin": "incoming_sensienti_traits_v0_1_t2_presociale"
+  "data_origin": "incoming_sentience_traits_v1_0_t2_pre_sociale"
 }

--- a/data/traits/_drafts/postural_endurance.json
+++ b/data/traits/_drafts/postural_endurance.json
@@ -12,10 +12,10 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.postural_endurance.mutazione_indotta",
-  "uso_funzione": "i18n:traits.postural_endurance.uso_funzione",
-  "spinta_selettiva": "i18n:traits.postural_endurance.spinta_selettiva",
+  "uso_funzione": "Tier Sapiente (T6). Milestone: Senses 37/37; Ambulation 26/26.",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },
-  "data_origin": "incoming_sensienti_traits_v0_1_t6_proto_umano"
+  "data_origin": "incoming_sentience_traits_v1_0_t6_sapiente"
 }

--- a/data/traits/_drafts/sheltering.json
+++ b/data/traits/_drafts/sheltering.json
@@ -12,10 +12,10 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.sheltering.mutazione_indotta",
-  "uso_funzione": "i18n:traits.sheltering.uso_funzione",
-  "spinta_selettiva": "i18n:traits.sheltering.spinta_selettiva",
+  "uso_funzione": "Tier Avanzato (T5). Milestone: Memorie echoic/iconic multiple; AB 11 pain.",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },
-  "data_origin": "incoming_sensienti_traits_v0_1_t5_culturale"
+  "data_origin": "incoming_sentience_traits_v1_0_t5_avanzato"
 }

--- a/data/traits/_drafts/startle_reflex.json
+++ b/data/traits/_drafts/startle_reflex.json
@@ -12,10 +12,10 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.startle_reflex.mutazione_indotta",
-  "uso_funzione": "i18n:traits.startle_reflex.uso_funzione",
-  "spinta_selettiva": "i18n:traits.startle_reflex.spinta_selettiva",
+  "uso_funzione": "Tier Proto‑Sentiente (T1). Milestone: Senses (core).",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },
-  "data_origin": "incoming_sensienti_traits_v0_1_t1_protosentiente"
+  "data_origin": "incoming_sentience_traits_v1_0_t1_proto_sentiente"
 }

--- a/data/traits/_drafts/teach_action.json
+++ b/data/traits/_drafts/teach_action.json
@@ -12,10 +12,10 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.teach_action.mutazione_indotta",
-  "uso_funzione": "i18n:traits.teach_action.uso_funzione",
-  "spinta_selettiva": "i18n:traits.teach_action.spinta_selettiva",
+  "uso_funzione": "Tier Civico (T4). Milestone: Sound Awareness/Chemotopy full; AB 05–09 climb/carry.",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },
-  "data_origin": "incoming_sensienti_traits_v0_1_t4_sociale"
+  "data_origin": "incoming_sentience_traits_v1_0_t4_civico"
 }

--- a/data/traits/_drafts/toolseed.json
+++ b/data/traits/_drafts/toolseed.json
@@ -12,10 +12,10 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.toolseed.mutazione_indotta",
-  "uso_funzione": "i18n:traits.toolseed.uso_funzione",
-  "spinta_selettiva": "i18n:traits.toolseed.spinta_selettiva",
+  "uso_funzione": "Tier Emergente (T3). Milestone: Senses mid+; AB 02–03 movement/carry.",
+  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
   "completion_flags": {
     "external_source": true
   },
-  "data_origin": "incoming_sensienti_traits_v0_1_t3_emergente"
+  "data_origin": "incoming_sentience_traits_v1_0_t3_emergente"
 }

--- a/docs/process/sentience_rollout_plan.md
+++ b/docs/process/sentience_rollout_plan.md
@@ -1,0 +1,86 @@
+# Piano Rollout Sensienza (T1…T6)
+
+Questo documento coordina l'adozione dei nomi/codici definitivi dei tier di
+Sensienza all'interno del gioco e delle integrazioni esterne.
+
+## 1. Aggiornamento componenti core
+
+### Engine
+
+- Sincronizzare i preset dei encounter generator con i nuovi slug
+  (`incoming_sentience_traits_v1_0_t*`).
+- Validare i gate AI/energia usando i milestone ufficiali:
+  - T1 Proto‑Sentiente → _Senses (core)_
+  - T2 Pre‑Sociale → _Senses mid_ + _AB 01 Endurance_
+  - T3 Emergente → _Senses mid+_ + _AB 02–03 movement/carry_
+  - T4 Civico → _Sound Awareness/Chemotopy full_ + _AB 05–09 climb/carry_
+  - T5 Avanzato → _Memorie echoic/iconic multiple_ + _AB 11 pain_
+  - T6 Sapiente → _Senses 37/37_ + _Ambulation 26/26_
+- Verificare che i salvataggi serializzati non contengano più reference legacy
+  (`*_protosentiente`, `*_culturale`, `*_proto_umano`). In caso contrario,
+  applicare lo script di migrazione (`tools/migrations/traits_styleguide_migration.py`).
+
+### Services (generation/orchestrator)
+
+- Aggiornare le pipeline che popolano `data_origin` e metadati dei trait nei
+  mock bundle di build: usare il nuovo manifest `incoming/sentience_traits_v1.0.yaml`.
+- Rinfrescare i cataloghi condivisi (`docs/catalog/*.json`) e riesportare le
+  build di test con la tassonomia aggiornata.
+- Pianificare smoke test post-deploy con seed sensience per garantire che le
+  build di demo non presentino mismatch.
+
+### Analytics
+
+- Allineare i dashboard (trait coverage, balance) ai nuovi label. Aggiornare
+  eventuali filtri o pivot manuali che menzionano i tier legacy.
+- Aggiornare i playbook di QA/BI in `reports/` con screenshot o note che
+  evidenzino la nuova nomenclatura.
+- Coordinare con Data Science il monitoraggio di regressioni post-rollout
+  (telemetria sulle transizioni T1→T6 e uso degli hook interocettivi).
+
+### Documentazione esterna (API / SDK)
+
+- Pubblicare un estratto nel portale SDK con i nuovi codici tier + milestone
+  (vedi `docs/public/sentience_sdk.md`).
+- Aggiornare esempi e snippet di chiamate API che facevano riferimento alle
+  sigle legacy `Sensienti`.
+- Notificare partner e integratori tramite changelog pubblico.
+
+## 2. Coordinamento contenuti condivisi
+
+- **Team Game Design**: aggiornare manuali build, schede encounter e cheat-sheet
+  usati nei playtest con i nuovi nomi e milestone.
+- **Team Narrative/Localization**: rivedere copy e VO script per sostituire i
+  vecchi termini (Proto‑Senziente, Sociale, Culturale, Proto‑Umano) con i nomi
+  definitivi; confermare localizzazioni nelle lingue supportate.
+- **Distribuzione materiali**: rigenerare `manuali/` e `demo/` nella cartella
+  condivisa, allegando nota di versione con riferimento al manifest 1.0.
+
+## 3. Compatibilità e migrazione
+
+1. Eseguire lo script `tools/migrations/traits_styleguide_migration.py` in dry
+   run sui branch di feature o sui dump delle build.
+2. Se vengono rilevati riferimenti legacy, rilanciare con `--apply` (in un
+   branch dedicato) e allegare il log al ticket di rollout.
+3. Per salvataggi live:
+   - Pianificare una finestra di manutenzione con Ops.
+   - Eseguire backup prima della migrazione.
+   - Applicare lo script in modalità batch sugli slot interessati.
+4. Post-migrazione: verificare le sinergie e i gating con l'editor trait (`npm
+run style:check`).
+
+## 4. Piano di comunicazione
+
+| Fase       | Azione                                                       | Owner               | Canale             |
+| ---------- | ------------------------------------------------------------ | ------------------- | ------------------ |
+| T‑3 giorni | Bozza release notes (ITA+EN) con elenco tier e milestone     | Narrative           | Docs + Notion      |
+| T‑2 giorni | Annuncio interno su Mission Console con link al manifest 1.0 | Prod Ops            | Mission Console    |
+| T‑1 giorno | Aggiornare FAQ SDK e changelog pubblico                      | Developer Relations | Portal SDK         |
+| T          | Deploy + post su #launches con link a retro board            | Live Ops            | Slack              |
+| T+1        | Raccolta feedback, monitor telemetria T1→T6                  | Analytics           | Dashboard dedicato |
+
+**Feedback loop**
+
+- Creare ticket su `QA/Sentience` per ogni regressione o bug segnalato.
+- Monitorare grafici telemetrici (tempo medio transizione tier, uso hook) per 2
+  settimane e condividere sintesi nel weekly sync.

--- a/docs/process/trait_data_reference.md
+++ b/docs/process/trait_data_reference.md
@@ -4,15 +4,15 @@ Questa guida riassume dove risiedono i dati dei tratti e quali script utilizzare
 
 ## Struttura dei file
 
-| Percorso | Contenuto | Note |
-| --- | --- | --- |
-| `data/core/traits/glossary.json` | Glossario condiviso con label ufficiali, descrizioni sintetiche e collegamento al reference principale. | Usato da strumenti ETL e validazione. |
-| `data/traits/index.json` | Sorgente autorevole per tier, slot, sinergie, requisiti ambientali e metadati PI. | Duplicato in `docs/evo-tactics-pack/trait-reference.json` (web) e `packs/evo_tactics_pack/docs/catalog/trait_reference.json` (bundle pack); **tutte le copie vanno aggiornate insieme**. |
-| `data/traits/index.csv` | Indice rapido dei file trait con label, categoria/tipo, percorso, flag di completezza e nuovi campi `data_origin`, `biome_tags`, `usage_tags`, `has_biome`, `has_species_link`. | Generato da `node scripts/build_trait_index.js` per facilitare audit e inventari. |
-| `packs/evo_tactics_pack/docs/catalog/env_traits.json` | Mappa le condizioni ambientali (biomi, hazard, ecc.) ai tratti disponibili. | Necessario per report di coverage. |
-| `logs/trait_audit.md` | Output dell'audit di coerenza; deve essere privo di warning prima di aprire una PR. | Generato da `scripts/trait_audit.py`. |
-| `data/derived/analysis/trait_baseline.yaml` & `data/derived/analysis/trait_coverage_report.json` | Baseline e report di coverage aggiornati dagli script ETL. | Utili per verificare la copertura sui nove assi. |
-| `data/traits/_drafts/*.json` | Bozze generate automaticamente da fonti esterne. | Popolate da `python tools/py/import_external_traits.py`; contengono `completion_flags.external_source = true`. |
+| Percorso                                                                                         | Contenuto                                                                                                                                                                       | Note                                                                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data/core/traits/glossary.json`                                                                 | Glossario condiviso con label ufficiali, descrizioni sintetiche e collegamento al reference principale.                                                                         | Usato da strumenti ETL e validazione.                                                                                                                                                    |
+| `data/traits/index.json`                                                                         | Sorgente autorevole per tier, slot, sinergie, requisiti ambientali e metadati PI.                                                                                               | Duplicato in `docs/evo-tactics-pack/trait-reference.json` (web) e `packs/evo_tactics_pack/docs/catalog/trait_reference.json` (bundle pack); **tutte le copie vanno aggiornate insieme**. |
+| `data/traits/index.csv`                                                                          | Indice rapido dei file trait con label, categoria/tipo, percorso, flag di completezza e nuovi campi `data_origin`, `biome_tags`, `usage_tags`, `has_biome`, `has_species_link`. | Generato da `node scripts/build_trait_index.js` per facilitare audit e inventari.                                                                                                        |
+| `packs/evo_tactics_pack/docs/catalog/env_traits.json`                                            | Mappa le condizioni ambientali (biomi, hazard, ecc.) ai tratti disponibili.                                                                                                     | Necessario per report di coverage.                                                                                                                                                       |
+| `logs/trait_audit.md`                                                                            | Output dell'audit di coerenza; deve essere privo di warning prima di aprire una PR.                                                                                             | Generato da `scripts/trait_audit.py`.                                                                                                                                                    |
+| `data/derived/analysis/trait_baseline.yaml` & `data/derived/analysis/trait_coverage_report.json` | Baseline e report di coverage aggiornati dagli script ETL.                                                                                                                      | Utili per verificare la copertura sui nove assi.                                                                                                                                         |
+| `data/traits/_drafts/*.json`                                                                     | Bozze generate automaticamente da fonti esterne.                                                                                                                                | Popolate da `python tools/py/import_external_traits.py`; contengono `completion_flags.external_source = true`.                                                                           |
 
 ## Vincoli sui campi trait
 
@@ -32,18 +32,18 @@ Questa guida riassume dove risiedono i dati dei tratti e quali script utilizzare
 Per monitorare gli asset consegnati nei canvas e nei drop YAML è disponibile lo script `tools/py/import_external_traits.py`. Il parser utilizza:
 
 - **Appendici** (`appendici/*.txt`): front matter YAML per metadati e bullet `- **<sezione Tier N>**: ...` per estrarre i nomi dei tratti.
-- **Manifest sensienti** (`incoming/sensienti_traits_v0.1.yaml`): loader YAML (con normalizzazione della sezione `notes`) che converte i blocchi `tiers.*.grants_traits` in trait ID e descrizioni associate.
+- **Manifest sentience** (`incoming/sentience_traits_v1.0.yaml`): loader YAML definitivo con milestone sensoriali/motorie T1…T6 e hook interocettivi da cui derivare descrizioni e gating ufficiali.
 
 Esecuzione standard:
 
 ```bash
 python tools/py/import_external_traits.py \
   --appendix-dir appendici \
-  --incoming incoming/sensienti_traits_v0.1.yaml \
+  --incoming incoming/sentience_traits_v1.0.yaml \
   --output-dir data/traits/_drafts
 ```
 
-Il comando sovrascrive la directory di destinazione generando bozze conformi allo schema trait, già etichettate con `data_origin` e `completion_flags.external_source = true`. Gli identificatori `data_origin` vengono normalizzati in slug (`^[a-z0-9_]+$`), ad esempio `incoming_sensienti_traits_v0_1_t3_emergente`, così da rispettare il vincolo imposto dallo schema. Le bozze vanno poi integrate manualmente nel catalogo principale o scartate dopo la revisione.
+Il comando sovrascrive la directory di destinazione generando bozze conformi allo schema trait, già etichettate con `data_origin` e `completion_flags.external_source = true`. Gli identificatori `data_origin` vengono normalizzati in slug (`^[a-z0-9_]+$`), ad esempio `incoming_sentience_traits_v1_0_t3_emergente`, così da rispettare il vincolo imposto dallo schema. Le bozze vanno poi integrate manualmente nel catalogo principale o scartate dopo la revisione.
 
 Per includere il controllo nel workflow di audit è possibile avviare:
 

--- a/docs/public/sentience_sdk.md
+++ b/docs/public/sentience_sdk.md
@@ -1,0 +1,27 @@
+# Sentience Tier Reference (SDK)
+
+Questo documento riepiloga i codici definitivi dei tier di Sensienza da
+utilizzare nelle integrazioni API/SDK.
+
+| Codice | Label | Milestone gating | Note |
+| --- | --- | --- | --- |
+| `T1` | Proto‑Sentiente | Senses (core) | Uso base sensoriale; nessun linguaggio strutturato. |
+| `T2` | Pre‑Sociale | Senses mid; AB 01 Endurance | Bande opportunistiche, prime call vocali. |
+| `T3` | Emergente | Senses mid+; AB 02–03 movement/carry | Grooming rituale, attenzione condivisa. |
+| `T4` | Civico | Sound Awareness/Chemotopy full; AB 05–09 climb/carry | Ruoli sociali e strumenti lavorati. |
+| `T5` | Avanzato | Memorie echoic/iconic multiple; AB 11 pain | Istituzioni, archivi, linguaggio semantico. |
+| `T6` | Sapiente | Senses 37/37; Ambulation 26/26 | Città, diritto & scienza, linguaggio scritto. |
+
+## Interoception Hooks
+
+| ID | Label | Effetti |
+| --- | --- | --- |
+| `proprioception` | Propriocezione | `+1` step equilibrio/posizione; `-1` stack fatica sprint |
+| `vestibular` | Equilibrio (Vestibolare) | Vantaggio contro cadute; penalità carico `-1` tier |
+| `nociception` | Nocicezione | `quando Ferito: ritardi -1`; trigger difensivi reattivi |
+| `thermoception` | Termocezione | Clock caldo/freddo; resistenze gear/ambiente |
+
+### Integrazione
+- Endpoint `POST /traits/import` accetta i nuovi slug `incoming_sentience_traits_v1_0_t*`.
+- I client che consumano `GET /sentience/tiers` devono aggiornare la cache entro
+  24h dal rollout per evitare mismatch con i salvataggi migrati.

--- a/incoming/incoming_inventory.json
+++ b/incoming/incoming_inventory.json
@@ -762,10 +762,10 @@
     "stato": "File generico"
   },
   {
-    "percorso": "sensienti_traits_v0.1.yaml",
+    "percorso": "sentience_traits_v1.0.yaml",
     "tipo": "file",
-    "dettagli": "3.8 KiB; .1.yaml",
-    "stato": "Documento testo"
+    "dettagli": "3.3 KiB; .yaml",
+    "stato": "Manifest finale tier & interoception"
   },
   {
     "percorso": "species_index.html",

--- a/incoming/sentience_traits_v1.0.yaml
+++ b/incoming/sentience_traits_v1.0.yaml
@@ -1,0 +1,99 @@
+version: 1.0
+namespace: EvoTactics.Sentience
+summary: >-
+  Scala definitiva dei tier di Sensienza (T1…T6) con milestone sensoriali e motorie
+  validate dal pack `ancestors/rfc-sentience-v0.1`. Include anche gli hook
+  interocettivi canonici da integrare nel catalogo dei trait.
+tiers:
+  - id: T1
+    label: Proto‑Sentiente
+    flags:
+      - social:minimal
+      - tools:incidental
+      - language:none
+    descriptors:
+      - reattivo
+      - solitario/bande lasche
+    milestones:
+      - Senses (core)
+  - id: T2
+    label: Pre‑Sociale
+    flags:
+      - social:band
+      - tools:opportunistic
+      - language:calls
+    descriptors:
+      - mimicry
+      - segnali territoriali
+    milestones:
+      - Senses mid
+      - AB 01 Endurance
+  - id: T3
+    label: Emergente
+    flags:
+      - social:structured
+      - tools:deliberate
+      - language:proto-lexical
+    descriptors:
+      - grooming rituale
+      - attenzione condivisa
+    milestones:
+      - Senses mid+
+      - AB 02–03 movement/carry
+  - id: T4
+    label: Civico
+    flags:
+      - social:roles
+      - tools:crafted
+      - language:lexical
+    descriptors:
+      - divisione del lavoro
+      - proto‑legge
+    milestones:
+      - Sound Awareness/Chemotopy full
+      - AB 05–09 climb/carry
+  - id: T5
+    label: Avanzato
+    flags:
+      - social:institutions
+      - tools:complex
+      - language:semantic
+    descriptors:
+      - simbolismo
+      - archivi
+    milestones:
+      - Memorie echoic/iconic multiple
+      - AB 11 pain
+  - id: T6
+    label: Sapiente
+    flags:
+      - social:state
+      - tools:industrial
+      - language:written
+    descriptors:
+      - città
+      - diritto & scienza
+    milestones:
+      - Senses 37/37
+      - Ambulation 26/26
+interoception_traits:
+  - id: proprioception
+    label: Propriocezione
+    hooks:
+      - +1 step equilibrio/posizione
+      - -1 stack fatica sprint
+  - id: vestibular
+    label: Equilibrio (Vestibolare)
+    hooks:
+      - vantaggio vs cadute
+      - penalità carico -1 tier
+  - id: nociception
+    label: Nocicezione
+    hooks:
+      - 'quando Ferito: ritardi -1'
+      - trigger difensivi reattivi
+  - id: thermoception
+    label: Termocezione
+    hooks:
+      - clock caldo/freddo
+      - resistenze gear/ambiente

--- a/locales/it/traits.json
+++ b/locales/it/traits.json
@@ -210,8 +210,8 @@
       "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Balance Reflex",
       "mutazione_indotta": "Riduce penalità in piedi; sinergia con WA 03, WA 05.",
-      "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
-      "uso_funzione": "Tier Pre‑Sociale (T2). Richiede neuroni: WA 02, DE 01, DO 01"
+      "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+      "uso_funzione": "Tier Pre‑Sociale (T2). Milestone: Senses mid; AB 01 Endurance."
     },
     "barbigli_sensori_plasma": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
@@ -641,8 +641,8 @@
       "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Craft Loop",
       "mutazione_indotta": "Riduce di 1 i colpi richiesti con strumenti; si cumula con BB AL 01.",
-      "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
-      "uso_funzione": "Tier Culturale (T5). Richiede neuroni: NE 01, IN 02, AL 07"
+      "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+      "uso_funzione": "Tier Avanzato (T5). Milestone: Memorie echoic/iconic multiple; AB 11 pain."
     },
     "criostasi": {
       "fattore_mantenimento_energetico": "Da definire (import esterno)",
@@ -751,8 +751,8 @@
       "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Echoic Trace",
       "mutazione_indotta": "Memorizza 1 target uditivo addizionale (sinergia BB SS 01).",
-      "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
-      "uso_funzione": "Tier Senziente Emergente (T3). Richiede neuroni: WA 03, DE 05, SS 04, SO 06"
+      "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+      "uso_funzione": "Tier Emergente (T3). Milestone: Senses mid+; AB 02–03 movement/carry."
     },
     "eco_interno_riflesso": {
       "debolezza": "Estremamente disorientato da suoni o vibrazioni esterne forti e continue.",
@@ -830,8 +830,8 @@
       "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Executive Loop",
       "mutazione_indotta": "Concatena 1 azione gratuita di 'focus' o 'memorizza' tra due compiti.",
-      "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
-      "uso_funzione": "Tier Proto‑Umano (T6). Richiede neuroni: WA 05, WH 06, Intelligence_Core"
+      "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+      "uso_funzione": "Tier Sapiente (T6). Milestone: Senses 37/37; Ambulation 26/26."
     },
     "filamenti_digestivi_compattanti": {
       "debolezza": "Blocco intestinale se la dieta è priva di materiale 'legante'.",
@@ -1061,8 +1061,8 @@
       "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Group Form",
       "mutazione_indotta": "Bonus posizionale con 2+ alleati adiacenti.",
-      "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
-      "uso_funzione": "Tier Sociale (T4). Richiede neuroni: CM 06, DO 07, CO 1"
+      "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+      "uso_funzione": "Tier Civico (T4). Milestone: Sound Awareness/Chemotopy full; AB 05–09 climb/carry."
     },
     "gusci_criovetro": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
@@ -1084,8 +1084,8 @@
       "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Interoception Seed",
       "mutazione_indotta": "+1 ai tiri di Consapevolezza Corporea; segnali anticipati di fame/sete.",
-      "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
-      "uso_funzione": "Tier Proto‑Senziente (T1). Richiede neuroni: SO 01, SS 01, MS 01"
+      "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+      "uso_funzione": "Tier Proto‑Sentiente (T1). Milestone: Senses (core)."
     },
     "lamelle_shear": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
@@ -1235,8 +1235,8 @@
       "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Mimicry Basic",
       "mutazione_indotta": "Il clan imita switch/alterazioni semplici (pieno con CM 06).",
-      "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
-      "uso_funzione": "Tier Pre‑Sociale (T2). Richiede neuroni: WA 02, DE 01, DO 01"
+      "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+      "uso_funzione": "Tier Pre‑Sociale (T2). Milestone: Senses mid; AB 01 Endurance."
     },
     "mucillagine_simbionte_mangrovie": {
       "debolezza": "Acque eccessivamente pure diluiscono la mucillagine riducendo la protezione.",
@@ -1330,8 +1330,8 @@
       "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Postural Endurance",
       "mutazione_indotta": "Riduce consumo energia in piedi/corsa.",
-      "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
-      "uso_funzione": "Tier Proto‑Umano (T6). Richiede neuroni: WA 05, WH 06, Intelligence_Core"
+      "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+      "uso_funzione": "Tier Sapiente (T6). Milestone: Senses 37/37; Ambulation 26/26."
     },
     "random": {
       "debolezza": "Bassa affidabilità: richiede slot aggiuntivi per mitigare risultati sfavorevoli.",
@@ -1430,8 +1430,8 @@
       "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Sheltering",
       "mutazione_indotta": "Riduce stress in pericolo vicino a costruzioni.",
-      "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
-      "uso_funzione": "Tier Culturale (T5). Richiede neuroni: NE 01, IN 02, AL 07"
+      "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+      "uso_funzione": "Tier Avanzato (T5). Milestone: Memorie echoic/iconic multiple; AB 11 pain."
     },
     "sinapsi_coraline_polifoniche": {
       "debolezza": "Vibrazioni sintonizzate male possono generare feedback dolorosi e perdita di coscienza.",
@@ -1469,8 +1469,8 @@
       "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Startle Reflex",
       "mutazione_indotta": "Reazioni di fuga più rapide (sinergia con MS 02 se presente).",
-      "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
-      "uso_funzione": "Tier Proto‑Senziente (T1). Richiede neuroni: SO 01, SS 01, MS 01"
+      "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+      "uso_funzione": "Tier Proto‑Sentiente (T1). Milestone: Senses (core)."
     },
     "struttura_elastica_amorfa": {
       "debolezza": "Vulnerabilità a danni da taglio o perforazione (difficile cauterizzazione).",
@@ -1506,15 +1506,15 @@
       "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Teach Action",
       "mutazione_indotta": "Insegna 1 azione pratica al clan (switch/alter/transport).",
-      "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
-      "uso_funzione": "Tier Sociale (T4). Richiede neuroni: CM 06, DO 07, CO 1"
+      "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+      "uso_funzione": "Tier Civico (T4). Milestone: Sound Awareness/Chemotopy full; AB 05–09 climb/carry."
     },
     "toolseed": {
       "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Toolseed",
       "mutazione_indotta": "Progetti Rozzi: +5% successo alterazioni; si cumula con AL 01–03.",
-      "spinta_selettiva": "Origine esterna: EvoTactics.Sensienti. Validare allineamento con catalogo principale.",
-      "uso_funzione": "Tier Senziente Emergente (T3). Richiede neuroni: WA 03, DE 05, SS 04, SO 06"
+      "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+      "uso_funzione": "Tier Emergente (T3). Milestone: Senses mid+; AB 02–03 movement/carry."
     },
     "vello_condensatore_nebbie": {
       "debolezza": "In ambienti aridi accumula detriti che riducono la capacità di condensa.",

--- a/reports/data_inventory.md
+++ b/reports/data_inventory.md
@@ -134,7 +134,7 @@ I ruoli di responsabilità fanno riferimento alla pipeline agentica documentata 
 | incoming/personality_module.v1.json | 24.16 KB | 2025-10-29T18:47:07 | AG-Personality | N/D (grezzo) |
 | incoming/recon_meccaniche.json | 1.82 KB | 2025-10-29T18:47:07 | AG-Validation | N/D (grezzo) |
 | incoming/scan_engine_idents.py | 2.97 KB | 2025-10-29T18:47:07 | AG-Toolsmith | N/D (grezzo) |
-| incoming/sensienti_traits_v0.1.yaml | 3.77 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
+| incoming/sentience_traits_v1.0.yaml | 3.32 KB | 2025-10-29T18:47:07 | AG-Biome | Manifest finale |
 | incoming/species_index.html | 3.52 KB | 2025-10-29T18:47:07 | AG-Biome | N/D (grezzo) |
 
 ### Duplicati segnalati dallo script

--- a/reports/incoming/incoming_status_2025-10-30.csv
+++ b/reports/incoming/incoming_status_2025-10-30.csv
@@ -83,5 +83,5 @@ README_INTEGRAZIONE_MECCANICHE.md,.md,,Informativo,Note su integrazione meccanic
 README_SCAN_STAT_EVENTI.md,.md,,Da integrare,Procedura per scanner STAT/EVENTI; prossimo passo eseguire script e aggiornare compat_map.,Team Engine/Game
 recon_meccaniche.json,.json,,Informativo,Ricognizione asset esterni (GitHub/GDrive); segnala dipendenze extra-team.,"Team Esterni (Item-generator, GDrive)"
 scan_engine_idents.py,.py,,Pronto,Script operativo per individuare STAT/EVENTI nel codice.,
-sensienti_traits_v0.1.yaml,.yaml,,Bozza,Tier sensienti con placeholder codici neuroni; necessita verifica mapping.,Team Ancestors (codici neuroni)
+sentience_traits_v1.0.yaml,.yaml,,Pronto,Manifest finale sentience (tier e hook interocettivi) validato dal pack RFC.,Team Ancestors (codici neuroni)
 species_index.html,.html,,Bloccato,UI indice specie richiede file catalog_data.json non presente.,Esport catalog_data.json

--- a/reports/incoming/inventory-2025-10-30.md
+++ b/reports/incoming/inventory-2025-10-30.md
@@ -129,5 +129,5 @@
 | `personality_module.v1.json` | file | 24.2 KiB; .v1.json | Documento testo |
 | `recon_meccaniche.json` | file | 1.8 KiB; .json | Documento testo |
 | `scan_engine_idents.py` | file | 3.0 KiB; .py | File generico |
-| `sensienti_traits_v0.1.yaml` | file | 3.8 KiB; .1.yaml | Documento testo |
+| `sentience_traits_v1.0.yaml` | file | 3.3 KiB; .yaml | Manifest finale tier & interoception |
 | `species_index.html` | file | 3.5 KiB; .html | Documento testo |

--- a/tools/migrations/traits_styleguide_migration.py
+++ b/tools/migrations/traits_styleguide_migration.py
@@ -1,0 +1,145 @@
+"""Utilities to migrate trait data to the final sentience naming conventions.
+
+The helper rewrites the legacy ``incoming_sensienti_*`` identifiers used in
+`data/traits/_drafts` and refreshes the Italian locale entries so they reference
+Proto‑Sentiente → Sapiente with the new milestone wording.
+
+Run in dry-run mode (default) to inspect the changes; pass ``--apply`` to write
+updates back to disk::
+
+    python tools/migrations/traits_styleguide_migration.py \
+      --traits-dir data/traits/_drafts \
+      --locale-file locales/it/traits.json \
+      --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+LEGACY_ORIGINS = {
+    "incoming_sensienti_traits_v0_1_t1_protosentiente": "incoming_sentience_traits_v1_0_t1_proto_sentiente",
+    "incoming_sensienti_traits_v0_1_t2_presociale": "incoming_sentience_traits_v1_0_t2_pre_sociale",
+    "incoming_sensienti_traits_v0_1_t3_emergente": "incoming_sentience_traits_v1_0_t3_emergente",
+    "incoming_sensienti_traits_v0_1_t4_sociale": "incoming_sentience_traits_v1_0_t4_civico",
+    "incoming_sensienti_traits_v0_1_t5_culturale": "incoming_sentience_traits_v1_0_t5_avanzato",
+    "incoming_sensienti_traits_v0_1_t6_proto_umano": "incoming_sentience_traits_v1_0_t6_sapiente",
+}
+
+USAGE_STRINGS = {
+    "interoception_seed": "Tier Proto‑Sentiente (T1). Milestone: Senses (core).",
+    "startle_reflex": "Tier Proto‑Sentiente (T1). Milestone: Senses (core).",
+    "balance_reflex": "Tier Pre‑Sociale (T2). Milestone: Senses mid; AB 01 Endurance.",
+    "mimicry_basic": "Tier Pre‑Sociale (T2). Milestone: Senses mid; AB 01 Endurance.",
+    "toolseed": "Tier Emergente (T3). Milestone: Senses mid+; AB 02–03 movement/carry.",
+    "echoic_trace": "Tier Emergente (T3). Milestone: Senses mid+; AB 02–03 movement/carry.",
+    "group_form": "Tier Civico (T4). Milestone: Sound Awareness/Chemotopy full; AB 05–09 climb/carry.",
+    "teach_action": "Tier Civico (T4). Milestone: Sound Awareness/Chemotopy full; AB 05–09 climb/carry.",
+    "craft_loop": "Tier Avanzato (T5). Milestone: Memorie echoic/iconic multiple; AB 11 pain.",
+    "sheltering": "Tier Avanzato (T5). Milestone: Memorie echoic/iconic multiple; AB 11 pain.",
+    "postural_endurance": "Tier Sapiente (T6). Milestone: Senses 37/37; Ambulation 26/26.",
+    "executive_loop": "Tier Sapiente (T6). Milestone: Senses 37/37; Ambulation 26/26.",
+}
+
+SPINTA_TEMPLATE = (
+    "Origine esterna: EvoTactics.Sentience. "
+    "Validare allineamento con catalogo principale."
+)
+
+
+def iter_trait_files(directory: Path) -> Iterable[Path]:
+    yield from sorted(directory.glob("*.json"))
+
+
+def migrate_trait_file(path: Path, apply: bool) -> Tuple[bool, Dict[str, str]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    original_origin = payload.get("data_origin")
+    updated = False
+    notes: Dict[str, str] = {}
+
+    if isinstance(original_origin, str) and original_origin in LEGACY_ORIGINS:
+        payload["data_origin"] = LEGACY_ORIGINS[original_origin]
+        notes["data_origin"] = f"{original_origin} → {payload['data_origin']}"
+        updated = True
+
+    trait_id = payload.get("id")
+    if isinstance(trait_id, str) and trait_id in USAGE_STRINGS:
+        current_usage = payload.get("uso_funzione")
+        desired_usage = USAGE_STRINGS[trait_id]
+        if current_usage != desired_usage:
+            payload["uso_funzione"] = desired_usage
+            notes["uso_funzione"] = "updated milestone wording"
+            updated = True
+        current_spinta = payload.get("spinta_selettiva")
+        if current_spinta != SPINTA_TEMPLATE:
+            payload["spinta_selettiva"] = SPINTA_TEMPLATE
+            notes["spinta_selettiva"] = "normalized namespace"
+            updated = True
+
+    if updated and apply:
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return updated, notes
+
+
+def migrate_locale_file(path: Path, apply: bool) -> Tuple[bool, List[str]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    entries = payload.get("entries")
+    if not isinstance(entries, dict):
+        return False, []
+
+    changed = False
+    messages: List[str] = []
+    for trait_id, usage in USAGE_STRINGS.items():
+        entry = entries.get(trait_id)
+        if not isinstance(entry, dict):
+            continue
+        old_usage = entry.get("uso_funzione")
+        if old_usage != usage:
+            entry["uso_funzione"] = usage
+            messages.append(f"{trait_id}: uso_funzione")
+            changed = True
+        old_spinta = entry.get("spinta_selettiva")
+        if old_spinta != SPINTA_TEMPLATE:
+            entry["spinta_selettiva"] = SPINTA_TEMPLATE
+            messages.append(f"{trait_id}: spinta_selettiva")
+            changed = True
+
+    if changed and apply:
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return changed, messages
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--traits-dir", type=Path, default=Path("data/traits/_drafts"))
+    parser.add_argument("--locale-file", type=Path, default=Path("locales/it/traits.json"))
+    parser.add_argument("--apply", action="store_true", help="Scrive le modifiche sui file invece di stampare soltanto")
+    args = parser.parse_args()
+
+    total_updates = 0
+    for trait_path in iter_trait_files(args.traits_dir):
+        updated, notes = migrate_trait_file(trait_path, args.apply)
+        if updated:
+            total_updates += 1
+            note_str = ", ".join(f"{key}: {value}" for key, value in notes.items())
+            print(f"[traits] {trait_path}: {note_str}")
+
+    locale_updated, locale_notes = migrate_locale_file(args.locale_file, args.apply)
+    if locale_updated:
+        total_updates += 1
+        joined = ", ".join(locale_notes)
+        print(f"[locale] {args.locale_file}: {joined}")
+
+    if total_updates == 0:
+        print("Nessuna modifica necessaria – i file sono già allineati.")
+    elif not args.apply:
+        print("Eseguire con --apply per scrivere le modifiche sopra elencate.")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/tools/py/import_external_traits.py
+++ b/tools/py/import_external_traits.py
@@ -2,7 +2,7 @@
 """Generate draft trait files from external appendices and YAML drops.
 
 The importer converts the curated notes stored in ``appendici/*.txt`` and the
-incoming ``sensienti_traits_v0.1.yaml`` manifest into JSON stubs located in
+incoming ``sentience_traits_v1.0.yaml`` manifest into JSON stubs located in
 ``data/traits/_drafts``. Each stub follows the canonical trait schema so the
 team can iterate on the content without breaking validation tooling.
 
@@ -10,7 +10,7 @@ Usage example::
 
     python tools/py/import_external_traits.py \
         --appendix-dir appendici \
-        --incoming incoming/sensienti_traits_v0.1.yaml \
+        --incoming incoming/sentience_traits_v1.0.yaml \
         --output-dir data/traits/_drafts
 
 Re-running the command wipes previously generated files inside the target
@@ -31,7 +31,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_APPENDIX_DIR = REPO_ROOT / "appendici"
-DEFAULT_INCOMING_PATH = REPO_ROOT / "incoming" / "sensienti_traits_v0.1.yaml"
+DEFAULT_INCOMING_PATH = REPO_ROOT / "incoming" / "sentience_traits_v1.0.yaml"
 DEFAULT_OUTPUT_DIR = REPO_ROOT / "data" / "traits" / "_drafts"
 TRAIT_INDEX_PATH = REPO_ROOT / "data" / "traits" / "index.json"
 
@@ -222,6 +222,11 @@ def iter_yaml_seeds(path: Path) -> Iterable[TraitSeed]:
             requires_list = [str(item).strip() for item in requires if str(item).strip()]
         else:
             requires_list = []
+        milestones = tier_data.get("milestones") or []
+        if isinstance(milestones, list):
+            milestone_list = [str(item).strip() for item in milestones if str(item).strip()]
+        else:
+            milestone_list = []
         grants = tier_data.get("grants_traits") or []
         if not isinstance(grants, list):
             continue
@@ -238,9 +243,11 @@ def iter_yaml_seeds(path: Path) -> Iterable[TraitSeed]:
             description = trait_desc_str or (
                 f"Import da {namespace} ({label_info})."
             )
-            usage_parts = [
-                f"Tier {label_info} ({tier}).",
-            ]
+            usage_parts = [f"Tier {label_info} ({tier})."]
+            if milestone_list:
+                usage_parts.append(
+                    "Milestone: " + "; ".join(milestone_list)
+                )
             if requires_list:
                 usage_parts.append(
                     "Richiede neuroni: " + ", ".join(requires_list)


### PR DESCRIPTION
## Summary
- replace legacy sensienti manifest references with the final `incoming/sentience_traits_v1.0.yaml` and extend the importer/migration tooling
- refresh draft trait data, locales, and analytics guidance to use the Proto‑Sentiente→Sapiente milestones
- add rollout/communication plans and an SDK appendix for the sentience tiers

## Testing
- python tools/migrations/traits_styleguide_migration.py

------
https://chatgpt.com/codex/tasks/task_e_69073ca9d0b88332aed61477660a1a54