### PR TITLE
Document trait usage tag vocabulary and populate catalog

### DIFF
--- a/data/traits/difensivo/ali_membrana_sonica.json
+++ b/data/traits/difensivo/ali_membrana_sonica.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ali_membrana_sonica.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ali_membrana_sonica.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/difensivo/appendici_risonanti_marea.json
+++ b/data/traits/difensivo/appendici_risonanti_marea.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.appendici_risonanti_marea.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.appendici_risonanti_marea.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "laguna_bioreattiva"

--- a/data/traits/difensivo/barriere_miasma_glaciale.json
+++ b/data/traits/difensivo/barriere_miasma_glaciale.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.barriere_miasma_glaciale.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.barriere_miasma_glaciale.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caldera_glaciale"

--- a/data/traits/difensivo/branchie_microfiltri.json
+++ b/data/traits/difensivo/branchie_microfiltri.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.branchie_microfiltri.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.branchie_microfiltri.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "reef_luminescente"

--- a/data/traits/difensivo/capsule_paracadute.json
+++ b/data/traits/difensivo/capsule_paracadute.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.capsule_paracadute.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.capsule_paracadute.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"

--- a/data/traits/difensivo/circolazione_bifasica.json
+++ b/data/traits/difensivo/circolazione_bifasica.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.circolazione_bifasica.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.circolazione_bifasica.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caldera_glaciale"

--- a/data/traits/difensivo/coda_coppia_retroattiva.json
+++ b/data/traits/difensivo/coda_coppia_retroattiva.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.coda_coppia_retroattiva.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.coda_coppia_retroattiva.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "steppe_algoritmiche"

--- a/data/traits/difensivo/cute_resistente_sali.json
+++ b/data/traits/difensivo/cute_resistente_sali.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.cute_resistente_sali.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.cute_resistente_sali.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "badlands"

--- a/data/traits/difensivo/enzimi_antipredatori_algali.json
+++ b/data/traits/difensivo/enzimi_antipredatori_algali.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.enzimi_antipredatori_algali.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.enzimi_antipredatori_algali.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "reef_luminescente"

--- a/data/traits/difensivo/filtri_planctonici.json
+++ b/data/traits/difensivo/filtri_planctonici.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.filtri_planctonici.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.filtri_planctonici.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "laguna_bioreattiva"

--- a/data/traits/difensivo/ghiandole_fango_coesivo.json
+++ b/data/traits/difensivo/ghiandole_fango_coesivo.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ghiandole_fango_coesivo.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ghiandole_fango_coesivo.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"

--- a/data/traits/difensivo/giunti_antitorsione.json
+++ b/data/traits/difensivo/giunti_antitorsione.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.giunti_antitorsione.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.giunti_antitorsione.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"

--- a/data/traits/difensivo/lingua_cristallina.json
+++ b/data/traits/difensivo/lingua_cristallina.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.lingua_cristallina.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.lingua_cristallina.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"

--- a/data/traits/difensivo/mucose_barofile.json
+++ b/data/traits/difensivo/mucose_barofile.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.mucose_barofile.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.mucose_barofile.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "abisso_vulcanico"

--- a/data/traits/difesa/armatura_pietra_planare.json
+++ b/data/traits/difesa/armatura_pietra_planare.json
@@ -41,8 +41,12 @@
   "spinta_selettiva": "i18n:traits.armatura_pietra_planare.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.armatura_pietra_planare.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   }
 }

--- a/data/traits/difesa/mantello_meteoritico.json
+++ b/data/traits/difesa/mantello_meteoritico.json
@@ -42,8 +42,13 @@
   "spinta_selettiva": "i18n:traits.mantello_meteoritico.spinta_selettiva",
   "tier": "T3",
   "uso_funzione": "i18n:traits.mantello_meteoritico.uso_funzione",
+  "usage_tags": [
+    "sustain",
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   }
 }

--- a/data/traits/digestivo/filamenti_digestivi_compattanti.json
+++ b/data/traits/digestivo/filamenti_digestivi_compattanti.json
@@ -62,9 +62,13 @@
   "spinta_selettiva": "i18n:traits.filamenti_digestivi_compattanti.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.filamenti_digestivi_compattanti.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante",

--- a/data/traits/digestivo/ventriglio_gastroliti.json
+++ b/data/traits/digestivo/ventriglio_gastroliti.json
@@ -49,9 +49,13 @@
   "spinta_selettiva": "i18n:traits.ventriglio_gastroliti.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ventriglio_gastroliti.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/escretorio/spore_psichiche_silenziate.json
+++ b/data/traits/escretorio/spore_psichiche_silenziate.json
@@ -36,9 +36,14 @@
   "spinta_selettiva": "i18n:traits.spore_psichiche_silenziate.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.spore_psichiche_silenziate.uso_funzione",
+  "usage_tags": [
+    "controller",
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/idrostatico/sacche_galleggianti_ascensoriali.json
+++ b/data/traits/idrostatico/sacche_galleggianti_ascensoriali.json
@@ -52,9 +52,14 @@
   "spinta_selettiva": "i18n:traits.sacche_galleggianti_ascensoriali.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.sacche_galleggianti_ascensoriali.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopia_psionica_leggera",

--- a/data/traits/index.csv
+++ b/data/traits/index.csv
@@ -1,176 +1,196 @@
 id,label,category,type,path,completeness,data_origin,biome_tags,usage_tags,has_biome,has_species_link
-ali_membrana_sonica,Ali Membrana Sonica,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/ali_membrana_sonica.json,,coverage_q4_2025,,,true,false
-appendici_risonanti_marea,Appendici Risonanti Marea,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/appendici_risonanti_marea.json,,coverage_q4_2025,,,true,false
-barriere_miasma_glaciale,Barriere Miasma Glaciale,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/barriere_miasma_glaciale.json,,coverage_q4_2025,,,true,false
-branchie_microfiltri,Branchie Microfiltri,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/branchie_microfiltri.json,,coverage_q4_2025,,,true,false
-capsule_paracadute,Capsule Paracadute,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/capsule_paracadute.json,,coverage_q4_2025,,,true,false
-circolazione_bifasica,Circolazione Bifasica,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/circolazione_bifasica.json,,coverage_q4_2025,,,true,false
-coda_coppia_retroattiva,Coda Coppia Retroattiva,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/coda_coppia_retroattiva.json,,coverage_q4_2025,,,true,false
-cute_resistente_sali,Cute Resistente Sali,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/cute_resistente_sali.json,,coverage_q4_2025,,,true,false
-enzimi_antipredatori_algali,Enzimi Antipredatori Algali,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/enzimi_antipredatori_algali.json,,coverage_q4_2025,,,true,false
-filtri_planctonici,Filtri Planctonici,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/filtri_planctonici.json,,coverage_q4_2025,,,true,false
-ghiandole_fango_coesivo,Ghiandole Fango Coesivo,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/ghiandole_fango_coesivo.json,,coverage_q4_2025,,,true,false
-giunti_antitorsione,Giunti Antitorsione,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/giunti_antitorsione.json,,coverage_q4_2025,,,true,false
-lingua_cristallina,Lingua Cristallina,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/lingua_cristallina.json,,coverage_q4_2025,,,true,false
-mucose_barofile,Mucose Barofile,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/mucose_barofile.json,,coverage_q4_2025,,,true,false
-armatura_pietra_planare,Armatura di Pietra Planare,Difesa/Strutturale,Strutturale,data/traits/difesa/armatura_pietra_planare.json,,pathfinder_dataset,,,true,false
-mantello_meteoritico,Mantello Meteoritico,Difesa/Termoregolazione,Termoregolazione,data/traits/difesa/mantello_meteoritico.json,,pathfinder_dataset,,,true,false
-filamenti_digestivi_compattanti,Filamento materiali digeriti,Digestivo/Escretorio,Escretorio,data/traits/digestivo/filamenti_digestivi_compattanti.json,,controllo_psionico,,,true,false
-ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Digestivo/Alimentare,Alimentare,data/traits/digestivo/ventriglio_gastroliti.json,,controllo_psionico,,,true,false
-spore_psichiche_silenziate,Spora Psichica Silenziosa,Escretorio/Psichico,Psichico,data/traits/escretorio/spore_psichiche_silenziate.json,,controllo_psionico,,,true,false
-sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Idrostatico/Locomotorio,Locomotorio,data/traits/idrostatico/sacche_galleggianti_ascensoriali.json,,controllo_psionico,,,true,false
-ali_ioniche,Ali Ioniche,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/ali_ioniche.json,,coverage_q4_2025,,,true,false
-antenne_wideband,Antenne Wideband,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/antenne_wideband.json,,coverage_q4_2025,,,true,false
-artigli_sette_vie,Artigli a Sette Vie,Locomotorio/Prensile,Prensile,data/traits/locomotorio/artigli_sette_vie.json,,controllo_psionico,,,true,false
-artigli_sghiaccio_glaciale,Artigli Sghiaccio Glaciale,Locomotorio/Predatorio,Predatorio,data/traits/locomotorio/artigli_sghiaccio_glaciale.json,,controllo_psionico,,,true,false
-barbigli_sensori_plasma,Barbigli Sensori Plasma,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/barbigli_sensori_plasma.json,,coverage_q4_2025,,,true,false
-branchie_metalloidi,Branchie Metalloidi,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/branchie_metalloidi.json,,coverage_q4_2025,,,true,false
-capillari_fotovoltaici,Capillari Fotovoltaici,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/capillari_fotovoltaici.json,,coverage_q4_2025,,,true,false
-cartilagine_flessotermica_venti,Cartilagine Flessotermica dei Venti,Locomotorio/Adattivo,Adattivo,data/traits/locomotorio/cartilagine_flessotermica_venti.json,,controllo_psionico,,,true,false
-chemiorecettori_bromuro,Chemiorecettori Bromuro,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/chemiorecettori_bromuro.json,,coverage_q4_2025,,,true,false
-coda_contrappeso,Coda Contrappeso,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/coda_contrappeso.json,,coverage_q4_2025,,,true,false
-coda_frusta_cinetica,Coda a Frusta Cinetica,Locomotorio/Difensivo,Difensivo,data/traits/locomotorio/coda_frusta_cinetica.json,,controllo_psionico,,,true,false
-cuscinetti_elettrostatici,Cuscinetti Elettrostatici,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/cuscinetti_elettrostatici.json,,coverage_q4_2025,,,true,false
-enzimi_antifase_termica,Enzimi Antifase Termica,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/enzimi_antifase_termica.json,,coverage_q4_2025,,,true,false
-filamenti_termoconduzione,Filamenti Termoconduzione,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/filamenti_termoconduzione.json,,coverage_q4_2025,,,true,false
-ghiandole_fango_calde,Ghiandole Fango Calde,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/ghiandole_fango_calde.json,,coverage_q4_2025,,,true,false
-ghiandole_ventosa,Ghiandole Ventosa,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/ghiandole_ventosa.json,,coverage_q4_2025,,,true,false
-linfa_tampone,Linfa Tampone,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/linfa_tampone.json,,coverage_q4_2025,,,true,false
-mucose_aderenza_sonica,Mucose Aderenza Sonica,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/mucose_aderenza_sonica.json,,coverage_q4_2025,,,true,false
-zampe_a_molla,Zampe a Molla,Mobilità/Cinetico,Cinetico,data/traits/locomotorio/zampe_a_molla.json,,controllo_psionico,,,true,false
-zoccoli_risonanti_steppe,Zoccoli Risonanti delle Steppe,Locomotorio/Supporto,Supporto,data/traits/locomotorio/zoccoli_risonanti_steppe.json,,controllo_psionico,,,true,false
-antenne_dustsense,Antenne Dustsense,Digestivo/Metabolico,Metabolico,data/traits/metabolico/antenne_dustsense.json,,coverage_q4_2025,,,true,false
-appendici_thermotattiche,Appendici Thermotattiche,Digestivo/Metabolico,Metabolico,data/traits/metabolico/appendici_thermotattiche.json,,coverage_q4_2025,,,true,false
-batteri_endosimbionti_chemio,Batteri Endosimbionti Chemio,Digestivo/Metabolico,Metabolico,data/traits/metabolico/batteri_endosimbionti_chemio.json,,coverage_q4_2025,,,true,false
-branchie_solfatiche,Branchie Solfatiche,Digestivo/Metabolico,Metabolico,data/traits/metabolico/branchie_solfatiche.json,,coverage_q4_2025,,,true,false
-carapace_segmenti_logici,Carapace Segmenti Logici,Digestivo/Metabolico,Metabolico,data/traits/metabolico/carapace_segmenti_logici.json,,coverage_q4_2025,,,true,false
-circolazione_bifasica_palude,Circolazione Bifasica di Palude,Metabolico/Resilienza,Resilienza,data/traits/metabolico/circolazione_bifasica_palude.json,,controllo_psionico,,,true,false
-circolazione_cooling_loop,Circolazione Cooling Loop,Digestivo/Metabolico,Metabolico,data/traits/metabolico/circolazione_cooling_loop.json,,coverage_q4_2025,,,true,false
-coda_stabilizzatrice_filo,Coda Stabilizzatrice Filo,Digestivo/Metabolico,Metabolico,data/traits/metabolico/coda_stabilizzatrice_filo.json,,coverage_q4_2025,,,true,false
-criostasi_adattiva,Criostasi,Metabolico/Difensivo,Difensivo,data/traits/metabolico/criostasi_adattiva.json,,controllo_psionico,,,true,false
-cuticole_cerose,Cuticole Cerose,Digestivo/Metabolico,Metabolico,data/traits/metabolico/cuticole_cerose.json,,controllo_psionico,,,true,false
-enzimi_chelanti,Enzimi Chelanti,Digestivo/Metabolico,Metabolico,data/traits/metabolico/enzimi_chelanti.json,,controllo_psionico,,,true,false
-flagelli_ancoranti,Flagelli Ancoranti,Digestivo/Metabolico,Metabolico,data/traits/metabolico/flagelli_ancoranti.json,,coverage_q4_2025,,,true,false
-ghiandole_grafene,Ghiandole Grafene,Digestivo/Metabolico,Metabolico,data/traits/metabolico/ghiandole_grafene.json,,coverage_q4_2025,,,true,false
-grassi_termici,Grassi Termici,Digestivo/Metabolico,Metabolico,data/traits/metabolico/grassi_termici.json,,controllo_psionico,,,true,false
-luminescenza_aurorale,Luminescenza Aurorale,Digestivo/Metabolico,Metabolico,data/traits/metabolico/luminescenza_aurorale.json,,coverage_q4_2025,,,true,false
-sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Nervoso/Omeostatico,Omeostatico,data/traits/nervoso/sonno_emisferico_alternato.json,,controllo_psionico,,,true,false
-antenne_flusso_mareale,Antenne Flusso Mareale,Offensivo/Assalto,Assalto,data/traits/offensivo/antenne_flusso_mareale.json,,coverage_q4_2025,,,true,false
-artigli_induzione,Artigli Induzione,Offensivo/Assalto,Assalto,data/traits/offensivo/artigli_induzione.json,,coverage_q4_2025,,,true,false
-biochip_memoria,Biochip Memoria,Offensivo/Assalto,Assalto,data/traits/offensivo/biochip_memoria.json,,coverage_q4_2025,,,true,false
-camere_anticorrosione,Camere Anticorrosione,Offensivo/Assalto,Assalto,data/traits/offensivo/camere_anticorrosione.json,,coverage_q4_2025,,,true,false
-cartilagini_biofibre,Cartilagini Biofibre,Offensivo/Assalto,Assalto,data/traits/offensivo/cartilagini_biofibre.json,,coverage_q4_2025,,,true,false
-circolazione_supercritica,Circolazione Supercritica,Offensivo/Assalto,Assalto,data/traits/offensivo/circolazione_supercritica.json,,coverage_q4_2025,,,true,false
-coda_stabilizzatrice_vortex,Coda Stabilizzatrice Vortex,Offensivo/Assalto,Assalto,data/traits/offensivo/coda_stabilizzatrice_vortex.json,,coverage_q4_2025,,,true,false
-denti_chelatanti,Denti Chelatanti,Offensivo/Assalto,Assalto,data/traits/offensivo/denti_chelatanti.json,,coverage_q4_2025,,,true,false
-enzimi_metanoossidanti,Enzimi Metanoossidanti,Offensivo/Assalto,Assalto,data/traits/offensivo/enzimi_metanoossidanti.json,,coverage_q4_2025,,,true,false
-foliaggio_spugna,Foliaggio Spugna,Offensivo/Assalto,Assalto,data/traits/offensivo/foliaggio_spugna.json,,coverage_q4_2025,,,true,false
-frusta_fiammeggiante,Frusta Fiammeggiante,Offensivo/Controllo,Controllo,data/traits/offensivo/frusta_fiammeggiante.json,,pathfinder_dataset,,,true,false
-ghiandola_caustica,Ghiandola Caustica,Offensivo/Chimico,Chimico,data/traits/offensivo/ghiandola_caustica.json,,controllo_psionico,,,true,false
-ghiandole_iodoattive,Ghiandole Iodoattive,Offensivo/Assalto,Assalto,data/traits/offensivo/ghiandole_iodoattive.json,,coverage_q4_2025,,,true,false
-gusci_magnesio,Gusci Magnesio,Offensivo/Assalto,Assalto,data/traits/offensivo/gusci_magnesio.json,,coverage_q4_2025,,,true,false
-mantelli_geotermici,Mantelli Geotermici,Offensivo/Assalto,Assalto,data/traits/offensivo/mantelli_geotermici.json,,coverage_q4_2025,,,true,false
-sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Offensivo/Cinetico,Cinetico,data/traits/offensivo/sangue_piroforico.json,,controllo_psionico,,,true,false
-branchie_osmotiche_salmastra,Branchie Osmotiche Salmastre,Respiratorio/Osmoregolazione,Osmoregolazione,data/traits/respiratorio/branchie_osmotiche_salmastra.json,,controllo_psionico,,,true,false
-lamelle_termoforetiche,Lamelle Termoforetiche,Respiratorio/Termoregolazione,Termoregolazione,data/traits/respiratorio/lamelle_termoforetiche.json,,controllo_psionico,,,true,false
-membrane_eliofiltranti,Membrane Eliofiltranti,Respiratorio/Protezione,Protezione,data/traits/respiratorio/membrane_eliofiltranti.json,,controllo_psionico,,,true,false
-polmoni_cristallini_alta_quota,Polmoni Cristallini d'Alta Quota,Respiratorio/Aerobico,Aerobico,data/traits/respiratorio/polmoni_cristallini_alta_quota.json,,controllo_psionico,,,true,false
-respiro_a_scoppio,Respiro a scoppio,Respiratorio/Propulsivo,Propulsivo,data/traits/respiratorio/respiro_a_scoppio.json,,controllo_psionico,,,true,false
-nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Riproduttivo/Locomotorio,Locomotorio,data/traits/riproduttivo/nucleo_ovomotore_rotante.json,,controllo_psionico,,,true,false
-ali_fulminee,Ali Fulminee,Sensoriale/Analitico,Analitico,data/traits/sensoriale/ali_fulminee.json,,coverage_q4_2025,,,true,false
-antenne_plasmatiche_tempesta,Antenne Plasmatiche di Tempesta,Sensoriale/Offensivo,Offensivo,data/traits/sensoriale/antenne_plasmatiche_tempesta.json,,controllo_psionico,,,true,false
-antenne_waveguide,Antenne Waveguide,Sensoriale/Analitico,Analitico,data/traits/sensoriale/antenne_waveguide.json,,coverage_q4_2025,,,true,false
-baffi_mareomotori,Baffi Mareomotori,Sensoriale/Analitico,Analitico,data/traits/sensoriale/baffi_mareomotori.json,,coverage_q4_2025,,,true,false
-branchie_eoliche,Branchie Eoliche,Sensoriale/Analitico,Analitico,data/traits/sensoriale/branchie_eoliche.json,,coverage_q4_2025,,,true,false
-capillari_fluoridici,Capillari Fluoridici,Sensoriale/Analitico,Analitico,data/traits/sensoriale/capillari_fluoridici.json,,coverage_q4_2025,,,true,false
-cavita_risonanti_tundra,Cavità Risonanti della Tundra,Sensoriale/Supporto,Supporto,data/traits/sensoriale/cavita_risonanti_tundra.json,,controllo_psionico,,,true,false
-cervelletto_equilibrio_statico,Cervelletto Equilibrio Statico,Sensoriale/Analitico,Analitico,data/traits/sensoriale/cervelletto_equilibrio_statico.json,,coverage_q4_2025,,,true,false
-coda_balanciere,Coda Balanciere,Sensoriale/Analitico,Analitico,data/traits/sensoriale/coda_balanciere.json,,coverage_q4_2025,,,true,false
-cuore_multicamera_bassa_pressione,Cuore Multicamera Bassa Pressione,Sensoriale/Analitico,Analitico,data/traits/sensoriale/cuore_multicamera_bassa_pressione.json,,coverage_q4_2025,,,true,false
-echi_risonanti,Echi Risonanti,Sensoriale/Analitico,Analitico,data/traits/sensoriale/echi_risonanti.json,,coverage_q4_2025,,,true,false
-eco_interno_riflesso,Riflesso dell'Eco Interno,Sensoriale/Nervoso,Nervoso,data/traits/sensoriale/eco_interno_riflesso.json,,controllo_psionico,,,true,false
-filamenti_superconduttivi,Filamenti Superconduttivi,Sensoriale/Analitico,Analitico,data/traits/sensoriale/filamenti_superconduttivi.json,,coverage_q4_2025,,,true,false
-ghiandole_eco_mappanti,Ghiandole Eco Mappanti,Sensoriale/Analitico,Analitico,data/traits/sensoriale/ghiandole_eco_mappanti.json,,coverage_q4_2025,,,true,false
-ghiandole_resina_conduttiva,Ghiandole Resina Conduttiva,Sensoriale/Analitico,Analitico,data/traits/sensoriale/ghiandole_resina_conduttiva.json,,coverage_q4_2025,,,true,false
-lamine_scudo_silice,Lamine Scudo Silice,Sensoriale/Analitico,Analitico,data/traits/sensoriale/lamine_scudo_silice.json,,coverage_q4_2025,,,true,false
-lingua_tattile_trama,Lingua Tattile Trama-Sensibile,Sensoriale/Alimentare,Alimentare,data/traits/sensoriale/lingua_tattile_trama.json,,controllo_psionico,,,true,false
-midollo_antivibrazione,Midollo Antivibrazione,Sensoriale/Analitico,Analitico,data/traits/sensoriale/midollo_antivibrazione.json,,coverage_q4_2025,,,true,false
-occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Sensoriale/Visivo,Visivo,data/traits/sensoriale/occhi_infrarosso_composti.json,,controllo_psionico,,,true,false
-olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Sensoriale/Nervoso,Nervoso,data/traits/sensoriale/olfatto_risonanza_magnetica.json,,controllo_psionico,,,true,false
-sensori_geomagnetici,Sensori Geomagnetici,Sensoriale/Navigazione,Navigazione,data/traits/sensoriale/sensori_geomagnetici.json,,controllo_psionico,,,true,false
-antenne_reagenti,Antenne Reagenti,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/antenne_reagenti.json,,coverage_q4_2025,,,true,false
-artigli_scivolo_silente,Artigli Scivolo Silente,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/artigli_scivolo_silente.json,,coverage_q4_2025,,,true,false
-biofilm_iperarido,Biofilm Iperarido,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/biofilm_iperarido.json,,coverage_q4_2025,,,true,false
-bulbi_radici_permafrost,Bulbi Radici del Permafrost,Simbiotico/Nutrizione,Nutrizione,data/traits/simbiotico/bulbi_radici_permafrost.json,,controllo_psionico,,,true,false
-camere_nutrienti_vent,Camere Nutrienti Vent,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/camere_nutrienti_vent.json,,coverage_q4_2025,,,true,false
-cartilagini_flessoacustiche,Cartilagini Flessoacustiche,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/cartilagini_flessoacustiche.json,,coverage_q4_2025,,,true,false
-chioma_parassita_canopica,Chioma Parassita Canopica,Simbiotico/Utility,Utility,data/traits/simbiotico/chioma_parassita_canopica.json,,controllo_psionico,,,true,false
-ciste_salmastre,Ciste Salmastre,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/ciste_salmastre.json,,coverage_q4_2025,,,true,false
-coralli_partner,Coralli Partner,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/coralli_partner.json,,coverage_q4_2025,,,true,false
-denti_silice_termici,Denti Silice Termici,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/denti_silice_termici.json,,coverage_q4_2025,,,true,false
-epitelio_fosforescente,Epitelio Fosforescente,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/epitelio_fosforescente.json,,coverage_q4_2025,,,true,false
-ghiandole_cambio_salino,Ghiandole Cambio Salino,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/ghiandole_cambio_salino.json,,coverage_q4_2025,,,true,false
-ghiandole_nebbia_acida,Ghiandole Nebbia Acida,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/ghiandole_nebbia_acida.json,,coverage_q4_2025,,,true,false
-lamelle_sincroniche,Lamelle Sincroniche,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/lamelle_sincroniche.json,,coverage_q4_2025,,,true,false
-membrane_planata_vectored,Membrane Planata Vectored,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/membrane_planata_vectored.json,,coverage_q4_2025,,,true,false
-mucillagine_simbionte_mangrovie,Mucillagine Simbionte delle Mangrovie,Simbiotico/Difensivo,Difensivo,data/traits/simbiotico/mucillagine_simbionte_mangrovie.json,,controllo_psionico,,,true,false
-nodi_micorrizici_oracolari,Nodi Micorrizici Oracolari,Simbiotico/Nervoso,Nervoso,data/traits/simbiotico/nodi_micorrizici_oracolari.json,,controllo_psionico,,,true,false
-sacche_spore_stratosferiche,Sacche di Spore Stratosferiche,Simbiotico/Supporto,Supporto,data/traits/simbiotico/sacche_spore_stratosferiche.json,,controllo_psionico,,,true,false
-sinapsi_coraline_polifoniche,Sinapsi Coraline Polifoniche,Simbiotico/Comunicazione,Comunicazione,data/traits/simbiotico/sinapsi_coraline_polifoniche.json,,controllo_psionico,,,true,false
-species_affinity,,,,data/traits/species_affinity.json,,,,,false,false
-antenne_microonde_cavernose,Antenne Microonde Cavernose,Strategico/Tattico,Tattico,data/traits/strategia/antenne_microonde_cavernose.json,,coverage_q4_2025,,,true,false
-artigli_radice,Artigli Radice,Strategico/Tattico,Tattico,data/traits/strategia/artigli_radice.json,,coverage_q4_2025,,,true,false
-biofilm_glow,Biofilm Glow,Strategico/Tattico,Tattico,data/traits/strategia/biofilm_glow.json,,coverage_q4_2025,,,true,false
-camere_mirage,Camere Mirage,Strategico/Tattico,Tattico,data/traits/strategia/camere_mirage.json,,coverage_q4_2025,,,true,false
-cartilagini_desertiche,Cartilagini Desertiche,Strategico/Tattico,Tattico,data/traits/strategia/cartilagini_desertiche.json,,coverage_q4_2025,,,true,false
-ciste_riduttive,Ciste Riduttive,Strategico/Tattico,Tattico,data/traits/strategia/ciste_riduttive.json,,coverage_q4_2025,,,true,false
-colonne_vibromagnetiche,Colonne Vibromagnetiche,Strategico/Tattico,Tattico,data/traits/strategia/colonne_vibromagnetiche.json,,coverage_q4_2025,,,true,false
-denti_ossidoferro,Denti Ossidoferro,Strategico/Tattico,Tattico,data/traits/strategia/denti_ossidoferro.json,,coverage_q4_2025,,,true,false
-epidermide_dielettrica,Epidermide Dielettrica,Strategico/Tattico,Tattico,data/traits/strategia/epidermide_dielettrica.json,,coverage_q4_2025,,,true,false
-focus_frazionato,Focus Frazionato,Strategico/Psionico,Psionico,data/traits/strategia/focus_frazionato.json,,controllo_psionico,,,true,false
-ghiaccio_piezoelettrico,Ghiaccio Piezoelettrico,Strategico/Tattico,Tattico,data/traits/strategia/ghiaccio_piezoelettrico.json,,coverage_q4_2025,,,true,false
-ghiandole_minerali,Ghiandole Minerali,Strategico/Tattico,Tattico,data/traits/strategia/ghiandole_minerali.json,,coverage_q4_2025,,,true,false
-lamelle_shear,Lamelle Shear,Strategico/Tattico,Tattico,data/traits/strategia/lamelle_shear.json,,coverage_q4_2025,,,true,false
-membrane_captura_rugiada,Membrane Captura Rugiada,Strategico/Tattico,Tattico,data/traits/strategia/membrane_captura_rugiada.json,,coverage_q4_2025,,,true,false
-pathfinder,Pathfinder,Esplorazione/Tattico,Tattico,data/traits/strategia/pathfinder.json,,controllo_psionico,foresta_acida;foresta_miceliale,scout;support,true,true
-pianificatore,Pianificatore,Strategico/Tattico,Tattico,data/traits/strategia/pianificatore.json,,controllo_psionico,,,true,false
-random,Trait Random,Flessibile/Generico,Generico,data/traits/strategia/random.json,,controllo_psionico,,,true,false
-tattiche_di_branco,Tattiche di Branco,Strategico/Tattico,Tattico,data/traits/strategia/tattiche_di_branco.json,,controllo_psionico,,,true,false
-antenne_tesla,Antenne Tesla,Strutturale/Adattivo,Adattivo,data/traits/strutturale/antenne_tesla.json,,coverage_q4_2025,,,true,false
-artigli_vetrificati,Artigli Vetrificati,Strutturale/Adattivo,Adattivo,data/traits/strutturale/artigli_vetrificati.json,,coverage_q4_2025,,,true,false
-branchie_dual_mode,Branchie Dual Mode,Strutturale/Adattivo,Adattivo,data/traits/strutturale/branchie_dual_mode.json,,coverage_q4_2025,,,true,false
-capillari_criogenici,Capillari Criogenici,Strutturale/Adattivo,Adattivo,data/traits/strutturale/capillari_criogenici.json,,coverage_q4_2025,,,true,false
-carapace_fase_variabile,Carapace a Variazione di Fase,Strutturale/Difensivo,Difensivo,data/traits/strutturale/carapace_fase_variabile.json,,controllo_psionico,,,true,false
-carapace_luminiscente_abissale,Carapace Luminiscente Abissale,Strutturale/Sensoriale,Sensoriale,data/traits/strutturale/carapace_luminiscente_abissale.json,,controllo_psionico,,,true,false
-cartilagini_pseudometalliche,Cartilagini Pseudometalliche,Strutturale/Adattivo,Adattivo,data/traits/strutturale/cartilagini_pseudometalliche.json,,coverage_q4_2025,,,true,false
-cisti_iperbariche,Cisti Iperbariche,Strutturale/Adattivo,Adattivo,data/traits/strutturale/cisti_iperbariche.json,,coverage_q4_2025,,,true,false
-cromofori_alert_acido,Cromofori Alert Acido,Strutturale/Adattivo,Adattivo,data/traits/strutturale/cromofori_alert_acido.json,,coverage_q4_2025,,,true,false
-denti_tuning_fork,Denti Tuning Fork,Strutturale/Adattivo,Adattivo,data/traits/strutturale/denti_tuning_fork.json,,coverage_q4_2025,,,true,false
-filamenti_magnetotrofi,Filamenti Magnetotrofi,Strutturale/Adattivo,Adattivo,data/traits/strutturale/filamenti_magnetotrofi.json,,coverage_q4_2025,,,true,false
-ghiandole_condensa_ozono,Ghiandole Condensa Ozono,Strutturale/Adattivo,Adattivo,data/traits/strutturale/ghiandole_condensa_ozono.json,,coverage_q4_2025,,,true,false
-ghiandole_nebbia_ionica,Ghiandole Nebbia Ionica,Strutturale/Adattivo,Adattivo,data/traits/strutturale/ghiandole_nebbia_ionica.json,,coverage_q4_2025,,,true,false
-lamine_filtranti_aeree,Lamine Filtranti Aeree,Strutturale/Adattivo,Adattivo,data/traits/strutturale/lamine_filtranti_aeree.json,,coverage_q4_2025,,,true,false
-membrane_pneumatofori,Membrane Pneumatofori,Strutturale/Adattivo,Adattivo,data/traits/strutturale/membrane_pneumatofori.json,,coverage_q4_2025,,,true,false
-scheletro_idro_regolante,Scheletro Idro-Regolante,Strutturale/Omeostatico,Omeostatico,data/traits/strutturale/scheletro_idro_regolante.json,,controllo_psionico,,,true,false
-struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Strutturale/Locomotorio,Locomotorio,data/traits/strutturale/struttura_elastica_amorfa.json,,controllo_psionico,,,true,false
-antenne_eco_turbina,Antenne Eco Turbina,Supporto/Logistico,Logistico,data/traits/supporto/antenne_eco_turbina.json,,coverage_q4_2025,,,true,false
-artigli_acidofagi,Artigli Acidofagi,Supporto/Logistico,Logistico,data/traits/supporto/artigli_acidofagi.json,,coverage_q4_2025,,,true,false
-aura_scudo_radianza,Aura Scudo di Radianza,Supporto/Difesa,Difesa,data/traits/supporto/aura_scudo_radianza.json,,pathfinder_dataset,,,true,false
-batteri_termofili_endosimbiosi,Batteri Termofili Endosimbiosi,Supporto/Logistico,Logistico,data/traits/supporto/batteri_termofili_endosimbiosi.json,,coverage_q4_2025,,,true,false
-branchie_turbina,Branchie Turbina,Supporto/Logistico,Logistico,data/traits/supporto/branchie_turbina.json,,coverage_q4_2025,,,true,false
-carapaci_ferruginosi,Carapaci Ferruginosi,Supporto/Logistico,Logistico,data/traits/supporto/carapaci_ferruginosi.json,,coverage_q4_2025,,,true,false
-circolazione_doppia,Circolazione Doppia,Supporto/Logistico,Logistico,data/traits/supporto/circolazione_doppia.json,,coverage_q4_2025,,,true,false
-coda_stabilizzatrice_geiser,Coda Stabilizzatrice Geiser,Supporto/Logistico,Logistico,data/traits/supporto/coda_stabilizzatrice_geiser.json,,coverage_q4_2025,,,true,false
-cuticole_neutralizzanti,Cuticole Neutralizzanti,Supporto/Logistico,Logistico,data/traits/supporto/cuticole_neutralizzanti.json,,coverage_q4_2025,,,true,false
-empatia_coordinativa,Empatia Coordinativa,Supporto/Empatico,Empatico,data/traits/supporto/empatia_coordinativa.json,,controllo_psionico,,,true,false
-enzimi_chelatori_rapidi,Enzimi Chelatori Rapidi,Supporto/Logistico,Logistico,data/traits/supporto/enzimi_chelatori_rapidi.json,,coverage_q4_2025,,,true,false
-foliage_fotocatodico,Foliage Fotocatodico,Supporto/Logistico,Logistico,data/traits/supporto/foliage_fotocatodico.json,,coverage_q4_2025,,,true,false
-ghiandole_inchiostro_luce,Ghiandole Inchiostro Luce,Supporto/Logistico,Logistico,data/traits/supporto/ghiandole_inchiostro_luce.json,,coverage_q4_2025,,,true,false
-gusci_criovetro,Gusci Criovetro,Supporto/Logistico,Logistico,data/traits/supporto/gusci_criovetro.json,,coverage_q4_2025,,,true,false
-luminescenza_hydrotermica,Luminescenza Hydrotermica,Supporto/Logistico,Logistico,data/traits/supporto/luminescenza_hydrotermica.json,,coverage_q4_2025,,,true,false
-risonanza_di_branco,Risonanza di Branco,Supporto/Coordinativo,Coordinativo,data/traits/supporto/risonanza_di_branco.json,,controllo_psionico,,,true,false
-mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Tegumentario/Difensivo,Difensivo,data/traits/tegumentario/mimetismo_cromatico_passivo.json,,controllo_psionico,,,true,false
-piume_solari_fotovoltaiche,Piume Solari Fotovoltaiche,Tegumentario/Energetico,Energetico,data/traits/tegumentario/piume_solari_fotovoltaiche.json,,controllo_psionico,,,true,false
-secrezione_rallentante_palmi,Mani secernano liquido rallentante,Tegumentario/Difensivo,Difensivo,data/traits/tegumentario/secrezione_rallentante_palmi.json,,controllo_psionico,,,true,false
-squame_rifrangenti_deserto,Squame Rifrangenti del Deserto,Tegumentario/Difensivo,Difensivo,data/traits/tegumentario/squame_rifrangenti_deserto.json,,controllo_psionico,,,true,false
-vello_condensatore_nebbie,Vello Condensatore di Nebbie,Tegumentario/Idratazione,Idratazione,data/traits/tegumentario/vello_condensatore_nebbie.json,,controllo_psionico,,,true,false
+artigli_a_sette_vie,i18n:traits.artigli_a_sette_vie.label,TODO/import_esterno,import_esterno,data/traits/_drafts/artigli_a_sette_vie.json,,appendix_a_canvas_originale,,,false,false
+balance_reflex,i18n:traits.balance_reflex.label,TODO/import_esterno,import_esterno,data/traits/_drafts/balance_reflex.json,,incoming_sentience_traits_v1_0_t2_pre_sociale,,,false,false
+coda_a_frusta_cinetica,i18n:traits.coda_a_frusta_cinetica.label,TODO/import_esterno,import_esterno,data/traits/_drafts/coda_a_frusta_cinetica.json,,appendix_a_canvas_originale,,,false,false
+craft_loop,i18n:traits.craft_loop.label,TODO/import_esterno,import_esterno,data/traits/_drafts/craft_loop.json,,incoming_sentience_traits_v1_0_t5_avanzato,,,false,false
+criostasi,i18n:traits.criostasi.label,TODO/import_esterno,import_esterno,data/traits/_drafts/criostasi.json,,appendix_a_canvas_originale,,,false,false
+echoic_trace,i18n:traits.echoic_trace.label,TODO/import_esterno,import_esterno,data/traits/_drafts/echoic_trace.json,,incoming_sentience_traits_v1_0_t3_emergente,,,false,false
+executive_loop,i18n:traits.executive_loop.label,TODO/import_esterno,import_esterno,data/traits/_drafts/executive_loop.json,,incoming_sentience_traits_v1_0_t6_sapiente,,,false,false
+focus_frazionato_2,i18n:traits.focus_frazionato_2.label,TODO/import_esterno,import_esterno,data/traits/_drafts/focus_frazionato_2.json,,appendix_a_canvas_originale,,,false,false
+group_form,i18n:traits.group_form.label,TODO/import_esterno,import_esterno,data/traits/_drafts/group_form.json,,incoming_sentience_traits_v1_0_t4_civico,,,false,false
+interoception_seed,i18n:traits.interoception_seed.label,TODO/import_esterno,import_esterno,data/traits/_drafts/interoception_seed.json,,incoming_sentience_traits_v1_0_t1_proto_sentiente,,,false,false
+mimicry_basic,i18n:traits.mimicry_basic.label,TODO/import_esterno,import_esterno,data/traits/_drafts/mimicry_basic.json,,incoming_sentience_traits_v1_0_t2_pre_sociale,,,false,false
+postural_endurance,i18n:traits.postural_endurance.label,TODO/import_esterno,import_esterno,data/traits/_drafts/postural_endurance.json,,incoming_sentience_traits_v1_0_t6_sapiente,,,false,false
+risonanza_di_branco_2,i18n:traits.risonanza_di_branco_2.label,TODO/import_esterno,import_esterno,data/traits/_drafts/risonanza_di_branco_2.json,,appendix_a_canvas_originale,,,false,false
+sacche_galleggianti_ascensoriali_2,i18n:traits.sacche_galleggianti_ascensoriali_2.label,TODO/import_esterno,import_esterno,data/traits/_drafts/sacche_galleggianti_ascensoriali_2.json,,appendix_a_canvas_originale,,,false,false
+scheletro_idro_regolante_2,i18n:traits.scheletro_idro_regolante_2.label,TODO/import_esterno,import_esterno,data/traits/_drafts/scheletro_idro_regolante_2.json,,appendix_a_canvas_originale,,,false,false
+sheltering,i18n:traits.sheltering.label,TODO/import_esterno,import_esterno,data/traits/_drafts/sheltering.json,,incoming_sentience_traits_v1_0_t5_avanzato,,,false,false
+startle_reflex,i18n:traits.startle_reflex.label,TODO/import_esterno,import_esterno,data/traits/_drafts/startle_reflex.json,,incoming_sentience_traits_v1_0_t1_proto_sentiente,,,false,false
+struttura_elastica_amorfa_2,i18n:traits.struttura_elastica_amorfa_2.label,TODO/import_esterno,import_esterno,data/traits/_drafts/struttura_elastica_amorfa_2.json,,appendix_a_canvas_originale,,,false,false
+tattiche_di_branco_2,i18n:traits.tattiche_di_branco_2.label,TODO/import_esterno,import_esterno,data/traits/_drafts/tattiche_di_branco_2.json,,appendix_a_canvas_originale,,,false,false
+teach_action,i18n:traits.teach_action.label,TODO/import_esterno,import_esterno,data/traits/_drafts/teach_action.json,,incoming_sentience_traits_v1_0_t4_civico,,,false,false
+toolseed,i18n:traits.toolseed.label,TODO/import_esterno,import_esterno,data/traits/_drafts/toolseed.json,,incoming_sentience_traits_v1_0_t3_emergente,,,false,false
+ali_membrana_sonica,i18n:traits.ali_membrana_sonica.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/ali_membrana_sonica.json,,coverage_q4_2025,caverna_risonante,tank,true,false
+appendici_risonanti_marea,i18n:traits.appendici_risonanti_marea.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/appendici_risonanti_marea.json,,coverage_q4_2025,laguna_bioreattiva,tank,true,false
+barriere_miasma_glaciale,i18n:traits.barriere_miasma_glaciale.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/barriere_miasma_glaciale.json,,coverage_q4_2025,caldera_glaciale,tank,true,false
+branchie_microfiltri,i18n:traits.branchie_microfiltri.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/branchie_microfiltri.json,,coverage_q4_2025,reef_luminescente,tank,true,false
+capsule_paracadute,i18n:traits.capsule_paracadute.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/capsule_paracadute.json,,coverage_q4_2025,stratosfera_tempestosa,tank,true,false
+circolazione_bifasica,i18n:traits.circolazione_bifasica.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/circolazione_bifasica.json,,coverage_q4_2025,caldera_glaciale,tank,true,false
+coda_coppia_retroattiva,i18n:traits.coda_coppia_retroattiva.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/coda_coppia_retroattiva.json,,coverage_q4_2025,steppe_algoritmiche,tank,true,false
+cute_resistente_sali,i18n:traits.cute_resistente_sali.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/cute_resistente_sali.json,,coverage_q4_2025,badlands,tank,true,false
+enzimi_antipredatori_algali,i18n:traits.enzimi_antipredatori_algali.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/enzimi_antipredatori_algali.json,,coverage_q4_2025,reef_luminescente,tank,true,false
+filtri_planctonici,i18n:traits.filtri_planctonici.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/filtri_planctonici.json,,coverage_q4_2025,laguna_bioreattiva,tank,true,false
+ghiandole_fango_coesivo,i18n:traits.ghiandole_fango_coesivo.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/ghiandole_fango_coesivo.json,,coverage_q4_2025,mangrovieto_cinetico,tank,true,false
+giunti_antitorsione,i18n:traits.giunti_antitorsione.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/giunti_antitorsione.json,,coverage_q4_2025,mangrovieto_cinetico,tank,true,false
+lingua_cristallina,i18n:traits.lingua_cristallina.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/lingua_cristallina.json,,coverage_q4_2025,pianura_salina_iperarida,tank,true,false
+mucose_barofile,i18n:traits.mucose_barofile.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/mucose_barofile.json,,coverage_q4_2025,abisso_vulcanico,tank,true,false
+armatura_pietra_planare,i18n:traits.armatura_pietra_planare.label,Difesa/Strutturale,Strutturale,data/traits/difesa/armatura_pietra_planare.json,,pathfinder_dataset,,tank,true,false
+mantello_meteoritico,i18n:traits.mantello_meteoritico.label,Difesa/Termoregolazione,Termoregolazione,data/traits/difesa/mantello_meteoritico.json,,pathfinder_dataset,,sustain;tank,true,false
+filamenti_digestivi_compattanti,i18n:traits.filamenti_digestivi_compattanti.label,Digestivo/Escretorio,Escretorio,data/traits/digestivo/filamenti_digestivi_compattanti.json,,controllo_psionico,caverna_risonante;falde_magnetiche_psioniche,sustain,true,false
+ventriglio_gastroliti,i18n:traits.ventriglio_gastroliti.label,Digestivo/Alimentare,Alimentare,data/traits/digestivo/ventriglio_gastroliti.json,,controllo_psionico,caverna_risonante,sustain,true,false
+spore_psichiche_silenziate,i18n:traits.spore_psichiche_silenziate.label,Escretorio/Psichico,Psichico,data/traits/escretorio/spore_psichiche_silenziate.json,,controllo_psionico,caverna_risonante,controller;sustain,true,false
+sacche_galleggianti_ascensoriali,i18n:traits.sacche_galleggianti_ascensoriali.label,Idrostatico/Locomotorio,Locomotorio,data/traits/idrostatico/sacche_galleggianti_ascensoriali.json,,controllo_psionico,canopia_psionica_leggera;orbita_psionica_inversa,scout;tank,true,false
+ali_ioniche,i18n:traits.ali_ioniche.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/ali_ioniche.json,,coverage_q4_2025,canopia_ionica,scout,true,false
+antenne_wideband,i18n:traits.antenne_wideband.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/antenne_wideband.json,,coverage_q4_2025,steppe_algoritmiche,scout,true,false
+artigli_sette_vie,i18n:traits.artigli_sette_vie.label,Locomotorio/Prensile,Prensile,data/traits/locomotorio/artigli_sette_vie.json,,controllo_psionico,caverna_risonante,breaker;scout,true,false
+artigli_sghiaccio_glaciale,i18n:traits.artigli_sghiaccio_glaciale.label,Locomotorio/Predatorio,Predatorio,data/traits/locomotorio/artigli_sghiaccio_glaciale.json,,controllo_psionico,calotte_glaciali,breaker;scout,true,false
+barbigli_sensori_plasma,i18n:traits.barbigli_sensori_plasma.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/barbigli_sensori_plasma.json,,coverage_q4_2025,stratosfera_tempestosa,scout,true,false
+branchie_metalloidi,i18n:traits.branchie_metalloidi.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/branchie_metalloidi.json,,coverage_q4_2025,abisso_vulcanico,scout,true,false
+capillari_fotovoltaici,i18n:traits.capillari_fotovoltaici.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/capillari_fotovoltaici.json,,coverage_q4_2025,canopia_ionica,scout,true,false
+cartilagine_flessotermica_venti,i18n:traits.cartilagine_flessotermica_venti.label,Locomotorio/Adattivo,Adattivo,data/traits/locomotorio/cartilagine_flessotermica_venti.json,,controllo_psionico,gole_ventose,scout;tank,true,false
+chemiorecettori_bromuro,i18n:traits.chemiorecettori_bromuro.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/chemiorecettori_bromuro.json,,coverage_q4_2025,pianura_salina_iperarida,scout,true,false
+coda_contrappeso,i18n:traits.coda_contrappeso.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/coda_contrappeso.json,,coverage_q4_2025,mangrovieto_cinetico,scout,true,false
+coda_frusta_cinetica,i18n:traits.coda_frusta_cinetica.label,Locomotorio/Difensivo,Difensivo,data/traits/locomotorio/coda_frusta_cinetica.json,,controllo_psionico,falde_magnetiche_psioniche;orbita_psionica_inversa,scout;tank,true,false
+cuscinetti_elettrostatici,i18n:traits.cuscinetti_elettrostatici.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/cuscinetti_elettrostatici.json,,coverage_q4_2025,pianura_salina_iperarida,scout,true,false
+enzimi_antifase_termica,i18n:traits.enzimi_antifase_termica.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/enzimi_antifase_termica.json,,coverage_q4_2025,caldera_glaciale,scout,true,false
+filamenti_termoconduzione,i18n:traits.filamenti_termoconduzione.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/filamenti_termoconduzione.json,,coverage_q4_2025,dorsale_termale_tropicale,scout,true,false
+ghiandole_fango_calde,i18n:traits.ghiandole_fango_calde.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/ghiandole_fango_calde.json,,coverage_q4_2025,abisso_vulcanico,scout,true,false
+ghiandole_ventosa,i18n:traits.ghiandole_ventosa.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/ghiandole_ventosa.json,,coverage_q4_2025,caldera_glaciale,scout,true,false
+linfa_tampone,i18n:traits.linfa_tampone.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/linfa_tampone.json,,coverage_q4_2025,foresta_acida,scout,true,false
+mucose_aderenza_sonica,i18n:traits.mucose_aderenza_sonica.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/mucose_aderenza_sonica.json,,coverage_q4_2025,caverna_risonante,scout,true,false
+zampe_a_molla,i18n:traits.zampe_a_molla.label,Mobilità/Cinetico,Cinetico,data/traits/locomotorio/zampe_a_molla.json,,controllo_psionico,foresta_miceliale,scout,true,false
+zoccoli_risonanti_steppe,i18n:traits.zoccoli_risonanti_steppe.label,Locomotorio/Supporto,Supporto,data/traits/locomotorio/zoccoli_risonanti_steppe.json,,controllo_psionico,steppe_risonanti,scout;support,true,false
+antenne_dustsense,i18n:traits.antenne_dustsense.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/antenne_dustsense.json,,coverage_q4_2025,pianura_salina_iperarida,sustain,true,false
+appendici_thermotattiche,i18n:traits.appendici_thermotattiche.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/appendici_thermotattiche.json,,coverage_q4_2025,abisso_vulcanico,sustain,true,false
+batteri_endosimbionti_chemio,i18n:traits.batteri_endosimbionti_chemio.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/batteri_endosimbionti_chemio.json,,coverage_q4_2025,abisso_vulcanico,sustain,true,false
+branchie_solfatiche,i18n:traits.branchie_solfatiche.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/branchie_solfatiche.json,,coverage_q4_2025,caldera_glaciale,sustain,true,false
+carapace_segmenti_logici,i18n:traits.carapace_segmenti_logici.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/carapace_segmenti_logici.json,,coverage_q4_2025,steppe_algoritmiche,sustain,true,false
+circolazione_bifasica_palude,i18n:traits.circolazione_bifasica_palude.label,Metabolico/Resilienza,Resilienza,data/traits/metabolico/circolazione_bifasica_palude.json,,controllo_psionico,paludi_gas_luminescenti,sustain;tank,true,false
+circolazione_cooling_loop,i18n:traits.circolazione_cooling_loop.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/circolazione_cooling_loop.json,,coverage_q4_2025,steppe_algoritmiche,sustain,true,false
+coda_stabilizzatrice_filo,i18n:traits.coda_stabilizzatrice_filo.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/coda_stabilizzatrice_filo.json,,coverage_q4_2025,canopia_ionica,sustain,true,false
+criostasi_adattiva,i18n:traits.criostasi_adattiva.label,Metabolico/Difensivo,Difensivo,data/traits/metabolico/criostasi_adattiva.json,,controllo_psionico,canopia_psionica_leggera;orbita_psionica_inversa,sustain;tank,true,false
+cuticole_cerose,i18n:traits.cuticole_cerose.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/cuticole_cerose.json,,controllo_psionico,foresta_miceliale,sustain,true,false
+enzimi_chelanti,i18n:traits.enzimi_chelanti.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/enzimi_chelanti.json,,controllo_psionico,foresta_miceliale,sustain,true,false
+flagelli_ancoranti,i18n:traits.flagelli_ancoranti.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/flagelli_ancoranti.json,,coverage_q4_2025,laguna_bioreattiva,sustain,true,false
+ghiandole_grafene,i18n:traits.ghiandole_grafene.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/ghiandole_grafene.json,,coverage_q4_2025,steppe_algoritmiche,sustain,true,false
+grassi_termici,i18n:traits.grassi_termici.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/grassi_termici.json,,controllo_psionico,foresta_miceliale,sustain,true,false
+luminescenza_aurorale,i18n:traits.luminescenza_aurorale.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/luminescenza_aurorale.json,,coverage_q4_2025,caldera_glaciale,sustain,true,false
+sonno_emisferico_alternato,i18n:traits.sonno_emisferico_alternato.label,Nervoso/Omeostatico,Omeostatico,data/traits/nervoso/sonno_emisferico_alternato.json,,controllo_psionico,caverna_risonante,controller;sustain,true,false
+antenne_flusso_mareale,i18n:traits.antenne_flusso_mareale.label,Offensivo/Assalto,Assalto,data/traits/offensivo/antenne_flusso_mareale.json,,coverage_q4_2025,laguna_bioreattiva,breaker,true,false
+artigli_induzione,i18n:traits.artigli_induzione.label,Offensivo/Assalto,Assalto,data/traits/offensivo/artigli_induzione.json,,coverage_q4_2025,canopia_ionica,breaker,true,false
+biochip_memoria,i18n:traits.biochip_memoria.label,Offensivo/Assalto,Assalto,data/traits/offensivo/biochip_memoria.json,,coverage_q4_2025,steppe_algoritmiche,breaker,true,false
+camere_anticorrosione,i18n:traits.camere_anticorrosione.label,Offensivo/Assalto,Assalto,data/traits/offensivo/camere_anticorrosione.json,,coverage_q4_2025,foresta_acida,breaker,true,false
+cartilagini_biofibre,i18n:traits.cartilagini_biofibre.label,Offensivo/Assalto,Assalto,data/traits/offensivo/cartilagini_biofibre.json,,coverage_q4_2025,reef_luminescente,breaker,true,false
+circolazione_supercritica,i18n:traits.circolazione_supercritica.label,Offensivo/Assalto,Assalto,data/traits/offensivo/circolazione_supercritica.json,,coverage_q4_2025,abisso_vulcanico,breaker,true,false
+coda_stabilizzatrice_vortex,i18n:traits.coda_stabilizzatrice_vortex.label,Offensivo/Assalto,Assalto,data/traits/offensivo/coda_stabilizzatrice_vortex.json,,coverage_q4_2025,stratosfera_tempestosa,breaker,true,false
+denti_chelatanti,i18n:traits.denti_chelatanti.label,Offensivo/Assalto,Assalto,data/traits/offensivo/denti_chelatanti.json,,coverage_q4_2025,foresta_acida,breaker,true,false
+enzimi_metanoossidanti,i18n:traits.enzimi_metanoossidanti.label,Offensivo/Assalto,Assalto,data/traits/offensivo/enzimi_metanoossidanti.json,,coverage_q4_2025,abisso_vulcanico,breaker,true,false
+foliaggio_spugna,i18n:traits.foliaggio_spugna.label,Offensivo/Assalto,Assalto,data/traits/offensivo/foliaggio_spugna.json,,coverage_q4_2025,mangrovieto_cinetico,breaker,true,false
+frusta_fiammeggiante,i18n:traits.frusta_fiammeggiante.label,Offensivo/Controllo,Controllo,data/traits/offensivo/frusta_fiammeggiante.json,,pathfinder_dataset,,breaker;controller,true,false
+ghiandola_caustica,i18n:traits.ghiandola_caustica.label,Offensivo/Chimico,Chimico,data/traits/offensivo/ghiandola_caustica.json,,controllo_psionico,foresta_miceliale,breaker,true,false
+ghiandole_iodoattive,i18n:traits.ghiandole_iodoattive.label,Offensivo/Assalto,Assalto,data/traits/offensivo/ghiandole_iodoattive.json,,coverage_q4_2025,pianura_salina_iperarida,breaker,true,false
+gusci_magnesio,i18n:traits.gusci_magnesio.label,Offensivo/Assalto,Assalto,data/traits/offensivo/gusci_magnesio.json,,coverage_q4_2025,dorsale_termale_tropicale,breaker,true,false
+mantelli_geotermici,i18n:traits.mantelli_geotermici.label,Offensivo/Assalto,Assalto,data/traits/offensivo/mantelli_geotermici.json,,coverage_q4_2025,caldera_glaciale,breaker,true,false
+sangue_piroforico,i18n:traits.sangue_piroforico.label,Offensivo/Cinetico,Cinetico,data/traits/offensivo/sangue_piroforico.json,,controllo_psionico,caverna_risonante,breaker,true,false
+branchie_osmotiche_salmastra,i18n:traits.branchie_osmotiche_salmastra.label,Respiratorio/Osmoregolazione,Osmoregolazione,data/traits/respiratorio/branchie_osmotiche_salmastra.json,,controllo_psionico,delta_salmastri,sustain,true,false
+lamelle_termoforetiche,i18n:traits.lamelle_termoforetiche.label,Respiratorio/Termoregolazione,Termoregolazione,data/traits/respiratorio/lamelle_termoforetiche.json,,controllo_psionico,sorgenti_geotermiche,sustain,true,false
+membrane_eliofiltranti,i18n:traits.membrane_eliofiltranti.label,Respiratorio/Protezione,Protezione,data/traits/respiratorio/membrane_eliofiltranti.json,,controllo_psionico,laghi_alcalini,sustain;tank,true,false
+polmoni_cristallini_alta_quota,i18n:traits.polmoni_cristallini_alta_quota.label,Respiratorio/Aerobico,Aerobico,data/traits/respiratorio/polmoni_cristallini_alta_quota.json,,controllo_psionico,picchi_cristallini,sustain,true,false
+respiro_a_scoppio,i18n:traits.respiro_a_scoppio.label,Respiratorio/Propulsivo,Propulsivo,data/traits/respiratorio/respiro_a_scoppio.json,,controllo_psionico,caverna_risonante,scout;sustain,true,false
+nucleo_ovomotore_rotante,i18n:traits.nucleo_ovomotore_rotante.label,Riproduttivo/Locomotorio,Locomotorio,data/traits/riproduttivo/nucleo_ovomotore_rotante.json,,controllo_psionico,caverna_risonante,scout;support,true,false
+ali_fulminee,i18n:traits.ali_fulminee.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/ali_fulminee.json,,coverage_q4_2025,stratosfera_tempestosa,scout;support,true,false
+antenne_plasmatiche_tempesta,i18n:traits.antenne_plasmatiche_tempesta.label,Sensoriale/Offensivo,Offensivo,data/traits/sensoriale/antenne_plasmatiche_tempesta.json,,controllo_psionico,cicloni_psionici,breaker;scout,true,false
+antenne_waveguide,i18n:traits.antenne_waveguide.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/antenne_waveguide.json,,coverage_q4_2025,reef_luminescente,scout;support,true,false
+baffi_mareomotori,i18n:traits.baffi_mareomotori.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/baffi_mareomotori.json,,coverage_q4_2025,mangrovieto_cinetico,scout;support,true,false
+branchie_eoliche,i18n:traits.branchie_eoliche.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/branchie_eoliche.json,,coverage_q4_2025,stratosfera_tempestosa,scout;support,true,false
+capillari_fluoridici,i18n:traits.capillari_fluoridici.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/capillari_fluoridici.json,,coverage_q4_2025,foresta_acida,scout;support,true,false
+cavita_risonanti_tundra,i18n:traits.cavita_risonanti_tundra.label,Sensoriale/Supporto,Supporto,data/traits/sensoriale/cavita_risonanti_tundra.json,,controllo_psionico,tundra_risonante,scout;support,true,false
+cervelletto_equilibrio_statico,i18n:traits.cervelletto_equilibrio_statico.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/cervelletto_equilibrio_statico.json,,coverage_q4_2025,canopia_ionica,scout;support,true,false
+coda_balanciere,i18n:traits.coda_balanciere.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/coda_balanciere.json,,coverage_q4_2025,caverna_risonante,scout;support,true,false
+cuore_multicamera_bassa_pressione,i18n:traits.cuore_multicamera_bassa_pressione.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/cuore_multicamera_bassa_pressione.json,,coverage_q4_2025,stratosfera_tempestosa,scout;support,true,false
+echi_risonanti,i18n:traits.echi_risonanti.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/echi_risonanti.json,,coverage_q4_2025,caverna_risonante,scout;support,true,false
+eco_interno_riflesso,i18n:traits.eco_interno_riflesso.label,Sensoriale/Nervoso,Nervoso,data/traits/sensoriale/eco_interno_riflesso.json,,controllo_psionico,canopia_psionica_leggera;falde_magnetiche_psioniche,controller;scout,true,false
+filamenti_superconduttivi,i18n:traits.filamenti_superconduttivi.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/filamenti_superconduttivi.json,,coverage_q4_2025,caldera_glaciale,scout;support,true,false
+ghiandole_eco_mappanti,i18n:traits.ghiandole_eco_mappanti.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/ghiandole_eco_mappanti.json,,coverage_q4_2025,caverna_risonante,scout;support,true,false
+ghiandole_resina_conduttiva,i18n:traits.ghiandole_resina_conduttiva.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/ghiandole_resina_conduttiva.json,,coverage_q4_2025,canopia_ionica,scout;support,true,false
+lamine_scudo_silice,i18n:traits.lamine_scudo_silice.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/lamine_scudo_silice.json,,coverage_q4_2025,dorsale_termale_tropicale,scout;support,true,false
+lingua_tattile_trama,i18n:traits.lingua_tattile_trama.label,Sensoriale/Alimentare,Alimentare,data/traits/sensoriale/lingua_tattile_trama.json,,controllo_psionico,caverna_risonante,scout;sustain,true,false
+midollo_antivibrazione,i18n:traits.midollo_antivibrazione.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/midollo_antivibrazione.json,,coverage_q4_2025,caverna_risonante,scout;support,true,false
+occhi_infrarosso_composti,i18n:traits.occhi_infrarosso_composti.label,Sensoriale/Visivo,Visivo,data/traits/sensoriale/occhi_infrarosso_composti.json,,controllo_psionico,caverna_risonante,scout,true,false
+olfatto_risonanza_magnetica,i18n:traits.olfatto_risonanza_magnetica.label,Sensoriale/Nervoso,Nervoso,data/traits/sensoriale/olfatto_risonanza_magnetica.json,,controllo_psionico,falde_magnetiche_psioniche;orbita_psionica_inversa,controller;scout,true,false
+sensori_geomagnetici,i18n:traits.sensori_geomagnetici.label,Sensoriale/Navigazione,Navigazione,data/traits/sensoriale/sensori_geomagnetici.json,,controllo_psionico,pianure_magnetiche,scout,true,false
+antenne_reagenti,i18n:traits.antenne_reagenti.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/antenne_reagenti.json,,coverage_q4_2025,foresta_acida,support,true,false
+artigli_scivolo_silente,i18n:traits.artigli_scivolo_silente.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/artigli_scivolo_silente.json,,coverage_q4_2025,caverna_risonante,support,true,false
+biofilm_iperarido,i18n:traits.biofilm_iperarido.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/biofilm_iperarido.json,,coverage_q4_2025,pianura_salina_iperarida,support,true,false
+bulbi_radici_permafrost,i18n:traits.bulbi_radici_permafrost.label,Simbiotico/Nutrizione,Nutrizione,data/traits/simbiotico/bulbi_radici_permafrost.json,,controllo_psionico,permafrost_psionico,support;sustain,true,false
+camere_nutrienti_vent,i18n:traits.camere_nutrienti_vent.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/camere_nutrienti_vent.json,,coverage_q4_2025,dorsale_termale_tropicale,support,true,false
+cartilagini_flessoacustiche,i18n:traits.cartilagini_flessoacustiche.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/cartilagini_flessoacustiche.json,,coverage_q4_2025,caverna_risonante,support,true,false
+chioma_parassita_canopica,i18n:traits.chioma_parassita_canopica.label,Simbiotico/Utility,Utility,data/traits/simbiotico/chioma_parassita_canopica.json,,controllo_psionico,canopie_sospese,support,true,false
+ciste_salmastre,i18n:traits.ciste_salmastre.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/ciste_salmastre.json,,coverage_q4_2025,pianura_salina_iperarida,support,true,false
+coralli_partner,i18n:traits.coralli_partner.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/coralli_partner.json,,coverage_q4_2025,reef_luminescente,support,true,false
+denti_silice_termici,i18n:traits.denti_silice_termici.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/denti_silice_termici.json,,coverage_q4_2025,dorsale_termale_tropicale,support,true,false
+epitelio_fosforescente,i18n:traits.epitelio_fosforescente.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/epitelio_fosforescente.json,,coverage_q4_2025,reef_luminescente,support,true,false
+ghiandole_cambio_salino,i18n:traits.ghiandole_cambio_salino.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/ghiandole_cambio_salino.json,,coverage_q4_2025,laguna_bioreattiva,support,true,false
+ghiandole_nebbia_acida,i18n:traits.ghiandole_nebbia_acida.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/ghiandole_nebbia_acida.json,,coverage_q4_2025,foresta_acida,support,true,false
+lamelle_sincroniche,i18n:traits.lamelle_sincroniche.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/lamelle_sincroniche.json,,coverage_q4_2025,steppe_algoritmiche,support,true,false
+membrane_planata_vectored,i18n:traits.membrane_planata_vectored.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/membrane_planata_vectored.json,,coverage_q4_2025,canopia_ionica,support,true,false
+mucillagine_simbionte_mangrovie,i18n:traits.mucillagine_simbionte_mangrovie.label,Simbiotico/Difensivo,Difensivo,data/traits/simbiotico/mucillagine_simbionte_mangrovie.json,,controllo_psionico,mangrovie_risonanti,support;tank,true,false
+nodi_micorrizici_oracolari,i18n:traits.nodi_micorrizici_oracolari.label,Simbiotico/Nervoso,Nervoso,data/traits/simbiotico/nodi_micorrizici_oracolari.json,,controllo_psionico,reti_micorriziche,controller;support,true,false
+sacche_spore_stratosferiche,i18n:traits.sacche_spore_stratosferiche.label,Simbiotico/Supporto,Supporto,data/traits/simbiotico/sacche_spore_stratosferiche.json,,controllo_psionico,stratosfera_portante,support,true,false
+sinapsi_coraline_polifoniche,i18n:traits.sinapsi_coraline_polifoniche.label,Simbiotico/Comunicazione,Comunicazione,data/traits/simbiotico/sinapsi_coraline_polifoniche.json,,controllo_psionico,barriere_coralline_psioniche,support,true,false
+antenne_microonde_cavernose,i18n:traits.antenne_microonde_cavernose.label,Strategico/Tattico,Tattico,data/traits/strategia/antenne_microonde_cavernose.json,,coverage_q4_2025,caverna_risonante,support,true,false
+artigli_radice,i18n:traits.artigli_radice.label,Strategico/Tattico,Tattico,data/traits/strategia/artigli_radice.json,,coverage_q4_2025,mangrovieto_cinetico,support,true,false
+biofilm_glow,i18n:traits.biofilm_glow.label,Strategico/Tattico,Tattico,data/traits/strategia/biofilm_glow.json,,coverage_q4_2025,reef_luminescente,support,true,false
+camere_mirage,i18n:traits.camere_mirage.label,Strategico/Tattico,Tattico,data/traits/strategia/camere_mirage.json,,coverage_q4_2025,pianura_salina_iperarida,support,true,false
+cartilagini_desertiche,i18n:traits.cartilagini_desertiche.label,Strategico/Tattico,Tattico,data/traits/strategia/cartilagini_desertiche.json,,coverage_q4_2025,pianura_salina_iperarida,support,true,false
+ciste_riduttive,i18n:traits.ciste_riduttive.label,Strategico/Tattico,Tattico,data/traits/strategia/ciste_riduttive.json,,coverage_q4_2025,laguna_bioreattiva,support,true,false
+colonne_vibromagnetiche,i18n:traits.colonne_vibromagnetiche.label,Strategico/Tattico,Tattico,data/traits/strategia/colonne_vibromagnetiche.json,,coverage_q4_2025,caverna_risonante,support,true,false
+denti_ossidoferro,i18n:traits.denti_ossidoferro.label,Strategico/Tattico,Tattico,data/traits/strategia/denti_ossidoferro.json,,coverage_q4_2025,abisso_vulcanico,support,true,false
+epidermide_dielettrica,i18n:traits.epidermide_dielettrica.label,Strategico/Tattico,Tattico,data/traits/strategia/epidermide_dielettrica.json,,coverage_q4_2025,stratosfera_tempestosa,support,true,false
+focus_frazionato,i18n:traits.focus_frazionato.label,Strategico/Psionico,Psionico,data/traits/strategia/focus_frazionato.json,,controllo_psionico,foresta_miceliale,controller;support,true,false
+ghiaccio_piezoelettrico,i18n:traits.ghiaccio_piezoelettrico.label,Strategico/Tattico,Tattico,data/traits/strategia/ghiaccio_piezoelettrico.json,,coverage_q4_2025,caldera_glaciale,support,true,false
+ghiandole_minerali,i18n:traits.ghiandole_minerali.label,Strategico/Tattico,Tattico,data/traits/strategia/ghiandole_minerali.json,,coverage_q4_2025,dorsale_termale_tropicale,support,true,false
+lamelle_shear,i18n:traits.lamelle_shear.label,Strategico/Tattico,Tattico,data/traits/strategia/lamelle_shear.json,,coverage_q4_2025,stratosfera_tempestosa,support,true,false
+membrane_captura_rugiada,i18n:traits.membrane_captura_rugiada.label,Strategico/Tattico,Tattico,data/traits/strategia/membrane_captura_rugiada.json,,coverage_q4_2025,pianura_salina_iperarida,support,true,false
+pathfinder,i18n:traits.pathfinder.label,Esplorazione/Tattico,Tattico,data/traits/strategia/pathfinder.json,,controllo_psionico,foresta_acida;foresta_miceliale,scout;support,true,false
+pianificatore,i18n:traits.pianificatore.label,Strategico/Tattico,Tattico,data/traits/strategia/pianificatore.json,,controllo_psionico,foresta_miceliale,support,true,false
+random,i18n:traits.random.label,Flessibile/Generico,Generico,data/traits/strategia/random.json,,controllo_psionico,foresta_miceliale,support;tank,true,true
+tattiche_di_branco,i18n:traits.tattiche_di_branco.label,Strategico/Tattico,Tattico,data/traits/strategia/tattiche_di_branco.json,,controllo_psionico,foresta_miceliale,support,true,false
+antenne_tesla,i18n:traits.antenne_tesla.label,Strutturale/Adattivo,Adattivo,data/traits/strutturale/antenne_tesla.json,,coverage_q4_2025,canopia_ionica,tank,true,false
+artigli_vetrificati,i18n:traits.artigli_vetrificati.label,Strutturale/Adattivo,Adattivo,data/traits/strutturale/artigli_vetrificati.json,,coverage_q4_2025,caldera_glaciale,tank,true,false
+branchie_dual_mode,i18n:traits.branchie_dual_mode.label,Strutturale/Adattivo,Adattivo,data/traits/strutturale/branchie_dual_mode.json,,coverage_q4_2025,laguna_bioreattiva,tank,true,false
+capillari_criogenici,i18n:traits.capillari_criogenici.label,Strutturale/Adattivo,Adattivo,data/traits/strutturale/capillari_criogenici.json,,coverage_q4_2025,caldera_glaciale,tank,true,false
+carapace_fase_variabile,i18n:traits.carapace_fase_variabile.label,Strutturale/Difensivo,Difensivo,data/traits/strutturale/carapace_fase_variabile.json,,controllo_psionico,canopia_psionica_leggera;falde_magnetiche_psioniche,tank,true,false
+carapace_luminiscente_abissale,i18n:traits.carapace_luminiscente_abissale.label,Strutturale/Sensoriale,Sensoriale,data/traits/strutturale/carapace_luminiscente_abissale.json,,controllo_psionico,abisso_luminescente,scout;tank,true,false
+cartilagini_pseudometalliche,i18n:traits.cartilagini_pseudometalliche.label,Strutturale/Adattivo,Adattivo,data/traits/strutturale/cartilagini_pseudometalliche.json,,coverage_q4_2025,abisso_vulcanico,tank,true,false
+cisti_iperbariche,i18n:traits.cisti_iperbariche.label,Strutturale/Adattivo,Adattivo,data/traits/strutturale/cisti_iperbariche.json,,coverage_q4_2025,abisso_vulcanico,tank,true,false
+cromofori_alert_acido,i18n:traits.cromofori_alert_acido.label,Strutturale/Adattivo,Adattivo,data/traits/strutturale/cromofori_alert_acido.json,,coverage_q4_2025,foresta_acida,tank,true,false
+denti_tuning_fork,i18n:traits.denti_tuning_fork.label,Strutturale/Adattivo,Adattivo,data/traits/strutturale/denti_tuning_fork.json,,coverage_q4_2025,caverna_risonante,tank,true,false
+filamenti_magnetotrofi,i18n:traits.filamenti_magnetotrofi.label,Strutturale/Adattivo,Adattivo,data/traits/strutturale/filamenti_magnetotrofi.json,,coverage_q4_2025,abisso_vulcanico,tank,true,false
+ghiandole_condensa_ozono,i18n:traits.ghiandole_condensa_ozono.label,Strutturale/Adattivo,Adattivo,data/traits/strutturale/ghiandole_condensa_ozono.json,,coverage_q4_2025,stratosfera_tempestosa,tank,true,false
+ghiandole_nebbia_ionica,i18n:traits.ghiandole_nebbia_ionica.label,Strutturale/Adattivo,Adattivo,data/traits/strutturale/ghiandole_nebbia_ionica.json,,coverage_q4_2025,canopia_ionica,tank,true,false
+lamine_filtranti_aeree,i18n:traits.lamine_filtranti_aeree.label,Strutturale/Adattivo,Adattivo,data/traits/strutturale/lamine_filtranti_aeree.json,,coverage_q4_2025,mangrovieto_cinetico,tank,true,false
+membrane_pneumatofori,i18n:traits.membrane_pneumatofori.label,Strutturale/Adattivo,Adattivo,data/traits/strutturale/membrane_pneumatofori.json,,coverage_q4_2025,mangrovieto_cinetico,tank,true,false
+scheletro_idro_regolante,i18n:traits.scheletro_idro_regolante.label,Strutturale/Omeostatico,Omeostatico,data/traits/strutturale/scheletro_idro_regolante.json,,controllo_psionico,caverna_risonante,sustain;tank,true,false
+struttura_elastica_amorfa,i18n:traits.struttura_elastica_amorfa.label,Strutturale/Locomotorio,Locomotorio,data/traits/strutturale/struttura_elastica_amorfa.json,,controllo_psionico,canopia_psionica_leggera;falde_magnetiche_psioniche,scout;tank,true,false
+antenne_eco_turbina,i18n:traits.antenne_eco_turbina.label,Supporto/Logistico,Logistico,data/traits/supporto/antenne_eco_turbina.json,,coverage_q4_2025,dorsale_termale_tropicale,support,true,false
+artigli_acidofagi,i18n:traits.artigli_acidofagi.label,Supporto/Logistico,Logistico,data/traits/supporto/artigli_acidofagi.json,,coverage_q4_2025,foresta_acida,support,true,false
+aura_scudo_radianza,i18n:traits.aura_scudo_radianza.label,Supporto/Difesa,Difesa,data/traits/supporto/aura_scudo_radianza.json,,pathfinder_dataset,,support;tank,true,false
+batteri_termofili_endosimbiosi,i18n:traits.batteri_termofili_endosimbiosi.label,Supporto/Logistico,Logistico,data/traits/supporto/batteri_termofili_endosimbiosi.json,,coverage_q4_2025,dorsale_termale_tropicale,support,true,false
+branchie_turbina,i18n:traits.branchie_turbina.label,Supporto/Logistico,Logistico,data/traits/supporto/branchie_turbina.json,,coverage_q4_2025,dorsale_termale_tropicale,support,true,false
+carapaci_ferruginosi,i18n:traits.carapaci_ferruginosi.label,Supporto/Logistico,Logistico,data/traits/supporto/carapaci_ferruginosi.json,,coverage_q4_2025,abisso_vulcanico,support,true,false
+circolazione_doppia,i18n:traits.circolazione_doppia.label,Supporto/Logistico,Logistico,data/traits/supporto/circolazione_doppia.json,,coverage_q4_2025,dorsale_termale_tropicale,support,true,false
+coda_stabilizzatrice_geiser,i18n:traits.coda_stabilizzatrice_geiser.label,Supporto/Logistico,Logistico,data/traits/supporto/coda_stabilizzatrice_geiser.json,,coverage_q4_2025,dorsale_termale_tropicale,support,true,false
+cuticole_neutralizzanti,i18n:traits.cuticole_neutralizzanti.label,Supporto/Logistico,Logistico,data/traits/supporto/cuticole_neutralizzanti.json,,coverage_q4_2025,foresta_acida,support,true,false
+empatia_coordinativa,i18n:traits.empatia_coordinativa.label,Supporto/Empatico,Empatico,data/traits/supporto/empatia_coordinativa.json,,controllo_psionico,foresta_miceliale,support,true,false
+enzimi_chelatori_rapidi,i18n:traits.enzimi_chelatori_rapidi.label,Supporto/Logistico,Logistico,data/traits/supporto/enzimi_chelatori_rapidi.json,,coverage_q4_2025,foresta_acida,support,true,false
+foliage_fotocatodico,i18n:traits.foliage_fotocatodico.label,Supporto/Logistico,Logistico,data/traits/supporto/foliage_fotocatodico.json,,coverage_q4_2025,foresta_acida,support,true,false
+ghiandole_inchiostro_luce,i18n:traits.ghiandole_inchiostro_luce.label,Supporto/Logistico,Logistico,data/traits/supporto/ghiandole_inchiostro_luce.json,,coverage_q4_2025,reef_luminescente,support,true,false
+gusci_criovetro,i18n:traits.gusci_criovetro.label,Supporto/Logistico,Logistico,data/traits/supporto/gusci_criovetro.json,,coverage_q4_2025,caldera_glaciale,support,true,false
+luminescenza_hydrotermica,i18n:traits.luminescenza_hydrotermica.label,Supporto/Logistico,Logistico,data/traits/supporto/luminescenza_hydrotermica.json,,coverage_q4_2025,abisso_vulcanico,support,true,false
+risonanza_di_branco,i18n:traits.risonanza_di_branco.label,Supporto/Coordinativo,Coordinativo,data/traits/supporto/risonanza_di_branco.json,,controllo_psionico,foresta_miceliale,support,true,false
+mimetismo_cromatico_passivo,i18n:traits.mimetismo_cromatico_passivo.label,Tegumentario/Difensivo,Difensivo,data/traits/tegumentario/mimetismo_cromatico_passivo.json,,controllo_psionico,canopia_psionica_leggera;falde_magnetiche_psioniche,tank,true,false
+piume_solari_fotovoltaiche,i18n:traits.piume_solari_fotovoltaiche.label,Tegumentario/Energetico,Energetico,data/traits/tegumentario/piume_solari_fotovoltaiche.json,,controllo_psionico,altipiani_solari,sustain;tank,true,false
+secrezione_rallentante_palmi,i18n:traits.secrezione_rallentante_palmi.label,Tegumentario/Difensivo,Difensivo,data/traits/tegumentario/secrezione_rallentante_palmi.json,,controllo_psionico,caverna_risonante,tank,true,false
+squame_rifrangenti_deserto,i18n:traits.squame_rifrangenti_deserto.label,Tegumentario/Difensivo,Difensivo,data/traits/tegumentario/squame_rifrangenti_deserto.json,,controllo_psionico,dune_cristalline,tank,true,false
+vello_condensatore_nebbie,i18n:traits.vello_condensatore_nebbie.label,Tegumentario/Idratazione,Idratazione,data/traits/tegumentario/vello_condensatore_nebbie.json,,controllo_psionico,foreste_nubose,sustain;tank,true,false

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -53,8 +53,13 @@
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "ali_ioniche": {
       "conflitti": [],
@@ -107,8 +112,12 @@
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "ali_membrana_sonica": {
       "conflitti": [],
@@ -161,8 +170,12 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "antenne_dustsense": {
       "conflitti": [],
@@ -215,8 +228,12 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "antenne_eco_turbina": {
       "conflitti": [],
@@ -269,8 +286,12 @@
       "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "antenne_flusso_mareale": {
       "conflitti": [],
@@ -323,8 +344,12 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker"
+      ]
     },
     "antenne_microonde_cavernose": {
       "conflitti": [],
@@ -377,8 +402,12 @@
       "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "antenne_plasmatiche_tempesta": {
       "conflitti": [],
@@ -441,8 +470,13 @@
       "uso_funzione": "Canalizza scariche atmosferiche in attacchi direzionati o scudi ionici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker",
+        "scout"
+      ]
     },
     "antenne_reagenti": {
       "conflitti": [],
@@ -495,8 +529,12 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "antenne_tesla": {
       "conflitti": [],
@@ -549,8 +587,12 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "antenne_waveguide": {
       "conflitti": [],
@@ -603,8 +645,13 @@
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "antenne_wideband": {
       "conflitti": [],
@@ -657,8 +704,12 @@
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "appendici_risonanti_marea": {
       "conflitti": [],
@@ -711,8 +762,12 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "appendici_thermotattiche": {
       "conflitti": [],
@@ -765,8 +820,12 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "armatura_pietra_planare": {
       "conflitti": [
@@ -844,8 +903,12 @@
       "uso_funzione": "Offre schermatura massiva e ancoraggio durante le aperture dimensionali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "artigli_acidofagi": {
       "conflitti": [],
@@ -898,8 +961,12 @@
       "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "artigli_induzione": {
       "conflitti": [],
@@ -952,8 +1019,12 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker"
+      ]
     },
     "artigli_radice": {
       "conflitti": [],
@@ -1006,8 +1077,12 @@
       "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "artigli_scivolo_silente": {
       "conflitti": [],
@@ -1060,8 +1135,12 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "artigli_sette_vie": {
       "conflitti": [],
@@ -1182,8 +1261,13 @@
       "uso_funzione": "Afferrare superfici irregolari o oggetti multipli.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker",
+        "scout"
+      ]
     },
     "artigli_sghiaccio_glaciale": {
       "conflitti": [],
@@ -1244,8 +1328,13 @@
       "uso_funzione": "Scalza e immobilizza i bersagli congelandoli al contatto.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker",
+        "scout"
+      ]
     },
     "artigli_vetrificati": {
       "conflitti": [],
@@ -1298,8 +1387,12 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "aura_scudo_radianza": {
       "conflitti": [
@@ -1357,8 +1450,13 @@
       "uso_funzione": "Proietta schermature luminose sincronizzate con i segnali tattici della squadra.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support",
+        "tank"
+      ]
     },
     "baffi_mareomotori": {
       "conflitti": [],
@@ -1411,8 +1509,13 @@
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "barbigli_sensori_plasma": {
       "conflitti": [],
@@ -1465,8 +1568,12 @@
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "barriere_miasma_glaciale": {
       "conflitti": [],
@@ -1519,8 +1626,12 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "batteri_endosimbionti_chemio": {
       "conflitti": [],
@@ -1573,8 +1684,12 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "batteri_termofili_endosimbiosi": {
       "conflitti": [],
@@ -1627,8 +1742,12 @@
       "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "biochip_memoria": {
       "conflitti": [],
@@ -1681,8 +1800,12 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker"
+      ]
     },
     "biofilm_glow": {
       "conflitti": [],
@@ -1735,8 +1858,12 @@
       "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "biofilm_iperarido": {
       "conflitti": [],
@@ -1789,8 +1916,12 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "branchie_dual_mode": {
       "conflitti": [],
@@ -1843,8 +1974,12 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "branchie_eoliche": {
       "conflitti": [],
@@ -1897,8 +2032,13 @@
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "branchie_metalloidi": {
       "conflitti": [],
@@ -1951,8 +2091,12 @@
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "branchie_microfiltri": {
       "conflitti": [],
@@ -2005,8 +2149,12 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "branchie_osmotiche_salmastra": {
       "conflitti": [
@@ -2068,8 +2216,12 @@
       "uso_funzione": "Bilancia sali e tossine sfruttando microvalvole controllate psionicamente.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "branchie_solfatiche": {
       "conflitti": [],
@@ -2122,8 +2274,12 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "branchie_turbina": {
       "conflitti": [],
@@ -2176,8 +2332,12 @@
       "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "bulbi_radici_permafrost": {
       "conflitti": [],
@@ -2239,8 +2399,13 @@
       "uso_funzione": "Rilascia energia e calore agli alleati radicati nella stessa rete subglaciale.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support",
+        "sustain"
+      ]
     },
     "camere_anticorrosione": {
       "conflitti": [],
@@ -2293,8 +2458,12 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker"
+      ]
     },
     "camere_mirage": {
       "conflitti": [],
@@ -2347,8 +2516,12 @@
       "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "camere_nutrienti_vent": {
       "conflitti": [],
@@ -2401,8 +2574,12 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "capillari_criogenici": {
       "conflitti": [],
@@ -2455,8 +2632,12 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "capillari_fluoridici": {
       "conflitti": [],
@@ -2509,8 +2690,13 @@
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "capillari_fotovoltaici": {
       "conflitti": [],
@@ -2563,8 +2749,12 @@
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "capsule_paracadute": {
       "conflitti": [],
@@ -2617,8 +2807,12 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "carapace_fase_variabile": {
       "conflitti": [
@@ -2766,8 +2960,12 @@
       "uso_funzione": "Durezza/densità del guscio modificabile rapidamente.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "carapace_luminiscente_abissale": {
       "conflitti": [
@@ -2831,8 +3029,13 @@
       "uso_funzione": "Emette segnali di branco e devia attacchi grazie a pattern luminosi cangianti.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "tank"
+      ]
     },
     "carapace_segmenti_logici": {
       "conflitti": [],
@@ -2885,8 +3088,12 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "carapaci_ferruginosi": {
       "conflitti": [],
@@ -2939,8 +3146,12 @@
       "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "cartilagine_flessotermica_venti": {
       "conflitti": [
@@ -3004,8 +3215,13 @@
       "uso_funzione": "Modula elasticità e rigidità muscolo-scheletrica per manovre evasive rapide.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "tank"
+      ]
     },
     "cartilagini_biofibre": {
       "conflitti": [],
@@ -3058,8 +3274,12 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker"
+      ]
     },
     "cartilagini_desertiche": {
       "conflitti": [],
@@ -3112,8 +3332,12 @@
       "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "cartilagini_flessoacustiche": {
       "conflitti": [],
@@ -3166,8 +3390,12 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "cartilagini_pseudometalliche": {
       "conflitti": [],
@@ -3220,8 +3448,12 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "cavita_risonanti_tundra": {
       "conflitti": [],
@@ -3284,8 +3516,13 @@
       "uso_funzione": "Amplifica segnali acustici per comunicazioni a lungo raggio nel gelo.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "cervelletto_equilibrio_statico": {
       "conflitti": [],
@@ -3338,8 +3575,13 @@
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "chemiorecettori_bromuro": {
       "conflitti": [],
@@ -3392,8 +3634,12 @@
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "chioma_parassita_canopica": {
       "conflitti": [],
@@ -3445,8 +3691,12 @@
       "uso_funzione": "Crea passaggi e nodi energetici condivisi nella canopia per movimenti rapidi.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "circolazione_bifasica": {
       "conflitti": [],
@@ -3499,8 +3749,12 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "circolazione_bifasica_palude": {
       "conflitti": [
@@ -3553,8 +3807,13 @@
       "uso_funzione": "Gestisce due circuiti circolatori per filtrare veleni e mantenere prestazioni elevate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain",
+        "tank"
+      ]
     },
     "circolazione_cooling_loop": {
       "conflitti": [],
@@ -3607,8 +3866,12 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "circolazione_doppia": {
       "conflitti": [],
@@ -3661,8 +3924,12 @@
       "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "circolazione_supercritica": {
       "conflitti": [],
@@ -3715,8 +3982,12 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker"
+      ]
     },
     "ciste_riduttive": {
       "conflitti": [],
@@ -3769,8 +4040,12 @@
       "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "ciste_salmastre": {
       "conflitti": [],
@@ -3823,8 +4098,12 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "cisti_iperbariche": {
       "conflitti": [],
@@ -3877,8 +4156,12 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "coda_balanciere": {
       "conflitti": [],
@@ -3931,8 +4214,13 @@
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "coda_contrappeso": {
       "conflitti": [],
@@ -3985,8 +4273,12 @@
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "coda_coppia_retroattiva": {
       "conflitti": [],
@@ -4039,8 +4331,12 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "coda_frusta_cinetica": {
       "conflitti": [],
@@ -4176,8 +4472,13 @@
       "uso_funzione": "Immagazzinare energia da ogni movimento per un colpo finale potente.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "tank"
+      ]
     },
     "coda_stabilizzatrice_filo": {
       "conflitti": [],
@@ -4230,8 +4531,12 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "coda_stabilizzatrice_geiser": {
       "conflitti": [],
@@ -4284,8 +4589,12 @@
       "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "coda_stabilizzatrice_vortex": {
       "conflitti": [],
@@ -4338,8 +4647,12 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker"
+      ]
     },
     "colonne_vibromagnetiche": {
       "conflitti": [],
@@ -4392,8 +4705,12 @@
       "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "coralli_partner": {
       "conflitti": [],
@@ -4446,8 +4763,12 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "criostasi_adattiva": {
       "conflitti": [
@@ -4535,8 +4856,13 @@
       "uso_funzione": "Sopravvivenza a condizioni ambientali estreme.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain",
+        "tank"
+      ]
     },
     "cromofori_alert_acido": {
       "conflitti": [],
@@ -4589,8 +4915,12 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "cuore_multicamera_bassa_pressione": {
       "conflitti": [],
@@ -4643,8 +4973,13 @@
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "cuscinetti_elettrostatici": {
       "conflitti": [],
@@ -4697,8 +5032,12 @@
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "cute_resistente_sali": {
       "conflitti": [],
@@ -4766,8 +5105,12 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "cuticole_cerose": {
       "conflitti": [],
@@ -4849,8 +5192,12 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "completion_flags": {
         "has_biome": false,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "cuticole_neutralizzanti": {
       "conflitti": [],
@@ -4903,8 +5250,12 @@
       "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "denti_chelatanti": {
       "conflitti": [],
@@ -4957,8 +5308,12 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker"
+      ]
     },
     "denti_ossidoferro": {
       "conflitti": [],
@@ -5011,8 +5366,12 @@
       "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "denti_silice_termici": {
       "conflitti": [],
@@ -5065,8 +5424,12 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "denti_tuning_fork": {
       "conflitti": [],
@@ -5119,8 +5482,12 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "echi_risonanti": {
       "conflitti": [],
@@ -5173,8 +5540,13 @@
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "eco_interno_riflesso": {
       "conflitti": [],
@@ -5283,8 +5655,13 @@
       "uso_funzione": "Utilizzo di onde sonore emesse internamente per mappare l'ambiente.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "controller",
+        "scout"
+      ]
     },
     "empatia_coordinativa": {
       "conflitti": [],
@@ -5392,8 +5769,12 @@
       "uso_funzione": "Collega cooldown difensivi e cura quando la squadra entra in finestra rischio.",
       "completion_flags": {
         "has_biome": false,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "enzimi_antifase_termica": {
       "conflitti": [],
@@ -5446,8 +5827,12 @@
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "enzimi_antipredatori_algali": {
       "conflitti": [],
@@ -5500,8 +5885,12 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "enzimi_chelanti": {
       "conflitti": [],
@@ -5549,8 +5938,12 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "completion_flags": {
         "has_biome": false,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "enzimi_chelatori_rapidi": {
       "conflitti": [],
@@ -5603,8 +5996,12 @@
       "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "enzimi_metanoossidanti": {
       "conflitti": [],
@@ -5657,8 +6054,12 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker"
+      ]
     },
     "epidermide_dielettrica": {
       "conflitti": [],
@@ -5711,8 +6112,12 @@
       "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "epitelio_fosforescente": {
       "conflitti": [],
@@ -5765,8 +6170,12 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "filamenti_digestivi_compattanti": {
       "conflitti": [],
@@ -5895,8 +6304,12 @@
       "uso_funzione": "Espulsione compatta e ordinata di scorie.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "filamenti_magnetotrofi": {
       "conflitti": [],
@@ -5949,8 +6362,12 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "filamenti_superconduttivi": {
       "conflitti": [],
@@ -6003,8 +6420,13 @@
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "filamenti_termoconduzione": {
       "conflitti": [],
@@ -6057,8 +6479,12 @@
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "filtri_planctonici": {
       "conflitti": [],
@@ -6111,8 +6537,12 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "flagelli_ancoranti": {
       "conflitti": [],
@@ -6165,8 +6595,12 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "focus_frazionato": {
       "conflitti": [],
@@ -6284,8 +6718,13 @@
       "uso_funzione": "Permette di gestire due ingaggi paralleli senza perdere efficienza.",
       "completion_flags": {
         "has_biome": false,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "controller",
+        "support"
+      ]
     },
     "foliage_fotocatodico": {
       "conflitti": [],
@@ -6338,8 +6777,12 @@
       "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "foliaggio_spugna": {
       "conflitti": [],
@@ -6392,8 +6835,12 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker"
+      ]
     },
     "frusta_fiammeggiante": {
       "conflitti": [
@@ -6458,8 +6905,13 @@
       "uso_funzione": "Afferra e disarma avversari o sigilla varchi planari con tagli di energia.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker",
+        "controller"
+      ]
     },
     "ghiaccio_piezoelettrico": {
       "conflitti": [],
@@ -6512,8 +6964,12 @@
       "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "ghiandola_caustica": {
       "conflitti": [],
@@ -6564,8 +7020,12 @@
       "uso_funzione": "Sblocco early di danni da acido per rompere armature leggere.",
       "completion_flags": {
         "has_biome": false,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker"
+      ]
     },
     "ghiandole_cambio_salino": {
       "conflitti": [],
@@ -6618,8 +7078,12 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "ghiandole_condensa_ozono": {
       "conflitti": [],
@@ -6672,8 +7136,12 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "ghiandole_eco_mappanti": {
       "conflitti": [],
@@ -6726,8 +7194,13 @@
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "ghiandole_fango_calde": {
       "conflitti": [],
@@ -6780,8 +7253,12 @@
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "ghiandole_fango_coesivo": {
       "conflitti": [],
@@ -6834,8 +7311,12 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "ghiandole_grafene": {
       "conflitti": [],
@@ -6888,8 +7369,12 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "ghiandole_inchiostro_luce": {
       "conflitti": [],
@@ -6942,8 +7427,12 @@
       "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "ghiandole_iodoattive": {
       "conflitti": [],
@@ -6996,8 +7485,12 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker"
+      ]
     },
     "ghiandole_minerali": {
       "conflitti": [],
@@ -7050,8 +7543,12 @@
       "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "ghiandole_nebbia_acida": {
       "conflitti": [],
@@ -7104,8 +7601,12 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "ghiandole_nebbia_ionica": {
       "conflitti": [],
@@ -7158,8 +7659,12 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "ghiandole_resina_conduttiva": {
       "conflitti": [],
@@ -7212,8 +7717,13 @@
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "ghiandole_ventosa": {
       "conflitti": [],
@@ -7266,8 +7776,12 @@
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "giunti_antitorsione": {
       "conflitti": [],
@@ -7320,8 +7834,12 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "grassi_termici": {
       "conflitti": [],
@@ -7403,8 +7921,12 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "completion_flags": {
         "has_biome": false,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "gusci_criovetro": {
       "conflitti": [],
@@ -7457,8 +7979,12 @@
       "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "gusci_magnesio": {
       "conflitti": [],
@@ -7511,8 +8037,12 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker"
+      ]
     },
     "lamelle_shear": {
       "conflitti": [],
@@ -7565,8 +8095,12 @@
       "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "lamelle_sincroniche": {
       "conflitti": [],
@@ -7619,8 +8153,12 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "lamelle_termoforetiche": {
       "conflitti": [
@@ -7701,8 +8239,12 @@
       "uso_funzione": "Regola lo scambio gassoso sfruttando gradienti termici controllati.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "lamine_filtranti_aeree": {
       "conflitti": [],
@@ -7755,8 +8297,12 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "lamine_scudo_silice": {
       "conflitti": [],
@@ -7809,8 +8355,13 @@
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "linfa_tampone": {
       "conflitti": [],
@@ -7863,8 +8414,12 @@
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "lingua_cristallina": {
       "conflitti": [],
@@ -7917,8 +8472,12 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "lingua_tattile_trama": {
       "conflitti": [],
@@ -7990,8 +8549,13 @@
       "uso_funzione": "\"Leggere\" la tessitura delle superfici per vibrazioni o micro-fratture.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "sustain"
+      ]
     },
     "luminescenza_aurorale": {
       "conflitti": [],
@@ -8044,8 +8608,12 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "luminescenza_hydrotermica": {
       "conflitti": [],
@@ -8098,8 +8666,12 @@
       "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "mantelli_geotermici": {
       "conflitti": [],
@@ -8152,8 +8724,12 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker"
+      ]
     },
     "mantello_meteoritico": {
       "conflitti": [
@@ -8218,8 +8794,13 @@
       "uso_funzione": "Assorbe colpi energetici estremi e converte il surplus in impulsi offensivi.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain",
+        "tank"
+      ]
     },
     "membrane_captura_rugiada": {
       "conflitti": [],
@@ -8272,8 +8853,12 @@
       "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "membrane_eliofiltranti": {
       "conflitti": [],
@@ -8325,8 +8910,13 @@
       "uso_funzione": "Filtra l'aria e i flussi luminosi rendendoli sicuri per tessuti delicati.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain",
+        "tank"
+      ]
     },
     "membrane_planata_vectored": {
       "conflitti": [],
@@ -8379,8 +8969,12 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "membrane_pneumatofori": {
       "conflitti": [],
@@ -8433,8 +9027,12 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "midollo_antivibrazione": {
       "conflitti": [],
@@ -8487,8 +9085,13 @@
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "mimetismo_cromatico_passivo": {
       "conflitti": [],
@@ -8604,8 +9207,12 @@
       "uso_funzione": "Assorbire e replicare il colore dell'ambiente circostante dopo contatto.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "mucillagine_simbionte_mangrovie": {
       "conflitti": [
@@ -8673,8 +9280,13 @@
       "uso_funzione": "Forma una barriera viva che neutralizza veleni e sigilla ferite.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support",
+        "tank"
+      ]
     },
     "mucose_aderenza_sonica": {
       "conflitti": [],
@@ -8727,8 +9339,12 @@
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "mucose_barofile": {
       "conflitti": [],
@@ -8781,8 +9397,12 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "nodi_micorrizici_oracolari": {
       "conflitti": [
@@ -8850,8 +9470,13 @@
       "uso_funzione": "Riceve presagi e segnali tattici dalla rete fungina per coordinare manovre di squadra.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "controller",
+        "support"
+      ]
     },
     "nucleo_ovomotore_rotante": {
       "conflitti": [
@@ -8933,8 +9558,13 @@
       "uso_funzione": "Organo Motorio Rotante: usato come 'ruota' centrale per il rotolamento.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     },
     "occhi_infrarosso_composti": {
       "conflitti": [],
@@ -8993,8 +9623,12 @@
       "uso_funzione": "Vista specializzata che percepisce il calore corporeo.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "olfatto_risonanza_magnetica": {
       "conflitti": [],
@@ -9118,8 +9752,13 @@
       "uso_funzione": "Percepire la direzione e la composizione di metalli o campi energetici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "controller",
+        "scout"
+      ]
     },
     "pathfinder": {
       "conflitti": [],
@@ -9241,8 +9880,12 @@
       "uso_funzione": "Coordina finestre di danno e difesa, mantenendo la squadra allineata al piano PI.",
       "completion_flags": {
         "has_biome": false,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "piume_solari_fotovoltaiche": {
       "conflitti": [
@@ -9296,8 +9939,13 @@
       "uso_funzione": "Convertire la radiazione solare in riserve energetiche per abilità a lungo raggio.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain",
+        "tank"
+      ]
     },
     "polmoni_cristallini_alta_quota": {
       "conflitti": [
@@ -9350,8 +9998,12 @@
       "uso_funzione": "Massimizza l'assorbimento di ossigeno rarefatto e filtra agenti nocivi.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "random": {
       "conflitti": [],
@@ -9397,8 +10049,13 @@
       "uso_funzione": "Slot jolly per testing o pareggiare budget PI quando serve varietà.",
       "completion_flags": {
         "has_biome": false,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support",
+        "tank"
+      ]
     },
     "respiro_a_scoppio": {
       "conflitti": [],
@@ -9486,8 +10143,13 @@
       "uso_funzione": "Rilasciare grandi quantità d'aria o energia in un getto potente.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "sustain"
+      ]
     },
     "risonanza_di_branco": {
       "conflitti": [],
@@ -9591,8 +10253,12 @@
       "uso_funzione": "Amplifica buff condivisi sincronizzando i timer di squadra.",
       "completion_flags": {
         "has_biome": false,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "sacche_galleggianti_ascensoriali": {
       "conflitti": [],
@@ -9711,8 +10377,13 @@
       "uso_funzione": "Controllo preciso della profondità e del movimento verticale.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "tank"
+      ]
     },
     "sacche_spore_stratosferiche": {
       "conflitti": [
@@ -9765,8 +10436,12 @@
       "uso_funzione": "Distribuisce simbionti di supporto e crea corridoi di movimento per la squadra.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "sangue_piroforico": {
       "conflitti": [
@@ -9855,8 +10530,12 @@
       "uso_funzione": "Meccanismo di difesa termico o chimico che si attiva con l'aria.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker"
+      ]
     },
     "scheletro_idro_regolante": {
       "conflitti": [
@@ -9991,8 +10670,13 @@
       "uso_funzione": "Assorbire o espellere rapidamente acqua dai tessuti ossei per modificare il peso.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain",
+        "tank"
+      ]
     },
     "secrezione_rallentante_palmi": {
       "conflitti": [
@@ -10052,8 +10736,12 @@
       "uso_funzione": "Neutralizzare o immobilizzare prede/nemici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "sensori_geomagnetici": {
       "conflitti": [],
@@ -10126,8 +10814,12 @@
       "uso_funzione": "Traccia linee di campo e memorizza corridoi magnetici per la migrazione.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "sinapsi_coraline_polifoniche": {
       "conflitti": [
@@ -10195,8 +10887,12 @@
       "uso_funzione": "Trasmette comandi e pattern tattici sfruttando armoniche subacquee.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "sonno_emisferico_alternato": {
       "conflitti": [],
@@ -10263,8 +10959,13 @@
       "uso_funzione": "Vigilanza continua pur garantendo riposo.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "controller",
+        "sustain"
+      ]
     },
     "spore_psichiche_silenziate": {
       "conflitti": [
@@ -10337,8 +11038,13 @@
       "uso_funzione": "Indurre uno stato di confusione o letargia negli individui vicini.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "controller",
+        "sustain"
+      ]
     },
     "squame_rifrangenti_deserto": {
       "conflitti": [
@@ -10391,8 +11097,12 @@
       "uso_funzione": "Rifrange la luce generando miraggi e dissipando attacchi energetici.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "tank"
+      ]
     },
     "struttura_elastica_amorfa": {
       "conflitti": [],
@@ -10532,8 +11242,13 @@
       "uso_funzione": "Flessibilità estrema e capacità di assumere forme diverse.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "tank"
+      ]
     },
     "tattiche_di_branco": {
       "conflitti": [],
@@ -10610,8 +11325,12 @@
       "uso_funzione": "Coordina prese e focus bersaglio condividendo segnali di priorità.",
       "completion_flags": {
         "has_biome": false,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "support"
+      ]
     },
     "vello_condensatore_nebbie": {
       "conflitti": [],
@@ -10662,8 +11381,13 @@
       "uso_funzione": "Condensa acqua atmosferica per supportare abilità metaboliche ad alto consumo.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain",
+        "tank"
+      ]
     },
     "ventriglio_gastroliti": {
       "conflitti": [],
@@ -10749,8 +11473,12 @@
       "uso_funzione": "Macinazione di cibo duro all'interno di un ventriglio.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "sustain"
+      ]
     },
     "zampe_a_molla": {
       "conflitti": [],
@@ -10813,8 +11541,12 @@
       "uso_funzione": "Dash esplosivi per mantenere il ritmo di ingaggio o disimpegno.",
       "completion_flags": {
         "has_biome": false,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout"
+      ]
     },
     "zoccoli_risonanti_steppe": {
       "conflitti": [
@@ -10867,8 +11599,13 @@
       "uso_funzione": "Propaga segnali ritmici che sincronizzano movimenti e abilità di squadra.",
       "completion_flags": {
         "has_biome": true,
-        "has_species_link": true
-      }
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ]
     }
   },
   "types": {

--- a/data/traits/locomotorio/ali_ioniche.json
+++ b/data/traits/locomotorio/ali_ioniche.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ali_ioniche.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ali_ioniche.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopia_ionica"

--- a/data/traits/locomotorio/antenne_wideband.json
+++ b/data/traits/locomotorio/antenne_wideband.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.antenne_wideband.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.antenne_wideband.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "steppe_algoritmiche"

--- a/data/traits/locomotorio/artigli_sette_vie.json
+++ b/data/traits/locomotorio/artigli_sette_vie.json
@@ -48,9 +48,14 @@
   "spinta_selettiva": "i18n:traits.artigli_sette_vie.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.artigli_sette_vie.uso_funzione",
+  "usage_tags": [
+    "breaker",
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/locomotorio/artigli_sghiaccio_glaciale.json
+++ b/data/traits/locomotorio/artigli_sghiaccio_glaciale.json
@@ -46,9 +46,14 @@
   "spinta_selettiva": "i18n:traits.artigli_sghiaccio_glaciale.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.artigli_sghiaccio_glaciale.uso_funzione",
+  "usage_tags": [
+    "breaker",
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "calotte_glaciali"

--- a/data/traits/locomotorio/barbigli_sensori_plasma.json
+++ b/data/traits/locomotorio/barbigli_sensori_plasma.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.barbigli_sensori_plasma.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.barbigli_sensori_plasma.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"

--- a/data/traits/locomotorio/branchie_metalloidi.json
+++ b/data/traits/locomotorio/branchie_metalloidi.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.branchie_metalloidi.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.branchie_metalloidi.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "abisso_vulcanico"

--- a/data/traits/locomotorio/capillari_fotovoltaici.json
+++ b/data/traits/locomotorio/capillari_fotovoltaici.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.capillari_fotovoltaici.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.capillari_fotovoltaici.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopia_ionica"

--- a/data/traits/locomotorio/cartilagine_flessotermica_venti.json
+++ b/data/traits/locomotorio/cartilagine_flessotermica_venti.json
@@ -49,9 +49,14 @@
   "spinta_selettiva": "i18n:traits.cartilagine_flessotermica_venti.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.cartilagine_flessotermica_venti.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "gole_ventose"

--- a/data/traits/locomotorio/chemiorecettori_bromuro.json
+++ b/data/traits/locomotorio/chemiorecettori_bromuro.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.chemiorecettori_bromuro.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.chemiorecettori_bromuro.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"

--- a/data/traits/locomotorio/coda_contrappeso.json
+++ b/data/traits/locomotorio/coda_contrappeso.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.coda_contrappeso.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.coda_contrappeso.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"

--- a/data/traits/locomotorio/coda_frusta_cinetica.json
+++ b/data/traits/locomotorio/coda_frusta_cinetica.json
@@ -76,9 +76,14 @@
   "spinta_selettiva": "i18n:traits.coda_frusta_cinetica.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.coda_frusta_cinetica.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "falde_magnetiche_psioniche",

--- a/data/traits/locomotorio/cuscinetti_elettrostatici.json
+++ b/data/traits/locomotorio/cuscinetti_elettrostatici.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.cuscinetti_elettrostatici.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.cuscinetti_elettrostatici.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"

--- a/data/traits/locomotorio/enzimi_antifase_termica.json
+++ b/data/traits/locomotorio/enzimi_antifase_termica.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.enzimi_antifase_termica.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.enzimi_antifase_termica.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caldera_glaciale"

--- a/data/traits/locomotorio/filamenti_termoconduzione.json
+++ b/data/traits/locomotorio/filamenti_termoconduzione.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.filamenti_termoconduzione.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.filamenti_termoconduzione.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"

--- a/data/traits/locomotorio/ghiandole_fango_calde.json
+++ b/data/traits/locomotorio/ghiandole_fango_calde.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ghiandole_fango_calde.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ghiandole_fango_calde.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "abisso_vulcanico"

--- a/data/traits/locomotorio/ghiandole_ventosa.json
+++ b/data/traits/locomotorio/ghiandole_ventosa.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ghiandole_ventosa.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ghiandole_ventosa.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caldera_glaciale"

--- a/data/traits/locomotorio/linfa_tampone.json
+++ b/data/traits/locomotorio/linfa_tampone.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.linfa_tampone.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.linfa_tampone.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_acida"

--- a/data/traits/locomotorio/mucose_aderenza_sonica.json
+++ b/data/traits/locomotorio/mucose_aderenza_sonica.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.mucose_aderenza_sonica.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.mucose_aderenza_sonica.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/locomotorio/zampe_a_molla.json
+++ b/data/traits/locomotorio/zampe_a_molla.json
@@ -59,9 +59,13 @@
   "spinta_selettiva": "i18n:traits.zampe_a_molla.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.zampe_a_molla.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_miceliale"

--- a/data/traits/locomotorio/zoccoli_risonanti_steppe.json
+++ b/data/traits/locomotorio/zoccoli_risonanti_steppe.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.zoccoli_risonanti_steppe.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.zoccoli_risonanti_steppe.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "steppe_risonanti"

--- a/data/traits/metabolico/antenne_dustsense.json
+++ b/data/traits/metabolico/antenne_dustsense.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.antenne_dustsense.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.antenne_dustsense.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"

--- a/data/traits/metabolico/appendici_thermotattiche.json
+++ b/data/traits/metabolico/appendici_thermotattiche.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.appendici_thermotattiche.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.appendici_thermotattiche.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "abisso_vulcanico"

--- a/data/traits/metabolico/batteri_endosimbionti_chemio.json
+++ b/data/traits/metabolico/batteri_endosimbionti_chemio.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.batteri_endosimbionti_chemio.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.batteri_endosimbionti_chemio.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "abisso_vulcanico"

--- a/data/traits/metabolico/branchie_solfatiche.json
+++ b/data/traits/metabolico/branchie_solfatiche.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.branchie_solfatiche.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.branchie_solfatiche.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caldera_glaciale"

--- a/data/traits/metabolico/carapace_segmenti_logici.json
+++ b/data/traits/metabolico/carapace_segmenti_logici.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.carapace_segmenti_logici.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.carapace_segmenti_logici.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "steppe_algoritmiche"

--- a/data/traits/metabolico/circolazione_bifasica_palude.json
+++ b/data/traits/metabolico/circolazione_bifasica_palude.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.circolazione_bifasica_palude.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.circolazione_bifasica_palude.uso_funzione",
+  "usage_tags": [
+    "sustain",
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "paludi_gas_luminescenti"

--- a/data/traits/metabolico/circolazione_cooling_loop.json
+++ b/data/traits/metabolico/circolazione_cooling_loop.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.circolazione_cooling_loop.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.circolazione_cooling_loop.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "steppe_algoritmiche"

--- a/data/traits/metabolico/coda_stabilizzatrice_filo.json
+++ b/data/traits/metabolico/coda_stabilizzatrice_filo.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.coda_stabilizzatrice_filo.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.coda_stabilizzatrice_filo.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopia_ionica"

--- a/data/traits/metabolico/criostasi_adattiva.json
+++ b/data/traits/metabolico/criostasi_adattiva.json
@@ -52,9 +52,14 @@
   "spinta_selettiva": "i18n:traits.criostasi_adattiva.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.criostasi_adattiva.uso_funzione",
+  "usage_tags": [
+    "sustain",
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopia_psionica_leggera",

--- a/data/traits/metabolico/cuticole_cerose.json
+++ b/data/traits/metabolico/cuticole_cerose.json
@@ -36,9 +36,13 @@
   "spinta_selettiva": "i18n:traits.cuticole_cerose.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.cuticole_cerose.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_miceliale"

--- a/data/traits/metabolico/enzimi_chelanti.json
+++ b/data/traits/metabolico/enzimi_chelanti.json
@@ -36,9 +36,13 @@
   "spinta_selettiva": "i18n:traits.enzimi_chelanti.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.enzimi_chelanti.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_miceliale"

--- a/data/traits/metabolico/flagelli_ancoranti.json
+++ b/data/traits/metabolico/flagelli_ancoranti.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.flagelli_ancoranti.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.flagelli_ancoranti.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "laguna_bioreattiva"

--- a/data/traits/metabolico/ghiandole_grafene.json
+++ b/data/traits/metabolico/ghiandole_grafene.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ghiandole_grafene.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ghiandole_grafene.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "steppe_algoritmiche"

--- a/data/traits/metabolico/grassi_termici.json
+++ b/data/traits/metabolico/grassi_termici.json
@@ -36,9 +36,13 @@
   "spinta_selettiva": "i18n:traits.grassi_termici.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.grassi_termici.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_miceliale"

--- a/data/traits/metabolico/luminescenza_aurorale.json
+++ b/data/traits/metabolico/luminescenza_aurorale.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.luminescenza_aurorale.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.luminescenza_aurorale.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caldera_glaciale"

--- a/data/traits/nervoso/sonno_emisferico_alternato.json
+++ b/data/traits/nervoso/sonno_emisferico_alternato.json
@@ -37,9 +37,14 @@
   "spinta_selettiva": "i18n:traits.sonno_emisferico_alternato.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.sonno_emisferico_alternato.uso_funzione",
+  "usage_tags": [
+    "controller",
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/offensivo/antenne_flusso_mareale.json
+++ b/data/traits/offensivo/antenne_flusso_mareale.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.antenne_flusso_mareale.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.antenne_flusso_mareale.uso_funzione",
+  "usage_tags": [
+    "breaker"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "laguna_bioreattiva"

--- a/data/traits/offensivo/artigli_induzione.json
+++ b/data/traits/offensivo/artigli_induzione.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.artigli_induzione.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.artigli_induzione.uso_funzione",
+  "usage_tags": [
+    "breaker"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopia_ionica"

--- a/data/traits/offensivo/biochip_memoria.json
+++ b/data/traits/offensivo/biochip_memoria.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.biochip_memoria.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.biochip_memoria.uso_funzione",
+  "usage_tags": [
+    "breaker"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "steppe_algoritmiche"

--- a/data/traits/offensivo/camere_anticorrosione.json
+++ b/data/traits/offensivo/camere_anticorrosione.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.camere_anticorrosione.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.camere_anticorrosione.uso_funzione",
+  "usage_tags": [
+    "breaker"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_acida"

--- a/data/traits/offensivo/cartilagini_biofibre.json
+++ b/data/traits/offensivo/cartilagini_biofibre.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.cartilagini_biofibre.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.cartilagini_biofibre.uso_funzione",
+  "usage_tags": [
+    "breaker"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "reef_luminescente"

--- a/data/traits/offensivo/circolazione_supercritica.json
+++ b/data/traits/offensivo/circolazione_supercritica.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.circolazione_supercritica.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.circolazione_supercritica.uso_funzione",
+  "usage_tags": [
+    "breaker"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "abisso_vulcanico"

--- a/data/traits/offensivo/coda_stabilizzatrice_vortex.json
+++ b/data/traits/offensivo/coda_stabilizzatrice_vortex.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.coda_stabilizzatrice_vortex.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.coda_stabilizzatrice_vortex.uso_funzione",
+  "usage_tags": [
+    "breaker"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"

--- a/data/traits/offensivo/denti_chelatanti.json
+++ b/data/traits/offensivo/denti_chelatanti.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.denti_chelatanti.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.denti_chelatanti.uso_funzione",
+  "usage_tags": [
+    "breaker"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_acida"

--- a/data/traits/offensivo/enzimi_metanoossidanti.json
+++ b/data/traits/offensivo/enzimi_metanoossidanti.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.enzimi_metanoossidanti.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.enzimi_metanoossidanti.uso_funzione",
+  "usage_tags": [
+    "breaker"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "abisso_vulcanico"

--- a/data/traits/offensivo/foliaggio_spugna.json
+++ b/data/traits/offensivo/foliaggio_spugna.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.foliaggio_spugna.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.foliaggio_spugna.uso_funzione",
+  "usage_tags": [
+    "breaker"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"

--- a/data/traits/offensivo/frusta_fiammeggiante.json
+++ b/data/traits/offensivo/frusta_fiammeggiante.json
@@ -42,8 +42,13 @@
   "spinta_selettiva": "i18n:traits.frusta_fiammeggiante.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.frusta_fiammeggiante.uso_funzione",
+  "usage_tags": [
+    "breaker",
+    "controller"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   }
 }

--- a/data/traits/offensivo/ghiandola_caustica.json
+++ b/data/traits/offensivo/ghiandola_caustica.json
@@ -40,9 +40,13 @@
   "spinta_selettiva": "i18n:traits.ghiandola_caustica.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ghiandola_caustica.uso_funzione",
+  "usage_tags": [
+    "breaker"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_miceliale"

--- a/data/traits/offensivo/ghiandole_iodoattive.json
+++ b/data/traits/offensivo/ghiandole_iodoattive.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ghiandole_iodoattive.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ghiandole_iodoattive.uso_funzione",
+  "usage_tags": [
+    "breaker"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"

--- a/data/traits/offensivo/gusci_magnesio.json
+++ b/data/traits/offensivo/gusci_magnesio.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.gusci_magnesio.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.gusci_magnesio.uso_funzione",
+  "usage_tags": [
+    "breaker"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"

--- a/data/traits/offensivo/mantelli_geotermici.json
+++ b/data/traits/offensivo/mantelli_geotermici.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.mantelli_geotermici.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.mantelli_geotermici.uso_funzione",
+  "usage_tags": [
+    "breaker"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caldera_glaciale"

--- a/data/traits/offensivo/sangue_piroforico.json
+++ b/data/traits/offensivo/sangue_piroforico.json
@@ -52,9 +52,13 @@
   "spinta_selettiva": "i18n:traits.sangue_piroforico.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.sangue_piroforico.uso_funzione",
+  "usage_tags": [
+    "breaker"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/respiratorio/branchie_osmotiche_salmastra.json
+++ b/data/traits/respiratorio/branchie_osmotiche_salmastra.json
@@ -47,9 +47,13 @@
   "spinta_selettiva": "i18n:traits.branchie_osmotiche_salmastra.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.branchie_osmotiche_salmastra.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "delta_salmastri"

--- a/data/traits/respiratorio/lamelle_termoforetiche.json
+++ b/data/traits/respiratorio/lamelle_termoforetiche.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.lamelle_termoforetiche.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.lamelle_termoforetiche.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "sorgenti_geotermiche"

--- a/data/traits/respiratorio/membrane_eliofiltranti.json
+++ b/data/traits/respiratorio/membrane_eliofiltranti.json
@@ -37,9 +37,14 @@
   "spinta_selettiva": "i18n:traits.membrane_eliofiltranti.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.membrane_eliofiltranti.uso_funzione",
+  "usage_tags": [
+    "sustain",
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "laghi_alcalini"

--- a/data/traits/respiratorio/polmoni_cristallini_alta_quota.json
+++ b/data/traits/respiratorio/polmoni_cristallini_alta_quota.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.polmoni_cristallini_alta_quota.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.polmoni_cristallini_alta_quota.uso_funzione",
+  "usage_tags": [
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "picchi_cristallini"

--- a/data/traits/respiratorio/respiro_a_scoppio.json
+++ b/data/traits/respiratorio/respiro_a_scoppio.json
@@ -37,9 +37,14 @@
   "spinta_selettiva": "i18n:traits.respiro_a_scoppio.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.respiro_a_scoppio.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/riproduttivo/nucleo_ovomotore_rotante.json
+++ b/data/traits/riproduttivo/nucleo_ovomotore_rotante.json
@@ -36,9 +36,14 @@
   "spinta_selettiva": "i18n:traits.nucleo_ovomotore_rotante.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.nucleo_ovomotore_rotante.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/sensoriale/ali_fulminee.json
+++ b/data/traits/sensoriale/ali_fulminee.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.ali_fulminee.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ali_fulminee.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"

--- a/data/traits/sensoriale/antenne_plasmatiche_tempesta.json
+++ b/data/traits/sensoriale/antenne_plasmatiche_tempesta.json
@@ -48,9 +48,14 @@
   "spinta_selettiva": "i18n:traits.antenne_plasmatiche_tempesta.spinta_selettiva",
   "tier": "T3",
   "uso_funzione": "i18n:traits.antenne_plasmatiche_tempesta.uso_funzione",
+  "usage_tags": [
+    "breaker",
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "cicloni_psionici"

--- a/data/traits/sensoriale/antenne_waveguide.json
+++ b/data/traits/sensoriale/antenne_waveguide.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.antenne_waveguide.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.antenne_waveguide.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "reef_luminescente"

--- a/data/traits/sensoriale/baffi_mareomotori.json
+++ b/data/traits/sensoriale/baffi_mareomotori.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.baffi_mareomotori.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.baffi_mareomotori.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"

--- a/data/traits/sensoriale/branchie_eoliche.json
+++ b/data/traits/sensoriale/branchie_eoliche.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.branchie_eoliche.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.branchie_eoliche.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"

--- a/data/traits/sensoriale/capillari_fluoridici.json
+++ b/data/traits/sensoriale/capillari_fluoridici.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.capillari_fluoridici.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.capillari_fluoridici.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_acida"

--- a/data/traits/sensoriale/cavita_risonanti_tundra.json
+++ b/data/traits/sensoriale/cavita_risonanti_tundra.json
@@ -48,9 +48,14 @@
   "spinta_selettiva": "i18n:traits.cavita_risonanti_tundra.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.cavita_risonanti_tundra.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "tundra_risonante"

--- a/data/traits/sensoriale/cervelletto_equilibrio_statico.json
+++ b/data/traits/sensoriale/cervelletto_equilibrio_statico.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.cervelletto_equilibrio_statico.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.cervelletto_equilibrio_statico.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopia_ionica"

--- a/data/traits/sensoriale/coda_balanciere.json
+++ b/data/traits/sensoriale/coda_balanciere.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.coda_balanciere.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.coda_balanciere.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/sensoriale/cuore_multicamera_bassa_pressione.json
+++ b/data/traits/sensoriale/cuore_multicamera_bassa_pressione.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.cuore_multicamera_bassa_pressione.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.cuore_multicamera_bassa_pressione.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"

--- a/data/traits/sensoriale/echi_risonanti.json
+++ b/data/traits/sensoriale/echi_risonanti.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.echi_risonanti.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.echi_risonanti.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/sensoriale/eco_interno_riflesso.json
+++ b/data/traits/sensoriale/eco_interno_riflesso.json
@@ -51,9 +51,14 @@
   "spinta_selettiva": "i18n:traits.eco_interno_riflesso.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.eco_interno_riflesso.uso_funzione",
+  "usage_tags": [
+    "controller",
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopia_psionica_leggera",

--- a/data/traits/sensoriale/filamenti_superconduttivi.json
+++ b/data/traits/sensoriale/filamenti_superconduttivi.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.filamenti_superconduttivi.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.filamenti_superconduttivi.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caldera_glaciale"

--- a/data/traits/sensoriale/ghiandole_eco_mappanti.json
+++ b/data/traits/sensoriale/ghiandole_eco_mappanti.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.ghiandole_eco_mappanti.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ghiandole_eco_mappanti.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/sensoriale/ghiandole_resina_conduttiva.json
+++ b/data/traits/sensoriale/ghiandole_resina_conduttiva.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.ghiandole_resina_conduttiva.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ghiandole_resina_conduttiva.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopia_ionica"

--- a/data/traits/sensoriale/lamine_scudo_silice.json
+++ b/data/traits/sensoriale/lamine_scudo_silice.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.lamine_scudo_silice.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.lamine_scudo_silice.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"

--- a/data/traits/sensoriale/lingua_tattile_trama.json
+++ b/data/traits/sensoriale/lingua_tattile_trama.json
@@ -36,9 +36,14 @@
   "spinta_selettiva": "i18n:traits.lingua_tattile_trama.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.lingua_tattile_trama.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/sensoriale/midollo_antivibrazione.json
+++ b/data/traits/sensoriale/midollo_antivibrazione.json
@@ -38,9 +38,14 @@
   "spinta_selettiva": "i18n:traits.midollo_antivibrazione.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.midollo_antivibrazione.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/sensoriale/occhi_infrarosso_composti.json
+++ b/data/traits/sensoriale/occhi_infrarosso_composti.json
@@ -36,9 +36,13 @@
   "spinta_selettiva": "i18n:traits.occhi_infrarosso_composti.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.occhi_infrarosso_composti.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/sensoriale/olfatto_risonanza_magnetica.json
+++ b/data/traits/sensoriale/olfatto_risonanza_magnetica.json
@@ -50,9 +50,14 @@
   "spinta_selettiva": "i18n:traits.olfatto_risonanza_magnetica.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.olfatto_risonanza_magnetica.uso_funzione",
+  "usage_tags": [
+    "controller",
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "falde_magnetiche_psioniche",

--- a/data/traits/sensoriale/sensori_geomagnetici.json
+++ b/data/traits/sensoriale/sensori_geomagnetici.json
@@ -37,9 +37,13 @@
   "spinta_selettiva": "i18n:traits.sensori_geomagnetici.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.sensori_geomagnetici.uso_funzione",
+  "usage_tags": [
+    "scout"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "pianure_magnetiche"

--- a/data/traits/simbiotico/antenne_reagenti.json
+++ b/data/traits/simbiotico/antenne_reagenti.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.antenne_reagenti.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.antenne_reagenti.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_acida"

--- a/data/traits/simbiotico/artigli_scivolo_silente.json
+++ b/data/traits/simbiotico/artigli_scivolo_silente.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.artigli_scivolo_silente.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.artigli_scivolo_silente.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/simbiotico/biofilm_iperarido.json
+++ b/data/traits/simbiotico/biofilm_iperarido.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.biofilm_iperarido.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.biofilm_iperarido.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"

--- a/data/traits/simbiotico/bulbi_radici_permafrost.json
+++ b/data/traits/simbiotico/bulbi_radici_permafrost.json
@@ -47,9 +47,14 @@
   "spinta_selettiva": "i18n:traits.bulbi_radici_permafrost.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.bulbi_radici_permafrost.uso_funzione",
+  "usage_tags": [
+    "support",
+    "sustain"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "permafrost_psionico"

--- a/data/traits/simbiotico/camere_nutrienti_vent.json
+++ b/data/traits/simbiotico/camere_nutrienti_vent.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.camere_nutrienti_vent.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.camere_nutrienti_vent.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"

--- a/data/traits/simbiotico/cartilagini_flessoacustiche.json
+++ b/data/traits/simbiotico/cartilagini_flessoacustiche.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.cartilagini_flessoacustiche.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.cartilagini_flessoacustiche.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/simbiotico/chioma_parassita_canopica.json
+++ b/data/traits/simbiotico/chioma_parassita_canopica.json
@@ -37,9 +37,13 @@
   "spinta_selettiva": "i18n:traits.chioma_parassita_canopica.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.chioma_parassita_canopica.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopie_sospese"

--- a/data/traits/simbiotico/ciste_salmastre.json
+++ b/data/traits/simbiotico/ciste_salmastre.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ciste_salmastre.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ciste_salmastre.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"

--- a/data/traits/simbiotico/coralli_partner.json
+++ b/data/traits/simbiotico/coralli_partner.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.coralli_partner.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.coralli_partner.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "reef_luminescente"

--- a/data/traits/simbiotico/denti_silice_termici.json
+++ b/data/traits/simbiotico/denti_silice_termici.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.denti_silice_termici.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.denti_silice_termici.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"

--- a/data/traits/simbiotico/epitelio_fosforescente.json
+++ b/data/traits/simbiotico/epitelio_fosforescente.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.epitelio_fosforescente.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.epitelio_fosforescente.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "reef_luminescente"

--- a/data/traits/simbiotico/ghiandole_cambio_salino.json
+++ b/data/traits/simbiotico/ghiandole_cambio_salino.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ghiandole_cambio_salino.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ghiandole_cambio_salino.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "laguna_bioreattiva"

--- a/data/traits/simbiotico/ghiandole_nebbia_acida.json
+++ b/data/traits/simbiotico/ghiandole_nebbia_acida.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ghiandole_nebbia_acida.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ghiandole_nebbia_acida.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_acida"

--- a/data/traits/simbiotico/lamelle_sincroniche.json
+++ b/data/traits/simbiotico/lamelle_sincroniche.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.lamelle_sincroniche.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.lamelle_sincroniche.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "steppe_algoritmiche"

--- a/data/traits/simbiotico/membrane_planata_vectored.json
+++ b/data/traits/simbiotico/membrane_planata_vectored.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.membrane_planata_vectored.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.membrane_planata_vectored.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopia_ionica"

--- a/data/traits/simbiotico/mucillagine_simbionte_mangrovie.json
+++ b/data/traits/simbiotico/mucillagine_simbionte_mangrovie.json
@@ -53,9 +53,14 @@
   "spinta_selettiva": "i18n:traits.mucillagine_simbionte_mangrovie.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.mucillagine_simbionte_mangrovie.uso_funzione",
+  "usage_tags": [
+    "support",
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "mangrovie_risonanti"

--- a/data/traits/simbiotico/nodi_micorrizici_oracolari.json
+++ b/data/traits/simbiotico/nodi_micorrizici_oracolari.json
@@ -53,9 +53,14 @@
   "spinta_selettiva": "i18n:traits.nodi_micorrizici_oracolari.spinta_selettiva",
   "tier": "T3",
   "uso_funzione": "i18n:traits.nodi_micorrizici_oracolari.uso_funzione",
+  "usage_tags": [
+    "controller",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "reti_micorriziche"

--- a/data/traits/simbiotico/sacche_spore_stratosferiche.json
+++ b/data/traits/simbiotico/sacche_spore_stratosferiche.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.sacche_spore_stratosferiche.spinta_selettiva",
   "tier": "T3",
   "uso_funzione": "i18n:traits.sacche_spore_stratosferiche.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "stratosfera_portante"

--- a/data/traits/simbiotico/sinapsi_coraline_polifoniche.json
+++ b/data/traits/simbiotico/sinapsi_coraline_polifoniche.json
@@ -53,9 +53,13 @@
   "spinta_selettiva": "i18n:traits.sinapsi_coraline_polifoniche.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.sinapsi_coraline_polifoniche.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "barriere_coralline_psioniche"

--- a/data/traits/strategia/antenne_microonde_cavernose.json
+++ b/data/traits/strategia/antenne_microonde_cavernose.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.antenne_microonde_cavernose.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.antenne_microonde_cavernose.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/strategia/artigli_radice.json
+++ b/data/traits/strategia/artigli_radice.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.artigli_radice.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.artigli_radice.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"

--- a/data/traits/strategia/biofilm_glow.json
+++ b/data/traits/strategia/biofilm_glow.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.biofilm_glow.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.biofilm_glow.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "reef_luminescente"

--- a/data/traits/strategia/camere_mirage.json
+++ b/data/traits/strategia/camere_mirage.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.camere_mirage.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.camere_mirage.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"

--- a/data/traits/strategia/cartilagini_desertiche.json
+++ b/data/traits/strategia/cartilagini_desertiche.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.cartilagini_desertiche.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.cartilagini_desertiche.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"

--- a/data/traits/strategia/ciste_riduttive.json
+++ b/data/traits/strategia/ciste_riduttive.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ciste_riduttive.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ciste_riduttive.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "laguna_bioreattiva"

--- a/data/traits/strategia/colonne_vibromagnetiche.json
+++ b/data/traits/strategia/colonne_vibromagnetiche.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.colonne_vibromagnetiche.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.colonne_vibromagnetiche.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/strategia/denti_ossidoferro.json
+++ b/data/traits/strategia/denti_ossidoferro.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.denti_ossidoferro.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.denti_ossidoferro.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "abisso_vulcanico"

--- a/data/traits/strategia/epidermide_dielettrica.json
+++ b/data/traits/strategia/epidermide_dielettrica.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.epidermide_dielettrica.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.epidermide_dielettrica.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"

--- a/data/traits/strategia/focus_frazionato.json
+++ b/data/traits/strategia/focus_frazionato.json
@@ -63,9 +63,14 @@
   "spinta_selettiva": "i18n:traits.focus_frazionato.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.focus_frazionato.uso_funzione",
+  "usage_tags": [
+    "controller",
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_miceliale"

--- a/data/traits/strategia/ghiaccio_piezoelettrico.json
+++ b/data/traits/strategia/ghiaccio_piezoelettrico.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ghiaccio_piezoelettrico.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ghiaccio_piezoelettrico.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caldera_glaciale"

--- a/data/traits/strategia/ghiandole_minerali.json
+++ b/data/traits/strategia/ghiandole_minerali.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ghiandole_minerali.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ghiandole_minerali.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"

--- a/data/traits/strategia/lamelle_shear.json
+++ b/data/traits/strategia/lamelle_shear.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.lamelle_shear.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.lamelle_shear.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"

--- a/data/traits/strategia/membrane_captura_rugiada.json
+++ b/data/traits/strategia/membrane_captura_rugiada.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.membrane_captura_rugiada.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.membrane_captura_rugiada.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"

--- a/data/traits/strategia/pianificatore.json
+++ b/data/traits/strategia/pianificatore.json
@@ -62,9 +62,13 @@
   "spinta_selettiva": "i18n:traits.pianificatore.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.pianificatore.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_miceliale"

--- a/data/traits/strategia/random.json
+++ b/data/traits/strategia/random.json
@@ -39,6 +39,10 @@
     "complementare": "adattivo",
     "core": "strategia"
   },
+  "usage_tags": [
+    "support",
+    "tank"
+  ],
   "species_affinity": [
     {
       "roles": [
@@ -53,7 +57,8 @@
   "uso_funzione": "i18n:traits.random.uso_funzione",
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": true
+    "has_species_link": true,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_miceliale"

--- a/data/traits/strategia/tattiche_di_branco.json
+++ b/data/traits/strategia/tattiche_di_branco.json
@@ -59,9 +59,13 @@
   "spinta_selettiva": "i18n:traits.tattiche_di_branco.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.tattiche_di_branco.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_miceliale"

--- a/data/traits/strutturale/antenne_tesla.json
+++ b/data/traits/strutturale/antenne_tesla.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.antenne_tesla.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.antenne_tesla.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopia_ionica"

--- a/data/traits/strutturale/artigli_vetrificati.json
+++ b/data/traits/strutturale/artigli_vetrificati.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.artigli_vetrificati.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.artigli_vetrificati.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caldera_glaciale"

--- a/data/traits/strutturale/branchie_dual_mode.json
+++ b/data/traits/strutturale/branchie_dual_mode.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.branchie_dual_mode.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.branchie_dual_mode.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "laguna_bioreattiva"

--- a/data/traits/strutturale/capillari_criogenici.json
+++ b/data/traits/strutturale/capillari_criogenici.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.capillari_criogenici.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.capillari_criogenici.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caldera_glaciale"

--- a/data/traits/strutturale/carapace_fase_variabile.json
+++ b/data/traits/strutturale/carapace_fase_variabile.json
@@ -77,9 +77,13 @@
   "spinta_selettiva": "i18n:traits.carapace_fase_variabile.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.carapace_fase_variabile.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopia_psionica_leggera",

--- a/data/traits/strutturale/carapace_luminiscente_abissale.json
+++ b/data/traits/strutturale/carapace_luminiscente_abissale.json
@@ -49,9 +49,14 @@
   "spinta_selettiva": "i18n:traits.carapace_luminiscente_abissale.spinta_selettiva",
   "tier": "T3",
   "uso_funzione": "i18n:traits.carapace_luminiscente_abissale.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "abisso_luminescente"

--- a/data/traits/strutturale/cartilagini_pseudometalliche.json
+++ b/data/traits/strutturale/cartilagini_pseudometalliche.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.cartilagini_pseudometalliche.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.cartilagini_pseudometalliche.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "abisso_vulcanico"

--- a/data/traits/strutturale/cisti_iperbariche.json
+++ b/data/traits/strutturale/cisti_iperbariche.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.cisti_iperbariche.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.cisti_iperbariche.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "abisso_vulcanico"

--- a/data/traits/strutturale/cromofori_alert_acido.json
+++ b/data/traits/strutturale/cromofori_alert_acido.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.cromofori_alert_acido.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.cromofori_alert_acido.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_acida"

--- a/data/traits/strutturale/denti_tuning_fork.json
+++ b/data/traits/strutturale/denti_tuning_fork.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.denti_tuning_fork.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.denti_tuning_fork.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/strutturale/filamenti_magnetotrofi.json
+++ b/data/traits/strutturale/filamenti_magnetotrofi.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.filamenti_magnetotrofi.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.filamenti_magnetotrofi.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "abisso_vulcanico"

--- a/data/traits/strutturale/ghiandole_condensa_ozono.json
+++ b/data/traits/strutturale/ghiandole_condensa_ozono.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ghiandole_condensa_ozono.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ghiandole_condensa_ozono.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"

--- a/data/traits/strutturale/ghiandole_nebbia_ionica.json
+++ b/data/traits/strutturale/ghiandole_nebbia_ionica.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ghiandole_nebbia_ionica.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ghiandole_nebbia_ionica.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopia_ionica"

--- a/data/traits/strutturale/lamine_filtranti_aeree.json
+++ b/data/traits/strutturale/lamine_filtranti_aeree.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.lamine_filtranti_aeree.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.lamine_filtranti_aeree.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"

--- a/data/traits/strutturale/membrane_pneumatofori.json
+++ b/data/traits/strutturale/membrane_pneumatofori.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.membrane_pneumatofori.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.membrane_pneumatofori.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"

--- a/data/traits/strutturale/scheletro_idro_regolante.json
+++ b/data/traits/strutturale/scheletro_idro_regolante.json
@@ -53,9 +53,14 @@
   "spinta_selettiva": "i18n:traits.scheletro_idro_regolante.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.scheletro_idro_regolante.uso_funzione",
+  "usage_tags": [
+    "sustain",
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/strutturale/struttura_elastica_amorfa.json
+++ b/data/traits/strutturale/struttura_elastica_amorfa.json
@@ -65,9 +65,14 @@
   "spinta_selettiva": "i18n:traits.struttura_elastica_amorfa.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.struttura_elastica_amorfa.uso_funzione",
+  "usage_tags": [
+    "scout",
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopia_psionica_leggera",

--- a/data/traits/supporto/antenne_eco_turbina.json
+++ b/data/traits/supporto/antenne_eco_turbina.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.antenne_eco_turbina.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.antenne_eco_turbina.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"

--- a/data/traits/supporto/artigli_acidofagi.json
+++ b/data/traits/supporto/artigli_acidofagi.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.artigli_acidofagi.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.artigli_acidofagi.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_acida"

--- a/data/traits/supporto/aura_scudo_radianza.json
+++ b/data/traits/supporto/aura_scudo_radianza.json
@@ -42,8 +42,13 @@
   "spinta_selettiva": "i18n:traits.aura_scudo_radianza.spinta_selettiva",
   "tier": "T3",
   "uso_funzione": "i18n:traits.aura_scudo_radianza.uso_funzione",
+  "usage_tags": [
+    "support",
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   }
 }

--- a/data/traits/supporto/batteri_termofili_endosimbiosi.json
+++ b/data/traits/supporto/batteri_termofili_endosimbiosi.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.batteri_termofili_endosimbiosi.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.batteri_termofili_endosimbiosi.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"

--- a/data/traits/supporto/branchie_turbina.json
+++ b/data/traits/supporto/branchie_turbina.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.branchie_turbina.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.branchie_turbina.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"

--- a/data/traits/supporto/carapaci_ferruginosi.json
+++ b/data/traits/supporto/carapaci_ferruginosi.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.carapaci_ferruginosi.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.carapaci_ferruginosi.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "abisso_vulcanico"

--- a/data/traits/supporto/circolazione_doppia.json
+++ b/data/traits/supporto/circolazione_doppia.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.circolazione_doppia.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.circolazione_doppia.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"

--- a/data/traits/supporto/coda_stabilizzatrice_geiser.json
+++ b/data/traits/supporto/coda_stabilizzatrice_geiser.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.coda_stabilizzatrice_geiser.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.coda_stabilizzatrice_geiser.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"

--- a/data/traits/supporto/cuticole_neutralizzanti.json
+++ b/data/traits/supporto/cuticole_neutralizzanti.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.cuticole_neutralizzanti.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.cuticole_neutralizzanti.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_acida"

--- a/data/traits/supporto/empatia_coordinativa.json
+++ b/data/traits/supporto/empatia_coordinativa.json
@@ -55,9 +55,13 @@
   "spinta_selettiva": "i18n:traits.empatia_coordinativa.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.empatia_coordinativa.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_miceliale"

--- a/data/traits/supporto/enzimi_chelatori_rapidi.json
+++ b/data/traits/supporto/enzimi_chelatori_rapidi.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.enzimi_chelatori_rapidi.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.enzimi_chelatori_rapidi.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_acida"

--- a/data/traits/supporto/foliage_fotocatodico.json
+++ b/data/traits/supporto/foliage_fotocatodico.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.foliage_fotocatodico.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.foliage_fotocatodico.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_acida"

--- a/data/traits/supporto/ghiandole_inchiostro_luce.json
+++ b/data/traits/supporto/ghiandole_inchiostro_luce.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.ghiandole_inchiostro_luce.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.ghiandole_inchiostro_luce.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "reef_luminescente"

--- a/data/traits/supporto/gusci_criovetro.json
+++ b/data/traits/supporto/gusci_criovetro.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.gusci_criovetro.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.gusci_criovetro.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caldera_glaciale"

--- a/data/traits/supporto/luminescenza_hydrotermica.json
+++ b/data/traits/supporto/luminescenza_hydrotermica.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.luminescenza_hydrotermica.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.luminescenza_hydrotermica.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "abisso_vulcanico"

--- a/data/traits/supporto/risonanza_di_branco.json
+++ b/data/traits/supporto/risonanza_di_branco.json
@@ -64,9 +64,13 @@
   "spinta_selettiva": "i18n:traits.risonanza_di_branco.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.risonanza_di_branco.uso_funzione",
+  "usage_tags": [
+    "support"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foresta_miceliale"

--- a/data/traits/tegumentario/mimetismo_cromatico_passivo.json
+++ b/data/traits/tegumentario/mimetismo_cromatico_passivo.json
@@ -64,9 +64,13 @@
   "spinta_selettiva": "i18n:traits.mimetismo_cromatico_passivo.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.mimetismo_cromatico_passivo.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "canopia_psionica_leggera",

--- a/data/traits/tegumentario/piume_solari_fotovoltaiche.json
+++ b/data/traits/tegumentario/piume_solari_fotovoltaiche.json
@@ -39,9 +39,14 @@
   "spinta_selettiva": "i18n:traits.piume_solari_fotovoltaiche.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.piume_solari_fotovoltaiche.uso_funzione",
+  "usage_tags": [
+    "sustain",
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "altipiani_solari"

--- a/data/traits/tegumentario/secrezione_rallentante_palmi.json
+++ b/data/traits/tegumentario/secrezione_rallentante_palmi.json
@@ -37,9 +37,13 @@
   "spinta_selettiva": "i18n:traits.secrezione_rallentante_palmi.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.secrezione_rallentante_palmi.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "caverna_risonante"

--- a/data/traits/tegumentario/squame_rifrangenti_deserto.json
+++ b/data/traits/tegumentario/squame_rifrangenti_deserto.json
@@ -38,9 +38,13 @@
   "spinta_selettiva": "i18n:traits.squame_rifrangenti_deserto.spinta_selettiva",
   "tier": "T2",
   "uso_funzione": "i18n:traits.squame_rifrangenti_deserto.uso_funzione",
+  "usage_tags": [
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "dune_cristalline"

--- a/data/traits/tegumentario/vello_condensatore_nebbie.json
+++ b/data/traits/tegumentario/vello_condensatore_nebbie.json
@@ -36,9 +36,14 @@
   "spinta_selettiva": "i18n:traits.vello_condensatore_nebbie.spinta_selettiva",
   "tier": "T1",
   "uso_funzione": "i18n:traits.vello_condensatore_nebbie.uso_funzione",
+  "usage_tags": [
+    "sustain",
+    "tank"
+  ],
   "completion_flags": {
     "has_biome": true,
-    "has_species_link": false
+    "has_species_link": false,
+    "has_usage_tags": true
   },
   "biome_tags": [
     "foreste_nubose"

--- a/docs/catalog/catalog_data.json
+++ b/docs/catalog/catalog_data.json
@@ -8,7 +8,9 @@
   },
   "traits": {
     "ali_fulminee": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -71,11 +73,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
     },
     "ali_ioniche": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -138,11 +142,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Richiede manutenzione costante delle strutture propulsive."
     },
     "ali_membrana_sonica": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -205,11 +211,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
     },
     "antenne_dustsense": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -272,11 +280,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
     },
     "antenne_eco_turbina": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -339,11 +349,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
     },
     "antenne_flusso_mareale": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -406,11 +418,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker"],
       "weakness": "Rischio di sovraccarico se scaricato senza controllo."
     },
     "antenne_microonde_cavernose": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -473,11 +487,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
     },
     "antenne_plasmatiche_tempesta": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -545,11 +561,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker", "scout"],
       "weakness": "Scariche elettriche massicce possono bruciare i recettori e compromettere la coordinazione."
     },
     "antenne_reagenti": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -612,11 +630,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
     },
     "antenne_tesla": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -679,11 +699,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Risonanze errate possono generare microfratture."
     },
     "antenne_waveguide": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -746,11 +768,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
     },
     "antenne_wideband": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -813,11 +837,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Richiede manutenzione costante delle strutture propulsive."
     },
     "appendici_risonanti_marea": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -880,11 +906,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
     },
     "appendici_thermotattiche": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -947,11 +975,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
     },
     "armatura_pietra_planare": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["frusta_fiammeggiante"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -1029,11 +1059,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Pesante: riduce mobilità in ambienti non supportati o a bassa gravità."
     },
     "artigli_acidofagi": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -1096,11 +1128,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
     },
     "artigli_induzione": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -1163,11 +1197,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker"],
       "weakness": "Rischio di sovraccarico se scaricato senza controllo."
     },
     "artigli_radice": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -1230,11 +1266,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
     },
     "artigli_scivolo_silente": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -1297,11 +1335,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
     },
     "artigli_sette_vie": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -1409,11 +1449,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker", "scout"],
       "weakness": "Angoli di presa limitati se la superficie è perfettamente liscia."
     },
     "artigli_sghiaccio_glaciale": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -1480,11 +1522,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker", "scout"],
       "weakness": "In ambienti temperati i tessuti subiscono microfratture e richiedono continue riparazioni."
     },
     "artigli_vetrificati": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -1547,11 +1591,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Risonanze errate possono generare microfratture."
     },
     "aura_scudo_radianza": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["mantello_meteoritico"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -1614,11 +1660,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support", "tank"],
       "weakness": "Soffre saturazione se esposta a ombre gravitazionali o zone di antimagia."
     },
     "baffi_mareomotori": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -1681,11 +1729,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
     },
     "barbigli_sensori_plasma": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -1748,11 +1798,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Richiede manutenzione costante delle strutture propulsive."
     },
     "barriere_miasma_glaciale": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -1815,11 +1867,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
     },
     "batteri_endosimbionti_chemio": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -1882,11 +1936,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
     },
     "batteri_termofili_endosimbiosi": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -1949,11 +2005,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
     },
     "biochip_memoria": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -2016,11 +2074,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker"],
       "weakness": "Rischio di sovraccarico se scaricato senza controllo."
     },
     "biofilm_glow": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -2083,11 +2143,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
     },
     "biofilm_iperarido": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -2150,11 +2212,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
     },
     "branchie_dual_mode": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -2217,11 +2281,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Risonanze errate possono generare microfratture."
     },
     "branchie_eoliche": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -2284,11 +2350,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
     },
     "branchie_metalloidi": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -2351,11 +2419,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Richiede manutenzione costante delle strutture propulsive."
     },
     "branchie_microfiltri": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -2418,11 +2488,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
     },
     "branchie_osmotiche_salmastra": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["polmoni_cristallini_alta_quota"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -2485,11 +2557,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Richiede accesso costante ad acqua salmastra; ambienti d'acqua dolce provocano stress ionico."
     },
     "branchie_solfatiche": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -2552,11 +2626,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
     },
     "branchie_turbina": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -2619,11 +2695,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
     },
     "bulbi_radici_permafrost": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -2690,11 +2768,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support", "sustain"],
       "weakness": "Disgeli improvvisi trasformano i bulbi in masse gelatinose che rallentano i movimenti."
     },
     "camere_anticorrosione": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -2757,11 +2837,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker"],
       "weakness": "Rischio di sovraccarico se scaricato senza controllo."
     },
     "camere_mirage": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -2824,11 +2906,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
     },
     "camere_nutrienti_vent": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -2891,11 +2975,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
     },
     "capillari_criogenici": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -2958,11 +3044,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Risonanze errate possono generare microfratture."
     },
     "capillari_fluoridici": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -3025,11 +3113,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
     },
     "capillari_fotovoltaici": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -3092,11 +3182,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Richiede manutenzione costante delle strutture propulsive."
     },
     "capsule_paracadute": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -3159,11 +3251,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
     },
     "carapace_fase_variabile": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["struttura_elastica_amorfa"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -3285,11 +3379,13 @@
         "optional": ["nano-rust-bloom", "sand-burrower"],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Debolezza strutturale durante la transizione tra le fasi di durezza."
     },
     "carapace_luminiscente_abissale": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["carapace_fase_variabile"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -3356,11 +3452,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "tank"],
       "weakness": "Luce intensa di superficie sovraccarica i biofotoni rendendo la corazza fragile."
     },
     "carapace_segmenti_logici": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -3423,11 +3521,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
     },
     "carapaci_ferruginosi": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -3490,11 +3590,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
     },
     "cartilagine_flessotermica_venti": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["scheletro_idro_regolante"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -3562,11 +3664,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "tank"],
       "weakness": "Temperature stabili riducono la reattività della cartilagine rendendo l'organismo lento."
     },
     "cartilagini_biofibre": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -3629,11 +3733,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker"],
       "weakness": "Rischio di sovraccarico se scaricato senza controllo."
     },
     "cartilagini_desertiche": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -3696,11 +3802,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
     },
     "cartilagini_flessoacustiche": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -3763,11 +3871,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
     },
     "cartilagini_pseudometalliche": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -3830,11 +3940,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Risonanze errate possono generare microfratture."
     },
     "cavita_risonanti_tundra": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -3902,11 +4014,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "In ambienti temperati l'eco interna produce rumori udibili che rivelano la posizione."
     },
     "cervelletto_equilibrio_statico": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -3969,11 +4083,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
     },
     "chemiorecettori_bromuro": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -4036,11 +4152,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Richiede manutenzione costante delle strutture propulsive."
     },
     "chioma_parassita_canopica": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -4103,11 +4221,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Se la pianta ospite muore la chioma psionica collassa causando shock sistemico."
     },
     "circolazione_bifasica": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -4170,11 +4290,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
     },
     "circolazione_bifasica_palude": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["sangue_piroforico"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -4237,11 +4359,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain", "tank"],
       "weakness": "Zone asciutte e calde causano stagnazione del circuito linfatico portando a tossicosi."
     },
     "circolazione_cooling_loop": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -4304,11 +4428,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
     },
     "circolazione_doppia": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -4371,11 +4497,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
     },
     "circolazione_supercritica": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -4438,11 +4566,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker"],
       "weakness": "Rischio di sovraccarico se scaricato senza controllo."
     },
     "ciste_riduttive": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -4505,11 +4635,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
     },
     "ciste_salmastre": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -4572,11 +4704,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
     },
     "cisti_iperbariche": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -4639,11 +4773,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Risonanze errate possono generare microfratture."
     },
     "coda_balanciere": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -4706,11 +4842,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
     },
     "coda_contrappeso": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -4773,11 +4911,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Richiede manutenzione costante delle strutture propulsive."
     },
     "coda_coppia_retroattiva": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -4840,11 +4980,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
     },
     "coda_frusta_cinetica": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -4966,11 +5108,13 @@
         "optional": ["dune-stalker"],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "tank"],
       "weakness": "Richiede un periodo di inattività o movimento preparatorio per massimizzare il danno."
     },
     "coda_stabilizzatrice_filo": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -5033,11 +5177,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
     },
     "coda_stabilizzatrice_geiser": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -5100,11 +5246,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
     },
     "coda_stabilizzatrice_vortex": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -5167,11 +5315,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker"],
       "weakness": "Rischio di sovraccarico se scaricato senza controllo."
     },
     "colonne_vibromagnetiche": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -5234,11 +5384,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
     },
     "coralli_partner": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -5301,11 +5453,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
     },
     "criostasi_adattiva": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["sangue_piroforico", "sacche_galleggianti_ascensoriali"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -5383,11 +5537,13 @@
         "optional": ["dune-stalker"],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain", "tank"],
       "weakness": "Vulnerabilità estrema agli attacchi chimici (veleni) in fase Criostasi."
     },
     "cromofori_alert_acido": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -5450,11 +5606,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Risonanze errate possono generare microfratture."
     },
     "cuore_multicamera_bassa_pressione": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -5517,11 +5675,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
     },
     "cuscinetti_elettrostatici": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -5584,11 +5744,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Richiede manutenzione costante delle strutture propulsive."
     },
     "cute_resistente_sali": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -5661,11 +5823,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
     },
     "cuticole_cerose": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -5769,11 +5933,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
     },
     "cuticole_neutralizzanti": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -5836,11 +6002,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
     },
     "denti_chelatanti": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -5903,11 +6071,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker"],
       "weakness": "Rischio di sovraccarico se scaricato senza controllo."
     },
     "denti_ossidoferro": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -5970,11 +6140,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
     },
     "denti_silice_termici": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -6037,11 +6209,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
     },
     "denti_tuning_fork": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -6104,11 +6278,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Risonanze errate possono generare microfratture."
     },
     "echi_risonanti": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -6171,11 +6347,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
     },
     "eco_interno_riflesso": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -6272,11 +6450,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["controller", "scout"],
       "weakness": "Estremamente disorientato da suoni o vibrazioni esterne forti e continue."
     },
     "empatia_coordinativa": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -6390,11 +6570,13 @@
         "optional": [],
         "synergy": ["aurora-bridge-runner", "zephyr-spore-courier"]
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende."
     },
     "enzimi_antifase_termica": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -6457,11 +6639,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Richiede manutenzione costante delle strutture propulsive."
     },
     "enzimi_antipredatori_algali": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -6524,11 +6708,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
     },
     "enzimi_chelanti": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -6596,11 +6782,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
     },
     "enzimi_chelatori_rapidi": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -6663,11 +6851,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
     },
     "enzimi_metanoossidanti": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -6730,11 +6920,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker"],
       "weakness": "Rischio di sovraccarico se scaricato senza controllo."
     },
     "epidermide_dielettrica": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -6797,11 +6989,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
     },
     "epitelio_fosforescente": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -6864,11 +7058,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
     },
     "filamenti_digestivi_compattanti": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -6981,11 +7177,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Blocco intestinale se la dieta è priva di materiale 'legante'."
     },
     "filamenti_magnetotrofi": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -7048,11 +7246,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Risonanze errate possono generare microfratture."
     },
     "filamenti_superconduttivi": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -7115,11 +7315,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
     },
     "filamenti_termoconduzione": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -7182,11 +7384,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Richiede manutenzione costante delle strutture propulsive."
     },
     "filtri_planctonici": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -7249,11 +7453,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
     },
     "flagelli_ancoranti": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -7316,11 +7522,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
     },
     "focus_frazionato": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -7435,11 +7643,13 @@
         "optional": ["glowcap-weaver", "myco-spire-warden"],
         "synergy": ["dune-stalker"]
       },
-      "usage_tags": [],
+      "usage_tags": ["controller", "support"],
       "weakness": "Rischio di overload mentale se tilt e aggro salgono oltre le soglie HUD."
     },
     "foliage_fotocatodico": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -7502,11 +7712,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
     },
     "foliaggio_spugna": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -7569,11 +7781,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker"],
       "weakness": "Rischio di sovraccarico se scaricato senza controllo."
     },
     "frusta_fiammeggiante": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["armatura_pietra_planare"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -7641,11 +7855,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker", "controller"],
       "weakness": "Consumante: richiede costante dissipazione termica per non bruciare la matrice portante."
     },
     "ghiaccio_piezoelettrico": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -7708,11 +7924,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
     },
     "ghiandola_caustica": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -7780,11 +7998,13 @@
         "optional": ["slag-veil-ambusher"],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker"],
       "weakness": "Gestione accurata delle riserve per non calare sotto i budget PE previsto."
     },
     "ghiandole_cambio_salino": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -7847,11 +8067,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
     },
     "ghiandole_condensa_ozono": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -7914,11 +8136,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Risonanze errate possono generare microfratture."
     },
     "ghiandole_eco_mappanti": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -7981,11 +8205,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
     },
     "ghiandole_fango_calde": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -8048,11 +8274,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Richiede manutenzione costante delle strutture propulsive."
     },
     "ghiandole_fango_coesivo": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -8115,11 +8343,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
     },
     "ghiandole_grafene": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -8182,11 +8412,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
     },
     "ghiandole_inchiostro_luce": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -8249,11 +8481,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
     },
     "ghiandole_iodoattive": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -8316,11 +8550,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker"],
       "weakness": "Rischio di sovraccarico se scaricato senza controllo."
     },
     "ghiandole_minerali": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -8383,11 +8619,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
     },
     "ghiandole_nebbia_acida": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -8450,11 +8688,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
     },
     "ghiandole_nebbia_ionica": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -8517,11 +8757,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Risonanze errate possono generare microfratture."
     },
     "ghiandole_resina_conduttiva": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -8584,11 +8826,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
     },
     "ghiandole_ventosa": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -8651,11 +8895,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Richiede manutenzione costante delle strutture propulsive."
     },
     "giunti_antitorsione": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -8718,11 +8964,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
     },
     "grassi_termici": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -8826,11 +9074,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
     },
     "gusci_criovetro": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -8893,11 +9143,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
     },
     "gusci_magnesio": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -8960,11 +9212,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker"],
       "weakness": "Rischio di sovraccarico se scaricato senza controllo."
     },
     "lamelle_shear": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -9027,11 +9281,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
     },
     "lamelle_sincroniche": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -9094,11 +9350,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
     },
     "lamelle_termoforetiche": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["criostasi_adattiva"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -9181,11 +9439,13 @@
         "optional": ["dune-stalker"],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Rende instabile la fisiologia in ambienti a gelo improvviso, con rischio di microfratture vascolari."
     },
     "lamine_filtranti_aeree": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -9248,11 +9508,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Risonanze errate possono generare microfratture."
     },
     "lamine_scudo_silice": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -9315,11 +9577,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
     },
     "linfa_tampone": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -9382,11 +9646,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Richiede manutenzione costante delle strutture propulsive."
     },
     "lingua_cristallina": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -9449,11 +9715,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
     },
     "lingua_tattile_trama": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -9537,11 +9805,13 @@
         ],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "sustain"],
       "weakness": "Estrema vulnerabilità della lingua a contaminanti chimici o acidi."
     },
     "luminescenza_aurorale": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -9604,11 +9874,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Sensibile a tossine sconosciute finché non vengono adattate."
     },
     "luminescenza_hydrotermica": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -9671,11 +9943,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Soffre se separato dalla rete cooperativa del gruppo."
     },
     "mantelli_geotermici": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -9738,11 +10012,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker"],
       "weakness": "Rischio di sovraccarico se scaricato senza controllo."
     },
     "mantello_meteoritico": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["aura_scudo_radianza"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -9810,11 +10086,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain", "tank"],
       "weakness": "Vulnerabile a scariche di freddo gravitazionale che irrigidiscono il mantello."
     },
     "membrane_captura_rugiada": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -9877,11 +10155,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Richiede tempo di pianificazione prima di rendere il massimo."
     },
     "membrane_eliofiltranti": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -9944,11 +10224,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain", "tank"],
       "weakness": "Atmosfere acide degradano rapidamente il film eliofiltrante."
     },
     "membrane_planata_vectored": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -10011,11 +10293,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Dipendenza da partner stabili per evitare collasso funzionale."
     },
     "membrane_pneumatofori": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -10078,11 +10362,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Risonanze errate possono generare microfratture."
     },
     "midollo_antivibrazione": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -10145,11 +10431,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale."
     },
     "mimetismo_cromatico_passivo": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -10254,11 +10542,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "La colorazione è fissa finché non c'è un nuovo contatto prolungato."
     },
     "mucillagine_simbionte_mangrovie": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["ghiandola_caustica"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -10338,11 +10628,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support", "tank"],
       "weakness": "Acque eccessivamente pure diluiscono la mucillagine riducendo la protezione."
     },
     "mucose_aderenza_sonica": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -10405,11 +10697,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Richiede manutenzione costante delle strutture propulsive."
     },
     "mucose_barofile": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -10472,11 +10766,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Peso aggiuntivo che riduce agilità se non calibrato."
     },
     "nodi_micorrizici_oracolari": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["spore_psichiche_silenziate"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -10556,11 +10852,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["controller", "support"],
       "weakness": "Se la rete micorrizica viene recisa, l'organismo soffre crisi percettive e perdita di orientamento."
     },
     "nucleo_ovomotore_rotante": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["secrezione_rallentante_palmi"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -10643,11 +10941,13 @@
         "optional": ["rust-scavenger"],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Impossibilità di muoversi su superfici irregolari o in salita ripida."
     },
     "occhi_infrarosso_composti": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -10715,11 +11015,13 @@
         "optional": ["aurora-bridge-runner", "zephyr-spore-courier"],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Accecamento temporaneo da fonti di calore intenso e concentrato."
     },
     "olfatto_risonanza_magnetica": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -10822,7 +11124,7 @@
         "optional": ["dune-stalker", "magneto-ridge-hunter"],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["controller", "scout"],
       "weakness": "Sensibilità a forti interferenze elettromagnetiche (es. fulmini o minerali magnetici)."
     },
     "pathfinder": {
@@ -10897,7 +11199,9 @@
       "weakness": "Valore ridotto in scenari a corridoio o con tilt già stabilizzato."
     },
     "pianificatore": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -10974,11 +11278,13 @@
         "optional": [],
         "synergy": ["glowcap-weaver", "myco-spire-warden"]
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Rigidità tattica se gli input di telemetria arrivano in ritardo."
     },
     "piume_solari_fotovoltaiche": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["criostasi_adattiva"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -11041,11 +11347,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain", "tank"],
       "weakness": "Ombre prolungate o polveri dense riducono drasticamente la produzione energetica."
     },
     "polmoni_cristallini_alta_quota": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["branchie_osmotiche_salmastra"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -11108,11 +11416,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Particolato pesante o sabbia vulcanica graffia i cristalli riducendo l'efficienza respiratoria."
     },
     "random": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -11169,11 +11479,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support", "tank"],
       "weakness": "Bassa affidabilità: richiede slot aggiuntivi per mitigare risultati sfavorevoli."
     },
     "respiro_a_scoppio": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -11261,11 +11573,13 @@
         "optional": ["dune-stalker", "magneto-ridge-hunter", "slag-veil-ambusher"],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "sustain"],
       "weakness": "Vulnerabilità respiratoria subito dopo l'utilizzo (tempo di ricarica)."
     },
     "risonanza_di_branco": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -11371,11 +11685,13 @@
         "optional": [],
         "synergy": ["aurora-bridge-runner", "dune-stalker", "zephyr-spore-courier"]
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Stress elevato se la coesione cala sotto i target di telemetria."
     },
     "sacche_galleggianti_ascensoriali": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -11478,11 +11794,13 @@
         "optional": ["dune-stalker", "echo-wing"],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "tank"],
       "weakness": "Rischio di barotrauma se la pressione esterna cambia troppo rapidamente."
     },
     "sacche_spore_stratosferiche": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["respiro_a_scoppio"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -11545,11 +11863,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Correnti ionizzate possono incendiare le sacche rendendo l'organismo instabile."
     },
     "sangue_piroforico": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["criostasi_adattiva", "scheletro_idro_regolante"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -11642,11 +11962,13 @@
         "optional": ["nano-rust-bloom"],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["breaker"],
       "weakness": "Rischio di auto-combustione in caso di ferita profonda in atmosfera ricca di ossigeno."
     },
     "scheletro_idro_regolante": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["sangue_piroforico"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -11777,11 +12099,13 @@
         "optional": ["rust-scavenger"],
         "synergy": ["slag-veil-ambusher"]
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain", "tank"],
       "weakness": "Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio."
     },
     "secrezione_rallentante_palmi": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["carapace_fase_variabile", "nucleo_ovomotore_rotante"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -11849,11 +12173,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Esaurimento rapido delle riserve di liquido con tempo di ricarica prolungato."
     },
     "sensori_geomagnetici": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -11931,11 +12257,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Tempeste solari possono saturare il segnale magnetico, causando disorientamento prolungato."
     },
     "sinapsi_coraline_polifoniche": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["spore_psichiche_silenziate"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -12015,11 +12343,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Vibrazioni sintonizzate male possono generare feedback dolorosi e perdita di coscienza."
     },
     "sonno_emisferico_alternato": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -12092,11 +12422,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["controller", "sustain"],
       "weakness": "Vulnerabilità a suoni/stimoli che colpiscono entrambi i lobi contemporaneamente."
     },
     "spore_psichiche_silenziate": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["respiro_a_scoppio"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -12174,11 +12506,13 @@
         "optional": ["myco-spire-warden"],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["controller", "sustain"],
       "weakness": "Funzionalità ridotta in presenza di vento forte o umidità elevata."
     },
     "squame_rifrangenti_deserto": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["mimetismo_cromatico_passivo"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -12241,11 +12575,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["tank"],
       "weakness": "Soffre danni da feedback termico se colpito da raggi concentrati o laser."
     },
     "struttura_elastica_amorfa": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -12372,11 +12708,13 @@
         "optional": [],
         "synergy": ["magneto-ridge-hunter"]
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "tank"],
       "weakness": "Vulnerabilità a danni da taglio o perforazione (difficile cauterizzazione)."
     },
     "tattiche_di_branco": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -12464,11 +12802,13 @@
         "optional": [],
         "synergy": ["dune-stalker", "magneto-ridge-hunter", "slag-veil-ambusher"]
       },
-      "usage_tags": [],
+      "usage_tags": ["support"],
       "weakness": "Richiede formazione stabile; cala se la coesione precipita sotto il target."
     },
     "vello_condensatore_nebbie": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -12531,11 +12871,13 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain", "tank"],
       "weakness": "In ambienti aridi accumula detriti che riducono la capacità di condensa."
     },
     "ventriglio_gastroliti": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -12628,11 +12970,13 @@
         "optional": ["ferrocolonia-magnetotattica"],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["sustain"],
       "weakness": "Usura e rottura del ventriglio se i gastroliti sono esauriti o troppo lisci."
     },
     "zampe_a_molla": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": [],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -12711,11 +13055,13 @@
         "optional": ["sand-burrower"],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout"],
       "weakness": "Perdita di valore su mappe con spazi stretti o controllo setup elevato."
     },
     "zoccoli_risonanti_steppe": {
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "conflicts": ["zampe_a_molla"],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -12778,7 +13124,7 @@
         "optional": [],
         "synergy": []
       },
-      "usage_tags": [],
+      "usage_tags": ["scout", "support"],
       "weakness": "Suoli cedevoli come sabbie mobili annullano la vibrazione e riducono la trazione."
     }
   }

--- a/docs/process/trait_data_reference.md
+++ b/docs/process/trait_data_reference.md
@@ -23,6 +23,8 @@ Questa guida riassume dove risiedono i dati dei tratti e quali script utilizzare
 - Gli identificatori (`id`, `sinergie[]`, `conflitti[]`, `biome_tags[]`, `usage_tags[]`, `data_origin`)
   utilizzano slug `^[a-z0-9_]+$` e ogni file JSON deve avere un `id` corrispondente al nome del file.
 - Gli slot (`slot[]`) accettano soltanto lettere maiuscole singole (A–Z) e non possono ripetersi.
+- `usage_tags` deve contenere 1–2 tag tattici dal vocabolario ufficiale (vedi sotto) e non può essere
+  lasciato vuoto sui trait canonici.
 - `metrics[].unit` accetta esclusivamente stringhe UCUM senza spazi (`m/s`, `Cel`, `1`, `kPa`, …) mentre
   `metrics[].name` deve essere già ripulito.
 - Le entry `species_affinity` validano sia il formato dello slug (`species_id` supporta trattini ma non
@@ -54,6 +56,18 @@ python scripts/trait_audit.py --import-external-drafts
 ```
 
 Lo step richiama l'importer prima di eseguire le verifiche esistenti, così da produrre sempre l'elenco aggiornato dei draft.
+
+### Vocabolario `usage_tags`
+
+I tag d'uso identificano il ruolo tattico prevalente di ciascun tratto e alimentano filtri UI,
+analytics e checklist automatiche. I valori ammessi sono:
+
+- `scout` – Ricognizione, sensori, mobilità e raccolta informazione rapida.
+- `breaker` – Assalto diretto, penetrazione difese e output offensivo concentrato.
+- `support` – Abilitazione del team, logistica, coordinamento e strumenti tattici.
+- `tank` – Mitigazione danni, protezione, schermature e gestione dell'aggro.
+- `sustain` – Economia risorse, guarigione, rigenerazione o mantenimento energetico.
+- `controller` – Controllo del campo, crowd control, psionica o manipolazione degli spazi.
 
 ## Workflow di aggiornamento
 

--- a/tests/snapshots/species_builder_predatore.json
+++ b/tests/snapshots/species_builder_predatore.json
@@ -2,15 +2,9 @@
   "id": "synthetic-1d37afd07a",
   "display_name": "Predatore / Coda a Frusta Cinetica",
   "summary": "Artigli a Sette Vie, Coda a Frusta Cinetica, Scheletro Idro-Regolante",
-  "description": "Sintesi genetica focalizzata su Artigli a Sette Vie e Coda a Frusta Cinetica con impronta morfologica defensive, locomotor, omeostatico, prehensile, structural; comportamento climber. Ottimizzata per biomi: caverna_risonante, falde_magnetiche_psioniche, orbita_psionica_inversa.",
+  "description": "Sintesi genetica focalizzata su Artigli a Sette Vie e Coda a Frusta Cinetica con impronta morfologica defensive, locomotor, omeostatico, prehensile, structural; comportamento climber, breaker, scout, tank, sustain. Ottimizzata per biomi: caverna_risonante, falde_magnetiche_psioniche, orbita_psionica_inversa.",
   "morphology": {
-    "families": [
-      "defensive",
-      "locomotor",
-      "omeostatico",
-      "prehensile",
-      "structural"
-    ],
+    "families": ["defensive", "locomotor", "omeostatico", "prehensile", "structural"],
     "adaptations": [
       "Dita lunghe e segmentate con punte a uncino multiplo.",
       "Precauzione: Angoli di presa limitati se la superficie è perfettamente liscia.",
@@ -19,16 +13,10 @@
       "Struttura ossea porosa capace di scambio rapido di fluidi.",
       "Precauzione: Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio."
     ],
-    "environments": [
-      "caverna_risonante",
-      "falde_magnetiche_psioniche",
-      "orbita_psionica_inversa"
-    ]
+    "environments": ["caverna_risonante", "falde_magnetiche_psioniche", "orbita_psionica_inversa"]
   },
   "behavior": {
-    "tags": [
-      "climber"
-    ],
+    "tags": ["climber", "breaker", "scout", "tank", "sustain"],
     "drives": [
       "Afferrare superfici irregolari o oggetti multipli.",
       "Arrampicarsi su pareti rocciose o vegetazione densa.",
@@ -45,11 +33,7 @@
     "synergy_score": 0.333
   },
   "traits": {
-    "core": [
-      "artigli_sette_vie",
-      "coda_frusta_cinetica",
-      "scheletro_idro_regolante"
-    ],
+    "core": ["artigli_sette_vie", "coda_frusta_cinetica", "scheletro_idro_regolante"],
     "derived": [
       "ali_ioniche",
       "antenne_flusso_mareale",
@@ -99,355 +83,258 @@
       "struttura_elastica_amorfa",
       "tattiche_di_branco"
     ],
-    "conflicts": [
-      "sangue_piroforico"
-    ],
+    "conflicts": ["sangue_piroforico"],
     "metadata": {
-      "usage_tags": [],
+      "usage_tags": ["breaker", "scout", "sustain", "tank"],
       "species_affinity": [
         {
           "species_id": "dune-stalker",
-          "roles": [
-            "core",
-            "optional"
-          ],
+          "roles": ["core", "optional"],
           "weight": 12.0
         },
         {
           "species_id": "magneto-ridge-hunter",
-          "roles": [
-            "core",
-            "optional"
-          ],
+          "roles": ["core", "optional"],
           "weight": 12.0
         },
         {
           "species_id": "slag-veil-ambusher",
-          "roles": [
-            "core",
-            "optional",
-            "synergy"
-          ],
+          "roles": ["core", "optional", "synergy"],
           "weight": 6.0
         },
         {
           "species_id": "nano-rust-bloom",
-          "roles": [
-            "core",
-            "optional"
-          ],
+          "roles": ["core", "optional"],
           "weight": 4.0
         },
         {
           "species_id": "sand-burrower",
-          "roles": [
-            "core",
-            "optional"
-          ],
+          "roles": ["core", "optional"],
           "weight": 4.0
         },
         {
           "species_id": "bulette-fase",
-          "roles": [
-            "optional"
-          ],
+          "roles": ["optional"],
           "weight": 2.0
         },
         {
           "species_id": "caverna-risonante-trait-keeper",
-          "roles": [
-            "optional"
-          ],
+          "roles": ["optional"],
           "weight": 2.0
         },
         {
           "species_id": "marilith-vault",
-          "roles": [
-            "optional"
-          ],
+          "roles": ["optional"],
           "weight": 2.0
         },
         {
           "species_id": "balor-fission",
-          "roles": [
-            "optional"
-          ],
+          "roles": ["optional"],
           "weight": 1.0
         },
         {
           "species_id": "couatl-aurora",
-          "roles": [
-            "optional"
-          ],
+          "roles": ["optional"],
           "weight": 1.0
         },
         {
           "species_id": "cryo-lynx",
-          "roles": [
-            "optional"
-          ],
+          "roles": ["optional"],
           "weight": 1.0
         },
         {
           "species_id": "falde-magnetiche-psioniche-trait-keeper",
-          "roles": [
-            "optional"
-          ],
+          "roles": ["optional"],
           "weight": 1.0
         },
         {
           "species_id": "magnet-fathom-surveyor",
-          "roles": [
-            "optional"
-          ],
+          "roles": ["optional"],
           "weight": 1.0
         },
         {
           "species_id": "orbita-psionica-inversa-trait-keeper",
-          "roles": [
-            "optional"
-          ],
+          "roles": ["optional"],
           "weight": 1.0
         },
         {
           "species_id": "otyugh-sentinella",
-          "roles": [
-            "optional"
-          ],
+          "roles": ["optional"],
           "weight": 1.0
         },
         {
           "species_id": "resonant-claw-hunter",
-          "roles": [
-            "optional"
-          ],
+          "roles": ["optional"],
           "weight": 1.0
         },
         {
           "species_id": "rust-scavenger",
-          "roles": [
-            "optional"
-          ],
+          "roles": ["optional"],
           "weight": 1.0
         },
         {
           "species_id": "steppe-bison-mini",
-          "roles": [
-            "optional"
-          ],
+          "roles": ["optional"],
           "weight": 1.0
         }
       ],
-      "completion_flags": {},
+      "completion_flags": {
+        "has_usage_tags": true
+      },
       "per_trait": {
         "artigli_sette_vie": {
-          "usage_tags": [],
+          "usage_tags": ["breaker", "scout"],
           "species_affinity": [
             {
               "species_id": "dune-stalker",
-              "roles": [
-                "core",
-                "optional"
-              ],
+              "roles": ["core", "optional"],
               "weight": 4.0
             },
             {
               "species_id": "magneto-ridge-hunter",
-              "roles": [
-                "core",
-                "optional"
-              ],
+              "roles": ["core", "optional"],
               "weight": 4.0
             },
             {
               "species_id": "balor-fission",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             },
             {
               "species_id": "caverna-risonante-trait-keeper",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             },
             {
               "species_id": "couatl-aurora",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             },
             {
               "species_id": "cryo-lynx",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             },
             {
               "species_id": "marilith-vault",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             },
             {
               "species_id": "otyugh-sentinella",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             },
             {
               "species_id": "resonant-claw-hunter",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             }
           ],
-          "completion_flags": {}
+          "completion_flags": {
+            "has_usage_tags": true
+          }
         },
         "coda_frusta_cinetica": {
-          "usage_tags": [],
+          "usage_tags": ["scout", "tank"],
           "species_affinity": [
             {
               "species_id": "dune-stalker",
-              "roles": [
-                "core",
-                "optional"
-              ],
+              "roles": ["core", "optional"],
               "weight": 4.0
             },
             {
               "species_id": "magneto-ridge-hunter",
-              "roles": [
-                "core",
-                "optional"
-              ],
+              "roles": ["core", "optional"],
               "weight": 4.0
             },
             {
               "species_id": "slag-veil-ambusher",
-              "roles": [
-                "core",
-                "optional"
-              ],
+              "roles": ["core", "optional"],
               "weight": 4.0
             },
             {
               "species_id": "bulette-fase",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             },
             {
               "species_id": "falde-magnetiche-psioniche-trait-keeper",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             },
             {
               "species_id": "marilith-vault",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             },
             {
               "species_id": "orbita-psionica-inversa-trait-keeper",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             }
           ],
-          "completion_flags": {}
+          "completion_flags": {
+            "has_usage_tags": true
+          }
         },
         "scheletro_idro_regolante": {
-          "usage_tags": [],
+          "usage_tags": ["sustain", "tank"],
           "species_affinity": [
             {
               "species_id": "dune-stalker",
-              "roles": [
-                "core",
-                "optional"
-              ],
+              "roles": ["core", "optional"],
               "weight": 4.0
             },
             {
               "species_id": "magneto-ridge-hunter",
-              "roles": [
-                "core",
-                "optional"
-              ],
+              "roles": ["core", "optional"],
               "weight": 4.0
             },
             {
               "species_id": "nano-rust-bloom",
-              "roles": [
-                "core",
-                "optional"
-              ],
+              "roles": ["core", "optional"],
               "weight": 4.0
             },
             {
               "species_id": "sand-burrower",
-              "roles": [
-                "core",
-                "optional"
-              ],
+              "roles": ["core", "optional"],
               "weight": 4.0
             },
             {
               "species_id": "slag-veil-ambusher",
-              "roles": [
-                "synergy"
-              ],
+              "roles": ["synergy"],
               "weight": 2.0
             },
             {
               "species_id": "bulette-fase",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             },
             {
               "species_id": "caverna-risonante-trait-keeper",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             },
             {
               "species_id": "magnet-fathom-surveyor",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             },
             {
               "species_id": "rust-scavenger",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             },
             {
               "species_id": "steppe-bison-mini",
-              "roles": [
-                "optional"
-              ],
+              "roles": ["optional"],
               "weight": 1.0
             }
           ],
-          "completion_flags": {}
+          "completion_flags": {
+            "has_usage_tags": true
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- Document the official `usage_tags` vocabulary in the trait workflow reference and call out the requirement to fill it on canonical entries.
- Populate `usage_tags` across the full trait catalog, update the aggregated indexes, and regenerate the CSV to reflect the new metadata flags.
- Extend the trait editor style guide check to warn when usage tags are missing or outside the allowed vocabulary.

## Testing
- npm run style:check

------
https://chatgpt.com/codex/tasks/task_e_6907b30595d483328c64a1a25c0b967f