### PR TITLE
Normalize trait data origins via editorial source mapping

### DIFF
--- a/data/traits/difensivo/ali_membrana_sonica.json
+++ b/data/traits/difensivo/ali_membrana_sonica.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/difensivo/appendici_risonanti_marea.json
+++ b/data/traits/difensivo/appendici_risonanti_marea.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "laguna_bioreattiva"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/difensivo/barriere_miasma_glaciale.json
+++ b/data/traits/difensivo/barriere_miasma_glaciale.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caldera_glaciale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/difensivo/branchie_microfiltri.json
+++ b/data/traits/difensivo/branchie_microfiltri.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "reef_luminescente"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/difensivo/capsule_paracadute.json
+++ b/data/traits/difensivo/capsule_paracadute.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/difensivo/circolazione_bifasica.json
+++ b/data/traits/difensivo/circolazione_bifasica.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caldera_glaciale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/difensivo/coda_coppia_retroattiva.json
+++ b/data/traits/difensivo/coda_coppia_retroattiva.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "steppe_algoritmiche"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/difensivo/cute_resistente_sali.json
+++ b/data/traits/difensivo/cute_resistente_sali.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "badlands"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/difensivo/enzimi_antipredatori_algali.json
+++ b/data/traits/difensivo/enzimi_antipredatori_algali.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "reef_luminescente"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/difensivo/filtri_planctonici.json
+++ b/data/traits/difensivo/filtri_planctonici.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "laguna_bioreattiva"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/difensivo/ghiandole_fango_coesivo.json
+++ b/data/traits/difensivo/ghiandole_fango_coesivo.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/difensivo/giunti_antitorsione.json
+++ b/data/traits/difensivo/giunti_antitorsione.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/difensivo/lingua_cristallina.json
+++ b/data/traits/difensivo/lingua_cristallina.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/difensivo/mucose_barofile.json
+++ b/data/traits/difensivo/mucose_barofile.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "abisso_vulcanico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/difesa/armatura_pietra_planare.json
+++ b/data/traits/difesa/armatura_pietra_planare.json
@@ -47,6 +47,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
-  }
+    "has_usage_tags": true,
+    "has_data_origin": true
+  },
+  "data_origin": "pathfinder_dataset"
 }

--- a/data/traits/difesa/mantello_meteoritico.json
+++ b/data/traits/difesa/mantello_meteoritico.json
@@ -49,6 +49,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
-  }
+    "has_usage_tags": true,
+    "has_data_origin": true
+  },
+  "data_origin": "pathfinder_dataset"
 }

--- a/data/traits/digestivo/filamenti_digestivi_compattanti.json
+++ b/data/traits/digestivo/filamenti_digestivi_compattanti.json
@@ -68,10 +68,12 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante",
     "falde_magnetiche_psioniche"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/digestivo/ventriglio_gastroliti.json
+++ b/data/traits/digestivo/ventriglio_gastroliti.json
@@ -55,9 +55,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/escretorio/spore_psichiche_silenziate.json
+++ b/data/traits/escretorio/spore_psichiche_silenziate.json
@@ -43,9 +43,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/idrostatico/sacche_galleggianti_ascensoriali.json
+++ b/data/traits/idrostatico/sacche_galleggianti_ascensoriali.json
@@ -59,10 +59,12 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopia_psionica_leggera",
     "orbita_psionica_inversa"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -54,12 +54,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ali_ioniche": {
       "conflitti": [],
@@ -113,11 +115,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ali_membrana_sonica": {
       "conflitti": [],
@@ -171,11 +175,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "antenne_dustsense": {
       "conflitti": [],
@@ -229,11 +235,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "antenne_eco_turbina": {
       "conflitti": [],
@@ -287,11 +295,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "antenne_flusso_mareale": {
       "conflitti": [],
@@ -345,11 +355,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "antenne_microonde_cavernose": {
       "conflitti": [],
@@ -403,11 +415,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "antenne_plasmatiche_tempesta": {
       "conflitti": [],
@@ -471,12 +485,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker",
         "scout"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "antenne_reagenti": {
       "conflitti": [],
@@ -530,11 +546,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "antenne_tesla": {
       "conflitti": [],
@@ -588,11 +606,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "antenne_waveguide": {
       "conflitti": [],
@@ -646,12 +666,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "antenne_wideband": {
       "conflitti": [],
@@ -705,11 +727,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "appendici_risonanti_marea": {
       "conflitti": [],
@@ -763,11 +787,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "appendici_thermotattiche": {
       "conflitti": [],
@@ -821,11 +847,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "armatura_pietra_planare": {
       "conflitti": [
@@ -904,11 +932,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "pathfinder_dataset"
     },
     "artigli_acidofagi": {
       "conflitti": [],
@@ -962,11 +992,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "artigli_induzione": {
       "conflitti": [],
@@ -1020,11 +1052,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "artigli_radice": {
       "conflitti": [],
@@ -1078,11 +1112,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "artigli_scivolo_silente": {
       "conflitti": [],
@@ -1136,11 +1172,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "artigli_sette_vie": {
       "conflitti": [],
@@ -1262,12 +1300,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker",
         "scout"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "artigli_sghiaccio_glaciale": {
       "conflitti": [],
@@ -1329,12 +1369,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker",
         "scout"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "artigli_vetrificati": {
       "conflitti": [],
@@ -1388,11 +1430,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "aura_scudo_radianza": {
       "conflitti": [
@@ -1451,12 +1495,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support",
         "tank"
-      ]
+      ],
+      "data_origin": "pathfinder_dataset"
     },
     "baffi_mareomotori": {
       "conflitti": [],
@@ -1510,12 +1556,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "barbigli_sensori_plasma": {
       "conflitti": [],
@@ -1569,11 +1617,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "barriere_miasma_glaciale": {
       "conflitti": [],
@@ -1627,11 +1677,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "batteri_endosimbionti_chemio": {
       "conflitti": [],
@@ -1685,11 +1737,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "batteri_termofili_endosimbiosi": {
       "conflitti": [],
@@ -1743,11 +1797,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "biochip_memoria": {
       "conflitti": [],
@@ -1801,11 +1857,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "biofilm_glow": {
       "conflitti": [],
@@ -1859,11 +1917,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "biofilm_iperarido": {
       "conflitti": [],
@@ -1917,11 +1977,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "branchie_dual_mode": {
       "conflitti": [],
@@ -1975,11 +2037,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "branchie_eoliche": {
       "conflitti": [],
@@ -2033,12 +2097,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "branchie_metalloidi": {
       "conflitti": [],
@@ -2092,11 +2158,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "branchie_microfiltri": {
       "conflitti": [],
@@ -2150,11 +2218,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "branchie_osmotiche_salmastra": {
       "conflitti": [
@@ -2217,11 +2287,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "branchie_solfatiche": {
       "conflitti": [],
@@ -2275,11 +2347,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "branchie_turbina": {
       "conflitti": [],
@@ -2333,11 +2407,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "bulbi_radici_permafrost": {
       "conflitti": [],
@@ -2400,12 +2476,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support",
         "sustain"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "camere_anticorrosione": {
       "conflitti": [],
@@ -2459,11 +2537,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "camere_mirage": {
       "conflitti": [],
@@ -2517,11 +2597,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "camere_nutrienti_vent": {
       "conflitti": [],
@@ -2575,11 +2657,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "capillari_criogenici": {
       "conflitti": [],
@@ -2633,11 +2717,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "capillari_fluoridici": {
       "conflitti": [],
@@ -2691,12 +2777,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "capillari_fotovoltaici": {
       "conflitti": [],
@@ -2750,11 +2838,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "capsule_paracadute": {
       "conflitti": [],
@@ -2808,11 +2898,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "carapace_fase_variabile": {
       "conflitti": [
@@ -2961,11 +3053,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "carapace_luminiscente_abissale": {
       "conflitti": [
@@ -3030,12 +3124,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "carapace_segmenti_logici": {
       "conflitti": [],
@@ -3089,11 +3185,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "carapaci_ferruginosi": {
       "conflitti": [],
@@ -3147,11 +3245,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "cartilagine_flessotermica_venti": {
       "conflitti": [
@@ -3216,12 +3316,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "cartilagini_biofibre": {
       "conflitti": [],
@@ -3275,11 +3377,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "cartilagini_desertiche": {
       "conflitti": [],
@@ -3333,11 +3437,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "cartilagini_flessoacustiche": {
       "conflitti": [],
@@ -3391,11 +3497,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "cartilagini_pseudometalliche": {
       "conflitti": [],
@@ -3449,11 +3557,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "cavita_risonanti_tundra": {
       "conflitti": [],
@@ -3517,12 +3627,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "cervelletto_equilibrio_statico": {
       "conflitti": [],
@@ -3576,12 +3688,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "chemiorecettori_bromuro": {
       "conflitti": [],
@@ -3635,11 +3749,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "chioma_parassita_canopica": {
       "conflitti": [],
@@ -3692,11 +3808,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "circolazione_bifasica": {
       "conflitti": [],
@@ -3750,11 +3868,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "circolazione_bifasica_palude": {
       "conflitti": [
@@ -3808,12 +3928,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain",
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "circolazione_cooling_loop": {
       "conflitti": [],
@@ -3867,11 +3989,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "circolazione_doppia": {
       "conflitti": [],
@@ -3925,11 +4049,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "circolazione_supercritica": {
       "conflitti": [],
@@ -3983,11 +4109,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ciste_riduttive": {
       "conflitti": [],
@@ -4041,11 +4169,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ciste_salmastre": {
       "conflitti": [],
@@ -4099,11 +4229,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "cisti_iperbariche": {
       "conflitti": [],
@@ -4157,11 +4289,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "coda_balanciere": {
       "conflitti": [],
@@ -4215,12 +4349,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "coda_contrappeso": {
       "conflitti": [],
@@ -4274,11 +4410,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "coda_coppia_retroattiva": {
       "conflitti": [],
@@ -4332,11 +4470,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "coda_frusta_cinetica": {
       "conflitti": [],
@@ -4473,12 +4613,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "coda_stabilizzatrice_filo": {
       "conflitti": [],
@@ -4532,11 +4674,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "coda_stabilizzatrice_geiser": {
       "conflitti": [],
@@ -4590,11 +4734,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "coda_stabilizzatrice_vortex": {
       "conflitti": [],
@@ -4648,11 +4794,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "colonne_vibromagnetiche": {
       "conflitti": [],
@@ -4706,11 +4854,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "coralli_partner": {
       "conflitti": [],
@@ -4764,11 +4914,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "criostasi_adattiva": {
       "conflitti": [
@@ -4857,12 +5009,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain",
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "cromofori_alert_acido": {
       "conflitti": [],
@@ -4916,11 +5070,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "cuore_multicamera_bassa_pressione": {
       "conflitti": [],
@@ -4974,12 +5130,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "cuscinetti_elettrostatici": {
       "conflitti": [],
@@ -5033,11 +5191,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "cute_resistente_sali": {
       "conflitti": [],
@@ -5106,11 +5266,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "cuticole_cerose": {
       "conflitti": [],
@@ -5193,11 +5355,13 @@
       "completion_flags": {
         "has_biome": false,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "cuticole_neutralizzanti": {
       "conflitti": [],
@@ -5251,11 +5415,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "denti_chelatanti": {
       "conflitti": [],
@@ -5309,11 +5475,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "denti_ossidoferro": {
       "conflitti": [],
@@ -5367,11 +5535,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "denti_silice_termici": {
       "conflitti": [],
@@ -5425,11 +5595,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "denti_tuning_fork": {
       "conflitti": [],
@@ -5483,11 +5655,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "echi_risonanti": {
       "conflitti": [],
@@ -5541,12 +5715,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "eco_interno_riflesso": {
       "conflitti": [],
@@ -5656,12 +5832,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "controller",
         "scout"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "empatia_coordinativa": {
       "conflitti": [],
@@ -5770,11 +5948,13 @@
       "completion_flags": {
         "has_biome": false,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "enzimi_antifase_termica": {
       "conflitti": [],
@@ -5828,11 +6008,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "enzimi_antipredatori_algali": {
       "conflitti": [],
@@ -5886,11 +6068,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "enzimi_chelanti": {
       "conflitti": [],
@@ -5939,11 +6123,13 @@
       "completion_flags": {
         "has_biome": false,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "enzimi_chelatori_rapidi": {
       "conflitti": [],
@@ -5997,11 +6183,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "enzimi_metanoossidanti": {
       "conflitti": [],
@@ -6055,11 +6243,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "epidermide_dielettrica": {
       "conflitti": [],
@@ -6113,11 +6303,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "epitelio_fosforescente": {
       "conflitti": [],
@@ -6171,11 +6363,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "filamenti_digestivi_compattanti": {
       "conflitti": [],
@@ -6305,11 +6499,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "filamenti_magnetotrofi": {
       "conflitti": [],
@@ -6363,11 +6559,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "filamenti_superconduttivi": {
       "conflitti": [],
@@ -6421,12 +6619,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "filamenti_termoconduzione": {
       "conflitti": [],
@@ -6480,11 +6680,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "filtri_planctonici": {
       "conflitti": [],
@@ -6538,11 +6740,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "flagelli_ancoranti": {
       "conflitti": [],
@@ -6596,11 +6800,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "focus_frazionato": {
       "conflitti": [],
@@ -6719,12 +6925,14 @@
       "completion_flags": {
         "has_biome": false,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "controller",
         "support"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "foliage_fotocatodico": {
       "conflitti": [],
@@ -6778,11 +6986,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "foliaggio_spugna": {
       "conflitti": [],
@@ -6836,11 +7046,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "frusta_fiammeggiante": {
       "conflitti": [
@@ -6906,12 +7118,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker",
         "controller"
-      ]
+      ],
+      "data_origin": "pathfinder_dataset"
     },
     "ghiaccio_piezoelettrico": {
       "conflitti": [],
@@ -6965,11 +7179,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ghiandola_caustica": {
       "conflitti": [],
@@ -7021,11 +7237,13 @@
       "completion_flags": {
         "has_biome": false,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "ghiandole_cambio_salino": {
       "conflitti": [],
@@ -7079,11 +7297,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ghiandole_condensa_ozono": {
       "conflitti": [],
@@ -7137,11 +7357,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ghiandole_eco_mappanti": {
       "conflitti": [],
@@ -7195,12 +7417,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ghiandole_fango_calde": {
       "conflitti": [],
@@ -7254,11 +7478,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ghiandole_fango_coesivo": {
       "conflitti": [],
@@ -7312,11 +7538,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ghiandole_grafene": {
       "conflitti": [],
@@ -7370,11 +7598,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ghiandole_inchiostro_luce": {
       "conflitti": [],
@@ -7428,11 +7658,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ghiandole_iodoattive": {
       "conflitti": [],
@@ -7486,11 +7718,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ghiandole_minerali": {
       "conflitti": [],
@@ -7544,11 +7778,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ghiandole_nebbia_acida": {
       "conflitti": [],
@@ -7602,11 +7838,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ghiandole_nebbia_ionica": {
       "conflitti": [],
@@ -7660,11 +7898,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ghiandole_resina_conduttiva": {
       "conflitti": [],
@@ -7718,12 +7958,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "ghiandole_ventosa": {
       "conflitti": [],
@@ -7777,11 +8019,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "giunti_antitorsione": {
       "conflitti": [],
@@ -7835,11 +8079,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "grassi_termici": {
       "conflitti": [],
@@ -7922,11 +8168,13 @@
       "completion_flags": {
         "has_biome": false,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "gusci_criovetro": {
       "conflitti": [],
@@ -7980,11 +8228,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "gusci_magnesio": {
       "conflitti": [],
@@ -8038,11 +8288,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "lamelle_shear": {
       "conflitti": [],
@@ -8096,11 +8348,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "lamelle_sincroniche": {
       "conflitti": [],
@@ -8154,11 +8408,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "lamelle_termoforetiche": {
       "conflitti": [
@@ -8240,11 +8496,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "lamine_filtranti_aeree": {
       "conflitti": [],
@@ -8298,11 +8556,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "lamine_scudo_silice": {
       "conflitti": [],
@@ -8356,12 +8616,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "linfa_tampone": {
       "conflitti": [],
@@ -8415,11 +8677,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "lingua_cristallina": {
       "conflitti": [],
@@ -8473,11 +8737,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "lingua_tattile_trama": {
       "conflitti": [],
@@ -8550,12 +8816,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "sustain"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "luminescenza_aurorale": {
       "conflitti": [],
@@ -8609,11 +8877,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "luminescenza_hydrotermica": {
       "conflitti": [],
@@ -8667,11 +8937,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "mantelli_geotermici": {
       "conflitti": [],
@@ -8725,11 +8997,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "mantello_meteoritico": {
       "conflitti": [
@@ -8795,12 +9069,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain",
         "tank"
-      ]
+      ],
+      "data_origin": "pathfinder_dataset"
     },
     "membrane_captura_rugiada": {
       "conflitti": [],
@@ -8854,11 +9130,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "membrane_eliofiltranti": {
       "conflitti": [],
@@ -8911,12 +9189,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain",
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "membrane_planata_vectored": {
       "conflitti": [],
@@ -8970,11 +9250,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "membrane_pneumatofori": {
       "conflitti": [],
@@ -9028,11 +9310,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "midollo_antivibrazione": {
       "conflitti": [],
@@ -9086,12 +9370,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "mimetismo_cromatico_passivo": {
       "conflitti": [],
@@ -9208,11 +9494,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "mucillagine_simbionte_mangrovie": {
       "conflitti": [
@@ -9281,12 +9569,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support",
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "mucose_aderenza_sonica": {
       "conflitti": [],
@@ -9340,11 +9630,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "mucose_barofile": {
       "conflitti": [],
@@ -9398,11 +9690,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "nodi_micorrizici_oracolari": {
       "conflitti": [
@@ -9471,12 +9765,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "controller",
         "support"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "nucleo_ovomotore_rotante": {
       "conflitti": [
@@ -9559,12 +9855,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "occhi_infrarosso_composti": {
       "conflitti": [],
@@ -9624,11 +9922,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "olfatto_risonanza_magnetica": {
       "conflitti": [],
@@ -9753,12 +10053,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "controller",
         "scout"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "pathfinder": {
       "conflitti": [],
@@ -9801,7 +10103,8 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "species_affinity": [
         {
@@ -9881,11 +10184,13 @@
       "completion_flags": {
         "has_biome": false,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "piume_solari_fotovoltaiche": {
       "conflitti": [
@@ -9940,12 +10245,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain",
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "polmoni_cristallini_alta_quota": {
       "conflitti": [
@@ -9999,11 +10306,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "random": {
       "conflitti": [],
@@ -10050,12 +10359,14 @@
       "completion_flags": {
         "has_biome": false,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support",
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "respiro_a_scoppio": {
       "conflitti": [],
@@ -10144,12 +10455,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "sustain"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "risonanza_di_branco": {
       "conflitti": [],
@@ -10254,11 +10567,13 @@
       "completion_flags": {
         "has_biome": false,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "sacche_galleggianti_ascensoriali": {
       "conflitti": [],
@@ -10378,12 +10693,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "sacche_spore_stratosferiche": {
       "conflitti": [
@@ -10437,11 +10754,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "sangue_piroforico": {
       "conflitti": [
@@ -10531,11 +10850,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "breaker"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "scheletro_idro_regolante": {
       "conflitti": [
@@ -10671,12 +10992,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain",
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "secrezione_rallentante_palmi": {
       "conflitti": [
@@ -10737,11 +11060,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "sensori_geomagnetici": {
       "conflitti": [],
@@ -10815,11 +11140,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "sinapsi_coraline_polifoniche": {
       "conflitti": [
@@ -10888,11 +11215,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "sonno_emisferico_alternato": {
       "conflitti": [],
@@ -10960,12 +11289,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "controller",
         "sustain"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "spore_psichiche_silenziate": {
       "conflitti": [
@@ -11039,12 +11370,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "controller",
         "sustain"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "squame_rifrangenti_deserto": {
       "conflitti": [
@@ -11098,11 +11431,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "struttura_elastica_amorfa": {
       "conflitti": [],
@@ -11243,12 +11578,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "tattiche_di_branco": {
       "conflitti": [],
@@ -11326,11 +11663,13 @@
       "completion_flags": {
         "has_biome": false,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "support"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "vello_condensatore_nebbie": {
       "conflitti": [],
@@ -11382,12 +11721,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain",
         "tank"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "ventriglio_gastroliti": {
       "conflitti": [],
@@ -11474,11 +11815,13 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "sustain"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "zampe_a_molla": {
       "conflitti": [],
@@ -11542,11 +11885,13 @@
       "completion_flags": {
         "has_biome": false,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     },
     "zoccoli_risonanti_steppe": {
       "conflitti": [
@@ -11600,12 +11945,14 @@
       "completion_flags": {
         "has_biome": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
       "usage_tags": [
         "scout",
         "support"
-      ]
+      ],
+      "data_origin": "controllo_psionico"
     }
   },
   "types": {

--- a/data/traits/locomotorio/ali_ioniche.json
+++ b/data/traits/locomotorio/ali_ioniche.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopia_ionica"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/locomotorio/antenne_wideband.json
+++ b/data/traits/locomotorio/antenne_wideband.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "steppe_algoritmiche"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/locomotorio/artigli_sette_vie.json
+++ b/data/traits/locomotorio/artigli_sette_vie.json
@@ -55,9 +55,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/locomotorio/artigli_sghiaccio_glaciale.json
+++ b/data/traits/locomotorio/artigli_sghiaccio_glaciale.json
@@ -53,9 +53,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "calotte_glaciali"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/locomotorio/barbigli_sensori_plasma.json
+++ b/data/traits/locomotorio/barbigli_sensori_plasma.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/locomotorio/branchie_metalloidi.json
+++ b/data/traits/locomotorio/branchie_metalloidi.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "abisso_vulcanico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/locomotorio/capillari_fotovoltaici.json
+++ b/data/traits/locomotorio/capillari_fotovoltaici.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopia_ionica"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/locomotorio/cartilagine_flessotermica_venti.json
+++ b/data/traits/locomotorio/cartilagine_flessotermica_venti.json
@@ -56,9 +56,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "gole_ventose"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/locomotorio/chemiorecettori_bromuro.json
+++ b/data/traits/locomotorio/chemiorecettori_bromuro.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/locomotorio/coda_contrappeso.json
+++ b/data/traits/locomotorio/coda_contrappeso.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/locomotorio/coda_frusta_cinetica.json
+++ b/data/traits/locomotorio/coda_frusta_cinetica.json
@@ -83,10 +83,12 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "falde_magnetiche_psioniche",
     "orbita_psionica_inversa"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/locomotorio/cuscinetti_elettrostatici.json
+++ b/data/traits/locomotorio/cuscinetti_elettrostatici.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/locomotorio/enzimi_antifase_termica.json
+++ b/data/traits/locomotorio/enzimi_antifase_termica.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caldera_glaciale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/locomotorio/filamenti_termoconduzione.json
+++ b/data/traits/locomotorio/filamenti_termoconduzione.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/locomotorio/ghiandole_fango_calde.json
+++ b/data/traits/locomotorio/ghiandole_fango_calde.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "abisso_vulcanico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/locomotorio/ghiandole_ventosa.json
+++ b/data/traits/locomotorio/ghiandole_ventosa.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caldera_glaciale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/locomotorio/linfa_tampone.json
+++ b/data/traits/locomotorio/linfa_tampone.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_acida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/locomotorio/mucose_aderenza_sonica.json
+++ b/data/traits/locomotorio/mucose_aderenza_sonica.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/locomotorio/zampe_a_molla.json
+++ b/data/traits/locomotorio/zampe_a_molla.json
@@ -65,9 +65,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_miceliale"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/locomotorio/zoccoli_risonanti_steppe.json
+++ b/data/traits/locomotorio/zoccoli_risonanti_steppe.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "steppe_risonanti"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/metabolico/antenne_dustsense.json
+++ b/data/traits/metabolico/antenne_dustsense.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/metabolico/appendici_thermotattiche.json
+++ b/data/traits/metabolico/appendici_thermotattiche.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "abisso_vulcanico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/metabolico/batteri_endosimbionti_chemio.json
+++ b/data/traits/metabolico/batteri_endosimbionti_chemio.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "abisso_vulcanico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/metabolico/branchie_solfatiche.json
+++ b/data/traits/metabolico/branchie_solfatiche.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caldera_glaciale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/metabolico/carapace_segmenti_logici.json
+++ b/data/traits/metabolico/carapace_segmenti_logici.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "steppe_algoritmiche"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/metabolico/circolazione_bifasica_palude.json
+++ b/data/traits/metabolico/circolazione_bifasica_palude.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "paludi_gas_luminescenti"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/metabolico/circolazione_cooling_loop.json
+++ b/data/traits/metabolico/circolazione_cooling_loop.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "steppe_algoritmiche"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/metabolico/coda_stabilizzatrice_filo.json
+++ b/data/traits/metabolico/coda_stabilizzatrice_filo.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopia_ionica"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/metabolico/criostasi_adattiva.json
+++ b/data/traits/metabolico/criostasi_adattiva.json
@@ -59,10 +59,12 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopia_psionica_leggera",
     "orbita_psionica_inversa"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/metabolico/cuticole_cerose.json
+++ b/data/traits/metabolico/cuticole_cerose.json
@@ -42,9 +42,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_miceliale"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/metabolico/enzimi_chelanti.json
+++ b/data/traits/metabolico/enzimi_chelanti.json
@@ -42,9 +42,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_miceliale"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/metabolico/flagelli_ancoranti.json
+++ b/data/traits/metabolico/flagelli_ancoranti.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "laguna_bioreattiva"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/metabolico/ghiandole_grafene.json
+++ b/data/traits/metabolico/ghiandole_grafene.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "steppe_algoritmiche"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/metabolico/grassi_termici.json
+++ b/data/traits/metabolico/grassi_termici.json
@@ -42,9 +42,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_miceliale"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/metabolico/luminescenza_aurorale.json
+++ b/data/traits/metabolico/luminescenza_aurorale.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caldera_glaciale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/nervoso/sonno_emisferico_alternato.json
+++ b/data/traits/nervoso/sonno_emisferico_alternato.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/offensivo/antenne_flusso_mareale.json
+++ b/data/traits/offensivo/antenne_flusso_mareale.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "laguna_bioreattiva"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/offensivo/artigli_induzione.json
+++ b/data/traits/offensivo/artigli_induzione.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopia_ionica"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/offensivo/biochip_memoria.json
+++ b/data/traits/offensivo/biochip_memoria.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "steppe_algoritmiche"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/offensivo/camere_anticorrosione.json
+++ b/data/traits/offensivo/camere_anticorrosione.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_acida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/offensivo/cartilagini_biofibre.json
+++ b/data/traits/offensivo/cartilagini_biofibre.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "reef_luminescente"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/offensivo/circolazione_supercritica.json
+++ b/data/traits/offensivo/circolazione_supercritica.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "abisso_vulcanico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/offensivo/coda_stabilizzatrice_vortex.json
+++ b/data/traits/offensivo/coda_stabilizzatrice_vortex.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/offensivo/denti_chelatanti.json
+++ b/data/traits/offensivo/denti_chelatanti.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_acida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/offensivo/enzimi_metanoossidanti.json
+++ b/data/traits/offensivo/enzimi_metanoossidanti.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "abisso_vulcanico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/offensivo/foliaggio_spugna.json
+++ b/data/traits/offensivo/foliaggio_spugna.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/offensivo/frusta_fiammeggiante.json
+++ b/data/traits/offensivo/frusta_fiammeggiante.json
@@ -49,6 +49,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
-  }
+    "has_usage_tags": true,
+    "has_data_origin": true
+  },
+  "data_origin": "pathfinder_dataset"
 }

--- a/data/traits/offensivo/ghiandola_caustica.json
+++ b/data/traits/offensivo/ghiandola_caustica.json
@@ -46,9 +46,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_miceliale"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/offensivo/ghiandole_iodoattive.json
+++ b/data/traits/offensivo/ghiandole_iodoattive.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/offensivo/gusci_magnesio.json
+++ b/data/traits/offensivo/gusci_magnesio.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/offensivo/mantelli_geotermici.json
+++ b/data/traits/offensivo/mantelli_geotermici.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caldera_glaciale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/offensivo/sangue_piroforico.json
+++ b/data/traits/offensivo/sangue_piroforico.json
@@ -58,9 +58,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/respiratorio/branchie_osmotiche_salmastra.json
+++ b/data/traits/respiratorio/branchie_osmotiche_salmastra.json
@@ -53,9 +53,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "delta_salmastri"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/respiratorio/lamelle_termoforetiche.json
+++ b/data/traits/respiratorio/lamelle_termoforetiche.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "sorgenti_geotermiche"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/respiratorio/membrane_eliofiltranti.json
+++ b/data/traits/respiratorio/membrane_eliofiltranti.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "laghi_alcalini"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/respiratorio/polmoni_cristallini_alta_quota.json
+++ b/data/traits/respiratorio/polmoni_cristallini_alta_quota.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "picchi_cristallini"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/respiratorio/respiro_a_scoppio.json
+++ b/data/traits/respiratorio/respiro_a_scoppio.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/riproduttivo/nucleo_ovomotore_rotante.json
+++ b/data/traits/riproduttivo/nucleo_ovomotore_rotante.json
@@ -43,9 +43,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/sensoriale/ali_fulminee.json
+++ b/data/traits/sensoriale/ali_fulminee.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/sensoriale/antenne_plasmatiche_tempesta.json
+++ b/data/traits/sensoriale/antenne_plasmatiche_tempesta.json
@@ -55,9 +55,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "cicloni_psionici"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/sensoriale/antenne_waveguide.json
+++ b/data/traits/sensoriale/antenne_waveguide.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "reef_luminescente"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/sensoriale/baffi_mareomotori.json
+++ b/data/traits/sensoriale/baffi_mareomotori.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/sensoriale/branchie_eoliche.json
+++ b/data/traits/sensoriale/branchie_eoliche.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/sensoriale/capillari_fluoridici.json
+++ b/data/traits/sensoriale/capillari_fluoridici.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_acida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/sensoriale/cavita_risonanti_tundra.json
+++ b/data/traits/sensoriale/cavita_risonanti_tundra.json
@@ -55,9 +55,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "tundra_risonante"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/sensoriale/cervelletto_equilibrio_statico.json
+++ b/data/traits/sensoriale/cervelletto_equilibrio_statico.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopia_ionica"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/sensoriale/coda_balanciere.json
+++ b/data/traits/sensoriale/coda_balanciere.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/sensoriale/cuore_multicamera_bassa_pressione.json
+++ b/data/traits/sensoriale/cuore_multicamera_bassa_pressione.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/sensoriale/echi_risonanti.json
+++ b/data/traits/sensoriale/echi_risonanti.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/sensoriale/eco_interno_riflesso.json
+++ b/data/traits/sensoriale/eco_interno_riflesso.json
@@ -58,10 +58,12 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopia_psionica_leggera",
     "falde_magnetiche_psioniche"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/sensoriale/filamenti_superconduttivi.json
+++ b/data/traits/sensoriale/filamenti_superconduttivi.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caldera_glaciale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/sensoriale/ghiandole_eco_mappanti.json
+++ b/data/traits/sensoriale/ghiandole_eco_mappanti.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/sensoriale/ghiandole_resina_conduttiva.json
+++ b/data/traits/sensoriale/ghiandole_resina_conduttiva.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopia_ionica"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/sensoriale/lamine_scudo_silice.json
+++ b/data/traits/sensoriale/lamine_scudo_silice.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/sensoriale/lingua_tattile_trama.json
+++ b/data/traits/sensoriale/lingua_tattile_trama.json
@@ -43,9 +43,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/sensoriale/midollo_antivibrazione.json
+++ b/data/traits/sensoriale/midollo_antivibrazione.json
@@ -45,9 +45,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/sensoriale/occhi_infrarosso_composti.json
+++ b/data/traits/sensoriale/occhi_infrarosso_composti.json
@@ -42,9 +42,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/sensoriale/olfatto_risonanza_magnetica.json
+++ b/data/traits/sensoriale/olfatto_risonanza_magnetica.json
@@ -57,10 +57,12 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "falde_magnetiche_psioniche",
     "orbita_psionica_inversa"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/sensoriale/sensori_geomagnetici.json
+++ b/data/traits/sensoriale/sensori_geomagnetici.json
@@ -43,9 +43,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "pianure_magnetiche"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/simbiotico/antenne_reagenti.json
+++ b/data/traits/simbiotico/antenne_reagenti.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_acida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/simbiotico/artigli_scivolo_silente.json
+++ b/data/traits/simbiotico/artigli_scivolo_silente.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/simbiotico/biofilm_iperarido.json
+++ b/data/traits/simbiotico/biofilm_iperarido.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/simbiotico/bulbi_radici_permafrost.json
+++ b/data/traits/simbiotico/bulbi_radici_permafrost.json
@@ -54,9 +54,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "permafrost_psionico"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/simbiotico/camere_nutrienti_vent.json
+++ b/data/traits/simbiotico/camere_nutrienti_vent.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/simbiotico/cartilagini_flessoacustiche.json
+++ b/data/traits/simbiotico/cartilagini_flessoacustiche.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/simbiotico/chioma_parassita_canopica.json
+++ b/data/traits/simbiotico/chioma_parassita_canopica.json
@@ -43,9 +43,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopie_sospese"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/simbiotico/ciste_salmastre.json
+++ b/data/traits/simbiotico/ciste_salmastre.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/simbiotico/coralli_partner.json
+++ b/data/traits/simbiotico/coralli_partner.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "reef_luminescente"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/simbiotico/denti_silice_termici.json
+++ b/data/traits/simbiotico/denti_silice_termici.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/simbiotico/epitelio_fosforescente.json
+++ b/data/traits/simbiotico/epitelio_fosforescente.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "reef_luminescente"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/simbiotico/ghiandole_cambio_salino.json
+++ b/data/traits/simbiotico/ghiandole_cambio_salino.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "laguna_bioreattiva"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/simbiotico/ghiandole_nebbia_acida.json
+++ b/data/traits/simbiotico/ghiandole_nebbia_acida.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_acida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/simbiotico/lamelle_sincroniche.json
+++ b/data/traits/simbiotico/lamelle_sincroniche.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "steppe_algoritmiche"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/simbiotico/membrane_planata_vectored.json
+++ b/data/traits/simbiotico/membrane_planata_vectored.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopia_ionica"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/simbiotico/mucillagine_simbionte_mangrovie.json
+++ b/data/traits/simbiotico/mucillagine_simbionte_mangrovie.json
@@ -60,9 +60,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "mangrovie_risonanti"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/simbiotico/nodi_micorrizici_oracolari.json
+++ b/data/traits/simbiotico/nodi_micorrizici_oracolari.json
@@ -60,9 +60,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "reti_micorriziche"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/simbiotico/sacche_spore_stratosferiche.json
+++ b/data/traits/simbiotico/sacche_spore_stratosferiche.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "stratosfera_portante"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/simbiotico/sinapsi_coraline_polifoniche.json
+++ b/data/traits/simbiotico/sinapsi_coraline_polifoniche.json
@@ -59,9 +59,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "barriere_coralline_psioniche"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/strategia/antenne_microonde_cavernose.json
+++ b/data/traits/strategia/antenne_microonde_cavernose.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strategia/artigli_radice.json
+++ b/data/traits/strategia/artigli_radice.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strategia/biofilm_glow.json
+++ b/data/traits/strategia/biofilm_glow.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "reef_luminescente"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strategia/camere_mirage.json
+++ b/data/traits/strategia/camere_mirage.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strategia/cartilagini_desertiche.json
+++ b/data/traits/strategia/cartilagini_desertiche.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strategia/ciste_riduttive.json
+++ b/data/traits/strategia/ciste_riduttive.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "laguna_bioreattiva"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strategia/colonne_vibromagnetiche.json
+++ b/data/traits/strategia/colonne_vibromagnetiche.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strategia/denti_ossidoferro.json
+++ b/data/traits/strategia/denti_ossidoferro.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "abisso_vulcanico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strategia/epidermide_dielettrica.json
+++ b/data/traits/strategia/epidermide_dielettrica.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strategia/focus_frazionato.json
+++ b/data/traits/strategia/focus_frazionato.json
@@ -70,9 +70,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_miceliale"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/strategia/ghiaccio_piezoelettrico.json
+++ b/data/traits/strategia/ghiaccio_piezoelettrico.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caldera_glaciale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strategia/ghiandole_minerali.json
+++ b/data/traits/strategia/ghiandole_minerali.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strategia/lamelle_shear.json
+++ b/data/traits/strategia/lamelle_shear.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strategia/membrane_captura_rugiada.json
+++ b/data/traits/strategia/membrane_captura_rugiada.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "pianura_salina_iperarida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strategia/pathfinder.json
+++ b/data/traits/strategia/pathfinder.json
@@ -50,7 +50,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "spinta_selettiva": "i18n:traits.pathfinder.spinta_selettiva",
   "tier": "T1",

--- a/data/traits/strategia/pianificatore.json
+++ b/data/traits/strategia/pianificatore.json
@@ -68,9 +68,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_miceliale"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/strategia/random.json
+++ b/data/traits/strategia/random.json
@@ -58,9 +58,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": true,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_miceliale"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/strategia/tattiche_di_branco.json
+++ b/data/traits/strategia/tattiche_di_branco.json
@@ -65,9 +65,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_miceliale"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/strutturale/antenne_tesla.json
+++ b/data/traits/strutturale/antenne_tesla.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopia_ionica"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strutturale/artigli_vetrificati.json
+++ b/data/traits/strutturale/artigli_vetrificati.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caldera_glaciale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strutturale/branchie_dual_mode.json
+++ b/data/traits/strutturale/branchie_dual_mode.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "laguna_bioreattiva"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strutturale/capillari_criogenici.json
+++ b/data/traits/strutturale/capillari_criogenici.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caldera_glaciale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strutturale/carapace_fase_variabile.json
+++ b/data/traits/strutturale/carapace_fase_variabile.json
@@ -83,10 +83,12 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopia_psionica_leggera",
     "falde_magnetiche_psioniche"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/strutturale/carapace_luminiscente_abissale.json
+++ b/data/traits/strutturale/carapace_luminiscente_abissale.json
@@ -56,9 +56,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "abisso_luminescente"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/strutturale/cartilagini_pseudometalliche.json
+++ b/data/traits/strutturale/cartilagini_pseudometalliche.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "abisso_vulcanico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strutturale/cisti_iperbariche.json
+++ b/data/traits/strutturale/cisti_iperbariche.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "abisso_vulcanico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strutturale/cromofori_alert_acido.json
+++ b/data/traits/strutturale/cromofori_alert_acido.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_acida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strutturale/denti_tuning_fork.json
+++ b/data/traits/strutturale/denti_tuning_fork.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strutturale/filamenti_magnetotrofi.json
+++ b/data/traits/strutturale/filamenti_magnetotrofi.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "abisso_vulcanico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strutturale/ghiandole_condensa_ozono.json
+++ b/data/traits/strutturale/ghiandole_condensa_ozono.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "stratosfera_tempestosa"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strutturale/ghiandole_nebbia_ionica.json
+++ b/data/traits/strutturale/ghiandole_nebbia_ionica.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopia_ionica"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strutturale/lamine_filtranti_aeree.json
+++ b/data/traits/strutturale/lamine_filtranti_aeree.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strutturale/membrane_pneumatofori.json
+++ b/data/traits/strutturale/membrane_pneumatofori.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "mangrovieto_cinetico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/strutturale/scheletro_idro_regolante.json
+++ b/data/traits/strutturale/scheletro_idro_regolante.json
@@ -60,9 +60,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/strutturale/struttura_elastica_amorfa.json
+++ b/data/traits/strutturale/struttura_elastica_amorfa.json
@@ -72,10 +72,12 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopia_psionica_leggera",
     "falde_magnetiche_psioniche"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/supporto/antenne_eco_turbina.json
+++ b/data/traits/supporto/antenne_eco_turbina.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/supporto/artigli_acidofagi.json
+++ b/data/traits/supporto/artigli_acidofagi.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_acida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/supporto/aura_scudo_radianza.json
+++ b/data/traits/supporto/aura_scudo_radianza.json
@@ -49,6 +49,8 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
-  }
+    "has_usage_tags": true,
+    "has_data_origin": true
+  },
+  "data_origin": "pathfinder_dataset"
 }

--- a/data/traits/supporto/batteri_termofili_endosimbiosi.json
+++ b/data/traits/supporto/batteri_termofili_endosimbiosi.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/supporto/branchie_turbina.json
+++ b/data/traits/supporto/branchie_turbina.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/supporto/carapaci_ferruginosi.json
+++ b/data/traits/supporto/carapaci_ferruginosi.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "abisso_vulcanico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/supporto/circolazione_doppia.json
+++ b/data/traits/supporto/circolazione_doppia.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/supporto/coda_stabilizzatrice_geiser.json
+++ b/data/traits/supporto/coda_stabilizzatrice_geiser.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "dorsale_termale_tropicale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/supporto/cuticole_neutralizzanti.json
+++ b/data/traits/supporto/cuticole_neutralizzanti.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_acida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/supporto/empatia_coordinativa.json
+++ b/data/traits/supporto/empatia_coordinativa.json
@@ -61,9 +61,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_miceliale"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/supporto/enzimi_chelatori_rapidi.json
+++ b/data/traits/supporto/enzimi_chelatori_rapidi.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_acida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/supporto/foliage_fotocatodico.json
+++ b/data/traits/supporto/foliage_fotocatodico.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_acida"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/supporto/ghiandole_inchiostro_luce.json
+++ b/data/traits/supporto/ghiandole_inchiostro_luce.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "reef_luminescente"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/supporto/gusci_criovetro.json
+++ b/data/traits/supporto/gusci_criovetro.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caldera_glaciale"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/supporto/luminescenza_hydrotermica.json
+++ b/data/traits/supporto/luminescenza_hydrotermica.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "abisso_vulcanico"
-  ]
+  ],
+  "data_origin": "coverage_q4_2025"
 }

--- a/data/traits/supporto/risonanza_di_branco.json
+++ b/data/traits/supporto/risonanza_di_branco.json
@@ -70,9 +70,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foresta_miceliale"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/tegumentario/mimetismo_cromatico_passivo.json
+++ b/data/traits/tegumentario/mimetismo_cromatico_passivo.json
@@ -70,10 +70,12 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "canopia_psionica_leggera",
     "falde_magnetiche_psioniche"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/tegumentario/piume_solari_fotovoltaiche.json
+++ b/data/traits/tegumentario/piume_solari_fotovoltaiche.json
@@ -46,9 +46,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "altipiani_solari"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/tegumentario/secrezione_rallentante_palmi.json
+++ b/data/traits/tegumentario/secrezione_rallentante_palmi.json
@@ -43,9 +43,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "caverna_risonante"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/tegumentario/squame_rifrangenti_deserto.json
+++ b/data/traits/tegumentario/squame_rifrangenti_deserto.json
@@ -44,9 +44,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "dune_cristalline"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/data/traits/tegumentario/vello_condensatore_nebbie.json
+++ b/data/traits/tegumentario/vello_condensatore_nebbie.json
@@ -43,9 +43,11 @@
   "completion_flags": {
     "has_biome": true,
     "has_species_link": false,
-    "has_usage_tags": true
+    "has_usage_tags": true,
+    "has_data_origin": true
   },
   "biome_tags": [
     "foreste_nubose"
-  ]
+  ],
+  "data_origin": "controllo_psionico"
 }

--- a/docs/editorial/trait_sources.json
+++ b/docs/editorial/trait_sources.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0",
+  "updated_at": "2025-11-16T00:00:00Z",
+  "sources": [
+    {
+      "slug": "controllo_psionico",
+      "title": "Controllo Psionico",
+      "kind": "expansion",
+      "aliases": ["controllo_psionico", "Controllo Psionico", "psionic_control"],
+      "notes": "Pacchetto narrativo psionico usato per i trait ambientati nei biomi risonanti."
+    },
+    {
+      "slug": "coverage_q4_2025",
+      "title": "Coverage Q4 2025",
+      "kind": "expansion",
+      "aliases": ["coverage_q4_2025", "Coverage Q4 2025", "coverage-q4-2025"],
+      "notes": "Set di copertura tattica Q4 2025, tratti di audit biome-wide e aggiornamenti ambiente."
+    },
+    {
+      "slug": "pathfinder_dataset",
+      "title": "Pathfinder Dataset",
+      "kind": "dataset",
+      "aliases": ["pathfinder_dataset", "Pathfinder Dataset", "pathfinder-dataset"],
+      "notes": "Semi narrativi dal dataset Pathfinder usati per i trait guida e onboarding."
+    }
+  ]
+}

--- a/docs/traits_template.md
+++ b/docs/traits_template.md
@@ -27,19 +27,19 @@ Il blocco sottostante riassume i campi obbligatori. Tutti i valori devono
 rispettare le regole indicate e sono validati automaticamente dal comando
 `python tools/py/trait_template_validator.py`.
 
-| Campo                           | Tipo         | Vincoli principali                                       | Descrizione |
-|---------------------------------|--------------|-----------------------------------------------------------|-------------|
-| `id`                            | string       | `^[a-z0-9_]+$`, deve coincidere con il nome del file      | Identificatore canonico. |
-| `label`                         | string       | non vuota                                                 | Nome visualizzato (deve avere controparte nel glossario/localizzazioni). |
-| `famiglia_tipologia`            | string       | non vuota (`Macro/Sub-tipo`)                              | Cluster funzionale. |
-| `fattore_mantenimento_energetico` | string     | non vuota                                                 | Costo narrativo/energetico. |
-| `tier`                          | string       | `T1`…`T6`                                                 | Gradino di progressione. |
-| `slot`                          | array[string]| ciascun elemento `^[A-Z]$`, array vuoto consentito        | Slot occupati. |
-| `sinergie`                      | array[string]| elementi `^[a-z0-9_]+$`                                   | Trait compatibili. |
-| `conflitti`                     | array[string]| elementi `^[a-z0-9_]+$`                                   | Trait incompatibili. |
-| `mutazione_indotta`             | string       | non vuota                                                 | Sintesi dell'adattamento. |
-| `uso_funzione`                  | string       | non vuota                                                 | Funzione in gioco. |
-| `spinta_selettiva`              | string       | non vuota                                                 | Motivazione evolutiva/tattica. |
+| Campo                             | Tipo          | Vincoli principali                                   | Descrizione                                                              |
+| --------------------------------- | ------------- | ---------------------------------------------------- | ------------------------------------------------------------------------ |
+| `id`                              | string        | `^[a-z0-9_]+$`, deve coincidere con il nome del file | Identificatore canonico.                                                 |
+| `label`                           | string        | non vuota                                            | Nome visualizzato (deve avere controparte nel glossario/localizzazioni). |
+| `famiglia_tipologia`              | string        | non vuota (`Macro/Sub-tipo`)                         | Cluster funzionale.                                                      |
+| `fattore_mantenimento_energetico` | string        | non vuota                                            | Costo narrativo/energetico.                                              |
+| `tier`                            | string        | `T1`…`T6`                                            | Gradino di progressione.                                                 |
+| `slot`                            | array[string] | ciascun elemento `^[A-Z]$`, array vuoto consentito   | Slot occupati.                                                           |
+| `sinergie`                        | array[string] | elementi `^[a-z0-9_]+$`                              | Trait compatibili.                                                       |
+| `conflitti`                       | array[string] | elementi `^[a-z0-9_]+$`                              | Trait incompatibili.                                                     |
+| `mutazione_indotta`               | string        | non vuota                                            | Sintesi dell'adattamento.                                                |
+| `uso_funzione`                    | string        | non vuota                                            | Funzione in gioco.                                                       |
+| `spinta_selettiva`                | string        | non vuota                                            | Motivazione evolutiva/tattica.                                           |
 
 Quando un campo testuale viene introdotto (es. `description`), ricordati di
 aggiungerlo al glossario e di eseguire `python scripts/sync_trait_locales.py`
@@ -65,16 +65,18 @@ per riflettere la modifica nelle localizzazioni.
 
 ## Sezioni opzionali
 
-| Campo/Blocco         | Dettagli |
-|----------------------|----------|
-| `slot_profile`       | Oggetto con chiavi obbligatorie `core` e `complementare`. Descrive la specializzazione primaria e secondaria del tratto. |
+| Campo/Blocco           | Dettagli                                                                                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `slot_profile`         | Oggetto con chiavi obbligatorie `core` e `complementare`. Descrive la specializzazione primaria e secondaria del tratto.                                                             |
 | `requisiti_ambientali` | Array di vincoli contestuali. Ogni elemento include `condizioni.biome_class`, la sorgente (`fonte`) e facoltativamente `capacita_richieste` e `meta` (`expansion`, `tier`, `notes`). |
-| `biome_tags`         | Array di biomi affini (stringhe `^[a-z0-9_]+$`) usati per indicare ambienti secondari o sinergie narrative. |
-| `usage_tags`         | Array di tag tattici (`scout`, `breaker`, `tank`, ecc.) normalizzati (`^[a-z0-9_]+$`) per filtri UI e analytics. |
-| `data_origin`        | Stringa (`^[a-z0-9_]+$`) che identifica il pacchetto o la fonte editoriale (es. `controllo_psionico`, `coverage_q4_2025`). |
-| `completion_flags`   | Oggetto di flag booleani (es. `has_biome`, `has_species_link`) per tracciare rapidamente lacune editoriali. |
-| `debolezza`          | Stringa opzionale per limiti intrinseci o vulnerabilità. |
-| `sinergie_pi`        | Oggetto con `co_occorrenze`, `forme`, `tabelle_random`, `combo_totale`. Serve per gli strumenti di pianificazione PI. |
+| `biome_tags`           | Array di biomi affini (stringhe `^[a-z0-9_]+$`) usati per indicare ambienti secondari o sinergie narrative.                                                                          |
+| `usage_tags`           | Array di tag tattici (`scout`, `breaker`, `tank`, ecc.) normalizzati (`^[a-z0-9_]+$`) per filtri UI e analytics.                                                                     |
+| `data_origin`          | Stringa (`^[a-z0-9_]+$`) che identifica il pacchetto o la fonte editoriale (es. `controllo_psionico`, `coverage_q4_2025`).                                                           |
+| `completion_flags`     | Oggetto di flag booleani (es. `has_biome`, `has_species_link`) per tracciare rapidamente lacune editoriali.                                                                          |
+| `debolezza`            | Stringa opzionale per limiti intrinseci o vulnerabilità.                                                                                                                             |
+| `sinergie_pi`          | Oggetto con `co_occorrenze`, `forme`, `tabelle_random`, `combo_totale`. Serve per gli strumenti di pianificazione PI.                                                                |
+
+> **Ricorda:** assegna sempre `data_origin` utilizzando gli slug pubblicati nel glossario editoriale (`docs/editorial/trait_sources.json`). Lo script `python tools/py/normalize_trait_style.py` può aggiornare i file esistenti, ma i trait nuovi devono già riferirsi alla sorgente corretta prima della PR.
 
 ### Sezioni annidate
 
@@ -87,7 +89,7 @@ per riflettere la modifica nelle localizzazioni.
   "biome_tags": ["laguna_bioreattiva", "foresta_miceliale"],
   "requisiti_ambientali": [
     {
-      "condizioni": {"biome_class": "foresta_acida"},
+      "condizioni": { "biome_class": "foresta_acida" },
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "coverage_q4_2025",
@@ -159,27 +161,27 @@ La tabella seguente collega ogni macro-tipologia a un trait reale nel
 repository. Tutti gli esempi rispettano lo schema base e includono le sezioni
 opzionali quando rilevanti.
 
-| Macro-tipologia | Sottotipi disponibili | Trait di esempio (ID — Label) | Percorso | Uso/funzione |
-|-----------------|-----------------------|-------------------------------|----------|--------------|
-| Difesa | Strutturale, Termoregolazione | `armatura_pietra_planare` — Armatura di Pietra Planare | `data/traits/difesa/armatura_pietra_planare.json` | Offre schermatura massiva e ancoraggio durante le aperture dimensionali. |
-| Digestivo | Alimentare, Escretorio, Metabolico | `filamenti_digestivi_compattanti` — Filamento materiali digeriti | `data/traits/digestivo/filamenti_digestivi_compattanti.json` | Espulsione compatta e ordinata di scorie. |
-| Escretorio | Psichico | `spore_psichiche_silenziate` — Spora Psichica Silenziosa | `data/traits/escretorio/spore_psichiche_silenziate.json` | Indurre uno stato di confusione o letargia negli individui vicini. |
-| Esplorazione | Tattico | `pathfinder` — Pathfinder | `data/traits/strategia/pathfinder.json` | Ottimizza esplorazione e controllo mappe multi-bioma. |
-| Flessibile | Generico | `random` — Trait Random | `data/traits/strategia/random.json` | Slot jolly per testing o pareggiare budget PI quando serve varietà. |
-| Idrostatico | Locomotorio | `sacche_galleggianti_ascensoriali` — Sacche galleggianti ascensoriali | `data/traits/idrostatico/sacche_galleggianti_ascensoriali.json` | Controllo preciso della profondità e del movimento verticale. |
-| Locomotorio | Adattivo, Difensivo, Mobilità, Predatorio, Prensile, Supporto | `ali_ioniche` — Ali Ioniche | `data/traits/locomotorio/ali_ioniche.json` | Ottimizza scatti direzionali e transizioni rapide fra livelli verticali. |
-| Metabolico | Difensivo, Resilienza | `circolazione_bifasica_palude` — Circolazione Bifasica di Palude | `data/traits/metabolico/circolazione_bifasica_palude.json` | Gestisce due circuiti circolatori per filtrare veleni e mantenere prestazioni elevate. |
-| Mobilità | Cinetico | `zampe_a_molla` — Zampe a Molla | `data/traits/locomotorio/zampe_a_molla.json` | Dash esplosivi per mantenere il ritmo di ingaggio o disimpegno. |
-| Nervoso | Omeostatico | `sonno_emisferico_alternato` — Dormire con solo metà cervello alla volta | `data/traits/nervoso/sonno_emisferico_alternato.json` | Vigilanza continua pur garantendo riposo. |
-| Offensivo | Assalto, Chimico, Cinetico, Controllo | `antenne_flusso_mareale` — Antenne Flusso Mareale | `data/traits/offensivo/antenne_flusso_mareale.json` | Aumenta penetrazione e burst durante finestre di vulnerabilità. |
-| Respiratorio | Aerobico, Osmoregolazione, Propulsivo, Protezione, Termoregolazione | `branchie_osmotiche_salmastra` — Branchie Osmotiche Salmastre | `data/traits/respiratorio/branchie_osmotiche_salmastra.json` | Bilancia sali e tossine sfruttando microvalvole controllate psionicamente. |
-| Riproduttivo | Locomotorio | `nucleo_ovomotore_rotante` — Uovo rotaia, uovo grande e uova piccole dentro... | `data/traits/riproduttivo/nucleo_ovomotore_rotante.json` | Organo motorio rotante per spostamenti rapidi in assetto riproduttivo. |
-| Sensoriale | Alimentare, Analitico, Navigazione, Nervoso, Offensivo, Supporto, Visivo | `ali_fulminee` — Ali Fulminee | `data/traits/sensoriale/ali_fulminee.json` | Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato. |
-| Simbiotico | Comunicazione, Cooperativo, Difensivo, Nervoso, Nutrizione, Supporto, Utility | `antenne_reagenti` — Antenne Reagenti | `data/traits/simbiotico/antenne_reagenti.json` | Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici. |
-| Strategico | Psionico, Tattico | `antenne_microonde_cavernose` — Antenne Microonde Cavernose | `data/traits/strategia/antenne_microonde_cavernose.json` | Sblocca pattern predittivi per trappole e imboscate coordinate. |
-| Strutturale | Adattivo, Difensivo, Locomotorio, Omeostatico, Sensoriale | `antenne_tesla` — Antenne Tesla | `data/traits/strutturale/antenne_tesla.json` | Regola densità e flessibilità per sopportare cambi repentini. |
-| Supporto | Coordinativo, Difesa, Empatico, Logistico | `antenne_eco_turbina` — Antenne Eco Turbina | `data/traits/supporto/antenne_eco_turbina.json` | Distribuisce riserve e modulazioni ritmiche per mantenere coesione. |
-| Tegumentario | Difensivo, Energetico, Idratazione | `ali_membrana_sonica` — Ali Membrana Sonica | `data/traits/difensivo/ali_membrana_sonica.json` | Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali. |
+| Macro-tipologia | Sottotipi disponibili                                                         | Trait di esempio (ID — Label)                                                  | Percorso                                                        | Uso/funzione                                                                           |
+| --------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Difesa          | Strutturale, Termoregolazione                                                 | `armatura_pietra_planare` — Armatura di Pietra Planare                         | `data/traits/difesa/armatura_pietra_planare.json`               | Offre schermatura massiva e ancoraggio durante le aperture dimensionali.               |
+| Digestivo       | Alimentare, Escretorio, Metabolico                                            | `filamenti_digestivi_compattanti` — Filamento materiali digeriti               | `data/traits/digestivo/filamenti_digestivi_compattanti.json`    | Espulsione compatta e ordinata di scorie.                                              |
+| Escretorio      | Psichico                                                                      | `spore_psichiche_silenziate` — Spora Psichica Silenziosa                       | `data/traits/escretorio/spore_psichiche_silenziate.json`        | Indurre uno stato di confusione o letargia negli individui vicini.                     |
+| Esplorazione    | Tattico                                                                       | `pathfinder` — Pathfinder                                                      | `data/traits/strategia/pathfinder.json`                         | Ottimizza esplorazione e controllo mappe multi-bioma.                                  |
+| Flessibile      | Generico                                                                      | `random` — Trait Random                                                        | `data/traits/strategia/random.json`                             | Slot jolly per testing o pareggiare budget PI quando serve varietà.                    |
+| Idrostatico     | Locomotorio                                                                   | `sacche_galleggianti_ascensoriali` — Sacche galleggianti ascensoriali          | `data/traits/idrostatico/sacche_galleggianti_ascensoriali.json` | Controllo preciso della profondità e del movimento verticale.                          |
+| Locomotorio     | Adattivo, Difensivo, Mobilità, Predatorio, Prensile, Supporto                 | `ali_ioniche` — Ali Ioniche                                                    | `data/traits/locomotorio/ali_ioniche.json`                      | Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.               |
+| Metabolico      | Difensivo, Resilienza                                                         | `circolazione_bifasica_palude` — Circolazione Bifasica di Palude               | `data/traits/metabolico/circolazione_bifasica_palude.json`      | Gestisce due circuiti circolatori per filtrare veleni e mantenere prestazioni elevate. |
+| Mobilità        | Cinetico                                                                      | `zampe_a_molla` — Zampe a Molla                                                | `data/traits/locomotorio/zampe_a_molla.json`                    | Dash esplosivi per mantenere il ritmo di ingaggio o disimpegno.                        |
+| Nervoso         | Omeostatico                                                                   | `sonno_emisferico_alternato` — Dormire con solo metà cervello alla volta       | `data/traits/nervoso/sonno_emisferico_alternato.json`           | Vigilanza continua pur garantendo riposo.                                              |
+| Offensivo       | Assalto, Chimico, Cinetico, Controllo                                         | `antenne_flusso_mareale` — Antenne Flusso Mareale                              | `data/traits/offensivo/antenne_flusso_mareale.json`             | Aumenta penetrazione e burst durante finestre di vulnerabilità.                        |
+| Respiratorio    | Aerobico, Osmoregolazione, Propulsivo, Protezione, Termoregolazione           | `branchie_osmotiche_salmastra` — Branchie Osmotiche Salmastre                  | `data/traits/respiratorio/branchie_osmotiche_salmastra.json`    | Bilancia sali e tossine sfruttando microvalvole controllate psionicamente.             |
+| Riproduttivo    | Locomotorio                                                                   | `nucleo_ovomotore_rotante` — Uovo rotaia, uovo grande e uova piccole dentro... | `data/traits/riproduttivo/nucleo_ovomotore_rotante.json`        | Organo motorio rotante per spostamenti rapidi in assetto riproduttivo.                 |
+| Sensoriale      | Alimentare, Analitico, Navigazione, Nervoso, Offensivo, Supporto, Visivo      | `ali_fulminee` — Ali Fulminee                                                  | `data/traits/sensoriale/ali_fulminee.json`                      | Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.          |
+| Simbiotico      | Comunicazione, Cooperativo, Difensivo, Nervoso, Nutrizione, Supporto, Utility | `antenne_reagenti` — Antenne Reagenti                                          | `data/traits/simbiotico/antenne_reagenti.json`                  | Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.                      |
+| Strategico      | Psionico, Tattico                                                             | `antenne_microonde_cavernose` — Antenne Microonde Cavernose                    | `data/traits/strategia/antenne_microonde_cavernose.json`        | Sblocca pattern predittivi per trappole e imboscate coordinate.                        |
+| Strutturale     | Adattivo, Difensivo, Locomotorio, Omeostatico, Sensoriale                     | `antenne_tesla` — Antenne Tesla                                                | `data/traits/strutturale/antenne_tesla.json`                    | Regola densità e flessibilità per sopportare cambi repentini.                          |
+| Supporto        | Coordinativo, Difesa, Empatico, Logistico                                     | `antenne_eco_turbina` — Antenne Eco Turbina                                    | `data/traits/supporto/antenne_eco_turbina.json`                 | Distribuisce riserve e modulazioni ritmiche per mantenere coesione.                    |
+| Tegumentario    | Difensivo, Energetico, Idratazione                                            | `ali_membrana_sonica` — Ali Membrana Sonica                                    | `data/traits/difensivo/ali_membrana_sonica.json`                | Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.            |
 
 ## Strumenti di validazione
 


### PR DESCRIPTION
## Summary
- add an editorial trait source glossary with canonical slugs for bundle coverage
- extend `normalize_trait_style.py` to load the glossary, auto-fill `data_origin`, and flag availability
- document the requirement in the trait template and normalize all trait JSON/index entries with the mapped origin slugs

## Testing
- python tools/py/normalize_trait_style.py

------
https://chatgpt.com/codex/tasks/task_e_6907b90278bc83329a0a2ccf33f7e96f