### PR TITLE
Fix go/no-go classification for trait conflicts

### DIFF
--- a/tools/deploy/goNoGo.js
+++ b/tools/deploy/goNoGo.js
@@ -46,7 +46,12 @@ function computeTraitDiagnosticsStatus(traitDiagnostics = {}) {
   const missingGlossary = toNumber(summary.glossary_missing ?? summary.glossaryMissing);
   const error = status.error ? String(status.error) : null;
   const passed = !error && conflicts === 0;
-  const severity = 'warning';
+  let severity = 'warning';
+  if (error || conflicts > 0) {
+    severity = 'critical';
+  } else if (matrixMismatch > 0 || missingGlossary > 0) {
+    severity = 'warning';
+  }
   const summaryParts = [];
   if (error) {
     summaryParts.push(`Errore diagnostica: ${error}`);


### PR DESCRIPTION
## Summary
- escalate trait diagnostics conflicts to critical severity so go/no-go reports no-go when conflicts are present

## Testing
- npm run test:api

------
https://chatgpt.com/codex/tasks/task_e_6902cb727d1883328bea416004c47f7a