### PR TITLE
Follow-up: honor autoApplicable flag in trait editor apply button

### DIFF
--- a/webapp/src/features/traits/Editor.tsx
+++ b/webapp/src/features/traits/Editor.tsx
@@ -1403,13 +1403,7 @@ const SuggestionList: React.FC<{
               : actionLabel === 'set'
                 ? 'Imposta il valore'
                 : null;
-        const canApplyFix = Boolean(
-          onApplySuggestion &&
-            fix &&
-            ((fix.type === 'set' && Object.prototype.hasOwnProperty.call(fix, 'value')) ||
-              (fix.type === 'append' && Object.prototype.hasOwnProperty.call(fix, 'value')) ||
-              fix.type === 'remove'),
-        );
+        const canApplyFix = Boolean(onApplySuggestion && isSuggestionAutoApplicable(suggestion));
         return (
           <li
             key={`${suggestion.path || 'root'}-${suggestion.message}-${index}`}


### PR DESCRIPTION
## Summary
- ensure the trait suggestion apply button only renders when the backend marks a fix as auto-applicable

## Testing
- npm run lint --workspaces --if-present

------
https://chatgpt.com/codex/tasks/task_e_6907a77924c08332963bc508fd656565