### PR TITLE
Add orchestrator load testing and expose Prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Starter repository per il progetto tattico co-op con sistema d20 e progressione evolutiva modulare. Il pacchetto include dati YAML, CLI in Python/TypeScript, backend Idea Engine, webapp di test e pipeline di pubblicazione per condividere rapidamente build, report e materiali di presentazione.
 
 ## Indice
+
 - [Panoramica](#panoramica)
 - [Tour del repository](#tour-del-repository)
 - [Setup rapido](#setup-rapido)
@@ -21,11 +22,13 @@ Starter repository per il progetto tattico co-op con sistema d20 e progressione 
 - [Licenza](#licenza)
 
 ## Panoramica
+
 - **Gioco**: tattico co-op con evoluzione a stadi, combinazioni MBTI/Enneagramma, biomi reattivi e mutazioni modulari.
 - **Starter kit**: dati YAML verificati, strumenti CLI per validare/generare contenuti, workflow CI preconfigurati e materiale di presentazione condivisibile.
 - **Obiettivo**: permettere bootstrap rapido di nuove istanze (locale o cloud) mantenendo consistenza tra dataset, orchestratore e deliverable di comunicazione.
 
 ## Settori e dipendenze
+
 - **Flow (generazione & validazione)** – vive principalmente in `services/generation/`, `tools/py`, `tools/ts` e nei dataset `data/core/`.
   Orchestratore Python, CLI e validator TypeScript condividono gli stessi schema YAML; le pipeline front/back usano il registry condiviso in `webapp/src/config/dataSources.ts`.
 - **Atlas (telemetria & dashboard)** – la webapp (`webapp/`) e le dashboard statiche in `docs/test-interface/` leggono gli snapshot `data/derived/` e i mock `webapp/public/data/`.
@@ -38,6 +41,7 @@ Starter repository per il progetto tattico co-op con sistema d20 e progressione 
 > Quando modifichi un settore, verifica le dipendenze a valle: ad esempio una variazione nei dataset implica rigenerare la webapp (`npm run webapp:deploy`), aggiornare i report (`reports/`) e rieseguire i test backend (`npm run test:api`).
 
 ## Tour del repository
+
 ```
 evo-tactics/
 ├─ data/                      # Dataset YAML (specie, biomi, telemetria, derived report)
@@ -55,6 +59,7 @@ evo-tactics/
 ```
 
 ## Setup rapido
+
 1. **Clona il repository** e posizionati nella root.
 2. **Dipendenze Node (root + tools/ts + webapp)**:
    ```bash
@@ -75,7 +80,9 @@ evo-tactics/
    ```
 
 ## CLI & strumenti
+
 ### Strumenti Python (`tools/py`)
+
 - Entry point unificato:
   ```bash
   cd tools/py
@@ -89,6 +96,7 @@ evo-tactics/
 - Wrapper legacy ancora disponibili (`roll_pack.py`, `generate_encounter.py`) reindirizzano al parser condiviso.
 
 #### Quick start — Python
+
 ```bash
 cd tools/py
 # CLI unificata con seed riproducibile e path opzionali
@@ -105,11 +113,13 @@ python3 generate_encounter.py savana
 ```
 
 #### Tutorial rapido · CLI Evo Tactics
+
 - Segui il [tutorial dedicato](docs/tutorials/cli-quickstart.md) per completare setup, validazione e roll demo.
 - ![CLI quickstart](assets/tutorials/cli-quickstart.svg)
 - Condividi anomalie o log significativi nel canale Slack `#feedback-enhancements`.
 
 ### Strumenti TypeScript (`tools/ts`)
+
 - Build e roll pack demo:
   ```bash
   cd tools/ts
@@ -126,6 +136,7 @@ python3 generate_encounter.py savana
 - Script di supporto: `scripts/run_lighthouse.mjs`, `scripts/ensure_chromium.mjs`, `scripts/postbuild.mjs`.
 
 #### Quick start — Node/TypeScript
+
 ```bash
 cd tools/ts
 npm install
@@ -139,6 +150,7 @@ node dist/roll_pack.js ENTP invoker --seed demo
 ```
 
 ## Backend Idea Engine
+
 - **Avvio API**: `npm run start:api` espone l'app Express su `http://0.0.0.0:3333` (porta configurabile con `PORT`). Il database NeDB di default vive in `data/idea_engine.db` (sovrascrivibile con `IDEA_ENGINE_DB`).
 - **Endpoint principali**:
   - `GET /api/health` – stato runtime.
@@ -152,8 +164,12 @@ node dist/roll_pack.js ENTP invoker --seed demo
   - `GET /api/v1/qa/status` (`/api/qa/status` legacy) – report QA corrente.
   - `GET /api/ideas/:id/report` – produce report Codex in HTML/JSON usando `server/report.js`.
 - **Orchestrazione**: la pipeline combina normalizzazione slug, fallback automatici per trait non validi e log strutturati (vedi `services/generation/*`).
+- **Bridge orchestrator**: il file di configurazione `config/orchestrator.json` controlla il pool Python usato dal bridge Node.
+  - `poolSize` definisce quanti worker paralleli avviare (default 2) e può essere aumentato quando si simulano carichi più elevati.
+  - `requestTimeoutMs` imposta la finestra massima (in millisecondi) per completare una generazione prima di forzare il retry/crash del worker.
 
 ### Flusso snapshot/telemetria demo (CLI → backend → webapp)
+
 1. **Generazione CLI** – esegui `npm run mock:generate` per ricreare lo snapshot Flow e il bundle Nebula demo. Lo script legge i dataset sorgente (`data/flow-shell/atlas-snapshot.json` + telemetria QA), valida payload e specie contro `packages/contracts` tramite AJV e scrive i JSON rigenerati in `webapp/public/data/flow/snapshots/` e `webapp/public/data/nebula/`.
 2. **Backend** – all'avvio Express registra gli stessi schemi (`generationSnapshot`, `species`, `telemetry`) e verifica ogni risposta sia live sia mock. Gli endpoint `/api/mock/*` servono direttamente i file generati dalla CLI garantendo coerenza con gli schemi condivisi.
 3. **Webapp** – la configurazione `webapp/src/config/dataSources.ts` punta alle nuove sorgenti fallback (`data/flow/...` e `data/nebula/...`). Dopo aver rigenerato i mock basta rilanciare la webapp per visualizzare gli aggiornamenti senza ulteriori passaggi manuali.
@@ -161,6 +177,7 @@ node dist/roll_pack.js ENTP invoker --seed demo
 > **Rigenera i mock** ogni volta che modifichi i dataset Flow/Nebula o i contratti: `npm run mock:generate` aggiorna snapshot e telemetria demo e fallisce immediatamente se lo schema non è rispettato.
 
 ### Pipeline generazione orchestrata
+
 - **Endpoint backend** – `POST /api/v1/generation/species` (alias legacy `/api/generation/species`) instrada le richieste
   dell'UI verso l'orchestratore Python (`services/generation/orchestrator.py`),
   normalizzando gli input (`trait_ids`, `seed`, `biome_id`).
@@ -178,11 +195,13 @@ node dist/roll_pack.js ENTP invoker --seed demo
   immediatamente alert e summary coerenti.
 
 ### Tutorial rapido · Feedback Idea Engine
+
 - Abilita il backend seguendo il [tutorial passo-passo](docs/tutorials/idea-engine-feedback.md).
 - ![Idea Engine feedback](assets/tutorials/idea-engine-feedback.svg)
 - Dopo ogni invio, annota follow-up o richieste extra in `#feedback-enhancements` (modulo Slack ora attivo di default).
 
 ## Dashboard web & showcase
+
 - **Dashboard test interface** (`docs/test-interface/`): carica YAML da `data/`, consente smoke test dei dataset e fetch manuali. Avvia un server statico locale con `python3 -m http.server 8000` e visita `http://localhost:8000/docs/test-interface/`.
 - **Deploy continuo**: il workflow GitHub Actions `deploy-test-interface` pubblica la dashboard su GitHub Pages. Imposta una sola volta Pages (`Settings → Pages → GitHub Actions`).
 - **Showcase pubblico**:
@@ -194,6 +213,7 @@ node dist/roll_pack.js ENTP invoker --seed demo
 - **Analytics SquadSync adaptive** — La pagina `/analytics/squadsync/` mette in evidenza le risposte adaptive e i picchi Delta provenienti dall'HUD; usa il mock aggiornato (`assets/analytics/squadsync_mock.svg`) e la dashboard canary (`tools/feedback/hud_canary_dashboard.yaml`) per condividere rapidamente KPI e follow-up.【F:public/analytics/squadsync/index.tsx†L1-L320】【F:assets/analytics/squadsync_mock.svg†L1-L58】【F:tools/feedback/hud_canary_dashboard.yaml†L1-L53】
 
 ### Showcase demo · preset "Bundle demo pubblico"
+
 ![Anteprima dossier showcase](public/showcase-dossier.svg)
 
 - **Tutorial rapido · Dashboard & Showcase** — [Guida sintetica](docs/tutorials/dashboard-tour.md) per avviare Vite e raccogliere materiale.
@@ -208,6 +228,7 @@ node dist/roll_pack.js ENTP invoker --seed demo
 - **Rigenerazione rapida** — esegui `python tools/py/build_showcase_materials.py` per aggiornare HTML, Base64 del PDF e cover `SVG` in `public/` partendo dal payload curato (`docs/presentations/showcase/showcase_dossier.yaml`).
 
 ## Dataset & Ecosystem Pack
+
 - **Dataset principali** in `data/` (specie, biomi, telemetria, trait) e `data/derived/analysis/trait_coverage_report.json` per insight sulla copertura trait/specie.
 - **Pack v1.7** (`packs/evo_tactics_pack/`): struttura autosufficiente con `data/`, `docs/`, `tools/` e report in `out/validation/`. Segui il README del pack per approfondimenti.
 - **Aggiornare il pack**:
@@ -223,6 +244,7 @@ node dist/roll_pack.js ENTP invoker --seed demo
 - **Copertura trait/specie**: report aggiornati e quicklook disponibili in `docs/catalog/species_trait_matrix.json` e `docs/catalog/species_trait_quicklook.csv`.
 
 ## Storico aggiornamenti & archivio
+
 - **Release 2025-12-06 — HUD Smart Alerts & SquadSync bridge** — aggiornato il Canvas con mock HUD/SquadSync, integrata la dashboard canary (`tools/feedback/hud_canary_dashboard.yaml`) e instradati i feedback overlay su `#feedback-enhancements`. Include i nuovi tutorial rapidi overlay/adaptive e refresh del changelog centrale.【F:docs/Canvas/feature-updates.md†L23-L39】【F:tools/feedback/hud_canary_dashboard.yaml†L1-L53】【F:docs/tutorials/hud-overlay-quickstart.md†L1-L116】【F:docs/tutorials/adaptive-engine-quickstart.md†L1-L129】 Dettagli completi in [`docs/changelog.md`](docs/changelog.md#2025-12-06-hud-smart-alerts--squadsync-bridge).
 - **Release 2025-12-02 — Feedback & Tutorial boost** — integrazione changelog nel README, attivazione del modulo feedback con Slack `#feedback-enhancements` e nuovi tutorial multimediali. Dettagli completi in [`docs/changelog.md`](docs/changelog.md#2025-12-02-feedback--tutorial-boost).
 - **Suite Badlands riallineata (2025-11-16)** — i YAML aggiornati in `packs/evo_tactics_pack/data/species/badlands/` sono stati verificati con `python tools/py/report_trait_coverage.py` riportando `traits_with_species = 27/29` e nessuna regola senza specie (`rules_missing_species_total = 0`). Consulta `data/analysis/trait_coverage_report.json`, `docs/catalog/species_trait_matrix.json` e `docs/catalog/species_trait_quicklook.csv` per il dettaglio e i pairing core/opzionali.
@@ -230,19 +252,23 @@ node dist/roll_pack.js ENTP invoker --seed demo
 - **Idea Engine — modulo feedback sempre attivo** — il widget embed (`docs/public/embed.js`) ora propone il modulo feedback anche offline, reindirizzando al canale `#feedback-enhancements` quando l'API non è configurata. Per la cronologia dettagliata consulta [`docs/ideas/changelog.md`](docs/ideas/changelog.md).
 
 ## Stato operativo & tracker
+
 - **Indice tracker & stato**: usa `docs/00-INDEX.md` per checklist quotidiane, log e roadmap; la sezione viene aggiornata automaticamente da [`scripts/daily_tracker_refresh.py`](scripts/daily_tracker_refresh.py) tramite il workflow [`daily-tracker-refresh`](.github/workflows/daily-tracker-refresh.yml).
 - **Log di riferimento**: `logs/traits_tracking.md`, `logs/web_status.md` e i report in `reports/incoming/` documentano l'avanzamento tecnico delle ultime sessioni.
 
 ### Recap operativo & prossimi step
+
 - [ ] Rivedi i log in `reports/incoming/validation/` e apri ticket per eventuali regressioni.
 - [ ] Aggiorna i tracker operativi in [`docs/00-INDEX.md`](docs/00-INDEX.md#tracker-operativi-e-log) dopo ogni sessione.
 - [ ] Riesegui `./scripts/report_incoming.sh --destination sessione-YYYY-MM-DD` al termine di ogni batch di upload.
 - [ ] Condividi su Drive i materiali rigenerati (`docs/presentations/showcase/*`) una volta verificati.
 
 ### Barra di completamento
+
 <progress value="0.7" max="1"></progress> **70 %** completato — aggiornare dopo il prossimo ciclo di validazione.
 
 ## Documentazione & tracker
+
 - **Indice operativo**: `docs/00-INDEX.md` aggrega checklist quotidiane, log e roadmap.
 - **Checklist**: consultare `docs/checklist/action-items.md`, `docs/checklist/milestones.md`, `docs/checklist/project-setup-todo.md` per stato avanzamento e task prioritari.
 - **Roadmap**: `docs/piani/roadmap.md` con milestone strategiche (telemetria VC, pacchetti PI, mating/nido).
@@ -251,6 +277,7 @@ node dist/roll_pack.js ENTP invoker --seed demo
 - **Tri-Sorgente (Roll + Personalità + Azioni)** — docs introduttive: [/docs/tri-sorgente/overview.md](docs/tri-sorgente/overview.md) • QA/KPI: [/docs/tri-sorgente/qa.md](docs/tri-sorgente/qa.md)
 
 ## Automazione & workflow
+
 - **Script principali**:
   - `scripts/report_incoming.sh` – archivia i batch in `reports/incoming/` (usare `--destination sessione-YYYY-MM-DD`).
   - `scripts/daily_tracker_refresh.py` – aggiorna automaticamente le sezioni tracker del README e dei log.
@@ -262,6 +289,7 @@ node dist/roll_pack.js ENTP invoker --seed demo
   - Workflow dedicati (`validate-naming`, `incoming-smoke`, `hud`, `qa-kpi-monitor`) documentati in `docs/ci.md` e `docs/ci-pipeline.md`.
 
 ## QA & test
+
 - **Python**: esegui dalla root con `PYTHONPATH=tools/py pytest` (copre RNG deterministici, builder, validator).
 - **TypeScript**: `npm --prefix tools/ts test` (include unit test Node e Playwright UI export modal).
 - **API Node**: `npm run test:api` lancia `node --test tests/api/*.test.js`.
@@ -272,6 +300,7 @@ node dist/roll_pack.js ENTP invoker --seed demo
 - **HUD & dashboard**: test Playwright dedicati (`tools/ts/tests`, `tests/hud_alerts.spec.ts`) e `tests/validate_dashboard.py` per smoke test.
 
 ## Integrazioni esterne
+
 - **Drive**: guida in `docs/drive-sync.md`; script `scripts/driveSync.gs`, `tools/drive/*.mjs` per sincronizzazioni e stage publishing (`npm run stage:publishing`).
 - **Sincronizzazione ChatGPT**:
   - Configura le fonti in `data/external/chatgpt_sources.yaml`.
@@ -279,7 +308,9 @@ node dist/roll_pack.js ENTP invoker --seed demo
   - Verifica gli snapshot in `docs/chatgpt_changes/<namespace>/` e aggiorna `docs/chatgpt_sync_status.md` con esiti.
 
 ## Distribuzione & condivisione
+
 ### Hosting statico webapp
+
 - **Base path**: configura `VITE_BASE_PATH` (o `BASE_PATH`) prima della build quando la dashboard viene
   servita da una sottocartella. Senza override viene usato `./` così che gli asset fingerprintati
   generati da Vite (`assets/[name]-[hash].*`) funzionino anche su bucket e Pages.
@@ -291,6 +322,7 @@ node dist/roll_pack.js ENTP invoker --seed demo
   `import.meta.env.BASE_URL` prima di caricare gli asset su hosting statico.
 
 ### Pubblicazione GitHub
+
 ```bash
 cd /path/alla/cartella/evo-tactics
 git init
@@ -302,11 +334,13 @@ git push -u origin main
 ```
 
 ### Condivisione su Google Drive
+
 - Comprimi la cartella del progetto o utilizza lo script `scripts/driveSync.gs` per automatizzare l'upload.
 - Per invii manuali, mantieni sincronizzati gli artifact rigenerati (`docs/presentations/showcase/*`, report in `packs/.../out/`).
 - Consulta `docs/drive-sync.md` per setup credenziali, test e trigger automatici.
 
 ## In arrivo
+
 - **Feedback toolkit**: lancio del pacchetto `tools/feedback` con form centralizzato e workflow di triage automatizzato.
 - **Dashboard insight**: report settimanale generato da `tools/feedback/report_generator.py` e pubblicato in `reports/feedback/`.
 - **Documentazione aggiornata**: guide operative in `docs/process/feedback_collection_pipeline.md` e `docs/tutorials/feedback-form.md`.
@@ -314,4 +348,5 @@ git push -u origin main
 Condividi suggerimenti e richieste tramite il [form di feedback](docs/tutorials/feedback-form.md).
 
 ## Licenza
+
 MIT — vedi [`LICENSE`](LICENSE).

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "cors": "^2.8.5",
         "express": "^4.19.2",
         "js-yaml": "^4.1.0",
-        "nedb-promises": "^6.2.3"
+        "nedb-promises": "^6.2.3",
+        "prom-client": "^15.1.2"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.9.0",
@@ -1427,6 +1428,15 @@
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
@@ -3252,6 +3262,12 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -7479,6 +7495,19 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -8885,6 +8914,15 @@
         "react-native-b4a": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/text-decoder": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:api && npm run test --workspace tools/ts && npm run test --workspace webapp",
     "preview": "npm run preview --workspace webapp",
     "test:web": "npm run test:web --workspace tools/ts",
-    "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && node --test tests/server/generationSnapshot.spec.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && ./node_modules/.bin/tsx tests/scripts/tune_items.test.ts && ./node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts && node --test tests/tools/deploy-checks.spec.js",
+    "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && node --test tests/server/generationSnapshot.spec.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-latency.spec.ts && ./node_modules/.bin/tsx tests/scripts/tune_items.test.ts && ./node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts && node --test tests/tools/deploy-checks.spec.js",
     "start:api": "node server/index.js",
     "build:idea-taxonomy": "node scripts/build-idea-taxonomy.js",
     "drive:generate-approved": "node tools/drive/generate-approved-assets.mjs",
@@ -36,7 +36,8 @@
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "js-yaml": "^4.1.0",
-    "nedb-promises": "^6.2.3"
+    "nedb-promises": "^6.2.3",
+    "prom-client": "^15.1.2"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.9.0",

--- a/scripts/loadtest-orchestrator.mjs
+++ b/scripts/loadtest-orchestrator.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { createGenerationOrchestratorBridge } = require('../server/services/orchestratorBridge');
+
+const DEFAULT_TRAITS = ['artigli_sette_vie', 'coda_frusta_cinetica', 'scheletro_idro_regolante'];
+
+function parseArgs(argv) {
+  const options = {
+    requests: 16,
+    concurrency: 4,
+    poolSize: null,
+    timeout: null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+    const value = argv[index + 1];
+    switch (arg) {
+      case '--requests':
+      case '--total':
+        options.requests = Number(value) || options.requests;
+        index += 1;
+        break;
+      case '--concurrency':
+        options.concurrency = Number(value) || options.concurrency;
+        index += 1;
+        break;
+      case '--pool-size':
+        options.poolSize = Number(value) || options.poolSize;
+        index += 1;
+        break;
+      case '--timeout':
+      case '--timeout-ms':
+        options.timeout = Number(value) || options.timeout;
+        index += 1;
+        break;
+      default:
+        break;
+    }
+  }
+  options.requests = Math.max(1, Math.floor(options.requests));
+  options.concurrency = Math.max(1, Math.floor(options.concurrency));
+  return options;
+}
+
+function computePercentile(values, percentile) {
+  if (!values.length) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.round(percentile * (sorted.length - 1))),
+  );
+  return sorted[index];
+}
+
+function computeMedian(values) {
+  if (!values.length) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[middle - 1] + sorted[middle]) / 2;
+  }
+  return sorted[middle];
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const poolSize = args.poolSize || undefined;
+  const timeout = args.timeout || undefined;
+  const totalRequests = args.requests;
+  const concurrency = Math.min(args.concurrency, totalRequests);
+
+  const orchestratorOptions = {
+    autoShutdownMs: null,
+  };
+  if (poolSize) {
+    orchestratorOptions.poolSize = poolSize;
+  }
+  if (timeout) {
+    orchestratorOptions.requestTimeoutMs = timeout;
+  }
+
+  let orchestrator;
+  const latencies = [];
+  const queueLatencies = [];
+  let errorCount = 0;
+  let retryCount = 0;
+  let heartbeatMissed = 0;
+
+  try {
+    orchestrator = createGenerationOrchestratorBridge(orchestratorOptions);
+
+    orchestrator.on('task:success', (event) => {
+      if (event?.action === 'generate-species') {
+        latencies.push(Number(event.durationMs || 0));
+        queueLatencies.push(Number(event.queueDurationMs || 0));
+      }
+    });
+
+    orchestrator.on('task:error', (event) => {
+      if (event?.action === 'generate-species') {
+        errorCount += 1;
+        console.error(
+          `[loadtest] errore durante la richiesta ${event.id}:`,
+          event.error?.message || event.error,
+        );
+      }
+    });
+
+    orchestrator.on('task:retry', (event) => {
+      if (event?.action === 'generate-species') {
+        retryCount += 1;
+      }
+    });
+
+    orchestrator.on('worker:heartbeat-missed', () => {
+      heartbeatMissed += 1;
+    });
+
+    const pending = { index: 0 };
+
+    async function runWorker(workerId) {
+      while (true) {
+        const current = pending.index;
+        if (current >= totalRequests) {
+          break;
+        }
+        pending.index += 1;
+        const requestId = `loadtest-${current + 1}`;
+        try {
+          await orchestrator.generateSpecies({
+            trait_ids: DEFAULT_TRAITS,
+            seed: current + 1,
+            request_id: requestId,
+          });
+        } catch (error) {
+          errorCount += 1;
+          console.error(
+            `[loadtest] worker ${workerId} errore ${requestId}:`,
+            error.message || error,
+          );
+        }
+      }
+    }
+
+    const workers = Array.from({ length: concurrency }).map((_, index) => runWorker(index + 1));
+    await Promise.all(workers);
+  } finally {
+    if (orchestrator) {
+      try {
+        await orchestrator.close();
+      } catch (error) {
+        console.warn('[loadtest] chiusura orchestrator fallita', error);
+      }
+    }
+  }
+
+  const totalLatency = latencies.reduce((acc, value) => acc + value, 0);
+  const averageLatency = latencies.length ? totalLatency / latencies.length : 0;
+  const medianLatency = computeMedian(latencies);
+  const p95Latency = computePercentile(latencies, 0.95);
+  const medianQueue = computeMedian(queueLatencies);
+
+  const summary = {
+    requests: totalRequests,
+    concurrency,
+    poolSize: poolSize || 'default',
+    timeoutMs: timeout || 'default',
+    completed: latencies.length,
+    errors: errorCount,
+    retries: retryCount,
+    heartbeatMissed,
+    latency: {
+      averageMs: Number(averageLatency.toFixed(2)),
+      medianMs: Number(medianLatency.toFixed(2)),
+      p95Ms: Number(p95Latency.toFixed(2)),
+      medianQueueMs: Number(medianQueue.toFixed(2)),
+    },
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+process.on('unhandledRejection', (error) => {
+  console.error('[loadtest] errore non gestito', error);
+  process.exitCode = 1;
+});
+
+main().catch((error) => {
+  console.error('[loadtest] esecuzione fallita', error);
+  process.exitCode = 1;
+});

--- a/server/routes/monitoring.js
+++ b/server/routes/monitoring.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const { getPrometheusRegistry } = require('../services/orchestratorMetrics');
+
+function createMonitoringRouter() {
+  const router = express.Router();
+
+  router.get('/metrics', async (req, res) => {
+    try {
+      const registry = getPrometheusRegistry();
+      res.setHeader('Content-Type', registry.contentType);
+      res.send(await registry.metrics());
+    } catch (error) {
+      res.status(503).json({ error: 'Metriche non disponibili', details: error?.message });
+    }
+  });
+
+  return router;
+}
+
+module.exports = { createMonitoringRouter };

--- a/server/services/orchestratorMetrics.js
+++ b/server/services/orchestratorMetrics.js
@@ -1,0 +1,97 @@
+const client = require('prom-client');
+
+const registry = new client.Registry();
+client.collectDefaultMetrics({ register: registry });
+
+const poolBusyGauge = new client.Gauge({
+  name: 'orchestrator_pool_busy_workers',
+  help: 'Numero di worker orchestrator occupati',
+  registers: [registry],
+});
+
+const poolQueueGauge = new client.Gauge({
+  name: 'orchestrator_pool_queue_length',
+  help: 'Numero di richieste in coda verso il bridge orchestrator',
+  registers: [registry],
+});
+
+const poolSizeGauge = new client.Gauge({
+  name: 'orchestrator_pool_total_workers',
+  help: 'Numero totale di worker attivi nel pool orchestrator',
+  registers: [registry],
+});
+
+const heartbeatMissedCounter = new client.Counter({
+  name: 'orchestrator_worker_heartbeat_missed_total',
+  help: 'Conteggio di heartbeat mancati dai worker orchestrator',
+  labelNames: ['worker_id'],
+  registers: [registry],
+});
+
+const taskRetryCounter = new client.Counter({
+  name: 'orchestrator_task_retries_total',
+  help: 'Numero di retry delle richieste orchestrator',
+  labelNames: ['action'],
+  registers: [registry],
+});
+
+const taskDurationHistogram = new client.Histogram({
+  name: 'orchestrator_task_duration_seconds',
+  help: 'Distribuzione delle durate delle richieste orchestrator',
+  labelNames: ['action'],
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 8, 13],
+  registers: [registry],
+});
+
+function updatePoolStats(stats) {
+  if (!stats || typeof stats !== 'object') {
+    return;
+  }
+  const size = Number(stats.size) || 0;
+  const available = Number(stats.available) || 0;
+  const busy = Math.max(0, size - available);
+  poolSizeGauge.set(size);
+  poolBusyGauge.set(busy);
+  poolQueueGauge.set(Number(stats.queue) || 0);
+}
+
+function registerOrchestratorBridgeMetrics(bridge) {
+  if (!bridge || typeof bridge.on !== 'function') {
+    return;
+  }
+
+  bridge.on('pool:stats', (stats) => {
+    updatePoolStats(stats);
+  });
+
+  bridge.on('worker:heartbeat-missed', (payload = {}) => {
+    const workerId = payload.workerId !== undefined ? String(payload.workerId) : 'unknown';
+    heartbeatMissedCounter.inc({ worker_id: workerId });
+  });
+
+  bridge.on('task:retry', (payload = {}) => {
+    const action = payload.action || 'unknown';
+    taskRetryCounter.inc({ action });
+  });
+
+  bridge.on('task:success', (payload = {}) => {
+    const action = payload.action || 'unknown';
+    const durationSeconds = Number(payload.durationMs || 0) / 1000;
+    if (Number.isFinite(durationSeconds) && durationSeconds >= 0) {
+      taskDurationHistogram.observe({ action }, durationSeconds);
+    }
+  });
+
+  if (typeof bridge.getPoolStats === 'function') {
+    updatePoolStats(bridge.getPoolStats());
+  }
+}
+
+function getPrometheusRegistry() {
+  return registry;
+}
+
+module.exports = {
+  getPrometheusRegistry,
+  registerOrchestratorBridgeMetrics,
+};

--- a/tests/server/orchestrator-latency.spec.ts
+++ b/tests/server/orchestrator-latency.spec.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { before, after, describe, it } from 'node:test';
+
+import { createGenerationOrchestratorBridge } from '../../server/services/orchestratorBridge';
+
+function median(values: number[]): number {
+  if (!values.length) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[middle - 1] + sorted[middle]) / 2;
+  }
+  return sorted[middle];
+}
+
+describe('generation orchestrator latency guardrail', () => {
+  const traitIds = ['artigli_sette_vie', 'coda_frusta_cinetica', 'scheletro_idro_regolante'];
+  let bridge: ReturnType<typeof createGenerationOrchestratorBridge>;
+  let previousEnv: { nodeEnv?: string; autoClose?: string | undefined };
+  const durations: number[] = [];
+
+  before(async () => {
+    previousEnv = {
+      nodeEnv: process.env.NODE_ENV,
+      autoClose: process.env.ORCHESTRATOR_AUTOCLOSE_MS,
+    };
+    process.env.NODE_ENV = 'test';
+    process.env.ORCHESTRATOR_AUTOCLOSE_MS = '0';
+    bridge = createGenerationOrchestratorBridge({
+      poolSize: 2,
+      requestTimeoutMs: 60_000,
+      heartbeatIntervalMs: 1_000,
+      heartbeatTimeoutMs: 5_000,
+      autoShutdownMs: null,
+    });
+    bridge.on('task:success', (event: any) => {
+      if (event?.action === 'generate-species' && Number.isFinite(event.durationMs)) {
+        durations.push(Number(event.durationMs));
+      }
+    });
+  });
+
+  after(async () => {
+    await bridge.close();
+    if (previousEnv.nodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousEnv.nodeEnv;
+    }
+    if (previousEnv.autoClose === undefined) {
+      delete process.env.ORCHESTRATOR_AUTOCLOSE_MS;
+    } else {
+      process.env.ORCHESTRATOR_AUTOCLOSE_MS = previousEnv.autoClose;
+    }
+  });
+
+  it('mantiene la latenza mediana sotto la soglia configurata', async () => {
+    durations.length = 0;
+    const totalRequests = 12;
+    const requests = Array.from({ length: totalRequests }).map((_, index) =>
+      bridge.generateSpecies({
+        trait_ids: traitIds,
+        seed: index + 1,
+        request_id: `latency-${index + 1}`,
+      }),
+    );
+
+    await Promise.all(requests);
+
+    assert.equal(
+      durations.length,
+      totalRequests,
+      'attese misurazioni di latenza per ogni richiesta generata',
+    );
+
+    const threshold = Number(process.env.ORCHESTRATOR_MEDIAN_LATENCY_THRESHOLD_MS || '4000');
+    const observedMedian = median(durations);
+
+    assert.ok(
+      observedMedian <= threshold,
+      `latency guardrail superato: mediana ${observedMedian}ms > soglia ${threshold}ms`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a load testing script that records bridge latency via the new event emitter
- expose Prometheus metrics for the orchestrator bridge and mount a monitoring endpoint
- document orchestrator pool/timeout options and add a median latency CI check

## Testing
- npm run test:api

------
https://chatgpt.com/codex/tasks/task_e_6907636cb77c83328dc96392ebdcd63c