### PR TITLE
Enhance trait editor validation and compliance automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/trait_contribution.md
+++ b/.github/ISSUE_TEMPLATE/trait_contribution.md
@@ -1,8 +1,8 @@
 ---
-name: "Proposta trait"
-about: "Suggerisci un nuovo tratto o una revisione importante"
-title: "[Trait] <titolo conciso>"
-labels: ["trait", "needs-triage"]
+name: 'Proposta trait'
+about: 'Suggerisci un nuovo tratto o una revisione importante'
+title: '[Trait] <titolo conciso>'
+labels: ['trait', 'needs-triage']
 assignees: []
 ---
 
@@ -39,6 +39,13 @@ assignees: []
 - [ ] Tier, slot e `slot_profile` allineati con la nomenclatura condivisa
 - [ ] Requisiti ambientali con `meta.tier`/`meta.notes` aggiornati e coerenti
 - [ ] Eseguito `scripts/trait_style_check.js` e allegati i report rilevanti
+- [ ] Suggerimenti "Applicabili" dell'editor gestiti (applicati o motivati)
+
+## KPI & report
+
+- [ ] Rigenerato `tools/py/styleguide_compliance_report.py` (JSON/Markdown allegati)
+- [ ] KPI sotto SLA commentati con piano di rientro oppure confermati dal reviewer
+- [ ] Bridge `logs/qa/latest-dashboard-metrics.json` aggiornato quando necessario
 
 ## Allegati
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       data: ${{ steps.filter.outputs.data }}
       deploy: ${{ steps.filter.outputs.deploy }}
+      styleguide: ${{ steps.filter.outputs.styleguide }}
 
     steps:
       - name: Checkout repository
@@ -49,6 +50,13 @@ jobs:
               - 'scripts/run_deploy_checks.sh'
               - 'tools/py/report_trait_coverage.py'
               - 'config/deploy/**'
+            styleguide:
+              - 'tools/py/styleguide_compliance_report.py'
+              - 'tools/py/styleguide_utils.py'
+              - 'logs/qa/latest-dashboard-metrics.json'
+              - 'reports/styleguide_compliance.*'
+              - 'scripts/cron/traits_monthly_maintenance.sh'
+              - '.github/workflows/traits-monthly-maintenance.yml'
 
   typescript-tests:
     runs-on: ubuntu-latest
@@ -294,6 +302,45 @@ jobs:
             reports/trait_style/ci_trait_style_report.md
           if-no-files-found: warn
 
+  styleguide-compliance:
+    runs-on: ubuntu-latest
+    needs:
+      - paths-filter
+    if: >-
+      needs.paths-filter.outputs.styleguide == 'true'
+      || needs.paths-filter.outputs.data == 'true'
+      || needs.paths-filter.outputs.python == 'true'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements-dev.txt ]; then
+            pip install -r requirements-dev.txt
+          fi
+
+      - name: Generate styleguide compliance report
+        run: python tools/py/styleguide_compliance_report.py --strict
+
+      - name: Upload styleguide artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: styleguide-compliance-${{ github.run_id }}
+          path: |
+            reports/styleguide_compliance.json
+            reports/styleguide_compliance.md
+            logs/trait_audit/styleguide_compliance_history.json
+          if-no-files-found: warn
+
   deployment-checks:
     runs-on: ubuntu-latest
     needs:
@@ -333,7 +380,7 @@ jobs:
       - name: Run deploy validation checks
         env:
           DEPLOY_DATA_DIR: ${{ github.workspace }}/data
-          CI: "true"
-          PLAYWRIGHT_REUSE_SERVER: "0"
-          DEPLOY_SKIP_SMOKE_TEST: "1"
+          CI: 'true'
+          PLAYWRIGHT_REUSE_SERVER: '0'
+          DEPLOY_SKIP_SMOKE_TEST: '1'
         run: scripts/run_deploy_checks.sh

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,9 @@
 - [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
 - [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
 - [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
+- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
+- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
+- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato
 - [ ] Documentazione/processi aggiornati ove necessario
 
 ## Testing

--- a/docs/process/training/trait_style_session.md
+++ b/docs/process/training/trait_style_session.md
@@ -30,6 +30,8 @@ laboratorio pratico con l'editor interno aggiornato e i nuovi report automatici.
    procedure precedenti, overview dei materiali.
 2. **Demo strumenti (20')** – Navigazione dell'editor con validazione live,
    spiegazione delle sezioni "Guida stile" e come interpretare badge/suggerimenti.
+   Dimostrazione dell'applicazione automatica dei fix (bottoni "Applica") e
+   del contatore "Applicabili" aggiornato in tempo reale.
 3. **Laboratorio (35')** – Lavoro a gruppi: ciascuno corregge un tratto reale
    utilizzando i suggerimenti dell'editor e lo script CLI. Condivisione rapida
    dei fix trovati.
@@ -42,6 +44,8 @@ laboratorio pratico con l'editor interno aggiornato e i nuovi report automatici.
 
 1. **Check locale** – L'autore esegue `npm run style:check` (alias dello script
    `scripts/trait_style_check.js`) e allega i report JSON/Markdown al branch.
+   Se presenti fix applicabili automaticamente, documenta nel PR quelli usati
+   tramite l'editor.
 2. **Revisione editoriale** – Il reviewer controlla che ogni campo testuale
    utilizzi il namespace i18n corretto (`i18n:traits.<id>.*`) e che `tier`/slot
    rispettino la guida (maiuscole, cluster condivisi, `slot_profile` completo).
@@ -50,7 +54,8 @@ laboratorio pratico con l'editor interno aggiornato e i nuovi report automatici.
    `completion_flags` (`has_biome`, `has_species_link`) di conseguenza.
 4. **Validazione automatica** – Se il report stile riporta errori, il PR viene
    bloccato finché `STYLE_ERRORS` = 0. I warning richiedono conferma esplicita
-   nel commento di review.
+   nel commento di review. Il KPI report (`styleguide_compliance_report.py`)
+   deve risultare "ok" oppure accompagnato da un piano di rientro.
 5. **Documentazione** – Aggiornare il template PR (sezione "Checklist guida
    stile") e annotare l'esito nel log di manutenzione mensile.
 
@@ -58,6 +63,8 @@ laboratorio pratico con l'editor interno aggiornato e i nuovi report automatici.
 
 - Report JSON/Markdown della lint (archiviati in `reports/trait_style/` o nei
   log di manutenzione) con riferimento nel PR/issue.
+- Snapshot aggiornato in `reports/styleguide_compliance.*` e aggiornamento del
+  bridge `logs/qa/latest-dashboard-metrics.json` per alimentare i dashboard KPI.
 - Note di review che indicano chi ha firmato la nomenclatura e le descrizioni.
 - Eventuali follow-up (es. nuove chiavi i18n da localizzare) tracciati nel
   backlog di design o localization.
@@ -67,6 +74,8 @@ laboratorio pratico con l'editor interno aggiornato e i nuovi report automatici.
 - Editor interno (`webapp` → Trait Editor) con suggerimenti in tempo reale.
 - Script CLI: `scripts/trait_style_check.js` e shortcut `npm run style:check`.
 - Cron job mensile `scripts/cron/traits_monthly_maintenance.sh` per monitorare
-  regressioni e allegare i report QA.
+  regressioni e allegare i report QA + compliance (`styleguide_compliance`).
 - Template aggiornati (`.github/ISSUE_TEMPLATE/trait_contribution.md`,
   `PULL_REQUEST_TEMPLATE.md`).
+- Report KPI `tools/py/styleguide_compliance_report.py` (con bridge dashboard)
+  per monitorare l'adozione in tempo quasi reale.

--- a/tools/py/README.md
+++ b/tools/py/README.md
@@ -47,7 +47,9 @@ python tools/py/styleguide_compliance_report.py \
   [--out-markdown reports/styleguide_compliance.md] \
   [--out-json reports/styleguide_compliance.json] \
   [--history-file logs/trait_audit/styleguide_compliance_history.json] \
-  [--sla-config config/styleguide_sla.json] [--strict]
+  [--sla-config config/styleguide_sla.json] \
+  [--dashboard-bridge logs/qa/latest-dashboard-metrics.json] \
+  [--dashboard-section styleguide] [--strict]
 ```
 
 - Calcola i KPI di conformità dello styleguide (naming, descrizioni localizzate, unità UCUM) e aggiorna
@@ -56,3 +58,5 @@ python tools/py/styleguide_compliance_report.py \
   scendono sotto le soglie definite in `config/styleguide_sla.json`.
 - Con `--strict` esce con codice di errore se una delle metriche viola lo SLA, abilitando trigger
   automatici per l'apertura di issue.
+- Aggiorna automaticamente il bridge `logs/qa/latest-dashboard-metrics.json` (se disponibile) con uno
+  snapshot sintetico dei KPI, così da alimentare i dashboard esistenti senza step aggiuntivi.

--- a/webapp/src/features/traits/editor.css
+++ b/webapp/src/features/traits/editor.css
@@ -46,7 +46,9 @@
   background: #fff;
   font: inherit;
   color: inherit;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .trait-editor__field input:focus,
@@ -113,7 +115,10 @@
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease,
+    border-color 0.18s ease;
 }
 
 .trait-editor__list button:hover {
@@ -182,7 +187,10 @@
   padding: 0.55rem 1.4rem;
   font: inherit;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+  transition:
+    background 0.2s ease,
+    transform 0.2s ease,
+    border-color 0.2s ease;
 }
 
 .trait-editor__actions button.primary {
@@ -416,6 +424,11 @@
   color: #bfdbfe;
 }
 
+.trait-editor__style-counter--actionable {
+  background: rgba(16, 185, 129, 0.25);
+  color: #bbf7d0;
+}
+
 .trait-editor__suggestions {
   margin: 0;
   padding-left: 1.1rem;
@@ -470,6 +483,32 @@
   display: block;
   color: rgba(226, 232, 240, 0.65);
   font-size: 0.72rem;
+}
+
+.trait-editor__suggestion-action {
+  margin-top: 0.25rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.55);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease,
+    transform 0.2s ease;
+}
+
+.trait-editor__suggestion-action:hover {
+  border-color: rgba(94, 234, 212, 0.65);
+  background: rgba(13, 148, 136, 0.45);
+  transform: translateY(-1px);
+}
+
+.trait-editor__suggestion-action:focus-visible {
+  outline: 2px solid rgba(94, 234, 212, 0.85);
+  outline-offset: 2px;
 }
 
 .trait-editor__message {


### PR DESCRIPTION
## Summary
- ✅ Implemented actionable style guide feedback in the trait editor (`webapp/src/features/traits/Editor.tsx`, `webapp/src/features/traits/editor.css`).  
  * Added utilities to apply backend “fix” suggestions directly in the UI, track the last applied suggestion, and expose an actionable counter/badge in the style panel.  
  * Added apply buttons to `SuggestionList` (field-level and panel) with supporting styles and keyboard focus states.
- ✅ Extended API validation output (`server/routes/traits.js`).  
  * Normalizes suggestions to annotate `fix.autoApplicable`, returns aggregated `corrections` metadata, and reports counts in the summary payload.
- ✅ Updated client-side service typing (`webapp/src/services/traitsService.ts`) to support the richer API response (auto-apply metadata + corrections list).
- ✅ Integrated styleguide compliance reporting into automation:  
  * CI pipeline update adding a dedicated job (`.github/workflows/ci.yml`).  
  * Monthly maintenance script now generates compliance reports, parses KPI info, and records anomalies (`scripts/cron/traits_monthly_maintenance.sh`).
- ✅ Enhanced CLI report (`tools/py/styleguide_compliance_report.py`, docs at `tools/py/README.md`).  
  * New CLI options (`--dashboard-bridge`, `--dashboard-section`), JSON summary section, and dashboard bridge updater.
- ✅ Documentation & templates aligned (`docs/process/training/trait_style_session.md`, `.github/ISSUE_TEMPLATE/trait_contribution.md`, `PULL_REQUEST_TEMPLATE.md`).
- ✅ Improved editor accessibility feedback with live status roles and contextual labels on suggestion apply controls (`webapp/src/features/traits/Editor.tsx`).

## Testing
- `npm run lint --workspaces --if-present`


------
https://chatgpt.com/codex/tasks/task_e_6907a160446483329c96e97d027b73a9