### PR TITLE
Add species affinity for random strategia trait

### DIFF
--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -9383,12 +9383,21 @@
         "complementare": "adattivo",
         "core": "strategia"
       },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sentinella-radice",
+          "weight": 1
+        }
+      ],
       "spinta_selettiva": "Draft rapidi o recuperi quando il tavolo necessita sorprese adattive.",
       "tier": "T1",
       "uso_funzione": "Slot jolly per testing o pareggiare budget PI quando serve varietà.",
       "completion_flags": {
         "has_biome": false,
-        "has_species_link": false
+        "has_species_link": true
       }
     },
     "respiro_a_scoppio": {

--- a/data/traits/strategia/random.json
+++ b/data/traits/strategia/random.json
@@ -39,11 +39,20 @@
     "complementare": "adattivo",
     "core": "strategia"
   },
+  "species_affinity": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "sentinella-radice",
+      "weight": 1
+    }
+  ],
   "spinta_selettiva": "i18n:traits.random.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.random.uso_funzione",
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": true
   }
 }


### PR DESCRIPTION
## Descrizione
- collega il tratto strategia `random` alla specie Sentinella Radice sia nel file sorgente sia nell'indice globale
- aggiorna i completion flag per indicare la presenza del collegamento specie

## Checklist guida stile & QA
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato
- [ ] Documentazione/processi aggiornati ove necessario

## Testing
- [x] Altro: `python tools/py/build_species_trait_bridge.py`

## Note
- Esecuzione di `python tools/py/build_species_trait_bridge.py` completata senza errori.

------
https://chatgpt.com/codex/tasks/task_e_6907aef34f1c8332b0d6fdbf78d4dfe7