### PR TITLE
Add missing trait definitions for expanded catalog

### DIFF
--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -5,305 +5,47 @@
     "trait_reference": "data/traits/index.json"
   },
   "traits": {
-    "antenne_plasmatiche_tempesta": {
-      "label_it": "Antenne Plasmatiche di Tempesta",
-      "label_en": "Storm Plasma Antennae",
-      "description_it": "Convoglia fulmini atmosferici in attacchi mirati o scudi ionici.",
-      "description_en": "Channels storm lightning into psionic strikes or shields."
+    "Invoker": {
+      "label_it": "Canalizzatore",
+      "label_en": "Invoker",
+      "description_it": "Paragrafo rituale mobile che convoglia energie planari e potenzia abilità psioniche del gruppo.",
+      "description_en": "Mobile ritual conduit channeling planar energies and boosting group psionics."
     },
-    "artigli_sette_vie": {
-      "label_en": "Seven-Way Talons",
-      "label_it": "Artigli a Sette Vie",
-      "description_it": "Artigli multipli che assicurano presa stabile su superfici irregolari.",
-      "description_en": "Multi-hook talons locking a steady grip on irregular surfaces."
+    "Skirmisher": {
+      "label_it": "Incursore Rapido",
+      "label_en": "Rapid Skirmisher",
+      "description_it": "Routine di movimento aggressivo che privilegia colpi mordi e fuggi e pressione laterale.",
+      "description_en": "Aggressive movement routine favoring hit-and-run strikes and lateral pressure."
     },
-    "artigli_sghiaccio_glaciale": {
-      "label_it": "Artigli Sghiaccio Glaciale",
-      "label_en": "Artigli Sghiaccio Glaciale",
-      "description_it": "Falangi criogeniche che congelano e fissano il bersaglio al contatto.",
-      "description_en": "Cryogenic claws that freeze and pin targets on contact."
+    "Strategist": {
+      "label_it": "Stratega di Campo",
+      "label_en": "Field Strategist",
+      "description_it": "Protocollo tattico che orchestra manovre coordinate e ridistribuzione rapida delle risorse.",
+      "description_en": "Tactical protocol orchestrating coordinated maneuvers and rapid resource redistribution."
     },
-    "branchie_osmotiche_salmastra": {
-      "label_it": "Branchie Osmotiche Salmastre",
-      "label_en": "Branchie Osmotiche Salmastre",
-      "description_it": "Branchie psioniche che filtrano sali e tossine in acque variabili.",
-      "description_en": "Psionic gills filtering salts and toxins in shifting waters."
+    "Support": {
+      "label_it": "Supporto Primario",
+      "label_en": "Primary Support",
+      "description_it": "Suite modulare per coordinare cure, ripristini e rifornimenti durante campagne prolungate.",
+      "description_en": "Modular suite coordinating heals, restores, and supplies during extended campaigns."
     },
-    "bulbi_radici_permafrost": {
-      "label_it": "Bulbi Radici del Permafrost",
-      "label_en": "Bulbi Radici del Permafrost",
-      "description_it": "Bulbi radice che rilasciano calore e nutrimento alle unità connesse.",
-      "description_en": "Root bulbs releasing heat and stores to linked allies."
+    "Vanguard": {
+      "label_it": "Avanguardia Rinforzata",
+      "label_en": "Reinforced Vanguard",
+      "description_it": "Assetto frontale corazzato che assorbe il primo impatto e fissa l'aggro nemico.",
+      "description_en": "Armored frontline setup absorbing opening impacts and locking enemy aggro."
     },
-    "carapace_fase_variabile": {
-      "label_en": "Phase-Shifting Carapace",
-      "label_it": "Carapace a Variazione di Fase",
-      "description_it": "Corazza che varia densità per bilanciare difesa e mobilità.",
-      "description_en": "Shell shifts density to balance defense and mobility."
+    "Warden": {
+      "label_it": "Custode Difensivo",
+      "label_en": "Defensive Warden",
+      "description_it": "Protocollo di tutela che erige barriere, contrappesi e snodi di controllo del campo.",
+      "description_en": "Guard protocol raising barriers, counterweights, and field control nodes."
     },
-    "carapace_luminiscente_abissale": {
-      "label_it": "Carapace Luminiscente Abissale",
-      "label_en": "Carapace Luminiscente Abissale",
-      "description_it": "Guscio bioluminescente che confonde i predatori nelle profondità.",
-      "description_en": "Bioluminescent shell confusing predators in abyssal dark."
-    },
-    "cartilagine_flessotermica_venti": {
-      "label_it": "Cartilagine Flessotermica dei Venti",
-      "label_en": "Cartilagine Flessotermica dei Venti",
-      "description_it": "Cartilagine termoreattiva che ottimizza virate e planate aeree.",
-      "description_en": "Thermo-reactive cartilage optimizing aerial turns."
-    },
-    "cavita_risonanti_tundra": {
-      "label_it": "Cavità Risonanti della Tundra",
-      "label_en": "Cavità Risonanti della Tundra",
-      "description_it": "Camere toraciche che proiettano richiami a lunga distanza nel gelo.",
-      "description_en": "Chest chambers projecting long-range calls through tundra frost."
-    },
-    "chioma_parassita_canopica": {
-      "label_it": "Chioma Parassita Canopica",
-      "label_en": "Chioma Parassita Canopica",
-      "description_it": "Filamenti parassiti che creano corsie energetiche nella canopia.",
-      "description_en": "Parasitic tendrils weaving energy lanes through canopy."
-    },
-    "circolazione_bifasica_palude": {
-      "label_it": "Circolazione Bifasica di Palude",
-      "label_en": "Swamp Biphase Circulation",
-      "description_it": "Doppio circuito sanguigno che separa ossigeno e agenti tossici in ambienti stagnanti.",
-      "description_en": "Dual blood circuits separating oxygen flow from toxins in stagnant wetlands."
-    },
-    "coda_frusta_cinetica": {
-      "label_en": "Kinetic Lash Tail",
-      "label_it": "Coda a Frusta Cinetica",
-      "description_it": "Coda elastica che accumula slancio per un colpo cinetico devastante.",
-      "description_en": "Elastic tail storing momentum for a devastating lash."
-    },
-    "criostasi_adattiva": {
-      "label_en": "Adaptive Cryostasis",
-      "label_it": "Criostasi",
-      "description_it": "Metabolismo sospeso che sopravvive a stagioni estreme prolungate.",
-      "description_en": "Suspended metabolism surviving protracted extreme seasons."
-    },
-    "eco_interno_riflesso": {
-      "label_en": "Internal Echo Reflex",
-      "label_it": "Riflesso dell'Eco Interno",
-      "description_it": "Sonar interno che mappa l'ambiente attraverso vibrazioni corporee.",
-      "description_en": "Internal sonar mapping surroundings via body reverbs."
-    },
-    "empatia_coordinativa": {
-      "label_en": "Coordinated Empathy",
-      "label_it": "Empatia Coordinativa",
-      "description_it": "Rete empatica che sincronizza cure e difese dell'intera squadra.",
-      "description_en": "Empathic mesh synchronizing team-wide heals and defenses."
-    },
-    "filamenti_digestivi_compattanti": {
-      "label_en": "Digestive Compaction Filaments",
-      "label_it": "Filamenti Digestivi Compattanti",
-      "description_it": "Filamenti digestivi che compattano scarti e liberano spazio vitale.",
-      "description_en": "Digestive filaments compact waste to free vital space."
-    },
-    "focus_frazionato": {
-      "label_en": "Fractional Focus",
-      "label_it": "Focus Frazionato",
-      "description_it": "Cortex biforcato che mantiene due minacce in sorveglianza attiva.",
-      "description_en": "Split cortex keeps two threats under active surveillance."
-    },
-    "ghiandola_caustica": {
-      "label_en": "Caustic Gland",
-      "label_it": "Ghiandola Caustica",
-      "description_it": "Ghiandola offensiva che spruzza acidi rapidi contro corazze leggere.",
-      "description_en": "Offensive gland spraying quick acid against light armor."
-    },
-    "lamelle_termoforetiche": {
-      "label_en": "Thermophoretic Lamellae",
-      "label_it": "Lamelle Termoforetiche",
-      "description_it": "Lamelle respiratorie che deviano gas estremi con gradienti termici.",
-      "description_en": "Respiratory lamellae deflect extreme gases via heat gradients."
-    },
-    "lingua_tattile_trama": {
-      "label_en": "Texture-Sensing Tongue",
-      "label_it": "Lingua Tattile Trama-Sensibile",
-      "description_it": "Lingua sensoriale che legge vibrazioni e fratture nascoste.",
-      "description_en": "Sensory tongue reading hidden vibrations and fractures."
-    },
-    "membrane_eliofiltranti": {
-      "label_it": "Membrane Eliofiltranti",
-      "label_en": "Membrane Eliofiltranti",
-      "description_it": "Membrane traslucide che schermano radiazioni e patogeni sospesi.",
-      "description_en": "Translucent membranes screening radiation and airborne pathogens."
-    },
-    "mimetismo_cromatico_passivo": {
-      "label_en": "Passive Chromatic Mimicry",
-      "label_it": "Ghiandole di Mimetismo Cromatico Passivo",
-      "description_it": "Cromatofori passivi che replicano lentamente i colori circostanti.",
-      "description_en": "Passive chromatophores slowly mirroring surrounding hues."
-    },
-    "mucillagine_simbionte_mangrovie": {
-      "label_it": "Mucillagine Simbionte delle Mangrovie",
-      "label_en": "Mucillagine Simbionte delle Mangrovie",
-      "description_it": "Mucosa simbionte che assorbe veleni e sigilla ferite palustri.",
-      "description_en": "Symbiotic mucus absorbing poisons and sealing swamp wounds."
-    },
-    "nodi_micorrizici_oracolari": {
-      "label_it": "Nodi Micorrizici Oracolari",
-      "label_en": "Nodi Micorrizici Oracolari",
-      "description_it": "Nodi micorrizici che anticipano minacce tramite segnali fungini.",
-      "description_en": "Mycorrhizal nodes foreseeing threats via fungal signals."
-    },
-    "nucleo_ovomotore_rotante": {
-      "label_en": "Rotating Ovomotor Core",
-      "label_it": "Uovo rotaia, uovo grande e uova piccole dentro...",
-      "description_it": "Nucleo rotante che trasforma il corpo in una ruota motrice.",
-      "description_en": "Rotating core turning the body into a driving wheel."
-    },
-    "occhi_infrarosso_composti": {
-      "label_en": "Infrared Compound Eyes",
-      "label_it": "Occhi Composti ad Infrarosso",
-      "description_it": "Ommatidi infrarossi che seguono scie termiche nell'oscurità.",
-      "description_en": "Infrared ommatidia tracking thermal trails in darkness."
-    },
-    "olfatto_risonanza_magnetica": {
-      "label_en": "Magnetic Resonance Scent",
-      "label_it": "Olfatto di Risonanza Magnetica",
-      "description_it": "Bulbi olfattivi che tracciano campi magnetici e vene metalliche.",
-      "description_en": "Olfactory nodes tracing magnetic fields and metal veins."
-    },
-    "pathfinder": {
-      "label_en": "Pathfinder",
-      "label_it": "Pathfinder",
-      "description_it": "Suite esplorativa che evidenzia rotte sicure tra biomi imprevedibili.",
-      "description_en": "Exploration suite highlighting safe routes across shifting biomes."
-    },
-    "pianificatore": {
-      "label_en": "Strategic Planner",
-      "label_it": "Pianificatore",
-      "description_it": "Modulo strategico che mantiene priorità e finestre d'attacco allineate.",
-      "description_en": "Strategic module keeping priorities and attack windows aligned."
-    },
-    "piume_solari_fotovoltaiche": {
-      "label_it": "Piume Solari Fotovoltaiche",
-      "label_en": "Piume Solari Fotovoltaiche",
-      "description_it": "Piumaggio fotovoltaico che immagazzina luce per lunghe missioni.",
-      "description_en": "Photovoltaic plumage storing sunlight for long sorties."
-    },
-    "polmoni_cristallini_alta_quota": {
-      "label_it": "Polmoni Cristallini d'Alta Quota",
-      "label_en": "Polmoni Cristallini d'Alta Quota",
-      "description_it": "Polmoni cristallini che concentrano ossigeno rarefatto in quota.",
-      "description_en": "Crystalline lungs concentrating thin high-altitude oxygen."
-    },
-    "random": {
-      "label_en": "Trait Random",
-      "label_it": "Trait Random",
-      "description_it": "Slot sperimentale che estrae tratti casuali dal pool controllato.",
-      "description_en": "Experimental slot drawing random traits from a curated pool."
-    },
-    "respiro_a_scoppio": {
-      "label_en": "Burst Breath Propulsion",
-      "label_it": "Respiro a scoppio",
-      "description_it": "Valvole toraciche che rilasciano getti propulsivi istantanei.",
-      "description_en": "Thoracic valves unleashing instantaneous propulsion bursts."
-    },
-    "risonanza_di_branco": {
-      "label_en": "Pack Resonance",
-      "label_it": "Risonanza di Branco",
-      "description_it": "Rete risonante che amplifica buff condivisi del branco.",
-      "description_en": "Resonant lattice amplifying the pack's shared buffs."
-    },
-    "sacche_galleggianti_ascensoriali": {
-      "label_en": "Elevating Buoyancy Sacs",
-      "label_it": "Sacche galleggianti ascensoriali",
-      "description_it": "Sacche gassose regolabili per controllare assetto e profondità.",
-      "description_en": "Adjustable gas sacs controlling buoyancy and depth."
-    },
-    "sacche_spore_stratosferiche": {
-      "label_it": "Sacche di Spore Stratosferiche",
-      "label_en": "Sacche di Spore Stratosferiche",
-      "description_it": "Vescicole stratosferiche che disperdono spore di supporto a lungo.",
-      "description_en": "Stratospheric vesicles dispersing long-range support spores."
-    },
-    "sangue_piroforico": {
-      "label_en": "Pyrophoric Blood",
-      "label_it": "Sangue che prende fuoco a contatto con l'ossigeno",
-      "description_it": "Fluido ematico che incendia l'aria colpendo chi perfora la corazza.",
-      "description_en": "Blood ignites on air contact, burning would-be piercers."
-    },
-    "scheletro_idro_regolante": {
-      "label_en": "Hydro-Regulating Skeleton",
-      "label_it": "Scheletro Idro-Regolante",
-      "description_it": "Ossa porose che modulano il contenuto idrico per mutare massa.",
-      "description_en": "Porous bones modulate water content to shift body mass."
-    },
-    "secrezione_rallentante_palmi": {
-      "label_en": "Retarding Palm Secretions",
-      "label_it": "Mani secernano liquido rallentante",
-      "description_it": "Palmi che rilasciano gel rallentante per bloccare bersagli rapidi.",
-      "description_en": "Palms exude slowing gel to snare fast targets."
-    },
-    "sensori_geomagnetici": {
-      "label_en": "Geomagnetic Resonance Sensors",
-      "label_it": "Sensori a Risonanza Geomagnetica",
-      "description_it": "Cristalli cranici che mappano corridoi geomagnetici invisibili.",
-      "description_en": "Cranial crystals mapping invisible geomagnetic corridors."
-    },
-    "sinapsi_coraline_polifoniche": {
-      "label_it": "Sinapsi Coraline Polifoniche",
-      "label_en": "Sinapsi Coraline Polifoniche",
-      "description_it": "Sinapsi coralline che trasmettono ordini tramite armoniche marine.",
-      "description_en": "Coralline synapses relaying orders through marine harmonics."
-    },
-    "sonno_emisferico_alternato": {
-      "label_en": "Unihemispheric Sleep",
-      "label_it": "Dormire con solo metà cervello alla volta",
-      "description_it": "Cervello alternato che veglia con un emisfero mentre l'altro riposa.",
-      "description_en": "Alternating hemispheres keep watch while the other sleeps."
-    },
-    "spore_psichiche_silenziate": {
-      "label_en": "Silent Psychic Spores",
-      "label_it": "Spora Psichica Silenziosa",
-      "description_it": "Spore psioniche che sedano e confondono i bersagli vicini.",
-      "description_en": "Psionic spores that lull and confuse nearby targets."
-    },
-    "squame_rifrangenti_deserto": {
-      "label_it": "Squame Rifrangenti del Deserto",
-      "label_en": "Squame Rifrangenti del Deserto",
-      "description_it": "Scaglie cristalline che diffondono calore e creano miraggi.",
-      "description_en": "Crystal scales diffusing heat and casting mirages."
-    },
-    "struttura_elastica_amorfa": {
-      "label_en": "Elastic Amorphous Frame",
-      "label_it": "Struttura elastica, allungabile, amorfa, retrattile",
-      "description_it": "Corpo amorfo che si estende e si compatta per evadere vincoli.",
-      "description_en": "Amorphous frame stretching or compressing to escape binds."
-    },
-    "tattiche_di_branco": {
-      "label_en": "Pack Tactics",
-      "label_it": "Tattiche di Branco",
-      "description_it": "Protocollo tattico che coordina focus e prese condivise.",
-      "description_en": "Tactical protocol coordinating shared focus and grapples."
-    },
-    "vello_condensatore_nebbie": {
-      "label_it": "Vello Condensatore di Nebbie",
-      "label_en": "Vello Condensatore di Nebbie",
-      "description_it": "Vello capillare che condensa nebbia in riserve idriche mobili.",
-      "description_en": "Capillary fleece condensing fog into mobile water reserves."
-    },
-    "ventriglio_gastroliti": {
-      "label_en": "Gastrolith Grinding Gizzard",
-      "label_it": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
-      "description_it": "Ventriglio muscoloso che macina cibi duri con gastroliti.",
-      "description_en": "Muscular gizzard grinding hard food with gastroliths."
-    },
-    "zampe_a_molla": {
-      "label_en": "Spring-Loaded Limbs",
-      "label_it": "Zampe a Molla",
-      "description_it": "Arti a molla che accumulano energia per balzi di riposizionamento.",
-      "description_en": "Spring-loaded limbs storing energy for repositioning leaps."
-    },
-    "zoccoli_risonanti_steppe": {
-      "label_it": "Zoccoli Risonanti delle Steppe",
-      "label_en": "Zoccoli Risonanti delle Steppe",
-      "description_it": "Zoccoli cavi che inviano onde ritmiche al branco sulle steppe.",
-      "description_en": "Hollow hooves sending rhythmic waves across the steppe pack."
+    "adattamento_volo": {
+      "label_it": "Adattamento al Volo",
+      "label_en": "Flight Adaptation",
+      "description_it": "Set di cavità aerostatiche e muscoli micro-regolati che consentono assetti stabili in vortici planari.",
+      "description_en": "Suite of aerostatic cavities and micro-tuned muscles enabling stable posture in planar vortices."
     },
     "ali_fulminee": {
       "label_it": "Ali Fulminee",
@@ -322,6 +64,12 @@
       "label_en": "Sonic Membrane Wings",
       "description_it": "Piastre vibranti che dissipano energia e attenuano impatti corrosivi.",
       "description_en": "Vibrating plates that dissipate energy and blunt corrosive impacts."
+    },
+    "ali_solari_fotoni": {
+      "label_it": "Ali Solari a Fotoni",
+      "label_en": "Photon Solar Wings",
+      "description_it": "Lamelle fotovoltaiche che convertono radiazione solare in spinta propulsiva e riserva energetica.",
+      "description_en": "Photovoltaic lamellae turning solar radiation into thrust and energy reserves."
     },
     "antenne_dustsense": {
       "label_it": "Antenne Dustsense",
@@ -346,6 +94,12 @@
       "label_en": "Antenne Microonde Cavernose",
       "description_it": "Antenne Microonde Cavernose permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caverna risonante.",
       "description_en": "Antenne Microonde Cavernose allow squads to predict trajectories and orchestrate multilayered setups within caverna risonante."
+    },
+    "antenne_plasmatiche_tempesta": {
+      "label_it": "Antenne Plasmatiche di Tempesta",
+      "label_en": "Storm Plasma Antennae",
+      "description_it": "Convoglia fulmini atmosferici in attacchi mirati o scudi ionici.",
+      "description_en": "Channels storm lightning into psionic strikes or shields."
     },
     "antenne_reagenti": {
       "label_it": "Antenne Reagenti",
@@ -383,6 +137,18 @@
       "description_it": "Appendici Thermotattiche permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di abisso vulcanico.",
       "description_en": "Appendici Thermotattiche allow squads to stabilise multi-source energy absorption and conversion within abisso vulcanico."
     },
+    "architetto": {
+      "label_it": "Nodo Architetto",
+      "label_en": "Architect Node",
+      "description_it": "Modulo di pianificazione che proietta strutture difensive e logistiche sul campo in tempo reale.",
+      "description_en": "Planning module projecting defensive and logistic structures on the field in real time."
+    },
+    "armatura_pietra_planare": {
+      "label_it": "Armatura di Pietra Planare",
+      "label_en": "Planar Stone Plating",
+      "description_it": "Corazza risonante scolpita da roccia extradimensionale che smorza onde d'urto.",
+      "description_en": "Resonant plating carved from extradimensional stone that dampens shockwaves."
+    },
     "artigli_acidofagi": {
       "label_it": "Artigli Acidofagi",
       "label_en": "Artigli Acidofagi",
@@ -394,6 +160,12 @@
       "label_en": "Artigli Induzione",
       "description_it": "Artigli Induzione permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di canopia ionica.",
       "description_en": "Artigli Induzione allow squads to channel kinetic or elemental energy into targeted strikes within canopia ionica."
+    },
+    "artigli_psionici": {
+      "label_it": "Artigli Psionici",
+      "label_en": "Psionic Talons",
+      "description_it": "Appendici energetiche che amplificano penetrazione e controllo motori tramite vettori psionici.",
+      "description_en": "Energetic appendages amplifying penetration and motor control through psionic vectors."
     },
     "artigli_radice": {
       "label_it": "Artigli Radice",
@@ -407,11 +179,35 @@
       "description_it": "Artigli Scivolo Silente permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di caverna risonante.",
       "description_en": "Artigli Scivolo Silente allow squads to synchronise allied organisms and mutualistic flows within caverna risonante."
     },
+    "artigli_sette_vie": {
+      "label_en": "Seven-Way Talons",
+      "label_it": "Artigli a Sette Vie",
+      "description_it": "Artigli multipli che assicurano presa stabile su superfici irregolari.",
+      "description_en": "Multi-hook talons locking a steady grip on irregular surfaces."
+    },
+    "artigli_sghiaccio_glaciale": {
+      "label_it": "Artigli Sghiaccio Glaciale",
+      "label_en": "Artigli Sghiaccio Glaciale",
+      "description_it": "Falangi criogeniche che congelano e fissano il bersaglio al contatto.",
+      "description_en": "Cryogenic claws that freeze and pin targets on contact."
+    },
     "artigli_vetrificati": {
       "label_it": "Artigli Vetrificati",
       "label_en": "Artigli Vetrificati",
       "description_it": "Artigli Vetrificati permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caldera glaciale.",
       "description_en": "Artigli Vetrificati allow squads to redistribute load and modulate structural rigidity within caldera glaciale."
+    },
+    "assenza_respirazione": {
+      "label_it": "Assenza di Respirazione",
+      "label_en": "Breathless Physiology",
+      "description_it": "Metabolismo anaerobico stabilizzato che elimina la dipendenza da ossigeno ambientale.",
+      "description_en": "Stabilized anaerobic metabolism removing dependence on environmental oxygen."
+    },
+    "aura_scudo_radianza": {
+      "label_it": "Aura Scudo di Radianza",
+      "label_en": "Radiant Shield Aura",
+      "description_it": "Campo fotoplasmatico che devia danni planari e sincronizza i battiti della squadra.",
+      "description_en": "Photoplasmic field that deflects planar damage while syncing squad vitals."
     },
     "baffi_mareomotori": {
       "label_it": "Baffi Mareomotori",
@@ -485,6 +281,12 @@
       "description_it": "Branchie Microfiltri permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di reef luminescente.",
       "description_en": "Branchie Microfiltri allow squads to disperse energy and attenuate corrosive or thermal impacts within reef luminescente."
     },
+    "branchie_osmotiche_salmastra": {
+      "label_it": "Branchie Osmotiche Salmastre",
+      "label_en": "Branchie Osmotiche Salmastre",
+      "description_it": "Branchie psioniche che filtrano sali e tossine in acque variabili.",
+      "description_en": "Psionic gills filtering salts and toxins in shifting waters."
+    },
     "branchie_solfatiche": {
       "label_it": "Branchie Solfatiche",
       "label_en": "Branchie Solfatiche",
@@ -496,6 +298,12 @@
       "label_en": "Branchie Turbina",
       "description_it": "Branchie Turbina permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
       "description_en": "Branchie Turbina allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale."
+    },
+    "bulbi_radici_permafrost": {
+      "label_it": "Bulbi Radici del Permafrost",
+      "label_en": "Bulbi Radici del Permafrost",
+      "description_it": "Bulbi radice che rilasciano calore e nutrimento alle unità connesse.",
+      "description_en": "Root bulbs releasing heat and stores to linked allies."
     },
     "camere_anticorrosione": {
       "label_it": "Camere Anticorrosione",
@@ -514,6 +322,12 @@
       "label_en": "Camere Nutrienti Vent",
       "description_it": "Camere Nutrienti Vent permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di dorsale termale tropicale.",
       "description_en": "Camere Nutrienti Vent allow squads to synchronise allied organisms and mutualistic flows within dorsale termale tropicale."
+    },
+    "campo_di_fase": {
+      "label_it": "Campo di Fase",
+      "label_en": "Phase Field",
+      "description_it": "Generatore che sfasa temporaneamente materia organica per attraversare ostacoli e colpi.",
+      "description_en": "Generator that temporarily phase-shifts organic matter to slip past obstacles and strikes."
     },
     "capillari_criogenici": {
       "label_it": "Capillari Criogenici",
@@ -539,6 +353,18 @@
       "description_it": "Capsule Paracadute permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di stratosfera tempestosa.",
       "description_en": "Capsule Paracadute allow squads to disperse energy and attenuate corrosive or thermal impacts within stratosfera tempestosa."
     },
+    "carapace_fase_variabile": {
+      "label_en": "Phase-Shifting Carapace",
+      "label_it": "Carapace a Variazione di Fase",
+      "description_it": "Corazza che varia densità per bilanciare difesa e mobilità.",
+      "description_en": "Shell shifts density to balance defense and mobility."
+    },
+    "carapace_luminiscente_abissale": {
+      "label_it": "Carapace Luminiscente Abissale",
+      "label_en": "Carapace Luminiscente Abissale",
+      "description_it": "Guscio bioluminescente che confonde i predatori nelle profondità.",
+      "description_en": "Bioluminescent shell confusing predators in abyssal dark."
+    },
     "carapace_segmenti_logici": {
       "label_it": "Carapace Segmenti Logici",
       "label_en": "Carapace Segmenti Logici",
@@ -550,6 +376,12 @@
       "label_en": "Carapaci Ferruginosi",
       "description_it": "Carapaci Ferruginosi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di abisso vulcanico.",
       "description_en": "Carapaci Ferruginosi allow squads to coordinate resource exchange and squad stabilisation parameters within abisso vulcanico."
+    },
+    "cartilagine_flessotermica_venti": {
+      "label_it": "Cartilagine Flessotermica dei Venti",
+      "label_en": "Cartilagine Flessotermica dei Venti",
+      "description_it": "Cartilagine termoreattiva che ottimizza virate e planate aeree.",
+      "description_en": "Thermo-reactive cartilage optimizing aerial turns."
     },
     "cartilagini_biofibre": {
       "label_it": "Cartilagini Biofibre",
@@ -575,6 +407,12 @@
       "description_it": "Cartilagini Pseudometalliche permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico.",
       "description_en": "Cartilagini Pseudometalliche allow squads to redistribute load and modulate structural rigidity within abisso vulcanico."
     },
+    "cavita_risonanti_tundra": {
+      "label_it": "Cavità Risonanti della Tundra",
+      "label_en": "Cavità Risonanti della Tundra",
+      "description_it": "Camere toraciche che proiettano richiami a lunga distanza nel gelo.",
+      "description_en": "Chest chambers projecting long-range calls through tundra frost."
+    },
     "cervelletto_equilibrio_statico": {
       "label_it": "Cervelletto Equilibrio Statico",
       "label_en": "Cervelletto Equilibrio Statico",
@@ -587,11 +425,35 @@
       "description_it": "Chemiorecettori Bromuro permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di pianura salina iperarida.",
       "description_en": "Chemiorecettori Bromuro allow squads to gain grip and controlled acceleration across extreme terrain within pianura salina iperarida."
     },
+    "chioma_parassita_canopica": {
+      "label_it": "Chioma Parassita Canopica",
+      "label_en": "Chioma Parassita Canopica",
+      "description_it": "Filamenti parassiti che creano corsie energetiche nella canopia.",
+      "description_en": "Parasitic tendrils weaving energy lanes through canopy."
+    },
+    "ciclo_vitale_anomalo": {
+      "label_it": "Ciclo Vitale Anomalo",
+      "label_en": "Anomalous Life Cycle",
+      "description_it": "Riproduzione non lineare che alterna fasi ibernate, scissioni e reincubazioni psioniche.",
+      "description_en": "Non-linear reproduction alternating hibernation phases, fission, and psionic reintegration."
+    },
+    "ciclo_vitale_completo": {
+      "label_it": "Ciclo Vitale Completo",
+      "label_en": "Complete Life Cycle",
+      "description_it": "Sequenza biologica stabile dalla fase larvale all'adulto con propagazione prevedibile.",
+      "description_en": "Stable biological sequence from larva to adult with predictable propagation."
+    },
     "circolazione_bifasica": {
       "label_it": "Circolazione Bifasica",
       "label_en": "Circolazione Bifasica",
       "description_it": "Circolazione Bifasica permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di caldera glaciale.",
       "description_en": "Circolazione Bifasica allow squads to disperse energy and attenuate corrosive or thermal impacts within caldera glaciale."
+    },
+    "circolazione_bifasica_palude": {
+      "label_it": "Circolazione Bifasica di Palude",
+      "label_en": "Swamp Biphase Circulation",
+      "description_it": "Doppio circuito sanguigno che separa ossigeno e agenti tossici in ambienti stagnanti.",
+      "description_en": "Dual blood circuits separating oxygen flow from toxins in stagnant wetlands."
     },
     "circolazione_cooling_loop": {
       "label_it": "Circolazione Cooling Loop",
@@ -647,6 +509,12 @@
       "description_it": "Coda Coppia Retroattiva permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di steppe algoritmiche.",
       "description_en": "Coda Coppia Retroattiva allow squads to disperse energy and attenuate corrosive or thermal impacts within steppe algoritmiche."
     },
+    "coda_frusta_cinetica": {
+      "label_en": "Kinetic Lash Tail",
+      "label_it": "Coda a Frusta Cinetica",
+      "description_it": "Coda elastica che accumula slancio per un colpo cinetico devastante.",
+      "description_en": "Elastic tail storing momentum for a devastating lash."
+    },
     "coda_stabilizzatrice_filo": {
       "label_it": "Coda Stabilizzatrice Filo",
       "label_en": "Coda Stabilizzatrice Filo",
@@ -676,6 +544,18 @@
       "label_en": "Coralli Partner",
       "description_it": "Coralli Partner permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di reef luminescente.",
       "description_en": "Coralli Partner allow squads to synchronise allied organisms and mutualistic flows within reef luminescente."
+    },
+    "corteccia_memetica": {
+      "label_it": "Corteccia Memetica",
+      "label_en": "Memetic Cortex",
+      "description_it": "Strato neurale adattivo che memorizza pattern tattici e li propaga via segnali memetici.",
+      "description_en": "Adaptive neural layer storing tactical patterns and propagating them through memetic signals."
+    },
+    "criostasi_adattiva": {
+      "label_en": "Adaptive Cryostasis",
+      "label_it": "Criostasi",
+      "description_it": "Metabolismo sospeso che sopravvive a stagioni estreme prolungate.",
+      "description_en": "Suspended metabolism surviving protracted extreme seasons."
     },
     "cromofori_alert_acido": {
       "label_it": "Cromofori Alert Acido",
@@ -743,6 +623,24 @@
       "description_it": "Echi Risonanti permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
       "description_en": "Echi Risonanti allow squads to interpret minute signals and unstable psionic patterns within caverna risonante."
     },
+    "eco_interno_riflesso": {
+      "label_en": "Internal Echo Reflex",
+      "label_it": "Riflesso dell'Eco Interno",
+      "description_it": "Sonar interno che mappa l'ambiente attraverso vibrazioni corporee.",
+      "description_en": "Internal sonar mapping surroundings via body reverbs."
+    },
+    "eco_sismico": {
+      "label_it": "Eco Sismico",
+      "label_en": "Seismic Echo",
+      "description_it": "Organi vibratili che leggono risonanze del terreno identificando cavità, trappole e movimento nascosto.",
+      "description_en": "Vibratory organs reading ground resonances to spot cavities, traps, and hidden movement."
+    },
+    "empatia_coordinativa": {
+      "label_en": "Coordinated Empathy",
+      "label_it": "Empatia Coordinativa",
+      "description_it": "Rete empatica che sincronizza cure e difese dell'intera squadra.",
+      "description_en": "Empathic mesh synchronizing team-wide heals and defenses."
+    },
     "enzimi_antifase_termica": {
       "label_it": "Enzimi Antifase Termica",
       "label_en": "Enzimi Antifase Termica",
@@ -785,6 +683,12 @@
       "description_it": "Epitelio Fosforescente permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di reef luminescente.",
       "description_en": "Epitelio Fosforescente allow squads to synchronise allied organisms and mutualistic flows within reef luminescente."
     },
+    "filamenti_digestivi_compattanti": {
+      "label_en": "Digestive Compaction Filaments",
+      "label_it": "Filamenti Digestivi Compattanti",
+      "description_it": "Filamenti digestivi che compattano scarti e liberano spazio vitale.",
+      "description_en": "Digestive filaments compact waste to free vital space."
+    },
     "filamenti_magnetotrofi": {
       "label_it": "Filamenti Magnetotrofi",
       "label_en": "Filamenti Magnetotrofi",
@@ -803,17 +707,35 @@
       "description_it": "Filamenti Termoconduzione permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di dorsale termale tropicale.",
       "description_en": "Filamenti Termoconduzione allow squads to gain grip and controlled acceleration across extreme terrain within dorsale termale tropicale."
     },
+    "filtri_bioattivi": {
+      "label_it": "Filtri Bioattivi",
+      "label_en": "Bioactive Filters",
+      "description_it": "Sistema di filtrazione che neutralizza tossine e patogeni trasformandoli in nutrienti secondari.",
+      "description_en": "Filtration system neutralizing toxins and pathogens, converting them into secondary nutrients."
+    },
     "filtri_planctonici": {
       "label_it": "Filtri Planctonici",
       "label_en": "Filtri Planctonici",
       "description_it": "Filtri Planctonici permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di laguna bioreattiva.",
       "description_en": "Filtri Planctonici allow squads to disperse energy and attenuate corrosive or thermal impacts within laguna bioreattiva."
     },
+    "fisiologia_predatoria": {
+      "label_it": "Fisiologia Predatoria",
+      "label_en": "Predatory Physiology",
+      "description_it": "Muscolatura e sensi calibrati per inseguimenti rapidi, colpi rapaci e consumo efficiente della preda.",
+      "description_en": "Musculature and senses tuned for rapid pursuit, raptorial strikes, and efficient prey consumption."
+    },
     "flagelli_ancoranti": {
       "label_it": "Flagelli Ancoranti",
       "label_en": "Flagelli Ancoranti",
       "description_it": "Flagelli Ancoranti permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di laguna bioreattiva.",
       "description_en": "Flagelli Ancoranti allow squads to stabilise multi-source energy absorption and conversion within laguna bioreattiva."
+    },
+    "focus_frazionato": {
+      "label_en": "Fractional Focus",
+      "label_it": "Focus Frazionato",
+      "description_it": "Cortex biforcato che mantiene due minacce in sorveglianza attiva.",
+      "description_en": "Split cortex keeps two threats under active surveillance."
     },
     "foliage_fotocatodico": {
       "label_it": "Foliage Fotocatodico",
@@ -827,11 +749,29 @@
       "description_it": "Foliaggio Spugna permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di mangrovieto cinetico.",
       "description_en": "Foliaggio Spugna allow squads to channel kinetic or elemental energy into targeted strikes within mangrovieto cinetico."
     },
+    "fotosintesi_bifase": {
+      "label_it": "Fotosintesi Bifase",
+      "label_en": "Biphase Photosynthesis",
+      "description_it": "Apparato cloroplastico duale che alterna assorbimento solare e radiazione lunare per produrre energia.",
+      "description_en": "Dual chloroplastic apparatus alternating solar and lunar radiation absorption for energy."
+    },
+    "frusta_fiammeggiante": {
+      "label_it": "Frusta Fiammeggiante",
+      "label_en": "Flame Lash",
+      "description_it": "Appendice di plasma vincolato capace di arpionare e incendiare bersagli.",
+      "description_en": "Bound plasma appendage that can hook and ignite targets."
+    },
     "ghiaccio_piezoelettrico": {
       "label_it": "Ghiaccio Piezoelettrico",
       "label_en": "Ghiaccio Piezoelettrico",
       "description_it": "Ghiaccio Piezoelettrico permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caldera glaciale.",
       "description_en": "Ghiaccio Piezoelettrico allow squads to predict trajectories and orchestrate multilayered setups within caldera glaciale."
+    },
+    "ghiandola_caustica": {
+      "label_en": "Caustic Gland",
+      "label_it": "Ghiandola Caustica",
+      "description_it": "Ghiandola offensiva che spruzza acidi rapidi contro corazze leggere.",
+      "description_en": "Offensive gland spraying quick acid against light armor."
     },
     "ghiandole_cambio_salino": {
       "label_it": "Ghiandole Cambio Salino",
@@ -899,6 +839,12 @@
       "description_it": "Ghiandole Nebbia Ionica permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di canopia ionica.",
       "description_en": "Ghiandole Nebbia Ionica allow squads to redistribute load and modulate structural rigidity within canopia ionica."
     },
+    "ghiandole_nettare_memetico": {
+      "label_it": "Ghiandole di Nettare Memetico",
+      "label_en": "Memetic Nectar Glands",
+      "description_it": "Organi secretori che rilasciano segnali biochimici capaci di sincronizzare sciami e alleati.",
+      "description_en": "Secretory organs releasing biochemical signals able to synchronize swarms and allies."
+    },
     "ghiandole_resina_conduttiva": {
       "label_it": "Ghiandole Resina Conduttiva",
       "label_en": "Ghiandole Resina Conduttiva",
@@ -935,6 +881,12 @@
       "description_it": "Gusci Magnesio permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di dorsale termale tropicale.",
       "description_en": "Gusci Magnesio allow squads to channel kinetic or elemental energy into targeted strikes within dorsale termale tropicale."
     },
+    "intangibilita_parziale": {
+      "label_it": "Intangibilità Parziale",
+      "label_en": "Partial Intangibility",
+      "description_it": "Fase controllata del tessuto corporeo che rende selettivamente permeabili porzioni anatomiche.",
+      "description_en": "Controlled phasing of body tissue making selected anatomy permeable."
+    },
     "lamelle_shear": {
       "label_it": "Lamelle Shear",
       "label_en": "Lamelle Shear",
@@ -946,6 +898,18 @@
       "label_en": "Lamelle Sincroniche",
       "description_it": "Lamelle Sincroniche permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di steppe algoritmiche.",
       "description_en": "Lamelle Sincroniche allow squads to synchronise allied organisms and mutualistic flows within steppe algoritmiche."
+    },
+    "lamelle_termoforetiche": {
+      "label_en": "Thermophoretic Lamellae",
+      "label_it": "Lamelle Termoforetiche",
+      "description_it": "Lamelle respiratorie che deviano gas estremi con gradienti termici.",
+      "description_en": "Respiratory lamellae deflect extreme gases via heat gradients."
+    },
+    "lamenti_diradanti": {
+      "label_it": "Lamenti Diradanti",
+      "label_en": "Thinning Wails",
+      "description_it": "Emissioni sonore che indeboliscono coesione nemica e disperdono sciami ostili.",
+      "description_en": "Sonic emissions weakening enemy cohesion and scattering hostile swarms."
     },
     "lamine_filtranti_aeree": {
       "label_it": "Lamine Filtranti Aeree",
@@ -971,6 +935,12 @@
       "description_it": "Lingua Cristallina permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di pianura salina iperarida.",
       "description_en": "Lingua Cristallina allow squads to disperse energy and attenuate corrosive or thermal impacts within pianura salina iperarida."
     },
+    "lingua_tattile_trama": {
+      "label_en": "Texture-Sensing Tongue",
+      "label_it": "Lingua Tattile Trama-Sensibile",
+      "description_it": "Lingua sensoriale che legge vibrazioni e fratture nascoste.",
+      "description_en": "Sensory tongue reading hidden vibrations and fractures."
+    },
     "luminescenza_aurorale": {
       "label_it": "Luminescenza Aurorale",
       "label_en": "Luminescenza Aurorale",
@@ -989,11 +959,41 @@
       "description_it": "Mantelli Geotermici permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di caldera glaciale.",
       "description_en": "Mantelli Geotermici allow squads to channel kinetic or elemental energy into targeted strikes within caldera glaciale."
     },
+    "mantello_meteoritico": {
+      "label_it": "Mantello Meteoritico",
+      "label_en": "Meteoric Mantle",
+      "description_it": "Strati ablativi rigeneranti che vaporizzano l'impatto convertendolo in impulso termico.",
+      "description_en": "Regenerating ablative layers that vaporize impacts into thermal pulses."
+    },
+    "maschera_illusoria": {
+      "label_it": "Maschera Illusoria",
+      "label_en": "Illusory Mask",
+      "description_it": "Involucro sensoriale che sovrascrive firma visiva e sonora con pattern ingannevoli.",
+      "description_en": "Sensory sheath overwriting visual and sonic signature with deceptive patterns."
+    },
+    "matrice_antimagia": {
+      "label_it": "Matrice Antimagia",
+      "label_en": "Antimagic Matrix",
+      "description_it": "Reticolo di cristalli neutri che assorbe flussi arcani e li dissipa come calore innocuo.",
+      "description_en": "Lattice of null crystals absorbing arcane flux and bleeding it as harmless heat."
+    },
     "membrane_captura_rugiada": {
       "label_it": "Membrane Captura Rugiada",
       "label_en": "Membrane Captura Rugiada",
       "description_it": "Membrane Captura Rugiada permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida.",
       "description_en": "Membrane Captura Rugiada allow squads to predict trajectories and orchestrate multilayered setups within pianura salina iperarida."
+    },
+    "membrane_eliofiltranti": {
+      "label_it": "Membrane Eliofiltranti",
+      "label_en": "Membrane Eliofiltranti",
+      "description_it": "Membrane traslucide che schermano radiazioni e patogeni sospesi.",
+      "description_en": "Translucent membranes screening radiation and airborne pathogens."
+    },
+    "membrane_osmotiche": {
+      "label_it": "Membrane Osmotiche",
+      "label_en": "Osmotic Membranes",
+      "description_it": "Strati semipermeabili che regolano scambi idrici e salini in ambienti variabili.",
+      "description_en": "Semipermeable layers regulating water and salt exchange in shifting environments."
     },
     "membrane_planata_vectored": {
       "label_it": "Membrane Planata Vectored",
@@ -1007,11 +1007,35 @@
       "description_it": "Membrane Pneumatofori permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di mangrovieto cinetico.",
       "description_en": "Membrane Pneumatofori allow squads to redistribute load and modulate structural rigidity within mangrovieto cinetico."
     },
+    "metabolismo_attivo": {
+      "label_it": "Metabolismo Attivo",
+      "label_en": "Active Metabolism",
+      "description_it": "Processo metabolico elevato che converte nutrienti con resa energetica massima.",
+      "description_en": "High-rate metabolism converting nutrients with maximal energy yield."
+    },
+    "metabolismo_sostentato": {
+      "label_it": "Metabolismo Sostentato",
+      "label_en": "Sustained Metabolism",
+      "description_it": "Profilo energetico ultra-efficiente che mantiene funzioni vitali con input minimi.",
+      "description_en": "Ultra-efficient energy profile keeping vital functions with minimal input."
+    },
     "midollo_antivibrazione": {
       "label_it": "Midollo Antivibrazione",
       "label_en": "Midollo Antivibrazione",
       "description_it": "Midollo Antivibrazione permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
       "description_en": "Midollo Antivibrazione allow squads to interpret minute signals and unstable psionic patterns within caverna risonante."
+    },
+    "mimetismo_cromatico_passivo": {
+      "label_en": "Passive Chromatic Mimicry",
+      "label_it": "Ghiandole di Mimetismo Cromatico Passivo",
+      "description_it": "Cromatofori passivi che replicano lentamente i colori circostanti.",
+      "description_en": "Passive chromatophores slowly mirroring surrounding hues."
+    },
+    "mucillagine_simbionte_mangrovie": {
+      "label_it": "Mucillagine Simbionte delle Mangrovie",
+      "label_en": "Mucillagine Simbionte delle Mangrovie",
+      "description_it": "Mucosa simbionte che assorbe veleni e sigilla ferite palustri.",
+      "description_en": "Symbiotic mucus absorbing poisons and sealing swamp wounds."
     },
     "mucose_aderenza_sonica": {
       "label_it": "Mucose Aderenza Sonica",
@@ -1025,29 +1049,299 @@
       "description_it": "Mucose Barofile permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di abisso vulcanico.",
       "description_en": "Mucose Barofile allow squads to disperse energy and attenuate corrosive or thermal impacts within abisso vulcanico."
     },
-    "aura_scudo_radianza": {
-      "label_it": "Aura Scudo di Radianza",
-      "label_en": "Radiant Shield Aura",
-      "description_it": "Campo fotoplasmatico che devia danni planari e sincronizza i battiti della squadra.",
-      "description_en": "Photoplasmic field that deflects planar damage while syncing squad vitals."
+    "nodi_micorrizici_oracolari": {
+      "label_it": "Nodi Micorrizici Oracolari",
+      "label_en": "Nodi Micorrizici Oracolari",
+      "description_it": "Nodi micorrizici che anticipano minacce tramite segnali fungini.",
+      "description_en": "Mycorrhizal nodes foreseeing threats via fungal signals."
     },
-    "frusta_fiammeggiante": {
-      "label_it": "Frusta Fiammeggiante",
-      "label_en": "Flame Lash",
-      "description_it": "Appendice di plasma vincolato capace di arpionare e incendiare bersagli.",
-      "description_en": "Bound plasma appendage that can hook and ignite targets."
+    "nodi_micotici": {
+      "label_it": "Nodi Micotici",
+      "label_en": "Mycotic Nodes",
+      "description_it": "Rete fungina simbionte che distribuisce segnali e nutrienti tra unità collegate.",
+      "description_en": "Symbiotic fungal network distributing signals and nutrients among linked units."
     },
-    "mantello_meteoritico": {
-      "label_it": "Mantello Meteoritico",
-      "label_en": "Meteoric Mantle",
-      "description_it": "Strati ablativi rigeneranti che vaporizzano l'impatto convertendolo in impulso termico.",
-      "description_en": "Regenerating ablative layers that vaporize impacts into thermal pulses."
+    "nuclei_di_controllo": {
+      "label_it": "Nuclei di Controllo",
+      "label_en": "Control Cores",
+      "description_it": "Cluster neurali centralizzati che coordinano membri subordinati e sistemi modulari.",
+      "description_en": "Centralized neural clusters coordinating subordinate members and modular systems."
     },
-    "armatura_pietra_planare": {
-      "label_it": "Armatura di Pietra Planare",
-      "label_en": "Planar Stone Plating",
-      "description_it": "Corazza risonante scolpita da roccia extradimensionale che smorza onde d'urto.",
-      "description_en": "Resonant plating carved from extradimensional stone that dampens shockwaves."
+    "nucleo_ovomotore_rotante": {
+      "label_en": "Rotating Ovomotor Core",
+      "label_it": "Uovo rotaia, uovo grande e uova piccole dentro...",
+      "description_it": "Nucleo rotante che trasforma il corpo in una ruota motrice.",
+      "description_en": "Rotating core turning the body into a driving wheel."
+    },
+    "occhi_infrarosso_composti": {
+      "label_en": "Infrared Compound Eyes",
+      "label_it": "Occhi Composti ad Infrarosso",
+      "description_it": "Ommatidi infrarossi che seguono scie termiche nell'oscurità.",
+      "description_en": "Infrared ommatidia tracking thermal trails in darkness."
+    },
+    "olfatto_risonanza_magnetica": {
+      "label_en": "Magnetic Resonance Scent",
+      "label_it": "Olfatto di Risonanza Magnetica",
+      "description_it": "Bulbi olfattivi che tracciano campi magnetici e vene metalliche.",
+      "description_en": "Olfactory nodes tracing magnetic fields and metal veins."
+    },
+    "origine_artificiale": {
+      "label_it": "Origine Artificiale",
+      "label_en": "Artificial Origin",
+      "description_it": "Fondazione sintetica che integra protocolli di manutenzione, backup e riassemblaggio.",
+      "description_en": "Synthetic foundation integrating maintenance protocols, backups, and reassembly flows."
+    },
+    "pathfinder": {
+      "label_en": "Pathfinder",
+      "label_it": "Pathfinder",
+      "description_it": "Suite esplorativa che evidenzia rotte sicure tra biomi imprevedibili.",
+      "description_en": "Exploration suite highlighting safe routes across shifting biomes."
+    },
+    "pelli_anti_ustione": {
+      "label_it": "Pelli Anti Ustione",
+      "label_en": "Burnshield Hide",
+      "description_it": "Derma rinforzato con cristalli refrattari che disperdono calore estremo.",
+      "description_en": "Reinforced dermis with refractive crystals dispersing extreme heat."
+    },
+    "pelli_cave": {
+      "label_it": "Pelli Cave",
+      "label_en": "Hollow Skins",
+      "description_it": "Tessuto tegumentario con camere d'aria isolanti che regolano temperatura corporea.",
+      "description_en": "Tegumentary tissue with insulating air chambers regulating body temperature."
+    },
+    "pelli_fitte": {
+      "label_it": "Pelli Fitte",
+      "label_en": "Dense Hide",
+      "description_it": "Strati epidermici sovrapposti che aumentano protezione fisica e isolamento.",
+      "description_en": "Layered epidermis boosting physical protection and insulation."
+    },
+    "pianificatore": {
+      "label_en": "Strategic Planner",
+      "label_it": "Pianificatore",
+      "description_it": "Modulo strategico che mantiene priorità e finestre d'attacco allineate.",
+      "description_en": "Strategic module keeping priorities and attack windows aligned."
+    },
+    "pigmenti_aurorali": {
+      "label_it": "Pigmenti Aurorali",
+      "label_en": "Auroral Pigments",
+      "description_it": "Cromofori luminescenti che deviano radiazioni fredde e fungono da segnalazione coordinata.",
+      "description_en": "Luminescent chromophores deflecting cold radiation and providing coordinated signaling."
+    },
+    "pigmenti_termici": {
+      "label_it": "Pigmenti Termici",
+      "label_en": "Thermal Pigments",
+      "description_it": "Pigmenti attivi che assorbono calore e lo rilasciano gradualmente per proteggere organi vitali.",
+      "description_en": "Active pigments absorbing heat and slowly releasing it to shield vital organs."
+    },
+    "piume_solari_fotovoltaiche": {
+      "label_it": "Piume Solari Fotovoltaiche",
+      "label_en": "Piume Solari Fotovoltaiche",
+      "description_it": "Piumaggio fotovoltaico che immagazzina luce per lunghe missioni.",
+      "description_en": "Photovoltaic plumage storing sunlight for long sorties."
+    },
+    "polmoni_cristallini_alta_quota": {
+      "label_it": "Polmoni Cristallini d'Alta Quota",
+      "label_en": "Polmoni Cristallini d'Alta Quota",
+      "description_it": "Polmoni cristallini che concentrano ossigeno rarefatto in quota.",
+      "description_en": "Crystalline lungs concentrating thin high-altitude oxygen."
+    },
+    "proboscide_polifaga": {
+      "label_it": "Proboscide Polifaga",
+      "label_en": "Polyphage Proboscis",
+      "description_it": "Apparato prensile multicanale che consente alimentazione da fonti liquide, solide e gassose.",
+      "description_en": "Multi-channel prehensile apparatus enabling feeding from liquid, solid, and gaseous sources."
+    },
+    "proteine_shock_termico": {
+      "label_it": "Proteine Shock Termico",
+      "label_en": "Heat-Shock Proteins",
+      "description_it": "Proteine chaperon che proteggono strutture cellulari da stress termici estremi.",
+      "description_en": "Chaperone proteins shielding cellular structures from extreme thermal stress."
+    },
+    "radici_ancora_planare": {
+      "label_it": "Radici Ancora Planare",
+      "label_en": "Planar Anchor Roots",
+      "description_it": "Apparato radicale che fissa l'organismo a superfici instabili e scambia energia planare.",
+      "description_en": "Root apparatus anchoring organisms to unstable surfaces while exchanging planar energy."
+    },
+    "random": {
+      "label_en": "Trait Random",
+      "label_it": "Trait Random",
+      "description_it": "Slot sperimentale che estrae tratti casuali dal pool controllato.",
+      "description_en": "Experimental slot drawing random traits from a curated pool."
+    },
+    "respirazione_biologica": {
+      "label_it": "Respirazione Biologica",
+      "label_en": "Biological Respiration",
+      "description_it": "Sistema respiratorio aerobico efficiente con scambio gassoso multistadio.",
+      "description_en": "Efficient aerobic respiratory system with multistage gas exchange."
+    },
+    "respiro_a_scoppio": {
+      "label_en": "Burst Breath Propulsion",
+      "label_it": "Respiro a scoppio",
+      "description_it": "Valvole toraciche che rilasciano getti propulsivi istantanei.",
+      "description_en": "Thoracic valves unleashing instantaneous propulsion bursts."
+    },
+    "reti_capillari_radici": {
+      "label_it": "Reti Capillari Radici",
+      "label_en": "Root Capillary Networks",
+      "description_it": "Estensioni vascolari che distribuiscono liquidi e nutrienti su intere colonie radicate.",
+      "description_en": "Vascular extensions distributing fluids and nutrients across rooted colonies."
+    },
+    "riflessi_preternaturali": {
+      "label_it": "Riflessi Preternaturali",
+      "label_en": "Preternatural Reflexes",
+      "description_it": "Circuiti neurali accelerati che anticipano movimenti e deviano minacce in millisecondi.",
+      "description_en": "Accelerated neural circuits anticipating motion and deflecting threats within milliseconds."
+    },
+    "rinforzi_modulari": {
+      "label_it": "Rinforzi Modulari",
+      "label_en": "Modular Reinforcements",
+      "description_it": "Placcature segmentate che si agganciano e sganciano per assorbire danni mirati.",
+      "description_en": "Segmented plating attaching and detaching to absorb targeted damage."
+    },
+    "risonanza_di_branco": {
+      "label_en": "Pack Resonance",
+      "label_it": "Risonanza di Branco",
+      "description_it": "Rete risonante che amplifica buff condivisi del branco.",
+      "description_en": "Resonant lattice amplifying the pack's shared buffs."
+    },
+    "sacche_galleggianti_ascensoriali": {
+      "label_en": "Elevating Buoyancy Sacs",
+      "label_it": "Sacche galleggianti ascensoriali",
+      "description_it": "Sacche gassose regolabili per controllare assetto e profondità.",
+      "description_en": "Adjustable gas sacs controlling buoyancy and depth."
+    },
+    "sacche_spore_stratosferiche": {
+      "label_it": "Sacche di Spore Stratosferiche",
+      "label_en": "Sacche di Spore Stratosferiche",
+      "description_it": "Vescicole stratosferiche che disperdono spore di supporto a lungo.",
+      "description_en": "Stratospheric vesicles dispersing long-range support spores."
+    },
+    "sangue_piroforico": {
+      "label_en": "Pyrophoric Blood",
+      "label_it": "Sangue che prende fuoco a contatto con l'ossigeno",
+      "description_it": "Fluido ematico che incendia l'aria colpendo chi perfora la corazza.",
+      "description_en": "Blood ignites on air contact, burning would-be piercers."
+    },
+    "scheletro_idro_regolante": {
+      "label_en": "Hydro-Regulating Skeleton",
+      "label_it": "Scheletro Idro-Regolante",
+      "description_it": "Ossa porose che modulano il contenuto idrico per mutare massa.",
+      "description_en": "Porous bones modulate water content to shift body mass."
+    },
+    "secrezione_rallentante_palmi": {
+      "label_en": "Retarding Palm Secretions",
+      "label_it": "Mani secernano liquido rallentante",
+      "description_it": "Palmi che rilasciano gel rallentante per bloccare bersagli rapidi.",
+      "description_en": "Palms exude slowing gel to snare fast targets."
+    },
+    "secrezioni_antisepsi": {
+      "label_it": "Secrezioni Antisepsi",
+      "label_en": "Antiseptic Secretions",
+      "description_it": "Fluido antimicrobico che sterilizza ferite e impedisce infezioni da agenti planari.",
+      "description_en": "Antimicrobial fluid sterilizing wounds and preventing planar agent infections."
+    },
+    "sensori_chimici": {
+      "label_it": "Sensori Chimici",
+      "label_en": "Chemical Sensors",
+      "description_it": "Recettori ipersensibili che mappano gas, feromoni e contaminanti con precisione.",
+      "description_en": "Hypersensitive receptors mapping gases, pheromones, and contaminants precisely."
+    },
+    "sensori_geomagnetici": {
+      "label_en": "Geomagnetic Resonance Sensors",
+      "label_it": "Sensori a Risonanza Geomagnetica",
+      "description_it": "Cristalli cranici che mappano corridoi geomagnetici invisibili.",
+      "description_en": "Cranial crystals mapping invisible geomagnetic corridors."
+    },
+    "sinapsi_coraline_polifoniche": {
+      "label_it": "Sinapsi Coraline Polifoniche",
+      "label_en": "Sinapsi Coraline Polifoniche",
+      "description_it": "Sinapsi coralline che trasmettono ordini tramite armoniche marine.",
+      "description_en": "Coralline synapses relaying orders through marine harmonics."
+    },
+    "sinapsi_riflettenti": {
+      "label_it": "Sinapsi Riflettenti",
+      "label_en": "Reflective Synapses",
+      "description_it": "Circuiti neurali che ripetono pattern esperti, fornendo microcorrezioni automatiche.",
+      "description_en": "Neural circuits replaying expert patterns, providing automatic micro-corrections."
+    },
+    "sinergizzatore_team": {
+      "label_it": "Sinergizzatore di Team",
+      "label_en": "Team Synergizer",
+      "description_it": "Nucleo di comando che monitorizza ruoli e amplifica combo cooperative.",
+      "description_en": "Command core monitoring roles and amplifying cooperative combos."
+    },
+    "sonno_emisferico_alternato": {
+      "label_en": "Unihemispheric Sleep",
+      "label_it": "Dormire con solo metà cervello alla volta",
+      "description_it": "Cervello alternato che veglia con un emisfero mentre l'altro riposa.",
+      "description_en": "Alternating hemispheres keep watch while the other sleeps."
+    },
+    "spore_psichiche_silenziate": {
+      "label_en": "Silent Psychic Spores",
+      "label_it": "Spora Psichica Silenziosa",
+      "description_it": "Spore psioniche che sedano e confondono i bersagli vicini.",
+      "description_en": "Psionic spores that lull and confuse nearby targets."
+    },
+    "squame_rifrangenti_deserto": {
+      "label_it": "Squame Rifrangenti del Deserto",
+      "label_en": "Squame Rifrangenti del Deserto",
+      "description_it": "Scaglie cristalline che diffondono calore e creano miraggi.",
+      "description_en": "Crystal scales diffusing heat and casting mirages."
+    },
+    "struttura_elastica_amorfa": {
+      "label_en": "Elastic Amorphous Frame",
+      "label_it": "Struttura elastica, allungabile, amorfa, retrattile",
+      "description_it": "Corpo amorfo che si estende e si compatta per evadere vincoli.",
+      "description_en": "Amorphous frame stretching or compressing to escape binds."
+    },
+    "tattiche_di_branco": {
+      "label_en": "Pack Tactics",
+      "label_it": "Tattiche di Branco",
+      "description_it": "Protocollo tattico che coordina focus e prese condivise.",
+      "description_en": "Tactical protocol coordinating shared focus and grapples."
+    },
+    "tessuti_adattivi": {
+      "label_it": "Tessuti Adattivi",
+      "label_en": "Adaptive Tissues",
+      "description_it": "Fasci cellulari che cambiano densità e rigidità per assorbire urti o generare spinta.",
+      "description_en": "Cellular bundles shifting density and rigidity to absorb impacts or generate thrust."
+    },
+    "vello_condensatore_nebbie": {
+      "label_it": "Vello Condensatore di Nebbie",
+      "label_en": "Vello Condensatore di Nebbie",
+      "description_it": "Vello capillare che condensa nebbia in riserve idriche mobili.",
+      "description_en": "Capillary fleece condensing fog into mobile water reserves."
+    },
+    "ventriglio_gastroliti": {
+      "label_en": "Gastrolith Grinding Gizzard",
+      "label_it": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
+      "description_it": "Ventriglio muscoloso che macina cibi duri con gastroliti.",
+      "description_en": "Muscular gizzard grinding hard food with gastroliths."
+    },
+    "visione_spettrale": {
+      "label_it": "Visione Spettrale",
+      "label_en": "Spectral Vision",
+      "description_it": "Retine stratificate capaci di leggere bande ultraviolette, infrarosse e psioniche.",
+      "description_en": "Layered retinas able to read ultraviolet, infrared, and psionic bands."
+    },
+    "voce_spettrale": {
+      "label_it": "Voce Spettrale",
+      "label_en": "Spectral Voice",
+      "description_it": "Emissione vocale multibanda che attraversa barriere fisiche e psioniche.",
+      "description_en": "Multiband vocal emission crossing physical and psionic barriers."
+    },
+    "zampe_a_molla": {
+      "label_en": "Spring-Loaded Limbs",
+      "label_it": "Zampe a Molla",
+      "description_it": "Arti a molla che accumulano energia per balzi di riposizionamento.",
+      "description_en": "Spring-loaded limbs storing energy for repositioning leaps."
+    },
+    "zoccoli_risonanti_steppe": {
+      "label_it": "Zoccoli Risonanti delle Steppe",
+      "label_en": "Zoccoli Risonanti delle Steppe",
+      "description_it": "Zoccoli cavi che inviano onde ritmiche al branco sulle steppe.",
+      "description_en": "Hollow hooves sending rhythmic waves across the steppe pack."
     }
   }
 }

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -2,6 +2,287 @@
   "schema_version": "2.0",
   "trait_glossary": "data/core/traits/glossary.json",
   "traits": {
+    "Invoker": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede concentrazione e difesa durante l'incanalamento.",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "Invoker",
+      "label": "Canalizzatore",
+      "mutazione_indotta": "Stabilisce glifi viventi che ruotano energia tramite il nucleo dell'unità.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "canalizzazione",
+        "core": "strategia"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Sostenere squadre psioniche nelle fasi più intense di incursioni planari.",
+      "tier": "T2",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Amplifica combo energetiche e rituali di rinforzo."
+    },
+    "Skirmisher": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Ridotta resistenza in ingaggi prolungati.",
+      "famiglia_tipologia": "Locomotorio/Predatorio",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "Skirmisher",
+      "label": "Incursore Rapido",
+      "mutazione_indotta": "Riprogramma fibre muscolari per sprint brevi ad alta accelerazione.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "locomotorio"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Contenere bersagli mobili e sfruttare flanchi.",
+      "tier": "T1",
+      "usage_tags": [
+        "breaker"
+      ],
+      "uso_funzione": "Apre varchi rapidi nelle linee avversarie e si ritira prima della reazione."
+    },
+    "Strategist": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede telemetria costante; degrada in presenza di disturbi psionici prolungati.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "Strategist",
+      "label": "Stratega di Campo",
+      "mutazione_indotta": "Installa nodi decisionali ausiliari che calcolano traiettorie ottimali per l'intero plotone.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "coordinazione",
+        "core": "strategia"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Mantenere vantaggio decisionale su fronti dinamici con squilibri di numeri.",
+      "tier": "T1",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Dirige ingaggi multipli garantendo priorità condivise e gestione ordinata delle risorse."
+    },
+    "Support": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Vulnerabile a sovraccarichi se più unità critiche richiedono assistenza simultanea.",
+      "famiglia_tipologia": "Supporto/Coordinativo",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "Support",
+      "label": "Supporto Primario",
+      "mutazione_indotta": "Integra sacche di distribuzione e nodi telemetrici per seguire lo stato alleato in tempo reale.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistica",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Prolungare l'operatività delle squadre lontano da basi logistiche dedicate.",
+      "tier": "T1",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Stabilizza il team fornendo risorse rigenerate, cure leggere e compensazioni di morale."
+    },
+    "Vanguard": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Mobilità ridotta mentre le ancore sono estese.",
+      "famiglia_tipologia": "Supporto/Difesa",
+      "fattore_mantenimento_energetico": "Medio (Continuo)",
+      "id": "Vanguard",
+      "label": "Avanguardia Rinforzata",
+      "mutazione_indotta": "Addensa carapaci frontali e spine di stabilizzazione.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "difesa",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Stabilizzare linee di combattimento contro assalti pesanti.",
+      "tier": "T1",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Tiene posizione e protegge assetti fragili durante l'ingaggio iniziale."
+    },
+    "Warden": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede costante consapevolezza situazionale e canali di comando puliti.",
+      "famiglia_tipologia": "Supporto/Difesa",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "Warden",
+      "label": "Custode Difensivo",
+      "mutazione_indotta": "Integra glifi difensivi che redistribuiscono danni.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "controllo",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Creare zone sicure in campagne prolungate.",
+      "tier": "T1",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Protegge linee arretrate e convoglia minacce su traiettorie previste."
+    },
+    "adattamento_volo": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Sensibile a shock sonici che alterano la pressione interna delle camere.",
+      "famiglia_tipologia": "Locomotorio/Adattivo",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "adattamento_volo",
+      "label": "Adattamento al Volo",
+      "mutazione_indotta": "Ristruttura fasci muscolari e sacche pneumatiche per ottimizzare rollio e planata prolungata.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilità",
+        "core": "locomotorio"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "archon-solare",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "balor-fission",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Garantire copertura aerea persistente su regioni con venti multidirezionali.",
+      "tier": "T1",
+      "usage_tags": [
+        "scout"
+      ],
+      "uso_funzione": "Consente volo continuo anche in correnti erratiche e durante transizioni gravitazionali."
+    },
     "ali_fulminee": {
       "completion_flags": {
         "has_biome": true,
@@ -182,6 +463,57 @@
         "tank"
       ],
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+    },
+    "ali_solari_fotoni": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Perde efficienza in ombra persistente o durante tempeste di cenere.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ali_solari_fotoni",
+      "label": "Ali Solari a Fotoni",
+      "mutazione_indotta": "Genera membrane cristalline che immagazzinano fotoni e rilasciano microspinte direzionali.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "locomotorio"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "archon-solare",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Ridurre il fabbisogno energetico delle unità volanti su rotte lunghe.",
+      "tier": "T1",
+      "usage_tags": [
+        "scout"
+      ],
+      "uso_funzione": "Fornisce accelerazioni gratuite durante pattugliamenti diurni o orbitali."
     },
     "antenne_dustsense": {
       "completion_flags": {
@@ -855,6 +1187,42 @@
       ],
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
     },
+    "architetto": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Necessita riserva materica dedicata; rallenta se le scorte crollano.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "architetto",
+      "label": "Nodo Architetto",
+      "mutazione_indotta": "Sviluppa sinapsi geometriche che tracciano ancoraggi e blueprint modulari.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "ingegneria",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Stabilizzare avamposti improvvisati in territori instabili.",
+      "tier": "T1",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Coordina costruzioni rapide, ponti provvisori e riparazioni sincronizzate."
+    },
     "armatura_pietra_planare": {
       "completion_flags": {
         "has_biome": true,
@@ -1057,6 +1425,50 @@
         "breaker"
       ],
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+    },
+    "artigli_psionici": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Assorbe molta concentrazione; vulnerabile a interferenze antimagia.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "artigli_psionici",
+      "label": "Artigli Psionici",
+      "mutazione_indotta": "Canalizza creste neuroconduttive che formano lame psioniche a geometria variabile.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "psionico",
+        "core": "offensivo"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Conferire ad assetti leggeri capacità d'assalto contro bersagli schermati.",
+      "tier": "T2",
+      "usage_tags": [
+        "breaker"
+      ],
+      "uso_funzione": "Taglia armature leggere e disarma avversari concentrando colpi telecinetici."
     },
     "artigli_radice": {
       "completion_flags": {
@@ -1435,6 +1847,57 @@
         "tank"
       ],
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+    },
+    "assenza_respirazione": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede spurghi frequenti per evitare accumulo di sottoprodotti metabolici.",
+      "famiglia_tipologia": "Respiratorio/Protezione",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "assenza_respirazione",
+      "label": "Assenza di Respirazione",
+      "mutazione_indotta": "Sigilla alveoli e inserisce camere catalitiche per riciclare gas metabolici.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "respiratorio"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "golem-runico",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Garantire continuità operativa in camere sigillate, vacuum o piani corrosivi.",
+      "tier": "T1",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Permette operazioni in ambienti privi di aria o saturi di agenti tossici."
     },
     "aura_scudo_radianza": {
       "completion_flags": {
@@ -2659,6 +3122,42 @@
       ],
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
     },
+    "campo_di_fase": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Genera risonanze collaterali che possono interferire con apparati sensoriali alleati.",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Alto (Continuo)",
+      "id": "campo_di_fase",
+      "label": "Campo di Fase",
+      "mutazione_indotta": "Stabilisce matrici cristalline che modulano frequenze di fase sui tessuti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "psionico",
+        "core": "strategia"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Consentire manovre evasive decisive contro artiglieria o trappole planari.",
+      "tier": "T2",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Offre invulnerabilità breve o passaggio attraverso coperture non line-of-sight."
+    },
     "capillari_criogenici": {
       "completion_flags": {
         "has_biome": true,
@@ -3804,6 +4303,150 @@
       ],
       "uso_funzione": "Crea passaggi e nodi energetici condivisi nella canopia per movimenti rapidi."
     },
+    "ciclo_vitale_anomalo": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Difficile sincronizzare con programmi di allevamento o catene logistiche standard.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ciclo_vitale_anomalo",
+      "label": "Ciclo Vitale Anomalo",
+      "mutazione_indotta": "Ristruttura organi germinali per riattivarsi su cicli imprevedibili.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "golem-runico",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Garantire persistenza di specie sintetiche o planari in ecosistemi ostili.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Mantiene popolazioni attive anche dopo perdite massicce tramite scissioni rigenerative."
+    },
+    "ciclo_vitale_completo": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Prevedibilità elevata che può essere sfruttata da predatori intelligenti.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ciclo_vitale_completo",
+      "label": "Ciclo Vitale Completo",
+      "mutazione_indotta": "Affina ghiandole endocrine e pattern epigenetici per mantenere cicli regolari.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "riproduttivo",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "archon-solare",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "balor-fission",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "treant-portale",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Massimizzare rendimento riproduttivo in ambienti regolati.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Facilita allevamento e rotazioni pianificate nelle colonie adattive."
+    },
     "circolazione_bifasica": {
       "completion_flags": {
         "has_biome": true,
@@ -4908,6 +5551,50 @@
       ],
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
     },
+    "corteccia_memetica": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Suscettibile a sovraccarichi memetici se esposto a segnali ostili.",
+      "famiglia_tipologia": "Sensoriale/Nervoso",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "corteccia_memetica",
+      "label": "Corteccia Memetica",
+      "mutazione_indotta": "Integra dendriti cristallini che replicano rapidamente schemi imparati.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "memetica",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "treant-portale",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Ridurre tempi di addestramento per squadre miste e neoformate.",
+      "tier": "T2",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Condivide schemi di combattimento e soluzioni ambientali in tempo reale."
+    },
     "criostasi_adattiva": {
       "completion_flags": {
         "has_biome": true,
@@ -5824,6 +6511,50 @@
       ],
       "uso_funzione": "Utilizzo di onde sonore emesse internamente per mappare l'ambiente."
     },
+    "eco_sismico": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Rumore meccanico continuo può saturare i recettori.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "eco_sismico",
+      "label": "Eco Sismico",
+      "mutazione_indotta": "Forma camere ossee e filamenti sensibili a microfratture e onde elastiche.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "geofonia",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Garantire sicurezza in biomi instabili o in città sotterranee.",
+      "tier": "T1",
+      "usage_tags": [
+        "scout"
+      ],
+      "uso_funzione": "Anticipa frane, movimenti sotterranei e intrusioni mimetizzate."
+    },
     "empatia_coordinativa": {
       "completion_flags": {
         "has_biome": false,
@@ -6671,6 +7402,50 @@
       ],
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
     },
+    "filtri_bioattivi": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Rallenta la digestione in assenza di sostanze da metabolizzare.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "filtri_bioattivi",
+      "label": "Filtri Bioattivi",
+      "mutazione_indotta": "Introduce microcolonie simbionti che degradano agenti chimici in catene nutrienti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "detox",
+        "core": "metabolico"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Espandere la gamma alimentare in territori compromessi.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Permette ingestione sicura di biomi contaminati e risorse marginali."
+    },
     "filtri_planctonici": {
       "completion_flags": {
         "has_biome": true,
@@ -6730,6 +7505,50 @@
         "tank"
       ],
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+    },
+    "fisiologia_predatoria": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede apporto calorico elevato per mantenere performance.",
+      "famiglia_tipologia": "Locomotorio/Predatorio",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "fisiologia_predatoria",
+      "label": "Fisiologia Predatoria",
+      "mutazione_indotta": "Potenzia fibre muscolari e dentizione per impatti rapidi e trattenimento.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "predazione",
+        "core": "offensivo"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Dominare catene alimentari dinamiche e contenere infestazioni aggressive.",
+      "tier": "T1",
+      "usage_tags": [
+        "breaker"
+      ],
+      "uso_funzione": "Eleva l'efficacia offensiva contro bersagli mobili o evasivi."
     },
     "flagelli_ancoranti": {
       "completion_flags": {
@@ -7036,6 +7855,42 @@
         "breaker"
       ],
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+    },
+    "fotosintesi_bifase": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Sensibile a blackout prolungati o cieli oscurati.",
+      "famiglia_tipologia": "Metabolico/Resilienza",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "fotosintesi_bifase",
+      "label": "Fotosintesi Bifase",
+      "mutazione_indotta": "Introduce lamelle pigmentate che cambiano configurazione tra fase diurna e notturna.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Stabilizzare colonie vegetali o fotosensibili in cicli lunghi irregolari.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Mantiene produzione energetica senza dipendere da fonti esterne continuative."
     },
     "frusta_fiammeggiante": {
       "completion_flags": {
@@ -7887,6 +8742,50 @@
       ],
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
     },
+    "ghiandole_nettare_memetico": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Può attrarre parassiti memetici se non schermato.",
+      "famiglia_tipologia": "Supporto/Empatico",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "ghiandole_nettare_memetico",
+      "label": "Ghiandole di Nettare Memetico",
+      "mutazione_indotta": "Coltiva sacche ghiandolari che diffondono feromoni memetici con pattern coordinativi.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Ridurre caos operativo in battaglie multi-nodo.",
+      "tier": "T2",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Aumenta coesione di squadra e velocità di risposta degli sciami collegati."
+    },
     "ghiandole_resina_conduttiva": {
       "completion_flags": {
         "has_biome": true,
@@ -8277,6 +9176,50 @@
       ],
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
     },
+    "intangibilita_parziale": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Fatica a mantenersi attivo sotto fuoco concentrato o campi antimagia.",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Alto (Continuo)",
+      "id": "intangibilita_parziale",
+      "label": "Intangibilità Parziale",
+      "mutazione_indotta": "Installa nodi quantici che modulano densità atomica per pochi istanti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "evasione",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Sbloccare percorsi impraticabili e sfuggire a crowd control.",
+      "tier": "T2",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Permette attraversamento di barriere, trappole e catene di contenimento."
+    },
     "lamelle_shear": {
       "completion_flags": {
         "has_biome": true,
@@ -8482,6 +9425,50 @@
         "sustain"
       ],
       "uso_funzione": "Regola lo scambio gassoso sfruttando gradienti termici controllati."
+    },
+    "lamenti_diradanti": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Efficacia ridotta contro unità sorde o schermate.",
+      "famiglia_tipologia": "Sensoriale/Supporto",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "lamenti_diradanti",
+      "label": "Lamenti Diradanti",
+      "mutazione_indotta": "Sviluppa corde vocali multiple che modulano frequenze dissonanti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "psicoacustica",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Contenere assalti di massa e agevolare disperdimento di branchi planari.",
+      "tier": "T2",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Riduce precisione e morale dei bersagli nell'area d'effetto."
     },
     "lamine_filtranti_aeree": {
       "completion_flags": {
@@ -9055,6 +10042,94 @@
       ],
       "uso_funzione": "Assorbe colpi energetici estremi e converte il surplus in impulsi offensivi."
     },
+    "maschera_illusoria": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Fragile contro sensori multispettrali avanzati.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "maschera_illusoria",
+      "label": "Maschera Illusoria",
+      "mutazione_indotta": "Genera organi olografici che rifrangono segnali in output scelti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mimetismo",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Confondere targeting automatico e ritardare rilevamento.",
+      "tier": "T1",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Occulta assetti prioritari o li presenta come obiettivi minori."
+    },
+    "matrice_antimagia": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Surriscaldamento se l'esposizione è prolungata senza dissipazione.",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Alto (Continuo)",
+      "id": "matrice_antimagia",
+      "label": "Matrice Antimagia",
+      "mutazione_indotta": "Integra nodi parafulmine e cristalli paraeterei nel tegumento.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "golem-runico",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Neutralizzare minacce magiche in scenari ad alta densità psionica.",
+      "tier": "T2",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Spezza incantesimi ostili, annulla campi di controllo e protegge assetti tecnologici."
+    },
     "membrane_captura_rugiada": {
       "completion_flags": {
         "has_biome": true,
@@ -9175,6 +10250,50 @@
       ],
       "uso_funzione": "Filtra l'aria e i flussi luminosi rendendoli sicuri per tessuti delicati."
     },
+    "membrane_osmotiche": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede cicli di purga regolari per evitare saturazione.",
+      "famiglia_tipologia": "Respiratorio/Osmoregolazione",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "membrane_osmotiche",
+      "label": "Membrane Osmotiche",
+      "mutazione_indotta": "Aggiunge microcanali adattivi che bilanciano gradienti salini.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "omeostasi",
+        "core": "respiratorio"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Garantire equilibrio idrico per assetti anfibi o planari.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Permette sopravvivenza prolungata in acque salmastre o deserti ionici."
+    },
     "membrane_planata_vectored": {
       "completion_flags": {
         "has_biome": true,
@@ -9294,6 +10413,150 @@
         "tank"
       ],
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+    },
+    "metabolismo_attivo": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Consumo calorico elevato che impone rifornimenti frequenti.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Medio (Continuo)",
+      "id": "metabolismo_attivo",
+      "label": "Metabolismo Attivo",
+      "mutazione_indotta": "Amplifica mitocondri e flussi enzimatici per sprigionare energia immediata.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "archon-solare",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "balor-fission",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "treant-portale",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Potenziare unità che necessitano output costante e recupero accelerato.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Supporta sforzi intensi e rigenerazione rapida durante campagne estese."
+    },
+    "metabolismo_sostentato": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Output esplosivo limitato rispetto ai profili attivi.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "metabolismo_sostentato",
+      "label": "Metabolismo Sostentato",
+      "mutazione_indotta": "Riprogramma cicli catabolici per recuperare ogni caloria disponibile.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "risparmio",
+        "core": "metabolico"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "golem-runico",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Mantenere operativi esploratori e costrutti in ambienti poveri di nutrienti.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Permette sopravvivenza prolungata senza rifornimenti o durante letarghi tattici."
     },
     "midollo_antivibrazione": {
       "completion_flags": {
@@ -9747,6 +11010,86 @@
       ],
       "uso_funzione": "Riceve presagi e segnali tattici dalla rete fungina per coordinare manovre di squadra."
     },
+    "nodi_micotici": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Vulnerabile a agenti antifungini mirati.",
+      "famiglia_tipologia": "Simbiotico/Supporto",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "nodi_micotici",
+      "label": "Nodi Micotici",
+      "mutazione_indotta": "Coltiva rizomi sensibili che formano hub di comunicazione sotterranei.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "simbiosi",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Stabilizzare difese statiche e colonie radicate.",
+      "tier": "T2",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Fornisce backup energetico e sincronizzazione di stato agli alleati connessi."
+    },
+    "nuclei_di_controllo": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Punto singolo d'insuccesso se neutralizzato.",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "nuclei_di_controllo",
+      "label": "Nuclei di Controllo",
+      "mutazione_indotta": "Integra nuclei gangliari corazzati con capacità broadcast a lungo raggio.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "comando",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "golem-runico",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Aumentare coesione di reti comandate da remoto.",
+      "tier": "T2",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Gestisce droni, appendici autonome e reparti subordinati."
+    },
     "nucleo_ovomotore_rotante": {
       "completion_flags": {
         "has_biome": true,
@@ -10033,6 +11376,57 @@
       ],
       "uso_funzione": "Percepire la direzione e la composizione di metalli o campi energetici."
     },
+    "origine_artificiale": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Dipende da ricambi o blueprint specifici.",
+      "famiglia_tipologia": "Strutturale/Omeostatico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "origine_artificiale",
+      "label": "Origine Artificiale",
+      "mutazione_indotta": "Installa matrici di auto-diagnosi e punti di montaggio standardizzati.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "ingegneria",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "golem-runico",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Rendere replicabili gli assetti costruiti in laboratorio.",
+      "tier": "T1",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Facilita riparazioni rapide e riprogrammazione modulare."
+    },
     "pathfinder": {
       "biome_tags": [
         "foresta_acida",
@@ -10089,6 +11483,188 @@
         "support"
       ],
       "uso_funzione": "Ottimizza esplorazione e controllo mappe multi-bioma."
+    },
+    "pelli_anti_ustione": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Riduce elasticità cutanea se disidratato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "pelli_anti_ustione",
+      "label": "Pelli Anti Ustione",
+      "mutazione_indotta": "Deposita scaglie silicatiche e fluidi anti-piretici negli strati superficiali.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "termico",
+        "core": "tegumentario"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "evento-tempesta-ferrosa",
+          "weight": 4
+        }
+      ],
+      "spinta_selettiva": "Consentire presenza prolungata in deserti ionici e fonderie planari.",
+      "tier": "T1",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Protegge da ustioni, plasma e scariche termiche improvvise."
+    },
+    "pelli_cave": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Ingombro aggiuntivo che rallenta in ambienti saturi d'acqua.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "pelli_cave",
+      "label": "Pelli Cave",
+      "mutazione_indotta": "Forma alveoli dermici che catturano aria calda o fredda a seconda del gradiente.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "termico",
+        "core": "tegumentario"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cactus-weaver",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-brinastorm",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-ondata-termica",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "noctule-termico",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "silica-bloom",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thermo-raptor",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Ridurre shock termici durante spostamenti rapidi tra biomi.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Stabilizza temperatura in climi continentali estremi."
+    },
+    "pelli_fitte": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Peso extra che limita movimenti rapidi.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "pelli_fitte",
+      "label": "Pelli Fitte",
+      "mutazione_indotta": "Addensa fibre collagene e microplacche cheratiniche.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "tegumentario"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-seme-uragano",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Rendere le linee frontali più resistenti senza sacrificare mobilità di base.",
+      "tier": "T1",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Riduce penetrazione di proiettili leggeri e dissipa impatti blandi."
     },
     "pianificatore": {
       "completion_flags": {
@@ -10162,6 +11738,144 @@
         "support"
       ],
       "uso_funzione": "Coordina finestre di danno e difesa, mantenendo la squadra allineata al piano PI."
+    },
+    "pigmenti_aurorali": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Può rendere visibili in scenari stealth.",
+      "famiglia_tipologia": "Tegumentario/Energetico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "pigmenti_aurorali",
+      "label": "Pigmenti Aurorali",
+      "mutazione_indotta": "Distribuisce cristalli fotoreattivi sotto la pelle.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "luminescenza",
+        "core": "tegumentario"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cactus-weaver",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-brinastorm",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-ondata-termica",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "noctule-termico",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "silica-bloom",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thermo-raptor",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "treant-portale",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Coordinare movimenti in tempeste magnetiche e notti polari.",
+      "tier": "T1",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Aiuta a disperdere gelo e funge da comunicazione ottica in tundre oscure."
+    },
+    "pigmenti_termici": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede cicli di scarico per non accumulare eccesso.",
+      "famiglia_tipologia": "Tegumentario/Energetico",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "pigmenti_termici",
+      "label": "Pigmenti Termici",
+      "mutazione_indotta": "Integra melanofori specializzati che modulano conduzione termica.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "termico",
+        "core": "tegumentario"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "evento-tempesta-ferrosa",
+          "weight": 4
+        }
+      ],
+      "spinta_selettiva": "Evitare colpi di calore e gestire improvvisi gradienti termici.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Regola sforzi in deserti ionici o camere vulcaniche."
     },
     "piume_solari_fotovoltaiche": {
       "completion_flags": {
@@ -10281,6 +11995,180 @@
       ],
       "uso_funzione": "Massimizza l'assorbimento di ossigeno rarefatto e filtra agenti nocivi."
     },
+    "proboscide_polifaga": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede igiene costante per prevenire infezioni crociate.",
+      "famiglia_tipologia": "Digestivo/Alimentare",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "proboscide_polifaga",
+      "label": "Proboscide Polifaga",
+      "mutazione_indotta": "Crea canali telescopici con denticoli intercambiabili e ghiandole solventi.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "raccolta",
+        "core": "digestivo"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Espandere dieta delle unità planarie adattabili.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Permette nutrimento versatile e raccolta risorse in biomi poveri."
+    },
+    "proteine_shock_termico": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Efficienza ridotta in ambienti criogenici senza co-tratti dedicati.",
+      "famiglia_tipologia": "Metabolico/Resilienza",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "proteine_shock_termico",
+      "label": "Proteine Shock Termico",
+      "mutazione_indotta": "Amplifica espressione di chaperon molecolari e sistemi di riparazione rapida.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "metabolico"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cactus-weaver",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-brinastorm",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-ondata-termica",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "noctule-termico",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "silica-bloom",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thermo-raptor",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Consentire operazioni in deserti e camere vulcaniche.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Impedisce denaturazione enzimatica in shock termici improvvisi."
+    },
+    "radici_ancora_planare": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Difficile da rimuovere rapidamente senza danni.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "radici_ancora_planare",
+      "label": "Radici Ancora Planare",
+      "mutazione_indotta": "Fa crescere radici cristalline che si agganciano a frattali rocciosi.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "ancoraggio",
+        "core": "strutturale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "treant-portale",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Stabilizzare infrastrutture mobili e punti di evacuazione.",
+      "tier": "T2",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Impedisce trascinamento da tempeste planari e crea nodi energetici stabili."
+    },
     "random": {
       "completion_flags": {
         "has_biome": false,
@@ -10334,6 +12222,99 @@
         "tank"
       ],
       "uso_funzione": "Slot jolly per testing o pareggiare budget PI quando serve varietà."
+    },
+    "respirazione_biologica": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Dipendenza da atmosfere respirabili.",
+      "famiglia_tipologia": "Respiratorio/Aerobico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "respirazione_biologica",
+      "label": "Respirazione Biologica",
+      "mutazione_indotta": "Ottimizza alveoli e rete capillare per massimizzare assorbimento di ossigeno.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "ossigeno",
+        "core": "respiratorio"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "archon-solare",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "balor-fission",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "treant-portale",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Aumentare resistenza delle unità organiche convenzionali.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Supporta sforzi prolungati in atmosfere standard."
     },
     "respiro_a_scoppio": {
       "completion_flags": {
@@ -10430,6 +12411,171 @@
         "sustain"
       ],
       "uso_funzione": "Rilasciare grandi quantità d'aria o energia in un getto potente."
+    },
+    "reti_capillari_radici": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Rotture della rete possono causare shock sistemici.",
+      "famiglia_tipologia": "Strutturale/Omeostatico",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "reti_capillari_radici",
+      "label": "Reti Capillari Radici",
+      "mutazione_indotta": "Crea capillari lignificati che collegano nodi periferici.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "nutrizione",
+        "core": "strutturale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cactus-weaver",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-brinastorm",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-ondata-termica",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "noctule-termico",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "silica-bloom",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thermo-raptor",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "treant-portale",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Sostenere megaflora e colonie interconnesse.",
+      "tier": "T2",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Bilancia idratazione e risorse tra esemplari distanti."
+    },
+    "riflessi_preternaturali": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Affatica il sistema nervoso se mantenuto troppo a lungo.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Alto (Continuo)",
+      "id": "riflessi_preternaturali",
+      "label": "Riflessi Preternaturali",
+      "mutazione_indotta": "Aggiunge sinapsi a doppio stadio e buffer neurochimici.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "reazione",
+        "core": "sensoriale"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Superare predatori rapidi o automatismi letali.",
+      "tier": "T2",
+      "usage_tags": [
+        "scout"
+      ],
+      "uso_funzione": "Consente schivate fulminee e contromisure immediate."
+    },
+    "rinforzi_modulari": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede manutenzione costante delle connessioni.",
+      "famiglia_tipologia": "Strutturale/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "rinforzi_modulari",
+      "label": "Rinforzi Modulari",
+      "mutazione_indotta": "Installa giunti magnetici che rilasciano moduli sacrificabili.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "armatura",
+        "core": "strutturale"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Prolungare integrità di strutture e bestie da assedio.",
+      "tier": "T2",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Distribuisce danni e protegge componenti vitali durante assedi."
     },
     "risonanza_di_branco": {
       "completion_flags": {
@@ -11025,6 +13171,86 @@
       ],
       "uso_funzione": "Neutralizzare o immobilizzare prede/nemici."
     },
+    "secrezioni_antisepsi": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Può interferire con simbionti benefici se abusato.",
+      "famiglia_tipologia": "Digestivo/Escretorio",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "secrezioni_antisepsi",
+      "label": "Secrezioni Antisepsi",
+      "mutazione_indotta": "Potenzia ghiandole escretorie con cocktail enzimatici disinfettanti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cura",
+        "core": "digestivo"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Mantenere linee operative in ambienti contaminati.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Disinfetta compagni feriti e riduce tempi di recupero."
+    },
+    "sensori_chimici": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Saturazione olfattiva può richiedere reset prolungato.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "sensori_chimici",
+      "label": "Sensori Chimici",
+      "mutazione_indotta": "Crea papille multifilari e camere olfattive potenziate.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "chimica",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Assicurare consapevolezza ambientale in regioni toxiche.",
+      "tier": "T1",
+      "usage_tags": [
+        "scout"
+      ],
+      "uso_funzione": "Identifica veleni, prede e tracce invisibili."
+    },
     "sensori_geomagnetici": {
       "completion_flags": {
         "has_biome": true,
@@ -11177,6 +13403,78 @@
         "support"
       ],
       "uso_funzione": "Trasmette comandi e pattern tattici sfruttando armoniche subacquee."
+    },
+    "sinapsi_riflettenti": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Può creare dipendenza da pattern preimpostati.",
+      "famiglia_tipologia": "Sensoriale/Nervoso",
+      "fattore_mantenimento_energetico": "Medio (Continuo)",
+      "id": "sinapsi_riflettenti",
+      "label": "Sinapsi Riflettenti",
+      "mutazione_indotta": "Integra specchi sinaptici che ricalcano impulsi ottimali.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "memoria",
+        "core": "sensoriale"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Velocizzare addestramento di unità d'élite.",
+      "tier": "T2",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Riduce errori motori e migliora coordinazione con compagni."
+    },
+    "sinergizzatore_team": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Caduta drastica di resa se i ruoli previsti mancano.",
+      "famiglia_tipologia": "Supporto/Coordinativo",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "sinergizzatore_team",
+      "label": "Sinergizzatore di Team",
+      "mutazione_indotta": "Installa relè neurali che sincronizzano potenziamenti e cooldown condivisi.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "sinergia",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Massimizzare output di squadre composite.",
+      "tier": "T2",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Aumenta efficacia delle abilità combinate e delle catene di ruolo."
     },
     "sonno_emisferico_alternato": {
       "completion_flags": {
@@ -11622,6 +13920,50 @@
       ],
       "uso_funzione": "Coordina prese e focus bersaglio condividendo segnali di priorità."
     },
+    "tessuti_adattivi": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Rallenta se sottoposto a stress costante senza riposo.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Medio (Continuo)",
+      "id": "tessuti_adattivi",
+      "label": "Tessuti Adattivi",
+      "mutazione_indotta": "Sviluppa fibre viscoelastiche con risposta controllata.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "adattamento",
+        "core": "strutturale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Adattarsi a pressioni variabili e combattimenti multi-terreno.",
+      "tier": "T2",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Permette alternanza rapida tra postura difensiva e sprint improvvisi."
+    },
     "vello_condensatore_nebbie": {
       "completion_flags": {
         "has_biome": true,
@@ -11773,6 +14115,101 @@
         "sustain"
       ],
       "uso_funzione": "Macinazione di cibo duro all'interno di un ventriglio."
+    },
+    "visione_spettrale": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Abbagliamento nelle esplosioni fotoniche improvvise.",
+      "famiglia_tipologia": "Sensoriale/Visivo",
+      "fattore_mantenimento_energetico": "Medio (Continuo)",
+      "id": "visione_spettrale",
+      "label": "Visione Spettrale",
+      "mutazione_indotta": "Aggiunge lenti multifase e filtri psionici alle unità ottiche.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "ricognizione",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "archon-solare",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Garantire copertura sensoriale totale in ambienti oscurati.",
+      "tier": "T1",
+      "usage_tags": [
+        "scout"
+      ],
+      "uso_funzione": "Scova minacce occultate da camuffamenti energetici o oscurità."
+    },
+    "voce_spettrale": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Può attirare creature sensibili al suono se non schermato.",
+      "famiglia_tipologia": "Sensoriale/Supporto",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "voce_spettrale",
+      "label": "Voce Spettrale",
+      "mutazione_indotta": "Configura corde vocali a risonanza variabile che modulano segnali armonici.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "comunicazione",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Mantenere controllo tattico in labirinti e dimensioni sovrapposte.",
+      "tier": "T1",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Coordina squadre separate, disorienta nemici e amplifica comandi psionici."
     },
     "zampe_a_molla": {
       "completion_flags": {

--- a/docs/evo-tactics-pack/trait-reference.json
+++ b/docs/evo-tactics-pack/trait-reference.json
@@ -2,6 +2,265 @@
   "schema_version": "2.0",
   "trait_glossary": "data/core/traits/glossary.json",
   "traits": {
+    "Invoker": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede concentrazione e difesa durante l'incanalamento.",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "Invoker",
+      "label": "Canalizzatore",
+      "mutazione_indotta": "Stabilisce glifi viventi che ruotano energia tramite il nucleo dell'unità.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "canalizzazione",
+        "core": "strategia"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Sostenere squadre psioniche nelle fasi più intense di incursioni planari.",
+      "tier": "T2",
+      "usage_tags": ["controller"],
+      "uso_funzione": "Amplifica combo energetiche e rituali di rinforzo."
+    },
+    "Skirmisher": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Ridotta resistenza in ingaggi prolungati.",
+      "famiglia_tipologia": "Locomotorio/Predatorio",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "Skirmisher",
+      "label": "Incursore Rapido",
+      "mutazione_indotta": "Riprogramma fibre muscolari per sprint brevi ad alta accelerazione.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "locomotorio"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Contenere bersagli mobili e sfruttare flanchi.",
+      "tier": "T1",
+      "usage_tags": ["breaker"],
+      "uso_funzione": "Apre varchi rapidi nelle linee avversarie e si ritira prima della reazione."
+    },
+    "Strategist": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede telemetria costante; degrada in presenza di disturbi psionici prolungati.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "Strategist",
+      "label": "Stratega di Campo",
+      "mutazione_indotta": "Installa nodi decisionali ausiliari che calcolano traiettorie ottimali per l'intero plotone.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "coordinazione",
+        "core": "strategia"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Mantenere vantaggio decisionale su fronti dinamici con squilibri di numeri.",
+      "tier": "T1",
+      "usage_tags": ["controller"],
+      "uso_funzione": "Dirige ingaggi multipli garantendo priorità condivise e gestione ordinata delle risorse."
+    },
+    "Support": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Vulnerabile a sovraccarichi se più unità critiche richiedono assistenza simultanea.",
+      "famiglia_tipologia": "Supporto/Coordinativo",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "Support",
+      "label": "Supporto Primario",
+      "mutazione_indotta": "Integra sacche di distribuzione e nodi telemetrici per seguire lo stato alleato in tempo reale.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistica",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Prolungare l'operatività delle squadre lontano da basi logistiche dedicate.",
+      "tier": "T1",
+      "usage_tags": ["support"],
+      "uso_funzione": "Stabilizza il team fornendo risorse rigenerate, cure leggere e compensazioni di morale."
+    },
+    "Vanguard": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Mobilità ridotta mentre le ancore sono estese.",
+      "famiglia_tipologia": "Supporto/Difesa",
+      "fattore_mantenimento_energetico": "Medio (Continuo)",
+      "id": "Vanguard",
+      "label": "Avanguardia Rinforzata",
+      "mutazione_indotta": "Addensa carapaci frontali e spine di stabilizzazione.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "difesa",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Stabilizzare linee di combattimento contro assalti pesanti.",
+      "tier": "T1",
+      "usage_tags": ["tank"],
+      "uso_funzione": "Tiene posizione e protegge assetti fragili durante l'ingaggio iniziale."
+    },
+    "Warden": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede costante consapevolezza situazionale e canali di comando puliti.",
+      "famiglia_tipologia": "Supporto/Difesa",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "Warden",
+      "label": "Custode Difensivo",
+      "mutazione_indotta": "Integra glifi difensivi che redistribuiscono danni.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "controllo",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Creare zone sicure in campagne prolungate.",
+      "tier": "T1",
+      "usage_tags": ["tank"],
+      "uso_funzione": "Protegge linee arretrate e convoglia minacce su traiettorie previste."
+    },
+    "adattamento_volo": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Sensibile a shock sonici che alterano la pressione interna delle camere.",
+      "famiglia_tipologia": "Locomotorio/Adattivo",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "adattamento_volo",
+      "label": "Adattamento al Volo",
+      "mutazione_indotta": "Ristruttura fasci muscolari e sacche pneumatiche per ottimizzare rollio e planata prolungata.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilità",
+        "core": "locomotorio"
+      },
+      "species_affinity": [
+        {
+          "roles": ["core"],
+          "species_id": "archon-solare",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "balor-fission",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "couatl-aurora",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Garantire copertura aerea persistente su regioni con venti multidirezionali.",
+      "tier": "T1",
+      "usage_tags": ["scout"],
+      "uso_funzione": "Consente volo continuo anche in correnti erratiche e durante transizioni gravitazionali."
+    },
     "ali_fulminee": {
       "label": "Ali Fulminee",
       "famiglia_tipologia": "Sensoriale/Analitico",
@@ -12,10 +271,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -52,10 +308,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -92,10 +345,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -122,6 +372,51 @@
         "tabelle_random": []
       }
     },
+    "ali_solari_fotoni": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Perde efficienza in ombra persistente o durante tempeste di cenere.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ali_solari_fotoni",
+      "label": "Ali Solari a Fotoni",
+      "mutazione_indotta": "Genera membrane cristalline che immagazzinano fotoni e rilasciano microspinte direzionali.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "locomotorio"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "archon-solare",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "couatl-aurora",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Ridurre il fabbisogno energetico delle unità volanti su rotte lunghe.",
+      "tier": "T1",
+      "usage_tags": ["scout"],
+      "uso_funzione": "Fornisce accelerazioni gratuite durante pattugliamenti diurni o orbitali."
+    },
     "antenne_dustsense": {
       "label": "Antenne Dustsense",
       "famiglia_tipologia": "Digestivo/Metabolico",
@@ -132,10 +427,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -172,10 +464,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -212,10 +501,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -252,10 +538,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -323,13 +606,8 @@
           "bioma:cicloni_psionici"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Tempestarii",
-          "HUD:Fulcro_Tempesta"
-        ],
-        "tabelle_random": [
-          "tabella:fulmini_empatici"
-        ]
+        "forme": ["Forma:Tempestarii", "HUD:Fulcro_Tempesta"],
+        "tabelle_random": ["tabella:fulmini_empatici"]
       }
     },
     "antenne_reagenti": {
@@ -342,10 +620,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -382,10 +657,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -422,10 +694,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -462,10 +731,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -502,10 +768,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -542,10 +805,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -572,6 +832,40 @@
         "tabelle_random": []
       }
     },
+    "architetto": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Necessita riserva materica dedicata; rallenta se le scorte crollano.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "architetto",
+      "label": "Nodo Architetto",
+      "mutazione_indotta": "Sviluppa sinapsi geometriche che tracciano ancoraggi e blueprint modulari.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "ingegneria",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Stabilizzare avamposti improvvisati in territori instabili.",
+      "tier": "T1",
+      "usage_tags": ["support"],
+      "uso_funzione": "Coordina costruzioni rapide, ponti provvisori e riparazioni sincronizzate."
+    },
     "armatura_pietra_planare": {
       "label": "Armatura di Pietra Planare",
       "famiglia_tipologia": "Difesa/Strutturale",
@@ -582,17 +876,11 @@
         "complementare": "strutturale",
         "core": "difesa"
       },
-      "sinergie": [
-        "carapace_fase_variabile"
-      ],
-      "conflitti": [
-        "frusta_fiammeggiante"
-      ],
+      "sinergie": ["carapace_fase_variabile"],
+      "conflitti": ["frusta_fiammeggiante"],
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "deploy_barrier"
-          ],
+          "capacita_richieste": ["deploy_barrier"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -625,10 +913,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -665,10 +950,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -695,6 +977,46 @@
         "tabelle_random": []
       }
     },
+    "artigli_psionici": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Assorbe molta concentrazione; vulnerabile a interferenze antimagia.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "artigli_psionici",
+      "label": "Artigli Psionici",
+      "mutazione_indotta": "Canalizza creste neuroconduttive che formano lame psioniche a geometria variabile.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "psionico",
+        "core": "offensivo"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "rakshasa-corte",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Conferire ad assetti leggeri capacità d'assalto contro bersagli schermati.",
+      "tier": "T2",
+      "usage_tags": ["breaker"],
+      "uso_funzione": "Taglia armature leggere e disarma avversari concentrando colpi telecinetici."
+    },
     "artigli_radice": {
       "label": "Artigli Radice",
       "famiglia_tipologia": "Strategico/Tattico",
@@ -705,10 +1027,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -745,10 +1064,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -816,13 +1132,8 @@
           "hud:GripNode_Psion"
         ],
         "combo_totale": 4,
-        "forme": [
-          "Forma:Predatore_Tessuto",
-          "HUD:GrappleBurst"
-        ],
-        "tabelle_random": [
-          "tabella:predazione_multicanale"
-        ]
+        "forme": ["Forma:Predatore_Tessuto", "HUD:GrappleBurst"],
+        "tabelle_random": ["tabella:predazione_multicanale"]
       }
     },
     "artigli_sghiaccio_glaciale": {
@@ -865,12 +1176,8 @@
           "hud:GlacierClaw_UI"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Assaltatore_Criogenico"
-        ],
-        "tabelle_random": [
-          "tabella:presa_criostatica"
-        ]
+        "forme": ["Forma:Assaltatore_Criogenico"],
+        "tabelle_random": ["tabella:presa_criostatica"]
       }
     },
     "artigli_vetrificati": {
@@ -883,10 +1190,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -913,6 +1217,51 @@
         "tabelle_random": []
       }
     },
+    "assenza_respirazione": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede spurghi frequenti per evitare accumulo di sottoprodotti metabolici.",
+      "famiglia_tipologia": "Respiratorio/Protezione",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "assenza_respirazione",
+      "label": "Assenza di Respirazione",
+      "mutazione_indotta": "Sigilla alveoli e inserisce camere catalitiche per riciclare gas metabolici.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "respiratorio"
+      },
+      "species_affinity": [
+        {
+          "roles": ["core"],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "golem-runico",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Garantire continuità operativa in camere sigillate, vacuum o piani corrosivi.",
+      "tier": "T1",
+      "usage_tags": ["tank"],
+      "uso_funzione": "Permette operazioni in ambienti privi di aria o saturi di agenti tossici."
+    },
     "aura_scudo_radianza": {
       "label": "Aura Scudo di Radianza",
       "famiglia_tipologia": "Supporto/Difesa",
@@ -923,18 +1272,11 @@
         "complementare": "difesa",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "conflitti": [
-        "mantello_meteoritico"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
+      "conflitti": ["mantello_meteoritico"],
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "flight"
-          ],
+          "capacita_richieste": ["flight"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -967,10 +1309,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1007,10 +1346,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1047,10 +1383,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1087,10 +1420,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1127,10 +1457,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1167,10 +1494,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1207,10 +1531,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1247,10 +1568,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1287,10 +1605,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1327,10 +1642,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1367,10 +1679,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1407,10 +1716,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1447,13 +1753,8 @@
         "complementare": "osmoregolazione",
         "core": "respiratorio"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "scheletro_idro_regolante"
-      ],
-      "conflitti": [
-        "polmoni_cristallini_alta_quota"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "scheletro_idro_regolante"],
+      "conflitti": ["polmoni_cristallini_alta_quota"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1478,12 +1779,8 @@
           "hud:EstuarioPsi"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Amfibio_Oracolare"
-        ],
-        "tabelle_random": [
-          "tabella:osmosi_psionica"
-        ]
+        "forme": ["Forma:Amfibio_Oracolare"],
+        "tabelle_random": ["tabella:osmosi_psionica"]
       }
     },
     "branchie_solfatiche": {
@@ -1496,10 +1793,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1536,10 +1830,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1606,13 +1897,8 @@
           "hud:RootMesh_Psi"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Archivio_Subglaciale",
-          "HUD:Radice_Proxy"
-        ],
-        "tabelle_random": [
-          "tabella:riserva_empatica"
-        ]
+        "forme": ["Forma:Archivio_Subglaciale", "HUD:Radice_Proxy"],
+        "tabelle_random": ["tabella:riserva_empatica"]
       }
     },
     "camere_anticorrosione": {
@@ -1625,10 +1911,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1665,10 +1948,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1705,10 +1985,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1735,6 +2012,40 @@
         "tabelle_random": []
       }
     },
+    "campo_di_fase": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Genera risonanze collaterali che possono interferire con apparati sensoriali alleati.",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Alto (Continuo)",
+      "id": "campo_di_fase",
+      "label": "Campo di Fase",
+      "mutazione_indotta": "Stabilisce matrici cristalline che modulano frequenze di fase sui tessuti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "psionico",
+        "core": "strategia"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Consentire manovre evasive decisive contro artiglieria o trappole planari.",
+      "tier": "T2",
+      "usage_tags": ["controller"],
+      "uso_funzione": "Offre invulnerabilità breve o passaggio attraverso coperture non line-of-sight."
+    },
     "capillari_criogenici": {
       "label": "Capillari Criogenici",
       "famiglia_tipologia": "Strutturale/Adattivo",
@@ -1745,10 +2056,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1785,10 +2093,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1825,10 +2130,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1865,10 +2167,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1925,9 +2224,7 @@
         "armatura_pietra_planare",
         "mantello_meteoritico"
       ],
-      "conflitti": [
-        "struttura_elastica_amorfa"
-      ],
+      "conflitti": ["struttura_elastica_amorfa"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1965,13 +2262,8 @@
           "hud:PhaseShift_Plate"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Guardiano_Cangiante",
-          "HUD:Placca_Sintonica"
-        ],
-        "tabelle_random": [
-          "tabella:assetto_fase"
-        ]
+        "forme": ["Forma:Guardiano_Cangiante", "HUD:Placca_Sintonica"],
+        "tabelle_random": ["tabella:assetto_fase"]
       }
     },
     "carapace_luminiscente_abissale": {
@@ -1989,9 +2281,7 @@
         "risonanza_di_branco",
         "sinapsi_coraline_polifoniche"
       ],
-      "conflitti": [
-        "carapace_fase_variabile"
-      ],
+      "conflitti": ["carapace_fase_variabile"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2016,13 +2306,8 @@
           "hud:AbyssLight_Array"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Lanterna_Abissale",
-          "HUD:LuminaNet"
-        ],
-        "tabelle_random": [
-          "tabella:segnali_bioluminosi"
-        ]
+        "forme": ["Forma:Lanterna_Abissale", "HUD:LuminaNet"],
+        "tabelle_random": ["tabella:segnali_bioluminosi"]
       }
     },
     "carapace_segmenti_logici": {
@@ -2035,10 +2320,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2075,10 +2357,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2121,9 +2400,7 @@
         "sacche_galleggianti_ascensoriali",
         "zoccoli_risonanti_steppe"
       ],
-      "conflitti": [
-        "scheletro_idro_regolante"
-      ],
+      "conflitti": ["scheletro_idro_regolante"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2148,12 +2425,8 @@
           "hud:VentSplice_Halo"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Planatore_Psionico"
-        ],
-        "tabelle_random": [
-          "tabella:assetto_eolico"
-        ]
+        "forme": ["Forma:Planatore_Psionico"],
+        "tabelle_random": ["tabella:assetto_eolico"]
       }
     },
     "cartilagini_biofibre": {
@@ -2166,10 +2439,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2206,10 +2476,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2246,10 +2513,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2286,10 +2550,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2357,13 +2618,8 @@
           "hud:TundraPulse"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Cantore_Tundra",
-          "HUD:EchoGrid"
-        ],
-        "tabelle_random": [
-          "tabella:canti_ipersonici"
-        ]
+        "forme": ["Forma:Cantore_Tundra", "HUD:EchoGrid"],
+        "tabelle_random": ["tabella:canti_ipersonici"]
       }
     },
     "cervelletto_equilibrio_statico": {
@@ -2376,10 +2632,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2416,10 +2669,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2456,10 +2706,7 @@
         "complementare": "utility",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "bulbi_radici_permafrost",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["bulbi_radici_permafrost", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2485,6 +2732,126 @@
         "tabelle_random": []
       }
     },
+    "ciclo_vitale_anomalo": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Difficile sincronizzare con programmi di allevamento o catene logistiche standard.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ciclo_vitale_anomalo",
+      "label": "Ciclo Vitale Anomalo",
+      "mutazione_indotta": "Ristruttura organi germinali per riattivarsi su cicli imprevedibili.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": ["core"],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "golem-runico",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Garantire persistenza di specie sintetiche o planari in ecosistemi ostili.",
+      "tier": "T1",
+      "usage_tags": ["sustain"],
+      "uso_funzione": "Mantiene popolazioni attive anche dopo perdite massicce tramite scissioni rigenerative."
+    },
+    "ciclo_vitale_completo": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Prevedibilità elevata che può essere sfruttata da predatori intelligenti.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ciclo_vitale_completo",
+      "label": "Ciclo Vitale Completo",
+      "mutazione_indotta": "Affina ghiandole endocrine e pattern epigenetici per mantenere cicli regolari.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "riproduttivo",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": ["core"],
+          "species_id": "archon-solare",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "balor-fission",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "bulette-fase",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "couatl-aurora",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "marilith-vault",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "otyugh-sentinella",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "rakshasa-corte",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "treant-portale",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Massimizzare rendimento riproduttivo in ambienti regolati.",
+      "tier": "T1",
+      "usage_tags": ["sustain"],
+      "uso_funzione": "Facilita allevamento e rotazioni pianificate nelle colonie adattive."
+    },
     "circolazione_bifasica": {
       "label": "Circolazione Bifasica",
       "famiglia_tipologia": "Tegumentario/Difensivo",
@@ -2495,10 +2862,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2535,12 +2899,8 @@
         "complementare": "resilienza",
         "core": "metabolico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie"
-      ],
-      "conflitti": [
-        "sangue_piroforico"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie"],
+      "conflitti": ["sangue_piroforico"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2575,10 +2935,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2615,10 +2972,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2655,10 +3009,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2695,10 +3046,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2735,10 +3083,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2775,10 +3120,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2815,10 +3157,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2855,10 +3194,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2895,10 +3231,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3013,10 +3346,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3053,10 +3383,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3093,10 +3420,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3133,10 +3457,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3173,10 +3494,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3203,6 +3521,46 @@
         "tabelle_random": []
       }
     },
+    "corteccia_memetica": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Suscettibile a sovraccarichi memetici se esposto a segnali ostili.",
+      "famiglia_tipologia": "Sensoriale/Nervoso",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "corteccia_memetica",
+      "label": "Corteccia Memetica",
+      "mutazione_indotta": "Integra dendriti cristallini che replicano rapidamente schemi imparati.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "memetica",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "treant-portale",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Ridurre tempi di addestramento per squadre miste e neoformate.",
+      "tier": "T2",
+      "usage_tags": ["support"],
+      "uso_funzione": "Condivide schemi di combattimento e soluzioni ambientali in tempo reale."
+    },
     "criostasi_adattiva": {
       "label": "Criostasi",
       "famiglia_tipologia": "Metabolico/Difensivo",
@@ -3213,13 +3571,8 @@
         "complementare": "difensivo",
         "core": "metabolico"
       },
-      "sinergie": [
-        "cavita_risonanti_tundra"
-      ],
-      "conflitti": [
-        "sangue_piroforico",
-        "sacche_galleggianti_ascensoriali"
-      ],
+      "sinergie": ["cavita_risonanti_tundra"],
+      "conflitti": ["sangue_piroforico", "sacche_galleggianti_ascensoriali"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3267,10 +3620,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3307,10 +3657,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3347,10 +3694,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3387,10 +3731,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3427,10 +3768,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [],
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -3454,10 +3792,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3494,10 +3829,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3534,10 +3866,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3574,10 +3903,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3614,10 +3940,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3654,10 +3977,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3737,14 +4057,52 @@
         "tabelle_random": []
       }
     },
+    "eco_sismico": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Rumore meccanico continuo può saturare i recettori.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "eco_sismico",
+      "label": "Eco Sismico",
+      "mutazione_indotta": "Forma camere ossee e filamenti sensibili a microfratture e onde elastiche.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "geofonia",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "banshee-risonante",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Garantire sicurezza in biomi instabili o in città sotterranee.",
+      "tier": "T1",
+      "usage_tags": ["scout"],
+      "uso_funzione": "Anticipa frane, movimenti sotterranei e intrusioni mimetizzate."
+    },
     "empatia_coordinativa": {
       "label": "Empatia Coordinativa",
       "famiglia_tipologia": "Supporto/Empatico",
       "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
       "tier": "T1",
-      "slot": [
-        "A"
-      ],
+      "slot": ["A"],
       "slot_profile": {
         "complementare": "coordinazione",
         "core": "supporto"
@@ -3773,13 +4131,9 @@
       "spinta_selettiva": "Turni lunghi con rischio alto in cui serve mitigare tilt e HP critici.",
       "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "job_ability:Warden/Scudo_di_Risonanza"
-        ],
+        "co_occorrenze": ["job_ability:Warden/Scudo_di_Risonanza"],
         "combo_totale": 1,
-        "forme": [
-          "INFP"
-        ],
+        "forme": ["INFP"],
         "tabelle_random": []
       }
     },
@@ -3793,10 +4147,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3833,10 +4184,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3873,10 +4221,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [],
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -3900,10 +4245,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3940,10 +4282,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3980,10 +4319,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4020,10 +4356,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4124,10 +4457,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4164,10 +4494,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4204,10 +4531,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4234,6 +4558,46 @@
         "tabelle_random": []
       }
     },
+    "filtri_bioattivi": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Rallenta la digestione in assenza di sostanze da metabolizzare.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "filtri_bioattivi",
+      "label": "Filtri Bioattivi",
+      "mutazione_indotta": "Introduce microcolonie simbionti che degradano agenti chimici in catene nutrienti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "detox",
+        "core": "metabolico"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "otyugh-sentinella",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Espandere la gamma alimentare in territori compromessi.",
+      "tier": "T1",
+      "usage_tags": ["sustain"],
+      "uso_funzione": "Permette ingestione sicura di biomi contaminati e risorse marginali."
+    },
     "filtri_planctonici": {
       "label": "Filtri Planctonici",
       "famiglia_tipologia": "Tegumentario/Difensivo",
@@ -4244,10 +4608,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4274,6 +4635,46 @@
         "tabelle_random": []
       }
     },
+    "fisiologia_predatoria": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede apporto calorico elevato per mantenere performance.",
+      "famiglia_tipologia": "Locomotorio/Predatorio",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "fisiologia_predatoria",
+      "label": "Fisiologia Predatoria",
+      "mutazione_indotta": "Potenzia fibre muscolari e dentizione per impatti rapidi e trattenimento.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "predazione",
+        "core": "offensivo"
+      },
+      "species_affinity": [
+        {
+          "roles": ["core"],
+          "species_id": "bulette-fase",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Dominare catene alimentari dinamiche e contenere infestazioni aggressive.",
+      "tier": "T1",
+      "usage_tags": ["breaker"],
+      "uso_funzione": "Eleva l'efficacia offensiva contro bersagli mobili o evasivi."
+    },
     "flagelli_ancoranti": {
       "label": "Flagelli Ancoranti",
       "famiglia_tipologia": "Digestivo/Metabolico",
@@ -4284,10 +4685,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4319,10 +4717,7 @@
       "famiglia_tipologia": "Strategico/Psionico",
       "fattore_mantenimento_energetico": "Medio (Dividere l'attenzione su più canali)",
       "tier": "T1",
-      "slot": [
-        "A",
-        "C"
-      ],
+      "slot": ["A", "C"],
       "slot_profile": {
         "complementare": "psionico",
         "core": "strategia"
@@ -4360,11 +4755,7 @@
           "starter_bioma"
         ],
         "combo_totale": 3,
-        "forme": [
-          "ENTP",
-          "INFJ",
-          "INTP"
-        ],
+        "forme": ["ENTP", "INFJ", "INTP"],
         "tabelle_random": []
       }
     },
@@ -4378,10 +4769,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4418,10 +4806,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4448,6 +4833,40 @@
         "tabelle_random": []
       }
     },
+    "fotosintesi_bifase": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Sensibile a blackout prolungati o cieli oscurati.",
+      "famiglia_tipologia": "Metabolico/Resilienza",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "fotosintesi_bifase",
+      "label": "Fotosintesi Bifase",
+      "mutazione_indotta": "Introduce lamelle pigmentate che cambiano configurazione tra fase diurna e notturna.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Stabilizzare colonie vegetali o fotosensibili in cicli lunghi irregolari.",
+      "tier": "T1",
+      "usage_tags": ["sustain"],
+      "uso_funzione": "Mantiene produzione energetica senza dipendere da fonti esterne continuative."
+    },
     "frusta_fiammeggiante": {
       "label": "Frusta Fiammeggiante",
       "famiglia_tipologia": "Offensivo/Controllo",
@@ -4458,18 +4877,11 @@
         "complementare": "controllo",
         "core": "offensivo"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "mantello_meteoritico"
-      ],
-      "conflitti": [
-        "armatura_pietra_planare"
-      ],
+      "sinergie": ["focus_frazionato", "mantello_meteoritico"],
+      "conflitti": ["armatura_pietra_planare"],
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "void_stride"
-          ],
+          "capacita_richieste": ["void_stride"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -4502,10 +4914,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4537,9 +4946,7 @@
       "famiglia_tipologia": "Offensivo/Chimico",
       "fattore_mantenimento_energetico": "Medio (Produzione reagenti)",
       "tier": "T1",
-      "slot": [
-        "A"
-      ],
+      "slot": ["A"],
       "slot_profile": {
         "complementare": "assalto",
         "core": "offensivo"
@@ -4552,14 +4959,9 @@
       "spinta_selettiva": "Squadre che devono rispondere a guardie situazionali al turno 1-2.",
       "debolezza": "Gestione accurata delle riserve per non calare sotto i budget PE previsto.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "guardia_situazionale"
-        ],
+        "co_occorrenze": ["PE", "guardia_situazionale"],
         "combo_totale": 1,
-        "forme": [
-          "ISTP"
-        ],
+        "forme": ["ISTP"],
         "tabelle_random": []
       }
     },
@@ -4573,10 +4975,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4613,10 +5012,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4653,10 +5049,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4693,10 +5086,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4733,10 +5123,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4773,10 +5160,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4813,10 +5197,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4853,10 +5234,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4893,10 +5271,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4933,10 +5308,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4973,10 +5345,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5003,6 +5372,46 @@
         "tabelle_random": []
       }
     },
+    "ghiandole_nettare_memetico": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Può attrarre parassiti memetici se non schermato.",
+      "famiglia_tipologia": "Supporto/Empatico",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "ghiandole_nettare_memetico",
+      "label": "Ghiandole di Nettare Memetico",
+      "mutazione_indotta": "Coltiva sacche ghiandolari che diffondono feromoni memetici con pattern coordinativi.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "couatl-aurora",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Ridurre caos operativo in battaglie multi-nodo.",
+      "tier": "T2",
+      "usage_tags": ["support"],
+      "uso_funzione": "Aumenta coesione di squadra e velocità di risposta degli sciami collegati."
+    },
     "ghiandole_resina_conduttiva": {
       "label": "Ghiandole Resina Conduttiva",
       "famiglia_tipologia": "Sensoriale/Analitico",
@@ -5013,10 +5422,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5053,10 +5459,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5093,10 +5496,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5133,10 +5533,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [],
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -5160,10 +5557,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5200,10 +5594,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5230,6 +5621,46 @@
         "tabelle_random": []
       }
     },
+    "intangibilita_parziale": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Fatica a mantenersi attivo sotto fuoco concentrato o campi antimagia.",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Alto (Continuo)",
+      "id": "intangibilita_parziale",
+      "label": "Intangibilità Parziale",
+      "mutazione_indotta": "Installa nodi quantici che modulano densità atomica per pochi istanti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "evasione",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "banshee-risonante",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Sbloccare percorsi impraticabili e sfuggire a crowd control.",
+      "tier": "T2",
+      "usage_tags": ["controller"],
+      "uso_funzione": "Permette attraversamento di barriere, trappole e catene di contenimento."
+    },
     "lamelle_shear": {
       "label": "Lamelle Shear",
       "famiglia_tipologia": "Strategico/Tattico",
@@ -5240,10 +5671,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5280,10 +5708,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5320,12 +5745,8 @@
         "complementare": "termoregolazione",
         "core": "respiratorio"
       },
-      "sinergie": [
-        "sangue_piroforico"
-      ],
-      "conflitti": [
-        "criostasi_adattiva"
-      ],
+      "sinergie": ["sangue_piroforico"],
+      "conflitti": ["criostasi_adattiva"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5350,6 +5771,46 @@
         "tabelle_random": []
       }
     },
+    "lamenti_diradanti": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Efficacia ridotta contro unità sorde o schermate.",
+      "famiglia_tipologia": "Sensoriale/Supporto",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "lamenti_diradanti",
+      "label": "Lamenti Diradanti",
+      "mutazione_indotta": "Sviluppa corde vocali multiple che modulano frequenze dissonanti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "psicoacustica",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "banshee-risonante",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Contenere assalti di massa e agevolare disperdimento di branchi planari.",
+      "tier": "T2",
+      "usage_tags": ["controller"],
+      "uso_funzione": "Riduce precisione e morale dei bersagli nell'area d'effetto."
+    },
     "lamine_filtranti_aeree": {
       "label": "Lamine Filtranti Aeree",
       "famiglia_tipologia": "Strutturale/Adattivo",
@@ -5360,10 +5821,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5400,10 +5858,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5440,10 +5895,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5480,10 +5932,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5520,9 +5969,7 @@
         "complementare": "alimentare",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "olfatto_risonanza_magnetica"
-      ],
+      "sinergie": ["olfatto_risonanza_magnetica"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5558,10 +6005,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5598,10 +6042,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5638,10 +6079,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5678,18 +6116,11 @@
         "complementare": "termico",
         "core": "difesa"
       },
-      "sinergie": [
-        "frusta_fiammeggiante",
-        "carapace_fase_variabile"
-      ],
-      "conflitti": [
-        "aura_scudo_radianza"
-      ],
+      "sinergie": ["frusta_fiammeggiante", "carapace_fase_variabile"],
+      "conflitti": ["aura_scudo_radianza"],
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "fire_resist"
-          ],
+          "capacita_richieste": ["fire_resist"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -5712,6 +6143,86 @@
         "tabelle_random": []
       }
     },
+    "maschera_illusoria": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Fragile contro sensori multispettrali avanzati.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "maschera_illusoria",
+      "label": "Maschera Illusoria",
+      "mutazione_indotta": "Genera organi olografici che rifrangono segnali in output scelti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mimetismo",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "rakshasa-corte",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Confondere targeting automatico e ritardare rilevamento.",
+      "tier": "T1",
+      "usage_tags": ["controller"],
+      "uso_funzione": "Occulta assetti prioritari o li presenta come obiettivi minori."
+    },
+    "matrice_antimagia": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Surriscaldamento se l'esposizione è prolungata senza dissipazione.",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Alto (Continuo)",
+      "id": "matrice_antimagia",
+      "label": "Matrice Antimagia",
+      "mutazione_indotta": "Integra nodi parafulmine e cristalli paraeterei nel tegumento.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "golem-runico",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Neutralizzare minacce magiche in scenari ad alta densità psionica.",
+      "tier": "T2",
+      "usage_tags": ["controller"],
+      "uso_funzione": "Spezza incantesimi ostili, annulla campi di controllo e protegge assetti tecnologici."
+    },
     "membrane_captura_rugiada": {
       "label": "Membrane Captura Rugiada",
       "famiglia_tipologia": "Strategico/Tattico",
@@ -5722,10 +6233,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5762,10 +6270,7 @@
         "complementare": "protezione",
         "core": "respiratorio"
       },
-      "sinergie": [
-        "piume_solari_fotovoltaiche",
-        "polmoni_cristallini_alta_quota"
-      ],
+      "sinergie": ["piume_solari_fotovoltaiche", "polmoni_cristallini_alta_quota"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5791,6 +6296,46 @@
         "tabelle_random": []
       }
     },
+    "membrane_osmotiche": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede cicli di purga regolari per evitare saturazione.",
+      "famiglia_tipologia": "Respiratorio/Osmoregolazione",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "membrane_osmotiche",
+      "label": "Membrane Osmotiche",
+      "mutazione_indotta": "Aggiunge microcanali adattivi che bilanciano gradienti salini.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "omeostasi",
+        "core": "respiratorio"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "otyugh-sentinella",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Garantire equilibrio idrico per assetti anfibi o planari.",
+      "tier": "T1",
+      "usage_tags": ["sustain"],
+      "uso_funzione": "Permette sopravvivenza prolungata in acque salmastre o deserti ionici."
+    },
     "membrane_planata_vectored": {
       "label": "Membrane Planata Vectored",
       "famiglia_tipologia": "Simbiotico/Cooperativo",
@@ -5801,10 +6346,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5841,10 +6383,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5871,6 +6410,126 @@
         "tabelle_random": []
       }
     },
+    "metabolismo_attivo": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Consumo calorico elevato che impone rifornimenti frequenti.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Medio (Continuo)",
+      "id": "metabolismo_attivo",
+      "label": "Metabolismo Attivo",
+      "mutazione_indotta": "Amplifica mitocondri e flussi enzimatici per sprigionare energia immediata.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "species_affinity": [
+        {
+          "roles": ["core"],
+          "species_id": "archon-solare",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "balor-fission",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "bulette-fase",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "couatl-aurora",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "marilith-vault",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "otyugh-sentinella",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "rakshasa-corte",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "treant-portale",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Potenziare unità che necessitano output costante e recupero accelerato.",
+      "tier": "T1",
+      "usage_tags": ["sustain"],
+      "uso_funzione": "Supporta sforzi intensi e rigenerazione rapida durante campagne estese."
+    },
+    "metabolismo_sostentato": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Output esplosivo limitato rispetto ai profili attivi.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "metabolismo_sostentato",
+      "label": "Metabolismo Sostentato",
+      "mutazione_indotta": "Riprogramma cicli catabolici per recuperare ogni caloria disponibile.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "risparmio",
+        "core": "metabolico"
+      },
+      "species_affinity": [
+        {
+          "roles": ["core"],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "golem-runico",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Mantenere operativi esploratori e costrutti in ambienti poveri di nutrienti.",
+      "tier": "T1",
+      "usage_tags": ["sustain"],
+      "uso_funzione": "Permette sopravvivenza prolungata senza rifornimenti o durante letarghi tattici."
+    },
     "midollo_antivibrazione": {
       "label": "Midollo Antivibrazione",
       "famiglia_tipologia": "Sensoriale/Analitico",
@@ -5881,10 +6540,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6005,9 +6661,7 @@
         "membrane_planata_vectored",
         "nodi_micorrizici_oracolari"
       ],
-      "conflitti": [
-        "ghiandola_caustica"
-      ],
+      "conflitti": ["ghiandola_caustica"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6042,10 +6696,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6082,10 +6733,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6140,9 +6788,7 @@
         "membrane_planata_vectored",
         "mucillagine_simbionte_mangrovie"
       ],
-      "conflitti": [
-        "spore_psichiche_silenziate"
-      ],
+      "conflitti": ["spore_psichiche_silenziate"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6167,6 +6813,80 @@
         "tabelle_random": []
       }
     },
+    "nodi_micotici": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Vulnerabile a agenti antifungini mirati.",
+      "famiglia_tipologia": "Simbiotico/Supporto",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "nodi_micotici",
+      "label": "Nodi Micotici",
+      "mutazione_indotta": "Coltiva rizomi sensibili che formano hub di comunicazione sotterranei.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "simbiosi",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Stabilizzare difese statiche e colonie radicate.",
+      "tier": "T2",
+      "usage_tags": ["support"],
+      "uso_funzione": "Fornisce backup energetico e sincronizzazione di stato agli alleati connessi."
+    },
+    "nuclei_di_controllo": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Punto singolo d'insuccesso se neutralizzato.",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "nuclei_di_controllo",
+      "label": "Nuclei di Controllo",
+      "mutazione_indotta": "Integra nuclei gangliari corazzati con capacità broadcast a lungo raggio.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "comando",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "golem-runico",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Aumentare coesione di reti comandate da remoto.",
+      "tier": "T2",
+      "usage_tags": ["controller"],
+      "uso_funzione": "Gestisce droni, appendici autonome e reparti subordinati."
+    },
     "nucleo_ovomotore_rotante": {
       "label": "Uovo rotaia, uovo grande e uova piccole dentro...",
       "famiglia_tipologia": "Riproduttivo/Locomotorio",
@@ -6178,9 +6898,7 @@
         "core": "riproduttivo"
       },
       "sinergie": [],
-      "conflitti": [
-        "secrezione_rallentante_palmi"
-      ],
+      "conflitti": ["secrezione_rallentante_palmi"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6215,9 +6933,7 @@
         "complementare": "visivo",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "sonno_emisferico_alternato"
-      ],
+      "sinergie": ["sonno_emisferico_alternato"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6253,10 +6969,7 @@
         "complementare": "nervoso",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "eco_interno_riflesso",
-        "lingua_tattile_trama"
-      ],
+      "sinergie": ["eco_interno_riflesso", "lingua_tattile_trama"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6295,14 +7008,57 @@
         "tabelle_random": []
       }
     },
+    "origine_artificiale": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Dipende da ricambi o blueprint specifici.",
+      "famiglia_tipologia": "Strutturale/Omeostatico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "origine_artificiale",
+      "label": "Origine Artificiale",
+      "mutazione_indotta": "Installa matrici di auto-diagnosi e punti di montaggio standardizzati.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "ingegneria",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": ["core"],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "golem-runico",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Rendere replicabili gli assetti costruiti in laboratorio.",
+      "tier": "T1",
+      "usage_tags": ["support"],
+      "uso_funzione": "Facilita riparazioni rapide e riprogrammazione modulare."
+    },
     "pathfinder": {
       "label": "Pathfinder",
       "famiglia_tipologia": "Esplorazione/Tattico",
       "fattore_mantenimento_energetico": "Basso (Sincronizzazione con HUD di esplorazione)",
       "tier": "T1",
-      "slot": [
-        "A"
-      ],
+      "slot": ["A"],
       "slot_profile": {
         "complementare": "ricognizione",
         "core": "strategia"
@@ -6315,27 +7071,173 @@
       "spinta_selettiva": "Missioni con indice explore alto e opzioni opzionali da capitalizzare.",
       "debolezza": "Valore ridotto in scenari a corridoio o con tilt già stabilizzato.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "starter_bioma"],
         "combo_totale": 1,
-        "forme": [
-          "ENFP"
-        ],
+        "forme": ["ENFP"],
         "tabelle_random": []
       }
+    },
+    "pelli_anti_ustione": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Riduce elasticità cutanea se disidratato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "pelli_anti_ustione",
+      "label": "Pelli Anti Ustione",
+      "mutazione_indotta": "Deposita scaglie silicatiche e fluidi anti-piretici negli strati superficiali.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "termico",
+        "core": "tegumentario"
+      },
+      "species_affinity": [
+        {
+          "roles": ["core", "optional"],
+          "species_id": "evento-tempesta-ferrosa",
+          "weight": 4
+        }
+      ],
+      "spinta_selettiva": "Consentire presenza prolungata in deserti ionici e fonderie planari.",
+      "tier": "T1",
+      "usage_tags": ["tank"],
+      "uso_funzione": "Protegge da ustioni, plasma e scariche termiche improvvise."
+    },
+    "pelli_cave": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Ingombro aggiuntivo che rallenta in ambienti saturi d'acqua.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "pelli_cave",
+      "label": "Pelli Cave",
+      "mutazione_indotta": "Forma alveoli dermici che catturano aria calda o fredda a seconda del gradiente.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "termico",
+        "core": "tegumentario"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "cactus-weaver",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "evento-brinastorm",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "evento-ondata-termica",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "noctule-termico",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "silica-bloom",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "thermo-raptor",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Ridurre shock termici durante spostamenti rapidi tra biomi.",
+      "tier": "T1",
+      "usage_tags": ["sustain"],
+      "uso_funzione": "Stabilizza temperatura in climi continentali estremi."
+    },
+    "pelli_fitte": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Peso extra che limita movimenti rapidi.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "pelli_fitte",
+      "label": "Pelli Fitte",
+      "mutazione_indotta": "Addensa fibre collagene e microplacche cheratiniche.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "tegumentario"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "evento-seme-uragano",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Rendere le linee frontali più resistenti senza sacrificare mobilità di base.",
+      "tier": "T1",
+      "usage_tags": ["tank"],
+      "uso_funzione": "Riduce penetrazione di proiettili leggeri e dissipa impatti blandi."
     },
     "pianificatore": {
       "label": "Pianificatore",
       "famiglia_tipologia": "Strategico/Tattico",
       "fattore_mantenimento_energetico": "Medio (Analisi continua di stato squadre)",
       "tier": "T1",
-      "slot": [
-        "A",
-        "C"
-      ],
+      "slot": ["A", "C"],
       "slot_profile": {
         "complementare": "tattico",
         "core": "strategia"
@@ -6362,23 +7264,126 @@
       "spinta_selettiva": "Squadre che devono mantenere priorità multiple su turni lunghi.",
       "debolezza": "Rigidità tattica se gli input di telemetria arrivano in ritardo.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "guardia_situazionale",
-          "sigillo_forma",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "guardia_situazionale", "sigillo_forma", "starter_bioma"],
         "combo_totale": 6,
-        "forme": [
-          "ENTJ",
-          "ENTP",
-          "ESTJ",
-          "INTJ",
-          "ISTJ"
-        ],
+        "forme": ["ENTJ", "ENTP", "ESTJ", "INTJ", "ISTJ"],
         "tabelle_random": []
       }
+    },
+    "pigmenti_aurorali": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Può rendere visibili in scenari stealth.",
+      "famiglia_tipologia": "Tegumentario/Energetico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "pigmenti_aurorali",
+      "label": "Pigmenti Aurorali",
+      "mutazione_indotta": "Distribuisce cristalli fotoreattivi sotto la pelle.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "luminescenza",
+        "core": "tegumentario"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "cactus-weaver",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "evento-brinastorm",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "evento-ondata-termica",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "noctule-termico",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "silica-bloom",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "thermo-raptor",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "treant-portale",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Coordinare movimenti in tempeste magnetiche e notti polari.",
+      "tier": "T1",
+      "usage_tags": ["support"],
+      "uso_funzione": "Aiuta a disperdere gelo e funge da comunicazione ottica in tundre oscure."
+    },
+    "pigmenti_termici": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede cicli di scarico per non accumulare eccesso.",
+      "famiglia_tipologia": "Tegumentario/Energetico",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "pigmenti_termici",
+      "label": "Pigmenti Termici",
+      "mutazione_indotta": "Integra melanofori specializzati che modulano conduzione termica.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "termico",
+        "core": "tegumentario"
+      },
+      "species_affinity": [
+        {
+          "roles": ["core", "optional"],
+          "species_id": "evento-tempesta-ferrosa",
+          "weight": 4
+        }
+      ],
+      "spinta_selettiva": "Evitare colpi di calore e gestire improvvisi gradienti termici.",
+      "tier": "T1",
+      "usage_tags": ["sustain"],
+      "uso_funzione": "Regola sforzi in deserti ionici o camere vulcaniche."
     },
     "piume_solari_fotovoltaiche": {
       "label": "Piume Solari Fotovoltaiche",
@@ -6390,13 +7395,8 @@
         "complementare": "energetico",
         "core": "tegumentario"
       },
-      "sinergie": [
-        "membrane_eliofiltranti",
-        "sacche_spore_stratosferiche"
-      ],
-      "conflitti": [
-        "criostasi_adattiva"
-      ],
+      "sinergie": ["membrane_eliofiltranti", "sacche_spore_stratosferiche"],
+      "conflitti": ["criostasi_adattiva"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6431,12 +7431,8 @@
         "complementare": "aerobico",
         "core": "respiratorio"
       },
-      "sinergie": [
-        "membrane_eliofiltranti"
-      ],
-      "conflitti": [
-        "branchie_osmotiche_salmastra"
-      ],
+      "sinergie": ["membrane_eliofiltranti"],
+      "conflitti": ["branchie_osmotiche_salmastra"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6461,15 +7457,162 @@
         "tabelle_random": []
       }
     },
+    "proboscide_polifaga": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede igiene costante per prevenire infezioni crociate.",
+      "famiglia_tipologia": "Digestivo/Alimentare",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "proboscide_polifaga",
+      "label": "Proboscide Polifaga",
+      "mutazione_indotta": "Crea canali telescopici con denticoli intercambiabili e ghiandole solventi.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "raccolta",
+        "core": "digestivo"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "otyugh-sentinella",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Espandere dieta delle unità planarie adattabili.",
+      "tier": "T1",
+      "usage_tags": ["sustain"],
+      "uso_funzione": "Permette nutrimento versatile e raccolta risorse in biomi poveri."
+    },
+    "proteine_shock_termico": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Efficienza ridotta in ambienti criogenici senza co-tratti dedicati.",
+      "famiglia_tipologia": "Metabolico/Resilienza",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "proteine_shock_termico",
+      "label": "Proteine Shock Termico",
+      "mutazione_indotta": "Amplifica espressione di chaperon molecolari e sistemi di riparazione rapida.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "metabolico"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "cactus-weaver",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "evento-brinastorm",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "evento-ondata-termica",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "noctule-termico",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "silica-bloom",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "thermo-raptor",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Consentire operazioni in deserti e camere vulcaniche.",
+      "tier": "T1",
+      "usage_tags": ["sustain"],
+      "uso_funzione": "Impedisce denaturazione enzimatica in shock termici improvvisi."
+    },
+    "radici_ancora_planare": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Difficile da rimuovere rapidamente senza danni.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "radici_ancora_planare",
+      "label": "Radici Ancora Planare",
+      "mutazione_indotta": "Fa crescere radici cristalline che si agganciano a frattali rocciosi.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "ancoraggio",
+        "core": "strutturale"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "treant-portale",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Stabilizzare infrastrutture mobili e punti di evacuazione.",
+      "tier": "T2",
+      "usage_tags": ["tank"],
+      "uso_funzione": "Impedisce trascinamento da tempeste planari e crea nodi energetici stabili."
+    },
     "random": {
       "label": "Trait Random",
       "famiglia_tipologia": "Flessibile/Generico",
       "fattore_mantenimento_energetico": "Variabile (Dipende dal tratto estratto)",
       "tier": "T1",
-      "slot": [
-        "A",
-        "B"
-      ],
+      "slot": ["A", "B"],
       "slot_profile": {
         "complementare": "adattivo",
         "core": "strategia"
@@ -6482,17 +7625,86 @@
       "spinta_selettiva": "Draft rapidi o recuperi quando il tavolo necessita sorprese adattive.",
       "debolezza": "Bassa affidabilità: richiede slot aggiuntivi per mitigare risultati sfavorevoli.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "cap_pt",
-          "guardia_situazionale",
-          "job_ability:Random"
-        ],
+        "co_occorrenze": ["cap_pt", "guardia_situazionale", "job_ability:Random"],
         "combo_totale": 2,
-        "forme": [
-          "NEUTRA"
-        ],
+        "forme": ["NEUTRA"],
         "tabelle_random": []
       }
+    },
+    "respirazione_biologica": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Dipendenza da atmosfere respirabili.",
+      "famiglia_tipologia": "Respiratorio/Aerobico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "respirazione_biologica",
+      "label": "Respirazione Biologica",
+      "mutazione_indotta": "Ottimizza alveoli e rete capillare per massimizzare assorbimento di ossigeno.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "ossigeno",
+        "core": "respiratorio"
+      },
+      "species_affinity": [
+        {
+          "roles": ["core"],
+          "species_id": "archon-solare",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "balor-fission",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "bulette-fase",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "couatl-aurora",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "marilith-vault",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "otyugh-sentinella",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "rakshasa-corte",
+          "weight": 3
+        },
+        {
+          "roles": ["core"],
+          "species_id": "treant-portale",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Aumentare resistenza delle unità organiche convenzionali.",
+      "tier": "T1",
+      "usage_tags": ["sustain"],
+      "uso_funzione": "Supporta sforzi prolungati in atmosfere standard."
     },
     "respiro_a_scoppio": {
       "label": "Respiro a scoppio",
@@ -6504,10 +7716,7 @@
         "complementare": "propulsivo",
         "core": "respiratorio"
       },
-      "sinergie": [
-        "sacche_galleggianti_ascensoriali",
-        "squame_rifrangenti_deserto"
-      ],
+      "sinergie": ["sacche_galleggianti_ascensoriali", "squame_rifrangenti_deserto"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6533,16 +7742,155 @@
         "tabelle_random": []
       }
     },
+    "reti_capillari_radici": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Rotture della rete possono causare shock sistemici.",
+      "famiglia_tipologia": "Strutturale/Omeostatico",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "reti_capillari_radici",
+      "label": "Reti Capillari Radici",
+      "mutazione_indotta": "Crea capillari lignificati che collegano nodi periferici.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "nutrizione",
+        "core": "strutturale"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "cactus-weaver",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "evento-brinastorm",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "evento-ondata-termica",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "noctule-termico",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "silica-bloom",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "thermo-raptor",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "treant-portale",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Sostenere megaflora e colonie interconnesse.",
+      "tier": "T2",
+      "usage_tags": ["support"],
+      "uso_funzione": "Bilancia idratazione e risorse tra esemplari distanti."
+    },
+    "riflessi_preternaturali": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Affatica il sistema nervoso se mantenuto troppo a lungo.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Alto (Continuo)",
+      "id": "riflessi_preternaturali",
+      "label": "Riflessi Preternaturali",
+      "mutazione_indotta": "Aggiunge sinapsi a doppio stadio e buffer neurochimici.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "reazione",
+        "core": "sensoriale"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Superare predatori rapidi o automatismi letali.",
+      "tier": "T2",
+      "usage_tags": ["scout"],
+      "uso_funzione": "Consente schivate fulminee e contromisure immediate."
+    },
+    "rinforzi_modulari": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede manutenzione costante delle connessioni.",
+      "famiglia_tipologia": "Strutturale/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "rinforzi_modulari",
+      "label": "Rinforzi Modulari",
+      "mutazione_indotta": "Installa giunti magnetici che rilasciano moduli sacrificabili.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "armatura",
+        "core": "strutturale"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Prolungare integrità di strutture e bestie da assedio.",
+      "tier": "T2",
+      "usage_tags": ["tank"],
+      "uso_funzione": "Distribuisce danni e protegge componenti vitali durante assedi."
+    },
     "risonanza_di_branco": {
       "label": "Risonanza di Branco",
       "famiglia_tipologia": "Supporto/Coordinativo",
       "fattore_mantenimento_energetico": "Basso (Richiede mantenimento empatico)",
       "tier": "T1",
-      "slot": [
-        "A",
-        "B",
-        "C"
-      ],
+      "slot": ["A", "B", "C"],
       "slot_profile": {
         "complementare": "coordinazione",
         "core": "supporto"
@@ -6573,18 +7921,9 @@
       "spinta_selettiva": "Forme che eccellono in difesa coordinata e scudi sovrapposti.",
       "debolezza": "Stress elevato se la coesione cala sotto i target di telemetria.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "guardia_situazionale",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "guardia_situazionale", "starter_bioma"],
         "combo_totale": 3,
-        "forme": [
-          "ENFJ",
-          "INFP",
-          "ISFJ"
-        ],
+        "forme": ["ENFJ", "INFP", "ISFJ"],
         "tabelle_random": []
       }
     },
@@ -6652,12 +7991,8 @@
         "complementare": "supporto",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "piume_solari_fotovoltaiche"
-      ],
-      "conflitti": [
-        "respiro_a_scoppio"
-      ],
+      "sinergie": ["piume_solari_fotovoltaiche"],
+      "conflitti": ["respiro_a_scoppio"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6708,10 +8043,7 @@
         "lamelle_termoforetiche",
         "mantelli_geotermici"
       ],
-      "conflitti": [
-        "criostasi_adattiva",
-        "scheletro_idro_regolante"
-      ],
+      "conflitti": ["criostasi_adattiva", "scheletro_idro_regolante"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6764,9 +8096,7 @@
         "sacche_galleggianti_ascensoriali",
         "struttura_elastica_amorfa"
       ],
-      "conflitti": [
-        "sangue_piroforico"
-      ],
+      "conflitti": ["sangue_piroforico"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6802,10 +8132,7 @@
         "core": "tegumentario"
       },
       "sinergie": [],
-      "conflitti": [
-        "carapace_fase_variabile",
-        "nucleo_ovomotore_rotante"
-      ],
+      "conflitti": ["carapace_fase_variabile", "nucleo_ovomotore_rotante"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6830,6 +8157,80 @@
         "tabelle_random": []
       }
     },
+    "secrezioni_antisepsi": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Può interferire con simbionti benefici se abusato.",
+      "famiglia_tipologia": "Digestivo/Escretorio",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "secrezioni_antisepsi",
+      "label": "Secrezioni Antisepsi",
+      "mutazione_indotta": "Potenzia ghiandole escretorie con cocktail enzimatici disinfettanti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cura",
+        "core": "digestivo"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Mantenere linee operative in ambienti contaminati.",
+      "tier": "T1",
+      "usage_tags": ["sustain"],
+      "uso_funzione": "Disinfetta compagni feriti e riduce tempi di recupero."
+    },
+    "sensori_chimici": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Saturazione olfattiva può richiedere reset prolungato.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "sensori_chimici",
+      "label": "Sensori Chimici",
+      "mutazione_indotta": "Crea papille multifilari e camere olfattive potenziate.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "chimica",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "otyugh-sentinella",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Assicurare consapevolezza ambientale in regioni toxiche.",
+      "tier": "T1",
+      "usage_tags": ["scout"],
+      "uso_funzione": "Identifica veleni, prede e tracce invisibili."
+    },
     "sensori_geomagnetici": {
       "label": "Sensori Geomagnetici",
       "famiglia_tipologia": "Sensoriale/Navigazione",
@@ -6840,10 +8241,7 @@
         "complementare": "navigazione",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "eco_interno_riflesso"
-      ],
+      "sinergie": ["carapace_fase_variabile", "eco_interno_riflesso"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6897,9 +8295,7 @@
         "lamine_scudo_silice",
         "midollo_antivibrazione"
       ],
-      "conflitti": [
-        "spore_psichiche_silenziate"
-      ],
+      "conflitti": ["spore_psichiche_silenziate"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6924,6 +8320,74 @@
         "tabelle_random": []
       }
     },
+    "sinapsi_riflettenti": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Può creare dipendenza da pattern preimpostati.",
+      "famiglia_tipologia": "Sensoriale/Nervoso",
+      "fattore_mantenimento_energetico": "Medio (Continuo)",
+      "id": "sinapsi_riflettenti",
+      "label": "Sinapsi Riflettenti",
+      "mutazione_indotta": "Integra specchi sinaptici che ricalcano impulsi ottimali.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "memoria",
+        "core": "sensoriale"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Velocizzare addestramento di unità d'élite.",
+      "tier": "T2",
+      "usage_tags": ["support"],
+      "uso_funzione": "Riduce errori motori e migliora coordinazione con compagni."
+    },
+    "sinergizzatore_team": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Caduta drastica di resa se i ruoli previsti mancano.",
+      "famiglia_tipologia": "Supporto/Coordinativo",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "sinergizzatore_team",
+      "label": "Sinergizzatore di Team",
+      "mutazione_indotta": "Installa relè neurali che sincronizzano potenziamenti e cooldown condivisi.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "sinergia",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Massimizzare output di squadre composite.",
+      "tier": "T2",
+      "usage_tags": ["support"],
+      "uso_funzione": "Aumenta efficacia delle abilità combinate e delle catene di ruolo."
+    },
     "sonno_emisferico_alternato": {
       "label": "Dormire con solo metà cervello alla volta",
       "famiglia_tipologia": "Nervoso/Omeostatico",
@@ -6934,10 +8398,7 @@
         "complementare": "omeostatico",
         "core": "nervoso"
       },
-      "sinergie": [
-        "artigli_sghiaccio_glaciale",
-        "occhi_infrarosso_composti"
-      ],
+      "sinergie": ["artigli_sghiaccio_glaciale", "occhi_infrarosso_composti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6974,9 +8435,7 @@
         "core": "escretorio"
       },
       "sinergie": [],
-      "conflitti": [
-        "respiro_a_scoppio"
-      ],
+      "conflitti": ["respiro_a_scoppio"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -7011,12 +8470,8 @@
         "complementare": "difensivo",
         "core": "tegumentario"
       },
-      "sinergie": [
-        "respiro_a_scoppio"
-      ],
-      "conflitti": [
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["respiro_a_scoppio"],
+      "conflitti": ["mimetismo_cromatico_passivo"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -7113,9 +8568,7 @@
       "famiglia_tipologia": "Strategico/Tattico",
       "fattore_mantenimento_energetico": "Medio (Broadcast continuo di segnali)",
       "tier": "T1",
-      "slot": [
-        "B"
-      ],
+      "slot": ["B"],
       "slot_profile": {
         "complementare": "coordinazione",
         "core": "strategia"
@@ -7143,20 +8596,51 @@
       "spinta_selettiva": "Squadre che puntano a style bonus tramite assist e controllo spazio.",
       "debolezza": "Richiede formazione stabile; cala se la coesione precipita sotto il target.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "guardia_situazionale",
-          "sigillo_forma",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "guardia_situazionale", "sigillo_forma", "starter_bioma"],
         "combo_totale": 2,
-        "forme": [
-          "ESFJ",
-          "ESFP"
-        ],
+        "forme": ["ESFJ", "ESFP"],
         "tabelle_random": []
       }
+    },
+    "tessuti_adattivi": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Rallenta se sottoposto a stress costante senza riposo.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Medio (Continuo)",
+      "id": "tessuti_adattivi",
+      "label": "Tessuti Adattivi",
+      "mutazione_indotta": "Sviluppa fibre viscoelastiche con risposta controllata.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "adattamento",
+        "core": "strutturale"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "rakshasa-corte",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Adattarsi a pressioni variabili e combattimenti multi-terreno.",
+      "tier": "T2",
+      "usage_tags": ["tank"],
+      "uso_funzione": "Permette alternanza rapida tra postura difensiva e sprint improvvisi."
     },
     "vello_condensatore_nebbie": {
       "label": "Vello Condensatore di Nebbie",
@@ -7168,9 +8652,7 @@
         "complementare": "idratazione",
         "core": "tegumentario"
       },
-      "sinergie": [
-        "bulbi_radici_permafrost"
-      ],
+      "sinergie": ["bulbi_radici_permafrost"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -7247,15 +8729,97 @@
         "tabelle_random": []
       }
     },
+    "visione_spettrale": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Abbagliamento nelle esplosioni fotoniche improvvise.",
+      "famiglia_tipologia": "Sensoriale/Visivo",
+      "fattore_mantenimento_energetico": "Medio (Continuo)",
+      "id": "visione_spettrale",
+      "label": "Visione Spettrale",
+      "mutazione_indotta": "Aggiunge lenti multifase e filtri psionici alle unità ottiche.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "ricognizione",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "archon-solare",
+          "weight": 1
+        },
+        {
+          "roles": ["optional"],
+          "species_id": "marilith-vault",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Garantire copertura sensoriale totale in ambienti oscurati.",
+      "tier": "T1",
+      "usage_tags": ["scout"],
+      "uso_funzione": "Scova minacce occultate da camuffamenti energetici o oscurità."
+    },
+    "voce_spettrale": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Può attirare creature sensibili al suono se non schermato.",
+      "famiglia_tipologia": "Sensoriale/Supporto",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "voce_spettrale",
+      "label": "Voce Spettrale",
+      "mutazione_indotta": "Configura corde vocali a risonanza variabile che modulano segnali armonici.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "comunicazione",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": ["optional"],
+          "species_id": "banshee-risonante",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Mantenere controllo tattico in labirinti e dimensioni sovrapposte.",
+      "tier": "T1",
+      "usage_tags": ["controller"],
+      "uso_funzione": "Coordina squadre separate, disorienta nemici e amplifica comandi psionici."
+    },
     "zampe_a_molla": {
       "label": "Zampe a Molla",
       "famiglia_tipologia": "Mobilità/Cinetico",
       "fattore_mantenimento_energetico": "Basso (Carica elastica a turni alterni)",
       "tier": "T1",
-      "slot": [
-        "A",
-        "B"
-      ],
+      "slot": ["A", "B"],
       "slot_profile": {
         "complementare": "propulsione",
         "core": "locomotorio"
@@ -7284,16 +8848,9 @@
       "spinta_selettiva": "Metagame con forte pressione di aggro e necessità di riposizionamento.",
       "debolezza": "Perdita di valore su mappe con spazi stretti o controllo setup elevato.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "cap_pt",
-          "guardia_situazionale",
-          "job_ability:Skirmisher/Dash_Cut"
-        ],
+        "co_occorrenze": ["cap_pt", "guardia_situazionale", "job_ability:Skirmisher/Dash_Cut"],
         "combo_totale": 2,
-        "forme": [
-          "ESTP",
-          "ISFP"
-        ],
+        "forme": ["ESTP", "ISFP"],
         "tabelle_random": []
       }
     },
@@ -7307,12 +8864,8 @@
         "complementare": "supporto",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "cartilagine_flessotermica_venti"
-      ],
-      "conflitti": [
-        "zampe_a_molla"
-      ],
+      "sinergie": ["cartilagine_flessotermica_venti"],
+      "conflitti": ["zampe_a_molla"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -7343,9 +8896,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "difensivo"
-          ]
+          "type": ["difensivo"]
         }
       },
       "traits": [
@@ -7370,67 +8921,47 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "difesa"
-          ]
+          "type": ["difesa"]
         }
       },
-      "traits": [
-        "armatura_pietra_planare",
-        "mantello_meteoritico"
-      ],
+      "traits": ["armatura_pietra_planare", "mantello_meteoritico"],
       "type": "difesa"
     },
     "digestivo": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "digestivo"
-          ]
+          "type": ["digestivo"]
         }
       },
-      "traits": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "traits": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "type": "digestivo"
     },
     "escretorio": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "escretorio"
-          ]
+          "type": ["escretorio"]
         }
       },
-      "traits": [
-        "spore_psichiche_silenziate"
-      ],
+      "traits": ["spore_psichiche_silenziate"],
       "type": "escretorio"
     },
     "idrostatico": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "idrostatico"
-          ]
+          "type": ["idrostatico"]
         }
       },
-      "traits": [
-        "sacche_galleggianti_ascensoriali"
-      ],
+      "traits": ["sacche_galleggianti_ascensoriali"],
       "type": "idrostatico"
     },
     "locomotorio": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "locomotorio"
-          ]
+          "type": ["locomotorio"]
         }
       },
       "traits": [
@@ -7461,9 +8992,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "metabolico"
-          ]
+          "type": ["metabolico"]
         }
       },
       "traits": [
@@ -7489,23 +9018,17 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "nervoso"
-          ]
+          "type": ["nervoso"]
         }
       },
-      "traits": [
-        "sonno_emisferico_alternato"
-      ],
+      "traits": ["sonno_emisferico_alternato"],
       "type": "nervoso"
     },
     "offensivo": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "offensivo"
-          ]
+          "type": ["offensivo"]
         }
       },
       "traits": [
@@ -7532,9 +9055,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "respiratorio"
-          ]
+          "type": ["respiratorio"]
         }
       },
       "traits": [
@@ -7550,23 +9071,17 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "riproduttivo"
-          ]
+          "type": ["riproduttivo"]
         }
       },
-      "traits": [
-        "nucleo_ovomotore_rotante"
-      ],
+      "traits": ["nucleo_ovomotore_rotante"],
       "type": "riproduttivo"
     },
     "sensoriale": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "sensoriale"
-          ]
+          "type": ["sensoriale"]
         }
       },
       "traits": [
@@ -7598,9 +9113,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "simbiotico"
-          ]
+          "type": ["simbiotico"]
         }
       },
       "traits": [
@@ -7630,9 +9143,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "strategia"
-          ]
+          "type": ["strategia"]
         }
       },
       "traits": [
@@ -7661,9 +9172,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "strutturale"
-          ]
+          "type": ["strutturale"]
         }
       },
       "traits": [
@@ -7691,9 +9200,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "supporto"
-          ]
+          "type": ["supporto"]
         }
       },
       "traits": [
@@ -7720,9 +9227,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "tegumentario"
-          ]
+          "type": ["tegumentario"]
         }
       },
       "traits": [

--- a/packs/evo_tactics_pack/docs/catalog/trait_reference.json
+++ b/packs/evo_tactics_pack/docs/catalog/trait_reference.json
@@ -2,6 +2,287 @@
   "schema_version": "2.0",
   "trait_glossary": "data/core/traits/glossary.json",
   "traits": {
+    "Invoker": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede concentrazione e difesa durante l'incanalamento.",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "Invoker",
+      "label": "Canalizzatore",
+      "mutazione_indotta": "Stabilisce glifi viventi che ruotano energia tramite il nucleo dell'unità.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "canalizzazione",
+        "core": "strategia"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Sostenere squadre psioniche nelle fasi più intense di incursioni planari.",
+      "tier": "T2",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Amplifica combo energetiche e rituali di rinforzo."
+    },
+    "Skirmisher": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Ridotta resistenza in ingaggi prolungati.",
+      "famiglia_tipologia": "Locomotorio/Predatorio",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "Skirmisher",
+      "label": "Incursore Rapido",
+      "mutazione_indotta": "Riprogramma fibre muscolari per sprint brevi ad alta accelerazione.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "locomotorio"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Contenere bersagli mobili e sfruttare flanchi.",
+      "tier": "T1",
+      "usage_tags": [
+        "breaker"
+      ],
+      "uso_funzione": "Apre varchi rapidi nelle linee avversarie e si ritira prima della reazione."
+    },
+    "Strategist": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede telemetria costante; degrada in presenza di disturbi psionici prolungati.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "Strategist",
+      "label": "Stratega di Campo",
+      "mutazione_indotta": "Installa nodi decisionali ausiliari che calcolano traiettorie ottimali per l'intero plotone.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "coordinazione",
+        "core": "strategia"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Mantenere vantaggio decisionale su fronti dinamici con squilibri di numeri.",
+      "tier": "T1",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Dirige ingaggi multipli garantendo priorità condivise e gestione ordinata delle risorse."
+    },
+    "Support": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Vulnerabile a sovraccarichi se più unità critiche richiedono assistenza simultanea.",
+      "famiglia_tipologia": "Supporto/Coordinativo",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "Support",
+      "label": "Supporto Primario",
+      "mutazione_indotta": "Integra sacche di distribuzione e nodi telemetrici per seguire lo stato alleato in tempo reale.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistica",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Prolungare l'operatività delle squadre lontano da basi logistiche dedicate.",
+      "tier": "T1",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Stabilizza il team fornendo risorse rigenerate, cure leggere e compensazioni di morale."
+    },
+    "Vanguard": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Mobilità ridotta mentre le ancore sono estese.",
+      "famiglia_tipologia": "Supporto/Difesa",
+      "fattore_mantenimento_energetico": "Medio (Continuo)",
+      "id": "Vanguard",
+      "label": "Avanguardia Rinforzata",
+      "mutazione_indotta": "Addensa carapaci frontali e spine di stabilizzazione.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "difesa",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Stabilizzare linee di combattimento contro assalti pesanti.",
+      "tier": "T1",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Tiene posizione e protegge assetti fragili durante l'ingaggio iniziale."
+    },
+    "Warden": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede costante consapevolezza situazionale e canali di comando puliti.",
+      "famiglia_tipologia": "Supporto/Difesa",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "Warden",
+      "label": "Custode Difensivo",
+      "mutazione_indotta": "Integra glifi difensivi che redistribuiscono danni.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "controllo",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Creare zone sicure in campagne prolungate.",
+      "tier": "T1",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Protegge linee arretrate e convoglia minacce su traiettorie previste."
+    },
+    "adattamento_volo": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Sensibile a shock sonici che alterano la pressione interna delle camere.",
+      "famiglia_tipologia": "Locomotorio/Adattivo",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "adattamento_volo",
+      "label": "Adattamento al Volo",
+      "mutazione_indotta": "Ristruttura fasci muscolari e sacche pneumatiche per ottimizzare rollio e planata prolungata.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilità",
+        "core": "locomotorio"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "archon-solare",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "balor-fission",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Garantire copertura aerea persistente su regioni con venti multidirezionali.",
+      "tier": "T1",
+      "usage_tags": [
+        "scout"
+      ],
+      "uso_funzione": "Consente volo continuo anche in correnti erratiche e durante transizioni gravitazionali."
+    },
     "ali_fulminee": {
       "label": "Ali Fulminee",
       "famiglia_tipologia": "Sensoriale/Analitico",
@@ -121,6 +402,57 @@
         "forme": [],
         "tabelle_random": []
       }
+    },
+    "ali_solari_fotoni": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Perde efficienza in ombra persistente o durante tempeste di cenere.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ali_solari_fotoni",
+      "label": "Ali Solari a Fotoni",
+      "mutazione_indotta": "Genera membrane cristalline che immagazzinano fotoni e rilasciano microspinte direzionali.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "locomotorio"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "archon-solare",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Ridurre il fabbisogno energetico delle unità volanti su rotte lunghe.",
+      "tier": "T1",
+      "usage_tags": [
+        "scout"
+      ],
+      "uso_funzione": "Fornisce accelerazioni gratuite durante pattugliamenti diurni o orbitali."
     },
     "antenne_dustsense": {
       "label": "Antenne Dustsense",
@@ -572,6 +904,42 @@
         "tabelle_random": []
       }
     },
+    "architetto": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Necessita riserva materica dedicata; rallenta se le scorte crollano.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "architetto",
+      "label": "Nodo Architetto",
+      "mutazione_indotta": "Sviluppa sinapsi geometriche che tracciano ancoraggi e blueprint modulari.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "ingegneria",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Stabilizzare avamposti improvvisati in territori instabili.",
+      "tier": "T1",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Coordina costruzioni rapide, ponti provvisori e riparazioni sincronizzate."
+    },
     "armatura_pietra_planare": {
       "label": "Armatura di Pietra Planare",
       "famiglia_tipologia": "Difesa/Strutturale",
@@ -694,6 +1062,50 @@
         "forme": [],
         "tabelle_random": []
       }
+    },
+    "artigli_psionici": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Assorbe molta concentrazione; vulnerabile a interferenze antimagia.",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "artigli_psionici",
+      "label": "Artigli Psionici",
+      "mutazione_indotta": "Canalizza creste neuroconduttive che formano lame psioniche a geometria variabile.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "psionico",
+        "core": "offensivo"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Conferire ad assetti leggeri capacità d'assalto contro bersagli schermati.",
+      "tier": "T2",
+      "usage_tags": [
+        "breaker"
+      ],
+      "uso_funzione": "Taglia armature leggere e disarma avversari concentrando colpi telecinetici."
     },
     "artigli_radice": {
       "label": "Artigli Radice",
@@ -912,6 +1324,57 @@
         "forme": [],
         "tabelle_random": []
       }
+    },
+    "assenza_respirazione": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede spurghi frequenti per evitare accumulo di sottoprodotti metabolici.",
+      "famiglia_tipologia": "Respiratorio/Protezione",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "assenza_respirazione",
+      "label": "Assenza di Respirazione",
+      "mutazione_indotta": "Sigilla alveoli e inserisce camere catalitiche per riciclare gas metabolici.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "respiratorio"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "golem-runico",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Garantire continuità operativa in camere sigillate, vacuum o piani corrosivi.",
+      "tier": "T1",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Permette operazioni in ambienti privi di aria o saturi di agenti tossici."
     },
     "aura_scudo_radianza": {
       "label": "Aura Scudo di Radianza",
@@ -1735,6 +2198,42 @@
         "tabelle_random": []
       }
     },
+    "campo_di_fase": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Genera risonanze collaterali che possono interferire con apparati sensoriali alleati.",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Alto (Continuo)",
+      "id": "campo_di_fase",
+      "label": "Campo di Fase",
+      "mutazione_indotta": "Stabilisce matrici cristalline che modulano frequenze di fase sui tessuti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "psionico",
+        "core": "strategia"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Consentire manovre evasive decisive contro artiglieria o trappole planari.",
+      "tier": "T2",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Offre invulnerabilità breve o passaggio attraverso coperture non line-of-sight."
+    },
     "capillari_criogenici": {
       "label": "Capillari Criogenici",
       "famiglia_tipologia": "Strutturale/Adattivo",
@@ -2485,6 +2984,150 @@
         "tabelle_random": []
       }
     },
+    "ciclo_vitale_anomalo": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Difficile sincronizzare con programmi di allevamento o catene logistiche standard.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ciclo_vitale_anomalo",
+      "label": "Ciclo Vitale Anomalo",
+      "mutazione_indotta": "Ristruttura organi germinali per riattivarsi su cicli imprevedibili.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "golem-runico",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Garantire persistenza di specie sintetiche o planari in ecosistemi ostili.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Mantiene popolazioni attive anche dopo perdite massicce tramite scissioni rigenerative."
+    },
+    "ciclo_vitale_completo": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Prevedibilità elevata che può essere sfruttata da predatori intelligenti.",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ciclo_vitale_completo",
+      "label": "Ciclo Vitale Completo",
+      "mutazione_indotta": "Affina ghiandole endocrine e pattern epigenetici per mantenere cicli regolari.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "riproduttivo",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "archon-solare",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "balor-fission",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "treant-portale",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Massimizzare rendimento riproduttivo in ambienti regolati.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Facilita allevamento e rotazioni pianificate nelle colonie adattive."
+    },
     "circolazione_bifasica": {
       "label": "Circolazione Bifasica",
       "famiglia_tipologia": "Tegumentario/Difensivo",
@@ -3203,6 +3846,50 @@
         "tabelle_random": []
       }
     },
+    "corteccia_memetica": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Suscettibile a sovraccarichi memetici se esposto a segnali ostili.",
+      "famiglia_tipologia": "Sensoriale/Nervoso",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "corteccia_memetica",
+      "label": "Corteccia Memetica",
+      "mutazione_indotta": "Integra dendriti cristallini che replicano rapidamente schemi imparati.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "memetica",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "treant-portale",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Ridurre tempi di addestramento per squadre miste e neoformate.",
+      "tier": "T2",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Condivide schemi di combattimento e soluzioni ambientali in tempo reale."
+    },
     "criostasi_adattiva": {
       "label": "Criostasi",
       "famiglia_tipologia": "Metabolico/Difensivo",
@@ -3737,6 +4424,50 @@
         "tabelle_random": []
       }
     },
+    "eco_sismico": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Rumore meccanico continuo può saturare i recettori.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "eco_sismico",
+      "label": "Eco Sismico",
+      "mutazione_indotta": "Forma camere ossee e filamenti sensibili a microfratture e onde elastiche.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "geofonia",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Garantire sicurezza in biomi instabili o in città sotterranee.",
+      "tier": "T1",
+      "usage_tags": [
+        "scout"
+      ],
+      "uso_funzione": "Anticipa frane, movimenti sotterranei e intrusioni mimetizzate."
+    },
     "empatia_coordinativa": {
       "label": "Empatia Coordinativa",
       "famiglia_tipologia": "Supporto/Empatico",
@@ -4234,6 +4965,50 @@
         "tabelle_random": []
       }
     },
+    "filtri_bioattivi": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Rallenta la digestione in assenza di sostanze da metabolizzare.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "filtri_bioattivi",
+      "label": "Filtri Bioattivi",
+      "mutazione_indotta": "Introduce microcolonie simbionti che degradano agenti chimici in catene nutrienti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "detox",
+        "core": "metabolico"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Espandere la gamma alimentare in territori compromessi.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Permette ingestione sicura di biomi contaminati e risorse marginali."
+    },
     "filtri_planctonici": {
       "label": "Filtri Planctonici",
       "famiglia_tipologia": "Tegumentario/Difensivo",
@@ -4273,6 +5048,50 @@
         "forme": [],
         "tabelle_random": []
       }
+    },
+    "fisiologia_predatoria": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede apporto calorico elevato per mantenere performance.",
+      "famiglia_tipologia": "Locomotorio/Predatorio",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "fisiologia_predatoria",
+      "label": "Fisiologia Predatoria",
+      "mutazione_indotta": "Potenzia fibre muscolari e dentizione per impatti rapidi e trattenimento.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "predazione",
+        "core": "offensivo"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Dominare catene alimentari dinamiche e contenere infestazioni aggressive.",
+      "tier": "T1",
+      "usage_tags": [
+        "breaker"
+      ],
+      "uso_funzione": "Eleva l'efficacia offensiva contro bersagli mobili o evasivi."
     },
     "flagelli_ancoranti": {
       "label": "Flagelli Ancoranti",
@@ -4447,6 +5266,42 @@
         "forme": [],
         "tabelle_random": []
       }
+    },
+    "fotosintesi_bifase": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Sensibile a blackout prolungati o cieli oscurati.",
+      "famiglia_tipologia": "Metabolico/Resilienza",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "fotosintesi_bifase",
+      "label": "Fotosintesi Bifase",
+      "mutazione_indotta": "Introduce lamelle pigmentate che cambiano configurazione tra fase diurna e notturna.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Stabilizzare colonie vegetali o fotosensibili in cicli lunghi irregolari.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Mantiene produzione energetica senza dipendere da fonti esterne continuative."
     },
     "frusta_fiammeggiante": {
       "label": "Frusta Fiammeggiante",
@@ -5003,6 +5858,50 @@
         "tabelle_random": []
       }
     },
+    "ghiandole_nettare_memetico": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Può attrarre parassiti memetici se non schermato.",
+      "famiglia_tipologia": "Supporto/Empatico",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "ghiandole_nettare_memetico",
+      "label": "Ghiandole di Nettare Memetico",
+      "mutazione_indotta": "Coltiva sacche ghiandolari che diffondono feromoni memetici con pattern coordinativi.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Ridurre caos operativo in battaglie multi-nodo.",
+      "tier": "T2",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Aumenta coesione di squadra e velocità di risposta degli sciami collegati."
+    },
     "ghiandole_resina_conduttiva": {
       "label": "Ghiandole Resina Conduttiva",
       "famiglia_tipologia": "Sensoriale/Analitico",
@@ -5230,6 +6129,50 @@
         "tabelle_random": []
       }
     },
+    "intangibilita_parziale": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Fatica a mantenersi attivo sotto fuoco concentrato o campi antimagia.",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Alto (Continuo)",
+      "id": "intangibilita_parziale",
+      "label": "Intangibilità Parziale",
+      "mutazione_indotta": "Installa nodi quantici che modulano densità atomica per pochi istanti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "evasione",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Sbloccare percorsi impraticabili e sfuggire a crowd control.",
+      "tier": "T2",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Permette attraversamento di barriere, trappole e catene di contenimento."
+    },
     "lamelle_shear": {
       "label": "Lamelle Shear",
       "famiglia_tipologia": "Strategico/Tattico",
@@ -5349,6 +6292,50 @@
         "forme": [],
         "tabelle_random": []
       }
+    },
+    "lamenti_diradanti": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Efficacia ridotta contro unità sorde o schermate.",
+      "famiglia_tipologia": "Sensoriale/Supporto",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "lamenti_diradanti",
+      "label": "Lamenti Diradanti",
+      "mutazione_indotta": "Sviluppa corde vocali multiple che modulano frequenze dissonanti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "psicoacustica",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Contenere assalti di massa e agevolare disperdimento di branchi planari.",
+      "tier": "T2",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Riduce precisione e morale dei bersagli nell'area d'effetto."
     },
     "lamine_filtranti_aeree": {
       "label": "Lamine Filtranti Aeree",
@@ -5712,6 +6699,94 @@
         "tabelle_random": []
       }
     },
+    "maschera_illusoria": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Fragile contro sensori multispettrali avanzati.",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "maschera_illusoria",
+      "label": "Maschera Illusoria",
+      "mutazione_indotta": "Genera organi olografici che rifrangono segnali in output scelti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mimetismo",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Confondere targeting automatico e ritardare rilevamento.",
+      "tier": "T1",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Occulta assetti prioritari o li presenta come obiettivi minori."
+    },
+    "matrice_antimagia": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Surriscaldamento se l'esposizione è prolungata senza dissipazione.",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Alto (Continuo)",
+      "id": "matrice_antimagia",
+      "label": "Matrice Antimagia",
+      "mutazione_indotta": "Integra nodi parafulmine e cristalli paraeterei nel tegumento.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "golem-runico",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Neutralizzare minacce magiche in scenari ad alta densità psionica.",
+      "tier": "T2",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Spezza incantesimi ostili, annulla campi di controllo e protegge assetti tecnologici."
+    },
     "membrane_captura_rugiada": {
       "label": "Membrane Captura Rugiada",
       "famiglia_tipologia": "Strategico/Tattico",
@@ -5790,6 +6865,50 @@
         "forme": [],
         "tabelle_random": []
       }
+    },
+    "membrane_osmotiche": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede cicli di purga regolari per evitare saturazione.",
+      "famiglia_tipologia": "Respiratorio/Osmoregolazione",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "membrane_osmotiche",
+      "label": "Membrane Osmotiche",
+      "mutazione_indotta": "Aggiunge microcanali adattivi che bilanciano gradienti salini.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "omeostasi",
+        "core": "respiratorio"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Garantire equilibrio idrico per assetti anfibi o planari.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Permette sopravvivenza prolungata in acque salmastre o deserti ionici."
     },
     "membrane_planata_vectored": {
       "label": "Membrane Planata Vectored",
@@ -5870,6 +6989,150 @@
         "forme": [],
         "tabelle_random": []
       }
+    },
+    "metabolismo_attivo": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Consumo calorico elevato che impone rifornimenti frequenti.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Medio (Continuo)",
+      "id": "metabolismo_attivo",
+      "label": "Metabolismo Attivo",
+      "mutazione_indotta": "Amplifica mitocondri e flussi enzimatici per sprigionare energia immediata.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "archon-solare",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "balor-fission",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "treant-portale",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Potenziare unità che necessitano output costante e recupero accelerato.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Supporta sforzi intensi e rigenerazione rapida durante campagne estese."
+    },
+    "metabolismo_sostentato": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Output esplosivo limitato rispetto ai profili attivi.",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "metabolismo_sostentato",
+      "label": "Metabolismo Sostentato",
+      "mutazione_indotta": "Riprogramma cicli catabolici per recuperare ogni caloria disponibile.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "risparmio",
+        "core": "metabolico"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "golem-runico",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Mantenere operativi esploratori e costrutti in ambienti poveri di nutrienti.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Permette sopravvivenza prolungata senza rifornimenti o durante letarghi tattici."
     },
     "midollo_antivibrazione": {
       "label": "Midollo Antivibrazione",
@@ -6167,6 +7430,86 @@
         "tabelle_random": []
       }
     },
+    "nodi_micotici": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Vulnerabile a agenti antifungini mirati.",
+      "famiglia_tipologia": "Simbiotico/Supporto",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "nodi_micotici",
+      "label": "Nodi Micotici",
+      "mutazione_indotta": "Coltiva rizomi sensibili che formano hub di comunicazione sotterranei.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "simbiosi",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Stabilizzare difese statiche e colonie radicate.",
+      "tier": "T2",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Fornisce backup energetico e sincronizzazione di stato agli alleati connessi."
+    },
+    "nuclei_di_controllo": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Punto singolo d'insuccesso se neutralizzato.",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "nuclei_di_controllo",
+      "label": "Nuclei di Controllo",
+      "mutazione_indotta": "Integra nuclei gangliari corazzati con capacità broadcast a lungo raggio.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "comando",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "golem-runico",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Aumentare coesione di reti comandate da remoto.",
+      "tier": "T2",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Gestisce droni, appendici autonome e reparti subordinati."
+    },
     "nucleo_ovomotore_rotante": {
       "label": "Uovo rotaia, uovo grande e uova piccole dentro...",
       "famiglia_tipologia": "Riproduttivo/Locomotorio",
@@ -6295,6 +7638,57 @@
         "tabelle_random": []
       }
     },
+    "origine_artificiale": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Dipende da ricambi o blueprint specifici.",
+      "famiglia_tipologia": "Strutturale/Omeostatico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "origine_artificiale",
+      "label": "Origine Artificiale",
+      "mutazione_indotta": "Installa matrici di auto-diagnosi e punti di montaggio standardizzati.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "ingegneria",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "golem-runico",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Rendere replicabili gli assetti costruiti in laboratorio.",
+      "tier": "T1",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Facilita riparazioni rapide e riprogrammazione modulare."
+    },
     "pathfinder": {
       "label": "Pathfinder",
       "famiglia_tipologia": "Esplorazione/Tattico",
@@ -6326,6 +7720,188 @@
         ],
         "tabelle_random": []
       }
+    },
+    "pelli_anti_ustione": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Riduce elasticità cutanea se disidratato.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "pelli_anti_ustione",
+      "label": "Pelli Anti Ustione",
+      "mutazione_indotta": "Deposita scaglie silicatiche e fluidi anti-piretici negli strati superficiali.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "termico",
+        "core": "tegumentario"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "evento-tempesta-ferrosa",
+          "weight": 4
+        }
+      ],
+      "spinta_selettiva": "Consentire presenza prolungata in deserti ionici e fonderie planari.",
+      "tier": "T1",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Protegge da ustioni, plasma e scariche termiche improvvise."
+    },
+    "pelli_cave": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Ingombro aggiuntivo che rallenta in ambienti saturi d'acqua.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "pelli_cave",
+      "label": "Pelli Cave",
+      "mutazione_indotta": "Forma alveoli dermici che catturano aria calda o fredda a seconda del gradiente.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "termico",
+        "core": "tegumentario"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cactus-weaver",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-brinastorm",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-ondata-termica",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "noctule-termico",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "silica-bloom",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thermo-raptor",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Ridurre shock termici durante spostamenti rapidi tra biomi.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Stabilizza temperatura in climi continentali estremi."
+    },
+    "pelli_fitte": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Peso extra che limita movimenti rapidi.",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "pelli_fitte",
+      "label": "Pelli Fitte",
+      "mutazione_indotta": "Addensa fibre collagene e microplacche cheratiniche.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "tegumentario"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-seme-uragano",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Rendere le linee frontali più resistenti senza sacrificare mobilità di base.",
+      "tier": "T1",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Riduce penetrazione di proiettili leggeri e dissipa impatti blandi."
     },
     "pianificatore": {
       "label": "Pianificatore",
@@ -6379,6 +7955,144 @@
         ],
         "tabelle_random": []
       }
+    },
+    "pigmenti_aurorali": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Può rendere visibili in scenari stealth.",
+      "famiglia_tipologia": "Tegumentario/Energetico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "pigmenti_aurorali",
+      "label": "Pigmenti Aurorali",
+      "mutazione_indotta": "Distribuisce cristalli fotoreattivi sotto la pelle.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "luminescenza",
+        "core": "tegumentario"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cactus-weaver",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-brinastorm",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-ondata-termica",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "noctule-termico",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "silica-bloom",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thermo-raptor",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "treant-portale",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Coordinare movimenti in tempeste magnetiche e notti polari.",
+      "tier": "T1",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Aiuta a disperdere gelo e funge da comunicazione ottica in tundre oscure."
+    },
+    "pigmenti_termici": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede cicli di scarico per non accumulare eccesso.",
+      "famiglia_tipologia": "Tegumentario/Energetico",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "pigmenti_termici",
+      "label": "Pigmenti Termici",
+      "mutazione_indotta": "Integra melanofori specializzati che modulano conduzione termica.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "termico",
+        "core": "tegumentario"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "species_id": "evento-tempesta-ferrosa",
+          "weight": 4
+        }
+      ],
+      "spinta_selettiva": "Evitare colpi di calore e gestire improvvisi gradienti termici.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Regola sforzi in deserti ionici o camere vulcaniche."
     },
     "piume_solari_fotovoltaiche": {
       "label": "Piume Solari Fotovoltaiche",
@@ -6461,6 +8175,180 @@
         "tabelle_random": []
       }
     },
+    "proboscide_polifaga": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede igiene costante per prevenire infezioni crociate.",
+      "famiglia_tipologia": "Digestivo/Alimentare",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "proboscide_polifaga",
+      "label": "Proboscide Polifaga",
+      "mutazione_indotta": "Crea canali telescopici con denticoli intercambiabili e ghiandole solventi.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "raccolta",
+        "core": "digestivo"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Espandere dieta delle unità planarie adattabili.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Permette nutrimento versatile e raccolta risorse in biomi poveri."
+    },
+    "proteine_shock_termico": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Efficienza ridotta in ambienti criogenici senza co-tratti dedicati.",
+      "famiglia_tipologia": "Metabolico/Resilienza",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "proteine_shock_termico",
+      "label": "Proteine Shock Termico",
+      "mutazione_indotta": "Amplifica espressione di chaperon molecolari e sistemi di riparazione rapida.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "metabolico"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cactus-weaver",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-brinastorm",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-ondata-termica",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "noctule-termico",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "silica-bloom",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thermo-raptor",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Consentire operazioni in deserti e camere vulcaniche.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Impedisce denaturazione enzimatica in shock termici improvvisi."
+    },
+    "radici_ancora_planare": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Difficile da rimuovere rapidamente senza danni.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "radici_ancora_planare",
+      "label": "Radici Ancora Planare",
+      "mutazione_indotta": "Fa crescere radici cristalline che si agganciano a frattali rocciosi.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "ancoraggio",
+        "core": "strutturale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "treant-portale",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Stabilizzare infrastrutture mobili e punti di evacuazione.",
+      "tier": "T2",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Impedisce trascinamento da tempeste planari e crea nodi energetici stabili."
+    },
     "random": {
       "label": "Trait Random",
       "famiglia_tipologia": "Flessibile/Generico",
@@ -6493,6 +8381,99 @@
         ],
         "tabelle_random": []
       }
+    },
+    "respirazione_biologica": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Dipendenza da atmosfere respirabili.",
+      "famiglia_tipologia": "Respiratorio/Aerobico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "respirazione_biologica",
+      "label": "Respirazione Biologica",
+      "mutazione_indotta": "Ottimizza alveoli e rete capillare per massimizzare assorbimento di ossigeno.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "ossigeno",
+        "core": "respiratorio"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "archon-solare",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "balor-fission",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "bulette-fase",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "couatl-aurora",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "treant-portale",
+          "weight": 3
+        }
+      ],
+      "spinta_selettiva": "Aumentare resistenza delle unità organiche convenzionali.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Supporta sforzi prolungati in atmosfere standard."
     },
     "respiro_a_scoppio": {
       "label": "Respiro a scoppio",
@@ -6532,6 +8513,171 @@
         "forme": [],
         "tabelle_random": []
       }
+    },
+    "reti_capillari_radici": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Rotture della rete possono causare shock sistemici.",
+      "famiglia_tipologia": "Strutturale/Omeostatico",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "reti_capillari_radici",
+      "label": "Reti Capillari Radici",
+      "mutazione_indotta": "Crea capillari lignificati che collegano nodi periferici.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "nutrizione",
+        "core": "strutturale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "cactus-weaver",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-brinastorm",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "evento-ondata-termica",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "global-trait-keeper",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "noctule-termico",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "silica-bloom",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "thermo-raptor",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "treant-portale",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Sostenere megaflora e colonie interconnesse.",
+      "tier": "T2",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Bilancia idratazione e risorse tra esemplari distanti."
+    },
+    "riflessi_preternaturali": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Affatica il sistema nervoso se mantenuto troppo a lungo.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Alto (Continuo)",
+      "id": "riflessi_preternaturali",
+      "label": "Riflessi Preternaturali",
+      "mutazione_indotta": "Aggiunge sinapsi a doppio stadio e buffer neurochimici.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "reazione",
+        "core": "sensoriale"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Superare predatori rapidi o automatismi letali.",
+      "tier": "T2",
+      "usage_tags": [
+        "scout"
+      ],
+      "uso_funzione": "Consente schivate fulminee e contromisure immediate."
+    },
+    "rinforzi_modulari": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede manutenzione costante delle connessioni.",
+      "famiglia_tipologia": "Strutturale/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "rinforzi_modulari",
+      "label": "Rinforzi Modulari",
+      "mutazione_indotta": "Installa giunti magnetici che rilasciano moduli sacrificabili.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "armatura",
+        "core": "strutturale"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Prolungare integrità di strutture e bestie da assedio.",
+      "tier": "T2",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Distribuisce danni e protegge componenti vitali durante assedi."
     },
     "risonanza_di_branco": {
       "label": "Risonanza di Branco",
@@ -6830,6 +8976,86 @@
         "tabelle_random": []
       }
     },
+    "secrezioni_antisepsi": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Può interferire con simbionti benefici se abusato.",
+      "famiglia_tipologia": "Digestivo/Escretorio",
+      "fattore_mantenimento_energetico": "Medio (Ciclico)",
+      "id": "secrezioni_antisepsi",
+      "label": "Secrezioni Antisepsi",
+      "mutazione_indotta": "Potenzia ghiandole escretorie con cocktail enzimatici disinfettanti.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cura",
+        "core": "digestivo"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Mantenere linee operative in ambienti contaminati.",
+      "tier": "T1",
+      "usage_tags": [
+        "sustain"
+      ],
+      "uso_funzione": "Disinfetta compagni feriti e riduce tempi di recupero."
+    },
+    "sensori_chimici": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Saturazione olfattiva può richiedere reset prolungato.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "sensori_chimici",
+      "label": "Sensori Chimici",
+      "mutazione_indotta": "Crea papille multifilari e camere olfattive potenziate.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "chimica",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "otyugh-sentinella",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Assicurare consapevolezza ambientale in regioni toxiche.",
+      "tier": "T1",
+      "usage_tags": [
+        "scout"
+      ],
+      "uso_funzione": "Identifica veleni, prede e tracce invisibili."
+    },
     "sensori_geomagnetici": {
       "label": "Sensori Geomagnetici",
       "famiglia_tipologia": "Sensoriale/Navigazione",
@@ -6923,6 +9149,78 @@
         "forme": [],
         "tabelle_random": []
       }
+    },
+    "sinapsi_riflettenti": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Può creare dipendenza da pattern preimpostati.",
+      "famiglia_tipologia": "Sensoriale/Nervoso",
+      "fattore_mantenimento_energetico": "Medio (Continuo)",
+      "id": "sinapsi_riflettenti",
+      "label": "Sinapsi Riflettenti",
+      "mutazione_indotta": "Integra specchi sinaptici che ricalcano impulsi ottimali.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "memoria",
+        "core": "sensoriale"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Velocizzare addestramento di unità d'élite.",
+      "tier": "T2",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Riduce errori motori e migliora coordinazione con compagni."
+    },
+    "sinergizzatore_team": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Caduta drastica di resa se i ruoli previsti mancano.",
+      "famiglia_tipologia": "Supporto/Coordinativo",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "sinergizzatore_team",
+      "label": "Sinergizzatore di Team",
+      "mutazione_indotta": "Installa relè neurali che sincronizzano potenziamenti e cooldown condivisi.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "sinergia",
+        "core": "supporto"
+      },
+      "species_affinity": [],
+      "spinta_selettiva": "Massimizzare output di squadre composite.",
+      "tier": "T2",
+      "usage_tags": [
+        "support"
+      ],
+      "uso_funzione": "Aumenta efficacia delle abilità combinate e delle catene di ruolo."
     },
     "sonno_emisferico_alternato": {
       "label": "Dormire con solo metà cervello alla volta",
@@ -7158,6 +9456,50 @@
         "tabelle_random": []
       }
     },
+    "tessuti_adattivi": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Rallenta se sottoposto a stress costante senza riposo.",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Medio (Continuo)",
+      "id": "tessuti_adattivi",
+      "label": "Tessuti Adattivi",
+      "mutazione_indotta": "Sviluppa fibre viscoelastiche con risposta controllata.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "adattamento",
+        "core": "strutturale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "rakshasa-corte",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Adattarsi a pressioni variabili e combattimenti multi-terreno.",
+      "tier": "T2",
+      "usage_tags": [
+        "tank"
+      ],
+      "uso_funzione": "Permette alternanza rapida tra postura difensiva e sprint improvvisi."
+    },
     "vello_condensatore_nebbie": {
       "label": "Vello Condensatore di Nebbie",
       "famiglia_tipologia": "Tegumentario/Idratazione",
@@ -7246,6 +9588,101 @@
         "forme": [],
         "tabelle_random": []
       }
+    },
+    "visione_spettrale": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Abbagliamento nelle esplosioni fotoniche improvvise.",
+      "famiglia_tipologia": "Sensoriale/Visivo",
+      "fattore_mantenimento_energetico": "Medio (Continuo)",
+      "id": "visione_spettrale",
+      "label": "Visione Spettrale",
+      "mutazione_indotta": "Aggiunge lenti multifase e filtri psionici alle unità ottiche.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "ricognizione",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "archon-solare",
+          "weight": 1
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Garantire copertura sensoriale totale in ambienti oscurati.",
+      "tier": "T1",
+      "usage_tags": [
+        "scout"
+      ],
+      "uso_funzione": "Scova minacce occultate da camuffamenti energetici o oscurità."
+    },
+    "voce_spettrale": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Può attirare creature sensibili al suono se non schermato.",
+      "famiglia_tipologia": "Sensoriale/Supporto",
+      "fattore_mantenimento_energetico": "Medio (Attivo)",
+      "id": "voce_spettrale",
+      "label": "Voce Spettrale",
+      "mutazione_indotta": "Configura corde vocali a risonanza variabile che modulano segnali armonici.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "comunicazione",
+        "core": "supporto"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Mantenere controllo tattico in labirinti e dimensioni sovrapposte.",
+      "tier": "T1",
+      "usage_tags": [
+        "controller"
+      ],
+      "uso_funzione": "Coordina squadre separate, disorienta nemici e amplifica comandi psionici."
     },
     "zampe_a_molla": {
       "label": "Zampe a Molla",


### PR DESCRIPTION
## Summary
- add definitions for the 45 previously missing trait IDs referenced by the regenerated species matrix
- sync the trait glossary and bundled/web trait references with the new entries to keep downstream consumers in parity

## Testing
- python tools/py/check_missing_traits.py

------
https://chatgpt.com/codex/tasks/task_e_6907e8acedf083328dac42abd75be024