### PR TITLE
Fix optional orchestrator metrics instrumentation QA failures

### DIFF
--- a/server/routes/monitoring.js
+++ b/server/routes/monitoring.js
@@ -7,7 +7,11 @@ function createMonitoringRouter() {
   router.get('/metrics', async (req, res) => {
     try {
       const registry = getPrometheusRegistry();
-      res.setHeader('Content-Type', registry.contentType);
+      if (!registry) {
+        res.status(503).json({ error: 'Metriche orchestrator non abilitate' });
+        return;
+      }
+      res.setHeader('Content-Type', registry.contentType || 'text/plain');
       res.send(await registry.metrics());
     } catch (error) {
       res.status(503).json({ error: 'Metriche non disponibili', details: error?.message });


### PR DESCRIPTION
## Summary
- restore orchestrator bridge task event emissions while updating queue metrics per action
- ensure optional Prometheus metrics register default collectors and expose the registry for monitoring
- gracefully return 503 when orchestrator metrics are disabled in the monitoring route

## Testing
- npm run test:api

------
https://chatgpt.com/codex/tasks/task_e_690770732eac833297b8717b494bb614