### PR TITLE
Ensure core traits random and zampe_a_molla have species coverage

### DIFF
--- a/data/derived/analysis/trait_coverage_matrix.csv
+++ b/data/derived/analysis/trait_coverage_matrix.csv
@@ -339,6 +339,7 @@ pathfinder,Pathfinder,Pathfinder,foresta_miceliale,,1,1
 pianificatore,Pianificatore,Strategic Planner,foresta_miceliale,,1,1
 piume_solari_fotovoltaiche,Piume Solari Fotovoltaiche,Piume Solari Fotovoltaiche,altipiani_solari,cursoriale_quadrupede,0,1
 polmoni_cristallini_alta_quota,Polmoni Cristallini d'Alta Quota,Polmoni Cristallini d'Alta Quota,picchi_cristallini,cursoriale_quadrupede,0,1
+random,Trait Random,Trait Random,foresta_miceliale,,0,1
 respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,caverna_risonante,cursoriale_quadrupede,0,1
 respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,dorsale_termale_tropicale,scavenger_corazzato,1,1
 respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,mezzanotte_orbitale,cursoriale_quadrupede,1,1
@@ -389,4 +390,5 @@ vello_condensatore_nebbie,Vello Condensatore di Nebbie,Vello Condensatore di Neb
 ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,caverna_risonante,cursoriale_quadrupede,0,1
 ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,dorsale_termale_tropicale,scavenger_corazzato,1,1
 ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,mezzanotte_orbitale,cursoriale_quadrupede,1,1
+zampe_a_molla,Zampe a Molla,Spring-Loaded Limbs,dorsale_termale_tropicale,cursoriale_quadrupede,0,1
 zoccoli_risonanti_steppe,Zoccoli Risonanti delle Steppe,Zoccoli Risonanti delle Steppe,steppe_risonanti,cursoriale_quadrupede,0,1

--- a/data/derived/analysis/trait_coverage_report.json
+++ b/data/derived/analysis/trait_coverage_report.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-11-02T20:27:01+00:00",
+  "generated_at": "2025-11-02T20:46:09+00:00",
   "sources": {
     "env_traits": "packs/evo_tactics_pack/docs/catalog/env_traits.json",
     "trait_reference": "data/traits/index.json",
@@ -11,10 +11,10 @@
   "summary": {
     "traits_total": 174,
     "traits_with_rules": 147,
-    "traits_with_species": 172,
+    "traits_with_species": 174,
     "traits_with_affinity": 0,
     "rule_combos_total": 177,
-    "species_combos_total": 391,
+    "species_combos_total": 393,
     "rules_missing_species_total": 0,
     "affinity_missing_species_total": 0,
     "affinity_missing_matrix_total": 0,
@@ -54,6 +54,7 @@
       "occhi_infrarosso_composti",
       "piume_solari_fotovoltaiche",
       "polmoni_cristallini_alta_quota",
+      "random",
       "respiro_a_scoppio",
       "risonanza_di_branco",
       "sacche_spore_stratosferiche",
@@ -67,6 +68,7 @@
       "squame_rifrangenti_deserto",
       "vello_condensatore_nebbie",
       "ventriglio_gastroliti",
+      "zampe_a_molla",
       "zoccoli_risonanti_steppe"
     ]
   },
@@ -7216,12 +7218,26 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "sentinella-radice"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       }
@@ -8196,12 +8212,26 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "sand-burrower"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       }

--- a/logs/traits_tracking.md
+++ b/logs/traits_tracking.md
@@ -125,3 +125,9 @@
 - Inventario valido: core 30/30, mock 4/4.
 - Trait generator: core=30, enriched_species=12, nessun trait mancante rispetto all'inventario.
 - Bundle statico verificato con smoke test HTTP locale (tools/ts/dist presente).
+
+## 2025-11-02T20:46:42Z · traits_validator.py
+- Inventario: `docs/catalog/traits_inventory.json`
+- Risorse totali: 36 (core: 32/32, mock: 4/4)
+- Nessun avviso registrato.
+- ✅ Nessun errore critico.

--- a/packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml
@@ -54,9 +54,9 @@ derived_from_environment:
     - nucleo_ovomotore_rotante
     - sacche_galleggianti_ascensoriali
     - scheletro_idro_regolante
+    - zampe_a_molla
   optional_traits:
     - carapace_fase_variabile
-    - zampe_a_molla
   required_capabilities:
     - build_cover
     - dr_impact_cap

--- a/packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml
@@ -62,8 +62,8 @@ derived_from_environment:
     - focus_frazionato
     - pathfinder
     - pianificatore
-  optional_traits:
     - random
+  optional_traits:
     - empatia_coordinativa
 genetic_traits: []
 mate_synergy: []


### PR DESCRIPTION
## Summary
- update the sentinella-radice and sand-burrower species so the core traits `random` and `zampe_a_molla` are part of their environment-driven suggestions
- regenerate the trait coverage report and matrix to reflect the new species coverage counts for both traits
- append the traits tracking log with the latest validator execution confirming the inventory remains healthy

## Testing
- python tools/py/report_trait_coverage.py --env-traits packs/evo_tactics_pack/docs/catalog/env_traits.json --trait-reference data/traits/index.json --species-root packs/evo_tactics_pack/data/species --trait-glossary data/core/traits/glossary.json --out-json data/derived/analysis/trait_coverage_report.json --out-csv data/derived/analysis/trait_coverage_matrix.csv --strict
- python tools/py/traits_validator.py --inventory docs/catalog/traits_inventory.json


------
https://chatgpt.com/codex/tasks/task_e_6907c2cba4508332a80a0ca143c8d531