### PR TITLE
Fix flow shell fallback loading for static mission console

### DIFF
--- a/webapp/src/services/apiEndpoints.ts
+++ b/webapp/src/services/apiEndpoints.ts
@@ -134,7 +134,13 @@ export function resolveApiUrl(
       joinBase = apiBaseCandidate;
     } else {
       const resolvedApiBase = resolveRuntimeAwareBase(apiBaseCandidate, runtimeBase, '');
-      joinBase = resolvedApiBase ? joinUrl(baseUrl, resolvedApiBase) : baseUrl;
+      if (resolvedApiBase) {
+        joinBase = resolvedApiBase.startsWith('/')
+          ? resolvedApiBase
+          : joinUrl(baseUrl, resolvedApiBase);
+      } else {
+        joinBase = baseUrl;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- teach the mission console bootstrap and API helpers to derive their base path from the deployed index so static builds resolve local assets and APIs correctly
- always enable the flow snapshot fallback offline, keep fetch fallbacks permissive, and seed telemetry with snapshot logs so the EvoGene Deck view shows the expected QA data
- regenerate docs/mission-console assets with the updated data and exclude the bundle directory from Prettier checks for future builds
- avoid double joining runtime-derived API bases so static mission console deployments reuse the correct host prefix

## Testing
- npm run lint --workspaces --if-present

------
https://chatgpt.com/codex/tasks/task_e_6907a76f56e48332b3af529a05d7f5b0