### PR TITLE
Ensure matchmaking summaries are returned immutably

### DIFF
--- a/src/api/matchmaking.ts
+++ b/src/api/matchmaking.ts
@@ -32,6 +32,9 @@ interface CacheEntry {
   payload: MatchmakingSummary[];
 }
 
+const cloneSummaries = (summaries: MatchmakingSummary[]): MatchmakingSummary[] =>
+  summaries.map((entry) => ({ ...entry }));
+
 export type FlattenedFilters = Record<string, string | number | boolean>;
 
 export const MATCHMAKING_ENDPOINT = '/api/matchmaking';
@@ -125,7 +128,7 @@ export class MatchmakingClient {
     const cached = this.cache.get(key);
 
     if (cached && cached.expiresAt > currentTime) {
-      return cached.payload;
+      return cloneSummaries(cached.payload);
     }
 
     const url = `${this.baseUrl}${buildQueryString(filters)}`;
@@ -142,14 +145,14 @@ export class MatchmakingClient {
       throw new Error('Risposta matchmaking non valida.');
     }
 
-    const immutablePayload = payload.map((entry) => ({ ...entry }));
+    const cachedPayload = cloneSummaries(payload);
 
     this.cache.set(key, {
       expiresAt: currentTime + this.cacheTtlMs,
-      payload: immutablePayload,
+      payload: cachedPayload,
     });
 
-    return immutablePayload;
+    return cloneSummaries(cachedPayload);
   }
 }
 

--- a/tests/matchmaking/filters.spec.ts
+++ b/tests/matchmaking/filters.spec.ts
@@ -26,9 +26,9 @@ describe('Matchmaking — combinazione filtri', () => {
       const url =
         typeof input === 'string'
           ? input
-          : (typeof input === 'object' && input && 'url' in input
-              ? String((input as { url: string }).url)
-              : String(input));
+          : typeof input === 'object' && input && 'url' in input
+            ? String((input as { url: string }).url)
+            : String(input);
       capturedUrls.push(url);
       return {
         ok: true,
@@ -54,11 +54,7 @@ describe('Matchmaking — combinazione filtri', () => {
     const first = await client.fetchSummaries(filters);
     assert.strictEqual(first.length, 1, 'il payload deve essere restituito');
     assert.strictEqual(capturedUrls.length, 1, 'la prima richiesta deve raggiungere la rete');
-    assert.match(
-      capturedUrls[0],
-      /region=EU/,
-      'la query deve contenere il filtro regione',
-    );
+    assert.match(capturedUrls[0], /region=EU/, 'la query deve contenere il filtro regione');
     assert.match(capturedUrls[0], /mode=ranked/, 'la query deve contenere il filtro modalità');
     assert.match(capturedUrls[0], /teamSize=3/, 'la query deve includere la dimensione squadra');
     assert.match(capturedUrls[0], /crossplay=false/, 'la query deve includere cross-play');
@@ -72,7 +68,75 @@ describe('Matchmaking — combinazione filtri', () => {
     currentTime += 10_000;
     const third = await client.fetchSummaries(filters);
     assert.strictEqual(third.length, 1, 'anche dopo la scadenza deve tornare dati validi');
-    assert.strictEqual(capturedUrls.length, 2, 'dopo la scadenza deve essere effettuata una nuova richiesta');
+    assert.strictEqual(
+      capturedUrls.length,
+      2,
+      'dopo la scadenza deve essere effettuata una nuova richiesta',
+    );
+  });
+
+  it('mantiene immutabile il payload restituito dalla cache', async () => {
+    let currentTime = 1000;
+    let fetchCount = 0;
+    const responsePayload = [
+      {
+        id: 'match-002',
+        region: 'NA',
+        mode: 'casual',
+        playersInQueue: 850,
+        averageWaitTime: 42,
+        updatedAt: new Date().toISOString(),
+      },
+    ];
+
+    const fetchStub: typeof fetch = async () => {
+      fetchCount += 1;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => responsePayload,
+      } as unknown as Response;
+    };
+
+    const client = new MatchmakingClient({
+      fetch: fetchStub,
+      cacheTtlMs: 5_000,
+      now: () => currentTime,
+    });
+
+    const filters: MatchmakingFilter = { region: 'NA', mode: 'casual' };
+
+    const first = await client.fetchSummaries(filters);
+    assert.strictEqual(fetchCount, 1, 'la prima chiamata deve interrogare la rete');
+    first[0].playersInQueue = 9999;
+
+    const second = await client.fetchSummaries(filters);
+    assert.strictEqual(fetchCount, 1, 'la seconda chiamata deve usare la cache');
+    assert.notStrictEqual(second, first, 'la cache deve restituire un nuovo array');
+    assert.strictEqual(
+      second[0].playersInQueue,
+      responsePayload[0].playersInQueue,
+      'la risposta cache deve contenere i dati originali',
+    );
+
+    second[0].playersInQueue = 1234;
+    second.push({
+      id: 'match-extra',
+      region: 'NA',
+      mode: 'casual',
+      playersInQueue: 10,
+      averageWaitTime: 5,
+      updatedAt: responsePayload[0].updatedAt,
+    });
+
+    const third = await client.fetchSummaries(filters);
+    assert.strictEqual(fetchCount, 1, 'le richieste successive devono continuare a usare la cache');
+    assert.notStrictEqual(third, second, 'ogni chiamata deve restituire un nuovo array');
+    assert.deepStrictEqual(
+      third,
+      responsePayload,
+      'la mutazione della risposta cache non deve influenzare la cache interna',
+    );
   });
 
   it('registra eventi analytics per filtri combinati e reset', () => {


### PR DESCRIPTION
## Summary
- return deep copies of matchmaking summaries both when caching and when serving cached payloads
- extend the matchmaking cache test suite to ensure cached responses cannot be mutated externally

## Testing
- npx tsx --test tests/matchmaking/filters.spec.ts

------
https://chatgpt.com/codex/tasks/task_b_6907f4df3c3c832a9975fd9ca9c9c254