### PR TITLE
Add biome tags for coverage and psionic trait packs

### DIFF
--- a/data/traits/difensivo/ali_membrana_sonica.json
+++ b/data/traits/difensivo/ali_membrana_sonica.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/difensivo/appendici_risonanti_marea.json
+++ b/data/traits/difensivo/appendici_risonanti_marea.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "laguna_bioreattiva"
+  ]
 }

--- a/data/traits/difensivo/barriere_miasma_glaciale.json
+++ b/data/traits/difensivo/barriere_miasma_glaciale.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caldera_glaciale"
+  ]
 }

--- a/data/traits/difensivo/branchie_microfiltri.json
+++ b/data/traits/difensivo/branchie_microfiltri.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "reef_luminescente"
+  ]
 }

--- a/data/traits/difensivo/capsule_paracadute.json
+++ b/data/traits/difensivo/capsule_paracadute.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "stratosfera_tempestosa"
+  ]
 }

--- a/data/traits/difensivo/circolazione_bifasica.json
+++ b/data/traits/difensivo/circolazione_bifasica.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caldera_glaciale"
+  ]
 }

--- a/data/traits/difensivo/coda_coppia_retroattiva.json
+++ b/data/traits/difensivo/coda_coppia_retroattiva.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "steppe_algoritmiche"
+  ]
 }

--- a/data/traits/difensivo/cute_resistente_sali.json
+++ b/data/traits/difensivo/cute_resistente_sali.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "badlands"
+  ]
 }

--- a/data/traits/difensivo/enzimi_antipredatori_algali.json
+++ b/data/traits/difensivo/enzimi_antipredatori_algali.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "reef_luminescente"
+  ]
 }

--- a/data/traits/difensivo/filtri_planctonici.json
+++ b/data/traits/difensivo/filtri_planctonici.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "laguna_bioreattiva"
+  ]
 }

--- a/data/traits/difensivo/ghiandole_fango_coesivo.json
+++ b/data/traits/difensivo/ghiandole_fango_coesivo.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "mangrovieto_cinetico"
+  ]
 }

--- a/data/traits/difensivo/giunti_antitorsione.json
+++ b/data/traits/difensivo/giunti_antitorsione.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "mangrovieto_cinetico"
+  ]
 }

--- a/data/traits/difensivo/lingua_cristallina.json
+++ b/data/traits/difensivo/lingua_cristallina.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "pianura_salina_iperarida"
+  ]
 }

--- a/data/traits/difensivo/mucose_barofile.json
+++ b/data/traits/difensivo/mucose_barofile.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "abisso_vulcanico"
+  ]
 }

--- a/data/traits/digestivo/filamenti_digestivi_compattanti.json
+++ b/data/traits/digestivo/filamenti_digestivi_compattanti.json
@@ -65,5 +65,9 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante",
+    "falde_magnetiche_psioniche"
+  ]
 }

--- a/data/traits/digestivo/ventriglio_gastroliti.json
+++ b/data/traits/digestivo/ventriglio_gastroliti.json
@@ -52,5 +52,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/escretorio/spore_psichiche_silenziate.json
+++ b/data/traits/escretorio/spore_psichiche_silenziate.json
@@ -39,5 +39,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/idrostatico/sacche_galleggianti_ascensoriali.json
+++ b/data/traits/idrostatico/sacche_galleggianti_ascensoriali.json
@@ -55,5 +55,9 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopia_psionica_leggera",
+    "orbita_psionica_inversa"
+  ]
 }

--- a/data/traits/locomotorio/ali_ioniche.json
+++ b/data/traits/locomotorio/ali_ioniche.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopia_ionica"
+  ]
 }

--- a/data/traits/locomotorio/antenne_wideband.json
+++ b/data/traits/locomotorio/antenne_wideband.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "steppe_algoritmiche"
+  ]
 }

--- a/data/traits/locomotorio/artigli_sette_vie.json
+++ b/data/traits/locomotorio/artigli_sette_vie.json
@@ -51,5 +51,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/locomotorio/artigli_sghiaccio_glaciale.json
+++ b/data/traits/locomotorio/artigli_sghiaccio_glaciale.json
@@ -49,5 +49,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "calotte_glaciali"
+  ]
 }

--- a/data/traits/locomotorio/barbigli_sensori_plasma.json
+++ b/data/traits/locomotorio/barbigli_sensori_plasma.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "stratosfera_tempestosa"
+  ]
 }

--- a/data/traits/locomotorio/branchie_metalloidi.json
+++ b/data/traits/locomotorio/branchie_metalloidi.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "abisso_vulcanico"
+  ]
 }

--- a/data/traits/locomotorio/capillari_fotovoltaici.json
+++ b/data/traits/locomotorio/capillari_fotovoltaici.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopia_ionica"
+  ]
 }

--- a/data/traits/locomotorio/cartilagine_flessotermica_venti.json
+++ b/data/traits/locomotorio/cartilagine_flessotermica_venti.json
@@ -52,5 +52,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "gole_ventose"
+  ]
 }

--- a/data/traits/locomotorio/chemiorecettori_bromuro.json
+++ b/data/traits/locomotorio/chemiorecettori_bromuro.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "pianura_salina_iperarida"
+  ]
 }

--- a/data/traits/locomotorio/coda_contrappeso.json
+++ b/data/traits/locomotorio/coda_contrappeso.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "mangrovieto_cinetico"
+  ]
 }

--- a/data/traits/locomotorio/coda_frusta_cinetica.json
+++ b/data/traits/locomotorio/coda_frusta_cinetica.json
@@ -79,5 +79,9 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "falde_magnetiche_psioniche",
+    "orbita_psionica_inversa"
+  ]
 }

--- a/data/traits/locomotorio/cuscinetti_elettrostatici.json
+++ b/data/traits/locomotorio/cuscinetti_elettrostatici.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "pianura_salina_iperarida"
+  ]
 }

--- a/data/traits/locomotorio/enzimi_antifase_termica.json
+++ b/data/traits/locomotorio/enzimi_antifase_termica.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caldera_glaciale"
+  ]
 }

--- a/data/traits/locomotorio/filamenti_termoconduzione.json
+++ b/data/traits/locomotorio/filamenti_termoconduzione.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "dorsale_termale_tropicale"
+  ]
 }

--- a/data/traits/locomotorio/ghiandole_fango_calde.json
+++ b/data/traits/locomotorio/ghiandole_fango_calde.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "abisso_vulcanico"
+  ]
 }

--- a/data/traits/locomotorio/ghiandole_ventosa.json
+++ b/data/traits/locomotorio/ghiandole_ventosa.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caldera_glaciale"
+  ]
 }

--- a/data/traits/locomotorio/linfa_tampone.json
+++ b/data/traits/locomotorio/linfa_tampone.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_acida"
+  ]
 }

--- a/data/traits/locomotorio/mucose_aderenza_sonica.json
+++ b/data/traits/locomotorio/mucose_aderenza_sonica.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/locomotorio/zampe_a_molla.json
+++ b/data/traits/locomotorio/zampe_a_molla.json
@@ -62,5 +62,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_miceliale"
+  ]
 }

--- a/data/traits/locomotorio/zoccoli_risonanti_steppe.json
+++ b/data/traits/locomotorio/zoccoli_risonanti_steppe.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "steppe_risonanti"
+  ]
 }

--- a/data/traits/metabolico/antenne_dustsense.json
+++ b/data/traits/metabolico/antenne_dustsense.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "pianura_salina_iperarida"
+  ]
 }

--- a/data/traits/metabolico/appendici_thermotattiche.json
+++ b/data/traits/metabolico/appendici_thermotattiche.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "abisso_vulcanico"
+  ]
 }

--- a/data/traits/metabolico/batteri_endosimbionti_chemio.json
+++ b/data/traits/metabolico/batteri_endosimbionti_chemio.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "abisso_vulcanico"
+  ]
 }

--- a/data/traits/metabolico/branchie_solfatiche.json
+++ b/data/traits/metabolico/branchie_solfatiche.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caldera_glaciale"
+  ]
 }

--- a/data/traits/metabolico/carapace_segmenti_logici.json
+++ b/data/traits/metabolico/carapace_segmenti_logici.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "steppe_algoritmiche"
+  ]
 }

--- a/data/traits/metabolico/circolazione_bifasica_palude.json
+++ b/data/traits/metabolico/circolazione_bifasica_palude.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "paludi_gas_luminescenti"
+  ]
 }

--- a/data/traits/metabolico/circolazione_cooling_loop.json
+++ b/data/traits/metabolico/circolazione_cooling_loop.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "steppe_algoritmiche"
+  ]
 }

--- a/data/traits/metabolico/coda_stabilizzatrice_filo.json
+++ b/data/traits/metabolico/coda_stabilizzatrice_filo.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopia_ionica"
+  ]
 }

--- a/data/traits/metabolico/criostasi_adattiva.json
+++ b/data/traits/metabolico/criostasi_adattiva.json
@@ -55,5 +55,9 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopia_psionica_leggera",
+    "orbita_psionica_inversa"
+  ]
 }

--- a/data/traits/metabolico/cuticole_cerose.json
+++ b/data/traits/metabolico/cuticole_cerose.json
@@ -39,5 +39,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_miceliale"
+  ]
 }

--- a/data/traits/metabolico/enzimi_chelanti.json
+++ b/data/traits/metabolico/enzimi_chelanti.json
@@ -39,5 +39,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_miceliale"
+  ]
 }

--- a/data/traits/metabolico/flagelli_ancoranti.json
+++ b/data/traits/metabolico/flagelli_ancoranti.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "laguna_bioreattiva"
+  ]
 }

--- a/data/traits/metabolico/ghiandole_grafene.json
+++ b/data/traits/metabolico/ghiandole_grafene.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "steppe_algoritmiche"
+  ]
 }

--- a/data/traits/metabolico/grassi_termici.json
+++ b/data/traits/metabolico/grassi_termici.json
@@ -39,5 +39,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_miceliale"
+  ]
 }

--- a/data/traits/metabolico/luminescenza_aurorale.json
+++ b/data/traits/metabolico/luminescenza_aurorale.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caldera_glaciale"
+  ]
 }

--- a/data/traits/nervoso/sonno_emisferico_alternato.json
+++ b/data/traits/nervoso/sonno_emisferico_alternato.json
@@ -40,5 +40,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/offensivo/antenne_flusso_mareale.json
+++ b/data/traits/offensivo/antenne_flusso_mareale.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "laguna_bioreattiva"
+  ]
 }

--- a/data/traits/offensivo/artigli_induzione.json
+++ b/data/traits/offensivo/artigli_induzione.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopia_ionica"
+  ]
 }

--- a/data/traits/offensivo/biochip_memoria.json
+++ b/data/traits/offensivo/biochip_memoria.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "steppe_algoritmiche"
+  ]
 }

--- a/data/traits/offensivo/camere_anticorrosione.json
+++ b/data/traits/offensivo/camere_anticorrosione.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_acida"
+  ]
 }

--- a/data/traits/offensivo/cartilagini_biofibre.json
+++ b/data/traits/offensivo/cartilagini_biofibre.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "reef_luminescente"
+  ]
 }

--- a/data/traits/offensivo/circolazione_supercritica.json
+++ b/data/traits/offensivo/circolazione_supercritica.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "abisso_vulcanico"
+  ]
 }

--- a/data/traits/offensivo/coda_stabilizzatrice_vortex.json
+++ b/data/traits/offensivo/coda_stabilizzatrice_vortex.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "stratosfera_tempestosa"
+  ]
 }

--- a/data/traits/offensivo/denti_chelatanti.json
+++ b/data/traits/offensivo/denti_chelatanti.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_acida"
+  ]
 }

--- a/data/traits/offensivo/enzimi_metanoossidanti.json
+++ b/data/traits/offensivo/enzimi_metanoossidanti.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "abisso_vulcanico"
+  ]
 }

--- a/data/traits/offensivo/foliaggio_spugna.json
+++ b/data/traits/offensivo/foliaggio_spugna.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "mangrovieto_cinetico"
+  ]
 }

--- a/data/traits/offensivo/ghiandola_caustica.json
+++ b/data/traits/offensivo/ghiandola_caustica.json
@@ -43,5 +43,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_miceliale"
+  ]
 }

--- a/data/traits/offensivo/ghiandole_iodoattive.json
+++ b/data/traits/offensivo/ghiandole_iodoattive.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "pianura_salina_iperarida"
+  ]
 }

--- a/data/traits/offensivo/gusci_magnesio.json
+++ b/data/traits/offensivo/gusci_magnesio.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "dorsale_termale_tropicale"
+  ]
 }

--- a/data/traits/offensivo/mantelli_geotermici.json
+++ b/data/traits/offensivo/mantelli_geotermici.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caldera_glaciale"
+  ]
 }

--- a/data/traits/offensivo/sangue_piroforico.json
+++ b/data/traits/offensivo/sangue_piroforico.json
@@ -55,5 +55,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/respiratorio/branchie_osmotiche_salmastra.json
+++ b/data/traits/respiratorio/branchie_osmotiche_salmastra.json
@@ -50,5 +50,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "delta_salmastri"
+  ]
 }

--- a/data/traits/respiratorio/lamelle_termoforetiche.json
+++ b/data/traits/respiratorio/lamelle_termoforetiche.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "sorgenti_geotermiche"
+  ]
 }

--- a/data/traits/respiratorio/membrane_eliofiltranti.json
+++ b/data/traits/respiratorio/membrane_eliofiltranti.json
@@ -40,5 +40,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "laghi_alcalini"
+  ]
 }

--- a/data/traits/respiratorio/polmoni_cristallini_alta_quota.json
+++ b/data/traits/respiratorio/polmoni_cristallini_alta_quota.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "picchi_cristallini"
+  ]
 }

--- a/data/traits/respiratorio/respiro_a_scoppio.json
+++ b/data/traits/respiratorio/respiro_a_scoppio.json
@@ -40,5 +40,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/riproduttivo/nucleo_ovomotore_rotante.json
+++ b/data/traits/riproduttivo/nucleo_ovomotore_rotante.json
@@ -39,5 +39,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/sensoriale/ali_fulminee.json
+++ b/data/traits/sensoriale/ali_fulminee.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "stratosfera_tempestosa"
+  ]
 }

--- a/data/traits/sensoriale/antenne_plasmatiche_tempesta.json
+++ b/data/traits/sensoriale/antenne_plasmatiche_tempesta.json
@@ -51,5 +51,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "cicloni_psionici"
+  ]
 }

--- a/data/traits/sensoriale/antenne_waveguide.json
+++ b/data/traits/sensoriale/antenne_waveguide.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "reef_luminescente"
+  ]
 }

--- a/data/traits/sensoriale/baffi_mareomotori.json
+++ b/data/traits/sensoriale/baffi_mareomotori.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "mangrovieto_cinetico"
+  ]
 }

--- a/data/traits/sensoriale/branchie_eoliche.json
+++ b/data/traits/sensoriale/branchie_eoliche.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "stratosfera_tempestosa"
+  ]
 }

--- a/data/traits/sensoriale/capillari_fluoridici.json
+++ b/data/traits/sensoriale/capillari_fluoridici.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_acida"
+  ]
 }

--- a/data/traits/sensoriale/cavita_risonanti_tundra.json
+++ b/data/traits/sensoriale/cavita_risonanti_tundra.json
@@ -51,5 +51,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "tundra_risonante"
+  ]
 }

--- a/data/traits/sensoriale/cervelletto_equilibrio_statico.json
+++ b/data/traits/sensoriale/cervelletto_equilibrio_statico.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopia_ionica"
+  ]
 }

--- a/data/traits/sensoriale/coda_balanciere.json
+++ b/data/traits/sensoriale/coda_balanciere.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/sensoriale/cuore_multicamera_bassa_pressione.json
+++ b/data/traits/sensoriale/cuore_multicamera_bassa_pressione.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "stratosfera_tempestosa"
+  ]
 }

--- a/data/traits/sensoriale/echi_risonanti.json
+++ b/data/traits/sensoriale/echi_risonanti.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/sensoriale/eco_interno_riflesso.json
+++ b/data/traits/sensoriale/eco_interno_riflesso.json
@@ -54,5 +54,9 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopia_psionica_leggera",
+    "falde_magnetiche_psioniche"
+  ]
 }

--- a/data/traits/sensoriale/filamenti_superconduttivi.json
+++ b/data/traits/sensoriale/filamenti_superconduttivi.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caldera_glaciale"
+  ]
 }

--- a/data/traits/sensoriale/ghiandole_eco_mappanti.json
+++ b/data/traits/sensoriale/ghiandole_eco_mappanti.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/sensoriale/ghiandole_resina_conduttiva.json
+++ b/data/traits/sensoriale/ghiandole_resina_conduttiva.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopia_ionica"
+  ]
 }

--- a/data/traits/sensoriale/lamine_scudo_silice.json
+++ b/data/traits/sensoriale/lamine_scudo_silice.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "dorsale_termale_tropicale"
+  ]
 }

--- a/data/traits/sensoriale/lingua_tattile_trama.json
+++ b/data/traits/sensoriale/lingua_tattile_trama.json
@@ -39,5 +39,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/sensoriale/midollo_antivibrazione.json
+++ b/data/traits/sensoriale/midollo_antivibrazione.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/sensoriale/occhi_infrarosso_composti.json
+++ b/data/traits/sensoriale/occhi_infrarosso_composti.json
@@ -39,5 +39,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/sensoriale/olfatto_risonanza_magnetica.json
+++ b/data/traits/sensoriale/olfatto_risonanza_magnetica.json
@@ -53,5 +53,9 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "falde_magnetiche_psioniche",
+    "orbita_psionica_inversa"
+  ]
 }

--- a/data/traits/sensoriale/sensori_geomagnetici.json
+++ b/data/traits/sensoriale/sensori_geomagnetici.json
@@ -40,5 +40,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "pianure_magnetiche"
+  ]
 }

--- a/data/traits/simbiotico/antenne_reagenti.json
+++ b/data/traits/simbiotico/antenne_reagenti.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_acida"
+  ]
 }

--- a/data/traits/simbiotico/artigli_scivolo_silente.json
+++ b/data/traits/simbiotico/artigli_scivolo_silente.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/simbiotico/biofilm_iperarido.json
+++ b/data/traits/simbiotico/biofilm_iperarido.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "pianura_salina_iperarida"
+  ]
 }

--- a/data/traits/simbiotico/bulbi_radici_permafrost.json
+++ b/data/traits/simbiotico/bulbi_radici_permafrost.json
@@ -50,5 +50,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "permafrost_psionico"
+  ]
 }

--- a/data/traits/simbiotico/camere_nutrienti_vent.json
+++ b/data/traits/simbiotico/camere_nutrienti_vent.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "dorsale_termale_tropicale"
+  ]
 }

--- a/data/traits/simbiotico/cartilagini_flessoacustiche.json
+++ b/data/traits/simbiotico/cartilagini_flessoacustiche.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/simbiotico/chioma_parassita_canopica.json
+++ b/data/traits/simbiotico/chioma_parassita_canopica.json
@@ -40,5 +40,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopie_sospese"
+  ]
 }

--- a/data/traits/simbiotico/ciste_salmastre.json
+++ b/data/traits/simbiotico/ciste_salmastre.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "pianura_salina_iperarida"
+  ]
 }

--- a/data/traits/simbiotico/coralli_partner.json
+++ b/data/traits/simbiotico/coralli_partner.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "reef_luminescente"
+  ]
 }

--- a/data/traits/simbiotico/denti_silice_termici.json
+++ b/data/traits/simbiotico/denti_silice_termici.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "dorsale_termale_tropicale"
+  ]
 }

--- a/data/traits/simbiotico/epitelio_fosforescente.json
+++ b/data/traits/simbiotico/epitelio_fosforescente.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "reef_luminescente"
+  ]
 }

--- a/data/traits/simbiotico/ghiandole_cambio_salino.json
+++ b/data/traits/simbiotico/ghiandole_cambio_salino.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "laguna_bioreattiva"
+  ]
 }

--- a/data/traits/simbiotico/ghiandole_nebbia_acida.json
+++ b/data/traits/simbiotico/ghiandole_nebbia_acida.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_acida"
+  ]
 }

--- a/data/traits/simbiotico/lamelle_sincroniche.json
+++ b/data/traits/simbiotico/lamelle_sincroniche.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "steppe_algoritmiche"
+  ]
 }

--- a/data/traits/simbiotico/membrane_planata_vectored.json
+++ b/data/traits/simbiotico/membrane_planata_vectored.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopia_ionica"
+  ]
 }

--- a/data/traits/simbiotico/mucillagine_simbionte_mangrovie.json
+++ b/data/traits/simbiotico/mucillagine_simbionte_mangrovie.json
@@ -56,5 +56,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "mangrovie_risonanti"
+  ]
 }

--- a/data/traits/simbiotico/nodi_micorrizici_oracolari.json
+++ b/data/traits/simbiotico/nodi_micorrizici_oracolari.json
@@ -56,5 +56,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "reti_micorriziche"
+  ]
 }

--- a/data/traits/simbiotico/sacche_spore_stratosferiche.json
+++ b/data/traits/simbiotico/sacche_spore_stratosferiche.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "stratosfera_portante"
+  ]
 }

--- a/data/traits/simbiotico/sinapsi_coraline_polifoniche.json
+++ b/data/traits/simbiotico/sinapsi_coraline_polifoniche.json
@@ -56,5 +56,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "barriere_coralline_psioniche"
+  ]
 }

--- a/data/traits/strategia/antenne_microonde_cavernose.json
+++ b/data/traits/strategia/antenne_microonde_cavernose.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/strategia/artigli_radice.json
+++ b/data/traits/strategia/artigli_radice.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "mangrovieto_cinetico"
+  ]
 }

--- a/data/traits/strategia/biofilm_glow.json
+++ b/data/traits/strategia/biofilm_glow.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "reef_luminescente"
+  ]
 }

--- a/data/traits/strategia/camere_mirage.json
+++ b/data/traits/strategia/camere_mirage.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "pianura_salina_iperarida"
+  ]
 }

--- a/data/traits/strategia/cartilagini_desertiche.json
+++ b/data/traits/strategia/cartilagini_desertiche.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "pianura_salina_iperarida"
+  ]
 }

--- a/data/traits/strategia/ciste_riduttive.json
+++ b/data/traits/strategia/ciste_riduttive.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "laguna_bioreattiva"
+  ]
 }

--- a/data/traits/strategia/colonne_vibromagnetiche.json
+++ b/data/traits/strategia/colonne_vibromagnetiche.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/strategia/denti_ossidoferro.json
+++ b/data/traits/strategia/denti_ossidoferro.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "abisso_vulcanico"
+  ]
 }

--- a/data/traits/strategia/epidermide_dielettrica.json
+++ b/data/traits/strategia/epidermide_dielettrica.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "stratosfera_tempestosa"
+  ]
 }

--- a/data/traits/strategia/focus_frazionato.json
+++ b/data/traits/strategia/focus_frazionato.json
@@ -66,5 +66,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_miceliale"
+  ]
 }

--- a/data/traits/strategia/ghiaccio_piezoelettrico.json
+++ b/data/traits/strategia/ghiaccio_piezoelettrico.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caldera_glaciale"
+  ]
 }

--- a/data/traits/strategia/ghiandole_minerali.json
+++ b/data/traits/strategia/ghiandole_minerali.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "dorsale_termale_tropicale"
+  ]
 }

--- a/data/traits/strategia/lamelle_shear.json
+++ b/data/traits/strategia/lamelle_shear.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "stratosfera_tempestosa"
+  ]
 }

--- a/data/traits/strategia/membrane_captura_rugiada.json
+++ b/data/traits/strategia/membrane_captura_rugiada.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "pianura_salina_iperarida"
+  ]
 }

--- a/data/traits/strategia/pianificatore.json
+++ b/data/traits/strategia/pianificatore.json
@@ -65,5 +65,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_miceliale"
+  ]
 }

--- a/data/traits/strategia/random.json
+++ b/data/traits/strategia/random.json
@@ -54,5 +54,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": true
-  }
+  },
+  "biome_tags": [
+    "foresta_miceliale"
+  ]
 }

--- a/data/traits/strategia/tattiche_di_branco.json
+++ b/data/traits/strategia/tattiche_di_branco.json
@@ -62,5 +62,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_miceliale"
+  ]
 }

--- a/data/traits/strutturale/antenne_tesla.json
+++ b/data/traits/strutturale/antenne_tesla.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopia_ionica"
+  ]
 }

--- a/data/traits/strutturale/artigli_vetrificati.json
+++ b/data/traits/strutturale/artigli_vetrificati.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caldera_glaciale"
+  ]
 }

--- a/data/traits/strutturale/branchie_dual_mode.json
+++ b/data/traits/strutturale/branchie_dual_mode.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "laguna_bioreattiva"
+  ]
 }

--- a/data/traits/strutturale/capillari_criogenici.json
+++ b/data/traits/strutturale/capillari_criogenici.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caldera_glaciale"
+  ]
 }

--- a/data/traits/strutturale/carapace_fase_variabile.json
+++ b/data/traits/strutturale/carapace_fase_variabile.json
@@ -80,5 +80,9 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopia_psionica_leggera",
+    "falde_magnetiche_psioniche"
+  ]
 }

--- a/data/traits/strutturale/carapace_luminiscente_abissale.json
+++ b/data/traits/strutturale/carapace_luminiscente_abissale.json
@@ -52,5 +52,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "abisso_luminescente"
+  ]
 }

--- a/data/traits/strutturale/cartilagini_pseudometalliche.json
+++ b/data/traits/strutturale/cartilagini_pseudometalliche.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "abisso_vulcanico"
+  ]
 }

--- a/data/traits/strutturale/cisti_iperbariche.json
+++ b/data/traits/strutturale/cisti_iperbariche.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "abisso_vulcanico"
+  ]
 }

--- a/data/traits/strutturale/cromofori_alert_acido.json
+++ b/data/traits/strutturale/cromofori_alert_acido.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_acida"
+  ]
 }

--- a/data/traits/strutturale/denti_tuning_fork.json
+++ b/data/traits/strutturale/denti_tuning_fork.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/strutturale/filamenti_magnetotrofi.json
+++ b/data/traits/strutturale/filamenti_magnetotrofi.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "abisso_vulcanico"
+  ]
 }

--- a/data/traits/strutturale/ghiandole_condensa_ozono.json
+++ b/data/traits/strutturale/ghiandole_condensa_ozono.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "stratosfera_tempestosa"
+  ]
 }

--- a/data/traits/strutturale/ghiandole_nebbia_ionica.json
+++ b/data/traits/strutturale/ghiandole_nebbia_ionica.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopia_ionica"
+  ]
 }

--- a/data/traits/strutturale/lamine_filtranti_aeree.json
+++ b/data/traits/strutturale/lamine_filtranti_aeree.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "mangrovieto_cinetico"
+  ]
 }

--- a/data/traits/strutturale/membrane_pneumatofori.json
+++ b/data/traits/strutturale/membrane_pneumatofori.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "mangrovieto_cinetico"
+  ]
 }

--- a/data/traits/strutturale/scheletro_idro_regolante.json
+++ b/data/traits/strutturale/scheletro_idro_regolante.json
@@ -56,5 +56,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/strutturale/struttura_elastica_amorfa.json
+++ b/data/traits/strutturale/struttura_elastica_amorfa.json
@@ -68,5 +68,9 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopia_psionica_leggera",
+    "falde_magnetiche_psioniche"
+  ]
 }

--- a/data/traits/supporto/antenne_eco_turbina.json
+++ b/data/traits/supporto/antenne_eco_turbina.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "dorsale_termale_tropicale"
+  ]
 }

--- a/data/traits/supporto/artigli_acidofagi.json
+++ b/data/traits/supporto/artigli_acidofagi.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_acida"
+  ]
 }

--- a/data/traits/supporto/batteri_termofili_endosimbiosi.json
+++ b/data/traits/supporto/batteri_termofili_endosimbiosi.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "dorsale_termale_tropicale"
+  ]
 }

--- a/data/traits/supporto/branchie_turbina.json
+++ b/data/traits/supporto/branchie_turbina.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "dorsale_termale_tropicale"
+  ]
 }

--- a/data/traits/supporto/carapaci_ferruginosi.json
+++ b/data/traits/supporto/carapaci_ferruginosi.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "abisso_vulcanico"
+  ]
 }

--- a/data/traits/supporto/circolazione_doppia.json
+++ b/data/traits/supporto/circolazione_doppia.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "dorsale_termale_tropicale"
+  ]
 }

--- a/data/traits/supporto/coda_stabilizzatrice_geiser.json
+++ b/data/traits/supporto/coda_stabilizzatrice_geiser.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "dorsale_termale_tropicale"
+  ]
 }

--- a/data/traits/supporto/cuticole_neutralizzanti.json
+++ b/data/traits/supporto/cuticole_neutralizzanti.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_acida"
+  ]
 }

--- a/data/traits/supporto/empatia_coordinativa.json
+++ b/data/traits/supporto/empatia_coordinativa.json
@@ -58,5 +58,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_miceliale"
+  ]
 }

--- a/data/traits/supporto/enzimi_chelatori_rapidi.json
+++ b/data/traits/supporto/enzimi_chelatori_rapidi.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_acida"
+  ]
 }

--- a/data/traits/supporto/foliage_fotocatodico.json
+++ b/data/traits/supporto/foliage_fotocatodico.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_acida"
+  ]
 }

--- a/data/traits/supporto/ghiandole_inchiostro_luce.json
+++ b/data/traits/supporto/ghiandole_inchiostro_luce.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "reef_luminescente"
+  ]
 }

--- a/data/traits/supporto/gusci_criovetro.json
+++ b/data/traits/supporto/gusci_criovetro.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caldera_glaciale"
+  ]
 }

--- a/data/traits/supporto/luminescenza_hydrotermica.json
+++ b/data/traits/supporto/luminescenza_hydrotermica.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "abisso_vulcanico"
+  ]
 }

--- a/data/traits/supporto/risonanza_di_branco.json
+++ b/data/traits/supporto/risonanza_di_branco.json
@@ -67,5 +67,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foresta_miceliale"
+  ]
 }

--- a/data/traits/tegumentario/mimetismo_cromatico_passivo.json
+++ b/data/traits/tegumentario/mimetismo_cromatico_passivo.json
@@ -67,5 +67,9 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "canopia_psionica_leggera",
+    "falde_magnetiche_psioniche"
+  ]
 }

--- a/data/traits/tegumentario/piume_solari_fotovoltaiche.json
+++ b/data/traits/tegumentario/piume_solari_fotovoltaiche.json
@@ -42,5 +42,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "altipiani_solari"
+  ]
 }

--- a/data/traits/tegumentario/secrezione_rallentante_palmi.json
+++ b/data/traits/tegumentario/secrezione_rallentante_palmi.json
@@ -40,5 +40,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "caverna_risonante"
+  ]
 }

--- a/data/traits/tegumentario/squame_rifrangenti_deserto.json
+++ b/data/traits/tegumentario/squame_rifrangenti_deserto.json
@@ -41,5 +41,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "dune_cristalline"
+  ]
 }

--- a/data/traits/tegumentario/vello_condensatore_nebbie.json
+++ b/data/traits/tegumentario/vello_condensatore_nebbie.json
@@ -39,5 +39,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false
-  }
+  },
+  "biome_tags": [
+    "foreste_nubose"
+  ]
 }


### PR DESCRIPTION
## Summary
- populate the `biome_tags` field for all traits shipped in the `coverage_q4_2025` and `controllo_psionico` packages
- derive the tags from each entry's `requisiti_ambientali` so the completion flags remain coherent

## Testing
- python tools/py/normalize_trait_style.py

------
https://chatgpt.com/codex/tasks/task_e_6907b19f2c148332a78c7e80ed3603b5