### PR TITLE
Handle snake_case glow toggle thresholds

### DIFF
--- a/webapp/src/vfx/dynamicShader.js
+++ b/webapp/src/vfx/dynamicShader.js
@@ -25,15 +25,26 @@ const buildGlowResolver = (config) => {
     return () => config;
   }
   if (typeof config === 'object') {
-    const { default: defaultValue = true, minContrast, maxGamma, maxPulse } = config;
+    const {
+      default: defaultValue = true,
+      minContrast,
+      maxGamma,
+      maxPulse,
+      min_contrast,
+      max_gamma,
+      max_pulse,
+    } = config;
+    const resolvedMinContrast = typeof minContrast === 'number' ? minContrast : min_contrast;
+    const resolvedMaxGamma = typeof maxGamma === 'number' ? maxGamma : max_gamma;
+    const resolvedMaxPulse = typeof maxPulse === 'number' ? maxPulse : max_pulse;
     return (context) => {
-      if (typeof minContrast === 'number' && context.contrast < minContrast) {
+      if (typeof resolvedMinContrast === 'number' && context.contrast < resolvedMinContrast) {
         return false;
       }
-      if (typeof maxGamma === 'number' && context.gamma > maxGamma) {
+      if (typeof resolvedMaxGamma === 'number' && context.gamma > resolvedMaxGamma) {
         return false;
       }
-      if (typeof maxPulse === 'number' && Math.abs(context.pulse) > maxPulse) {
+      if (typeof resolvedMaxPulse === 'number' && Math.abs(context.pulse) > resolvedMaxPulse) {
         return false;
       }
       return Boolean(defaultValue);


### PR DESCRIPTION
## Summary
- normalize glow toggle threshold keys to work with snake_case mission config
- ensure glow suppression honors configured contrast, gamma, and pulse limits

## Testing
- npm --prefix webapp test -- --run tests/vfx/dynamicShader.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_6907ac91084c8332836198a527e5e296