### PR TITLE
Normalize PI trait slug references

### DIFF
--- a/data/derived/analysis/trait_env_mapping.json
+++ b/data/derived/analysis/trait_env_mapping.json
@@ -574,7 +574,7 @@
   "pi_usage": {
     "empatia_coordinativa": {
       "co_occorrenze": [
-        "job_ability:Warden/Scudo_di_Risonanza"
+        "job_ability:warden/scudo_di_risonanza"
       ],
       "combo_totale": 1,
       "forme": [
@@ -592,7 +592,7 @@
       "co_occorrenze": [
         "PE",
         "cap_pt",
-        "job_ability:Invoker/Sincronia",
+        "job_ability:invoker/sincronia",
         "sigillo_forma",
         "starter_bioma"
       ],
@@ -675,7 +675,7 @@
       "co_occorrenze": [
         "cap_pt",
         "guardia_situazionale",
-        "job_ability:Random"
+        "job_ability:random"
       ],
       "combo_totale": 2,
       "forme": [
@@ -738,7 +738,7 @@
       "co_occorrenze": [
         "cap_pt",
         "guardia_situazionale",
-        "job_ability:Skirmisher/Dash_Cut"
+        "job_ability:skirmisher/dash_cut"
       ],
       "combo_totale": 2,
       "forme": [

--- a/data/derived/mock/prod_snapshot/analysis/trait_env_mapping.json
+++ b/data/derived/mock/prod_snapshot/analysis/trait_env_mapping.json
@@ -574,7 +574,7 @@
   "pi_usage": {
     "empatia_coordinativa": {
       "co_occorrenze": [
-        "job_ability:Warden/Scudo_di_Risonanza"
+        "job_ability:warden/scudo_di_risonanza"
       ],
       "combo_totale": 1,
       "forme": [
@@ -592,7 +592,7 @@
       "co_occorrenze": [
         "PE",
         "cap_pt",
-        "job_ability:Invoker/Sincronia",
+        "job_ability:invoker/sincronia",
         "sigillo_forma",
         "starter_bioma"
       ],
@@ -675,7 +675,7 @@
       "co_occorrenze": [
         "cap_pt",
         "guardia_situazionale",
-        "job_ability:Random"
+        "job_ability:random"
       ],
       "combo_totale": 2,
       "forme": [
@@ -738,7 +738,7 @@
       "co_occorrenze": [
         "cap_pt",
         "guardia_situazionale",
-        "job_ability:Skirmisher/Dash_Cut"
+        "job_ability:skirmisher/dash_cut"
       ],
       "combo_totale": 2,
       "forme": [

--- a/data/derived/mock/prod_snapshot/data/packs.yaml
+++ b/data/derived/mock/prod_snapshot/data/packs.yaml
@@ -29,87 +29,87 @@ job_bias:
   harvester: [D, J]
 forms:
   ISTJ:
-    A: [trait_T1:Pianificatore, guardia_situazionale, sigillo_forma]
-    B: [job_ability:Vanguard/Muraglia, cap_pt, PE]
-    C: [trait_T1:Pianificatore, cap_pt, starter_bioma, PE]
+    A: [trait_T1:pianificatore, guardia_situazionale, sigillo_forma]
+    B: [job_ability:vanguard/muraglia, cap_pt, PE]
+    C: [trait_T1:pianificatore, cap_pt, starter_bioma, PE]
     bias_d12: {A: "1-5", B: "6-9", C: "10-12"}
   ISFJ:
-    A: [trait_T1:Risonanza_di_Branco, guardia_situazionale, starter_bioma, PE]
-    B: [job_ability:Warden/Aura_di_Sollievo, cap_pt, PE]
-    C: [job_ability:Warden/Purga, guardia_situazionale, PE]
+    A: [trait_T1:risonanza_di_branco, guardia_situazionale, starter_bioma, PE]
+    B: [job_ability:warden/aura_di_sollievo, cap_pt, PE]
+    C: [job_ability:warden/purga, guardia_situazionale, PE]
     bias_d12: {A: "1-4", B: "5-9", C: "10-12"}
   INFJ:
-    A: [trait_T1:Focus_Frazionato, cap_pt, starter_bioma, PE]
-    B: [job_ability:Invoker/Vena_Psionica, guardia_situazionale, PE]
-    C: [job_ability:Artificer/Mina_a_Pressione, cap_pt, PE]
+    A: [trait_T1:focus_frazionato, cap_pt, starter_bioma, PE]
+    B: [job_ability:invoker/vena_psionica, guardia_situazionale, PE]
+    C: [job_ability:artificer/mina_a_pressione, cap_pt, PE]
     bias_d12: {A: "1-4", B: "5-8", C: "9-12"}
   INTJ:
-    A: [job_ability:Invoker/Varchi_di_Forza, cap_pt, PE]
-    B: [job_ability:Artificer/Mina_a_Pressione, guardia_situazionale, PE]
-    C: [trait_T1:Pianificatore, sigillo_forma, starter_bioma, PE]
+    A: [job_ability:invoker/varchi_di_forza, cap_pt, PE]
+    B: [job_ability:artificer/mina_a_pressione, guardia_situazionale, PE]
+    C: [trait_T1:pianificatore, sigillo_forma, starter_bioma, PE]
     bias_d12: {A: "1-6", B: "7-9", C: "10-12"}
   ISTP:
-    A: [trait_T1:Ghiandola_Caustica, guardia_situazionale, PE, PE]
-    B: [job_ability:Skirmisher/Taglio_Opportunista, cap_pt, PE]
-    C: [job_ability:Artificer/Turret_Ematica, guardia_situazionale, PE]
+    A: [trait_T1:ghiandola_caustica, guardia_situazionale, PE, PE]
+    B: [job_ability:skirmisher/taglio_opportunista, cap_pt, PE]
+    C: [job_ability:artificer/turret_ematica, guardia_situazionale, PE]
     bias_d12: {B: "1-5", A: "6-8", C: "9-12"}
   ISFP:
-    A: [job_ability:Skirmisher/Smoke_Step, starter_bioma, PE, PE]
-    B: [trait_T1:Zampe_a_Molla, cap_pt, guardia_situazionale]
-    C: [job_ability:Skirmisher/Dash_Cut, cap_pt, PE]
+    A: [job_ability:skirmisher/smoke_step, starter_bioma, PE, PE]
+    B: [trait_T1:zampe_a_molla, cap_pt, guardia_situazionale]
+    C: [job_ability:skirmisher/dash_cut, cap_pt, PE]
     bias_d12: {A: "1-4", C: "5-8", B: "9-12"}
   INFP:
-    A: [trait_T1:Empatia_Coordinativa, job_ability:Warden/Scudo_di_Risonanza]
-    B: [job_ability:Warden/Aura_di_Sollievo, starter_bioma, PE, PE]
-    C: [trait_T1:Risonanza_di_Branco, cap_pt, guardia_situazionale]
+    A: [trait_T1:empatia_coordinativa, job_ability:warden/scudo_di_risonanza]
+    B: [job_ability:warden/aura_di_sollievo, starter_bioma, PE, PE]
+    C: [trait_T1:risonanza_di_branco, cap_pt, guardia_situazionale]
     bias_d12: {A: "1-6", B: "7-9", C: "10-12"}
   INTP:
-    A: [job_ability:Artificer/Turret_Ematica, cap_pt, PE]
-    B: [job_ability:Artificer/Neutralizzatore, guardia_situazionale, PE]
-    C: [trait_T1:Focus_Frazionato, sigillo_forma, starter_bioma, PE]
+    A: [job_ability:artificer/turret_ematica, cap_pt, PE]
+    B: [job_ability:artificer/neutralizzatore, guardia_situazionale, PE]
+    C: [trait_T1:focus_frazionato, sigillo_forma, starter_bioma, PE]
     bias_d12: {A: "1-5", B: "6-9", C: "10-12"}
   ESTP:
-    A: [job_ability:Skirmisher/Dash_Cut, trait_T1:Zampe_a_Molla]
-    B: [job_ability:Skirmisher/Raffica, guardia_situazionale, PE]
-    C: [job_ability:Invoker/Sincronia, cap_pt, PE]
+    A: [job_ability:skirmisher/dash_cut, trait_T1:zampe_a_molla]
+    B: [job_ability:skirmisher/raffica, guardia_situazionale, PE]
+    C: [job_ability:invoker/sincronia, cap_pt, PE]
     bias_d12: {A: "1-6", B: "7-9", C: "10-12"}
   ESFP:
-    A: [job_ability:Harvester/Taglia_Obiettivo, guardia_situazionale, PE]
-    B: [trait_T1:Tattiche_di_Branco, cap_pt, starter_bioma, PE]
-    C: [job_ability:Harvester/Rete_Predatoria, cap_pt, PE]
+    A: [job_ability:harvester/taglia_obiettivo, guardia_situazionale, PE]
+    B: [trait_T1:tattiche_di_branco, cap_pt, starter_bioma, PE]
+    C: [job_ability:harvester/rete_predatoria, cap_pt, PE]
     bias_d12: {A: "1-5", B: "6-8", C: "9-12"}
   ENFP:
-    A: [trait_T1:Pathfinder, cap_pt, starter_bioma, PE]
-    B: [job_ability:Invoker/Sincronia, guardia_situazionale, PE]
-    C: [job_ability:Skirmisher/Smoke_Step, cap_pt, PE]
+    A: [trait_T1:pathfinder, cap_pt, starter_bioma, PE]
+    B: [job_ability:invoker/sincronia, guardia_situazionale, PE]
+    C: [job_ability:skirmisher/smoke_step, cap_pt, PE]
     bias_d12: {A: "1-6", B: "7-8", C: "9-12"}
   ENTP:
-    A: [job_ability:Invoker/Sincronia, trait_T1:Focus_Frazionato]
-    B: [job_ability:Artificer/Rete_Sincro, cap_pt, PE]
-    C: [trait_T1:Pianificatore, guardia_situazionale, sigillo_forma]
+    A: [job_ability:invoker/sincronia, trait_T1:focus_frazionato]
+    B: [job_ability:artificer/rete_sincro, cap_pt, PE]
+    C: [trait_T1:pianificatore, guardia_situazionale, sigillo_forma]
     bias_d12: {A: "1-6", B: "7-9", C: "10-12"}
   ESTJ:
-    A: [job_ability:Vanguard/Muraglia, guardia_situazionale, PE]
-    B: [job_ability:Vanguard/Carica, cap_pt, PE]
-    C: [trait_T1:Pianificatore, sigillo_forma, starter_bioma, PE]
+    A: [job_ability:vanguard/muraglia, guardia_situazionale, PE]
+    B: [job_ability:vanguard/carica, cap_pt, PE]
+    C: [trait_T1:pianificatore, sigillo_forma, starter_bioma, PE]
     bias_d12: {A: "1-5", B: "6-9", C: "10-12"}
   ESFJ:
-    A: [job_ability:Warden/Scudo_di_Risonanza, cap_pt, PE]
-    B: [trait_T1:Tattiche_di_Branco, guardia_situazionale, sigillo_forma]
-    C: [job_ability:Warden/Aura_di_Sollievo, starter_bioma, PE, PE]
+    A: [job_ability:warden/scudo_di_risonanza, cap_pt, PE]
+    B: [trait_T1:tattiche_di_branco, guardia_situazionale, sigillo_forma]
+    C: [job_ability:warden/aura_di_sollievo, starter_bioma, PE, PE]
     bias_d12: {A: "1-5", B: "6-8", C: "9-12"}
   ENFJ:
-    A: [job_ability:Warden/Aura_di_Sollievo, starter_bioma, PE, PE]
-    B: [trait_T1:Risonanza_di_Branco, cap_pt, guardia_situazionale]
-    C: [job_ability:Harvester/Taglia_Obiettivo, cap_pt, PE]
+    A: [job_ability:warden/aura_di_sollievo, starter_bioma, PE, PE]
+    B: [trait_T1:risonanza_di_branco, cap_pt, guardia_situazionale]
+    C: [job_ability:harvester/taglia_obiettivo, cap_pt, PE]
     bias_d12: {A: "1-6", B: "7-8", C: "9-12"}
   ENTJ:
-    A: [job_ability:Harvester/Blocco_Rifornimenti, cap_pt, PE]
-    B: [job_ability:Vanguard/Sfida, guardia_situazionale, PE]
-    C: [trait_T1:Pianificatore, sigillo_forma, starter_bioma, PE]
+    A: [job_ability:harvester/blocco_rifornimenti, cap_pt, PE]
+    B: [job_ability:vanguard/sfida, guardia_situazionale, PE]
+    C: [trait_T1:pianificatore, sigillo_forma, starter_bioma, PE]
     bias_d12: {A: "1-6", B: "7-9", C: "10-12"}
   NEUTRA:
-    A: [trait_T1:Random, job_ability:Random]
-    B: [trait_T1:Random, guardia_situazionale, cap_pt]
-    C: [job_ability:Random, starter_bioma, cap_pt]
+    A: [trait_T1:random, job_ability:random]
+    B: [trait_T1:random, guardia_situazionale, cap_pt]
+    C: [job_ability:random, starter_bioma, cap_pt]
     bias_d12: {A: "1-4", B: "5-8", C: "9-12"}

--- a/data/derived/mock/prod_snapshot/packs.yaml
+++ b/data/derived/mock/prod_snapshot/packs.yaml
@@ -29,87 +29,87 @@ job_bias:
   harvester: [D, J]
 forms:
   ISTJ:
-    A: [trait_T1:Pianificatore, guardia_situazionale, sigillo_forma]
-    B: [job_ability:Vanguard/Muraglia, cap_pt, PE]
-    C: [trait_T1:Pianificatore, cap_pt, starter_bioma, PE]
+    A: [trait_T1:pianificatore, guardia_situazionale, sigillo_forma]
+    B: [job_ability:vanguard/muraglia, cap_pt, PE]
+    C: [trait_T1:pianificatore, cap_pt, starter_bioma, PE]
     bias_d12: {A: "1-5", B: "6-9", C: "10-12"}
   ISFJ:
-    A: [trait_T1:Risonanza_di_Branco, guardia_situazionale, starter_bioma, PE]
-    B: [job_ability:Warden/Aura_di_Sollievo, cap_pt, PE]
-    C: [job_ability:Warden/Purga, guardia_situazionale, PE]
+    A: [trait_T1:risonanza_di_branco, guardia_situazionale, starter_bioma, PE]
+    B: [job_ability:warden/aura_di_sollievo, cap_pt, PE]
+    C: [job_ability:warden/purga, guardia_situazionale, PE]
     bias_d12: {A: "1-4", B: "5-9", C: "10-12"}
   INFJ:
-    A: [trait_T1:Focus_Frazionato, cap_pt, starter_bioma, PE]
-    B: [job_ability:Invoker/Vena_Psionica, guardia_situazionale, PE]
-    C: [job_ability:Artificer/Mina_a_Pressione, cap_pt, PE]
+    A: [trait_T1:focus_frazionato, cap_pt, starter_bioma, PE]
+    B: [job_ability:invoker/vena_psionica, guardia_situazionale, PE]
+    C: [job_ability:artificer/mina_a_pressione, cap_pt, PE]
     bias_d12: {A: "1-4", B: "5-8", C: "9-12"}
   INTJ:
-    A: [job_ability:Invoker/Varchi_di_Forza, cap_pt, PE]
-    B: [job_ability:Artificer/Mina_a_Pressione, guardia_situazionale, PE]
-    C: [trait_T1:Pianificatore, sigillo_forma, starter_bioma, PE]
+    A: [job_ability:invoker/varchi_di_forza, cap_pt, PE]
+    B: [job_ability:artificer/mina_a_pressione, guardia_situazionale, PE]
+    C: [trait_T1:pianificatore, sigillo_forma, starter_bioma, PE]
     bias_d12: {A: "1-6", B: "7-9", C: "10-12"}
   ISTP:
-    A: [trait_T1:Ghiandola_Caustica, guardia_situazionale, PE, PE]
-    B: [job_ability:Skirmisher/Taglio_Opportunista, cap_pt, PE]
-    C: [job_ability:Artificer/Turret_Ematica, guardia_situazionale, PE]
+    A: [trait_T1:ghiandola_caustica, guardia_situazionale, PE, PE]
+    B: [job_ability:skirmisher/taglio_opportunista, cap_pt, PE]
+    C: [job_ability:artificer/turret_ematica, guardia_situazionale, PE]
     bias_d12: {B: "1-5", A: "6-8", C: "9-12"}
   ISFP:
-    A: [job_ability:Skirmisher/Smoke_Step, starter_bioma, PE, PE]
-    B: [trait_T1:Zampe_a_Molla, cap_pt, guardia_situazionale]
-    C: [job_ability:Skirmisher/Dash_Cut, cap_pt, PE]
+    A: [job_ability:skirmisher/smoke_step, starter_bioma, PE, PE]
+    B: [trait_T1:zampe_a_molla, cap_pt, guardia_situazionale]
+    C: [job_ability:skirmisher/dash_cut, cap_pt, PE]
     bias_d12: {A: "1-4", C: "5-8", B: "9-12"}
   INFP:
-    A: [trait_T1:Empatia_Coordinativa, job_ability:Warden/Scudo_di_Risonanza]
-    B: [job_ability:Warden/Aura_di_Sollievo, starter_bioma, PE, PE]
-    C: [trait_T1:Risonanza_di_Branco, cap_pt, guardia_situazionale]
+    A: [trait_T1:empatia_coordinativa, job_ability:warden/scudo_di_risonanza]
+    B: [job_ability:warden/aura_di_sollievo, starter_bioma, PE, PE]
+    C: [trait_T1:risonanza_di_branco, cap_pt, guardia_situazionale]
     bias_d12: {A: "1-6", B: "7-9", C: "10-12"}
   INTP:
-    A: [job_ability:Artificer/Turret_Ematica, cap_pt, PE]
-    B: [job_ability:Artificer/Neutralizzatore, guardia_situazionale, PE]
-    C: [trait_T1:Focus_Frazionato, sigillo_forma, starter_bioma, PE]
+    A: [job_ability:artificer/turret_ematica, cap_pt, PE]
+    B: [job_ability:artificer/neutralizzatore, guardia_situazionale, PE]
+    C: [trait_T1:focus_frazionato, sigillo_forma, starter_bioma, PE]
     bias_d12: {A: "1-5", B: "6-9", C: "10-12"}
   ESTP:
-    A: [job_ability:Skirmisher/Dash_Cut, trait_T1:Zampe_a_Molla]
-    B: [job_ability:Skirmisher/Raffica, guardia_situazionale, PE]
-    C: [job_ability:Invoker/Sincronia, cap_pt, PE]
+    A: [job_ability:skirmisher/dash_cut, trait_T1:zampe_a_molla]
+    B: [job_ability:skirmisher/raffica, guardia_situazionale, PE]
+    C: [job_ability:invoker/sincronia, cap_pt, PE]
     bias_d12: {A: "1-6", B: "7-9", C: "10-12"}
   ESFP:
-    A: [job_ability:Harvester/Taglia_Obiettivo, guardia_situazionale, PE]
-    B: [trait_T1:Tattiche_di_Branco, cap_pt, starter_bioma, PE]
-    C: [job_ability:Harvester/Rete_Predatoria, cap_pt, PE]
+    A: [job_ability:harvester/taglia_obiettivo, guardia_situazionale, PE]
+    B: [trait_T1:tattiche_di_branco, cap_pt, starter_bioma, PE]
+    C: [job_ability:harvester/rete_predatoria, cap_pt, PE]
     bias_d12: {A: "1-5", B: "6-8", C: "9-12"}
   ENFP:
-    A: [trait_T1:Pathfinder, cap_pt, starter_bioma, PE]
-    B: [job_ability:Invoker/Sincronia, guardia_situazionale, PE]
-    C: [job_ability:Skirmisher/Smoke_Step, cap_pt, PE]
+    A: [trait_T1:pathfinder, cap_pt, starter_bioma, PE]
+    B: [job_ability:invoker/sincronia, guardia_situazionale, PE]
+    C: [job_ability:skirmisher/smoke_step, cap_pt, PE]
     bias_d12: {A: "1-6", B: "7-8", C: "9-12"}
   ENTP:
-    A: [job_ability:Invoker/Sincronia, trait_T1:Focus_Frazionato]
-    B: [job_ability:Artificer/Rete_Sincro, cap_pt, PE]
-    C: [trait_T1:Pianificatore, guardia_situazionale, sigillo_forma]
+    A: [job_ability:invoker/sincronia, trait_T1:focus_frazionato]
+    B: [job_ability:artificer/rete_sincro, cap_pt, PE]
+    C: [trait_T1:pianificatore, guardia_situazionale, sigillo_forma]
     bias_d12: {A: "1-6", B: "7-9", C: "10-12"}
   ESTJ:
-    A: [job_ability:Vanguard/Muraglia, guardia_situazionale, PE]
-    B: [job_ability:Vanguard/Carica, cap_pt, PE]
-    C: [trait_T1:Pianificatore, sigillo_forma, starter_bioma, PE]
+    A: [job_ability:vanguard/muraglia, guardia_situazionale, PE]
+    B: [job_ability:vanguard/carica, cap_pt, PE]
+    C: [trait_T1:pianificatore, sigillo_forma, starter_bioma, PE]
     bias_d12: {A: "1-5", B: "6-9", C: "10-12"}
   ESFJ:
-    A: [job_ability:Warden/Scudo_di_Risonanza, cap_pt, PE]
-    B: [trait_T1:Tattiche_di_Branco, guardia_situazionale, sigillo_forma]
-    C: [job_ability:Warden/Aura_di_Sollievo, starter_bioma, PE, PE]
+    A: [job_ability:warden/scudo_di_risonanza, cap_pt, PE]
+    B: [trait_T1:tattiche_di_branco, guardia_situazionale, sigillo_forma]
+    C: [job_ability:warden/aura_di_sollievo, starter_bioma, PE, PE]
     bias_d12: {A: "1-5", B: "6-8", C: "9-12"}
   ENFJ:
-    A: [job_ability:Warden/Aura_di_Sollievo, starter_bioma, PE, PE]
-    B: [trait_T1:Risonanza_di_Branco, cap_pt, guardia_situazionale]
-    C: [job_ability:Harvester/Taglia_Obiettivo, cap_pt, PE]
+    A: [job_ability:warden/aura_di_sollievo, starter_bioma, PE, PE]
+    B: [trait_T1:risonanza_di_branco, cap_pt, guardia_situazionale]
+    C: [job_ability:harvester/taglia_obiettivo, cap_pt, PE]
     bias_d12: {A: "1-6", B: "7-8", C: "9-12"}
   ENTJ:
-    A: [job_ability:Harvester/Blocco_Rifornimenti, cap_pt, PE]
-    B: [job_ability:Vanguard/Sfida, guardia_situazionale, PE]
-    C: [trait_T1:Pianificatore, sigillo_forma, starter_bioma, PE]
+    A: [job_ability:harvester/blocco_rifornimenti, cap_pt, PE]
+    B: [job_ability:vanguard/sfida, guardia_situazionale, PE]
+    C: [trait_T1:pianificatore, sigillo_forma, starter_bioma, PE]
     bias_d12: {A: "1-6", B: "7-9", C: "10-12"}
   NEUTRA:
-    A: [trait_T1:Random, job_ability:Random]
-    B: [trait_T1:Random, guardia_situazionale, cap_pt]
-    C: [job_ability:Random, starter_bioma, cap_pt]
+    A: [trait_T1:random, job_ability:random]
+    B: [trait_T1:random, guardia_situazionale, cap_pt]
+    C: [job_ability:random, starter_bioma, cap_pt]
     bias_d12: {A: "1-4", B: "5-8", C: "9-12"}

--- a/data/packs.yaml
+++ b/data/packs.yaml
@@ -29,87 +29,87 @@ job_bias:
   harvester: [D, J]
 forms:
   ISTJ:
-    A: [trait_T1:Pianificatore, guardia_situazionale, sigillo_forma]
-    B: [job_ability:Vanguard/Muraglia, cap_pt, PE]
-    C: [trait_T1:Pianificatore, cap_pt, starter_bioma, PE]
+    A: [trait_T1:pianificatore, guardia_situazionale, sigillo_forma]
+    B: [job_ability:vanguard/muraglia, cap_pt, PE]
+    C: [trait_T1:pianificatore, cap_pt, starter_bioma, PE]
     bias_d12: {A: "1-5", B: "6-9", C: "10-12"}
   ISFJ:
-    A: [trait_T1:Risonanza_di_Branco, guardia_situazionale, starter_bioma, PE]
-    B: [job_ability:Warden/Aura_di_Sollievo, cap_pt, PE]
-    C: [job_ability:Warden/Purga, guardia_situazionale, PE]
+    A: [trait_T1:risonanza_di_branco, guardia_situazionale, starter_bioma, PE]
+    B: [job_ability:warden/aura_di_sollievo, cap_pt, PE]
+    C: [job_ability:warden/purga, guardia_situazionale, PE]
     bias_d12: {A: "1-4", B: "5-9", C: "10-12"}
   INFJ:
-    A: [trait_T1:Focus_Frazionato, cap_pt, starter_bioma, PE]
-    B: [job_ability:Invoker/Vena_Psionica, guardia_situazionale, PE]
-    C: [job_ability:Artificer/Mina_a_Pressione, cap_pt, PE]
+    A: [trait_T1:focus_frazionato, cap_pt, starter_bioma, PE]
+    B: [job_ability:invoker/vena_psionica, guardia_situazionale, PE]
+    C: [job_ability:artificer/mina_a_pressione, cap_pt, PE]
     bias_d12: {A: "1-4", B: "5-8", C: "9-12"}
   INTJ:
-    A: [job_ability:Invoker/Varchi_di_Forza, cap_pt, PE]
-    B: [job_ability:Artificer/Mina_a_Pressione, guardia_situazionale, PE]
-    C: [trait_T1:Pianificatore, sigillo_forma, starter_bioma, PE]
+    A: [job_ability:invoker/varchi_di_forza, cap_pt, PE]
+    B: [job_ability:artificer/mina_a_pressione, guardia_situazionale, PE]
+    C: [trait_T1:pianificatore, sigillo_forma, starter_bioma, PE]
     bias_d12: {A: "1-6", B: "7-9", C: "10-12"}
   ISTP:
-    A: [trait_T1:Ghiandola_Caustica, guardia_situazionale, PE, PE]
-    B: [job_ability:Skirmisher/Taglio_Opportunista, cap_pt, PE]
-    C: [job_ability:Artificer/Turret_Ematica, guardia_situazionale, PE]
+    A: [trait_T1:ghiandola_caustica, guardia_situazionale, PE, PE]
+    B: [job_ability:skirmisher/taglio_opportunista, cap_pt, PE]
+    C: [job_ability:artificer/turret_ematica, guardia_situazionale, PE]
     bias_d12: {B: "1-5", A: "6-8", C: "9-12"}
   ISFP:
-    A: [job_ability:Skirmisher/Smoke_Step, starter_bioma, PE, PE]
-    B: [trait_T1:Zampe_a_Molla, cap_pt, guardia_situazionale]
-    C: [job_ability:Skirmisher/Dash_Cut, cap_pt, PE]
+    A: [job_ability:skirmisher/smoke_step, starter_bioma, PE, PE]
+    B: [trait_T1:zampe_a_molla, cap_pt, guardia_situazionale]
+    C: [job_ability:skirmisher/dash_cut, cap_pt, PE]
     bias_d12: {A: "1-4", C: "5-8", B: "9-12"}
   INFP:
-    A: [trait_T1:Empatia_Coordinativa, job_ability:Warden/Scudo_di_Risonanza]
-    B: [job_ability:Warden/Aura_di_Sollievo, starter_bioma, PE, PE]
-    C: [trait_T1:Risonanza_di_Branco, cap_pt, guardia_situazionale]
+    A: [trait_T1:empatia_coordinativa, job_ability:warden/scudo_di_risonanza]
+    B: [job_ability:warden/aura_di_sollievo, starter_bioma, PE, PE]
+    C: [trait_T1:risonanza_di_branco, cap_pt, guardia_situazionale]
     bias_d12: {A: "1-6", B: "7-9", C: "10-12"}
   INTP:
-    A: [job_ability:Artificer/Turret_Ematica, cap_pt, PE]
-    B: [job_ability:Artificer/Neutralizzatore, guardia_situazionale, PE]
-    C: [trait_T1:Focus_Frazionato, sigillo_forma, starter_bioma, PE]
+    A: [job_ability:artificer/turret_ematica, cap_pt, PE]
+    B: [job_ability:artificer/neutralizzatore, guardia_situazionale, PE]
+    C: [trait_T1:focus_frazionato, sigillo_forma, starter_bioma, PE]
     bias_d12: {A: "1-5", B: "6-9", C: "10-12"}
   ESTP:
-    A: [job_ability:Skirmisher/Dash_Cut, trait_T1:Zampe_a_Molla]
-    B: [job_ability:Skirmisher/Raffica, guardia_situazionale, PE]
-    C: [job_ability:Invoker/Sincronia, cap_pt, PE]
+    A: [job_ability:skirmisher/dash_cut, trait_T1:zampe_a_molla]
+    B: [job_ability:skirmisher/raffica, guardia_situazionale, PE]
+    C: [job_ability:invoker/sincronia, cap_pt, PE]
     bias_d12: {A: "1-6", B: "7-9", C: "10-12"}
   ESFP:
-    A: [job_ability:Harvester/Taglia_Obiettivo, guardia_situazionale, PE]
-    B: [trait_T1:Tattiche_di_Branco, cap_pt, starter_bioma, PE]
-    C: [job_ability:Harvester/Rete_Predatoria, cap_pt, PE]
+    A: [job_ability:harvester/taglia_obiettivo, guardia_situazionale, PE]
+    B: [trait_T1:tattiche_di_branco, cap_pt, starter_bioma, PE]
+    C: [job_ability:harvester/rete_predatoria, cap_pt, PE]
     bias_d12: {A: "1-5", B: "6-8", C: "9-12"}
   ENFP:
-    A: [trait_T1:Pathfinder, cap_pt, starter_bioma, PE]
-    B: [job_ability:Invoker/Sincronia, guardia_situazionale, PE]
-    C: [job_ability:Skirmisher/Smoke_Step, cap_pt, PE]
+    A: [trait_T1:pathfinder, cap_pt, starter_bioma, PE]
+    B: [job_ability:invoker/sincronia, guardia_situazionale, PE]
+    C: [job_ability:skirmisher/smoke_step, cap_pt, PE]
     bias_d12: {A: "1-6", B: "7-8", C: "9-12"}
   ENTP:
-    A: [job_ability:Invoker/Sincronia, trait_T1:Focus_Frazionato]
-    B: [job_ability:Artificer/Rete_Sincro, cap_pt, PE]
-    C: [trait_T1:Pianificatore, guardia_situazionale, sigillo_forma]
+    A: [job_ability:invoker/sincronia, trait_T1:focus_frazionato]
+    B: [job_ability:artificer/rete_sincro, cap_pt, PE]
+    C: [trait_T1:pianificatore, guardia_situazionale, sigillo_forma]
     bias_d12: {A: "1-6", B: "7-9", C: "10-12"}
   ESTJ:
-    A: [job_ability:Vanguard/Muraglia, guardia_situazionale, PE]
-    B: [job_ability:Vanguard/Carica, cap_pt, PE]
-    C: [trait_T1:Pianificatore, sigillo_forma, starter_bioma, PE]
+    A: [job_ability:vanguard/muraglia, guardia_situazionale, PE]
+    B: [job_ability:vanguard/carica, cap_pt, PE]
+    C: [trait_T1:pianificatore, sigillo_forma, starter_bioma, PE]
     bias_d12: {A: "1-5", B: "6-9", C: "10-12"}
   ESFJ:
-    A: [job_ability:Warden/Scudo_di_Risonanza, cap_pt, PE]
-    B: [trait_T1:Tattiche_di_Branco, guardia_situazionale, sigillo_forma]
-    C: [job_ability:Warden/Aura_di_Sollievo, starter_bioma, PE, PE]
+    A: [job_ability:warden/scudo_di_risonanza, cap_pt, PE]
+    B: [trait_T1:tattiche_di_branco, guardia_situazionale, sigillo_forma]
+    C: [job_ability:warden/aura_di_sollievo, starter_bioma, PE, PE]
     bias_d12: {A: "1-5", B: "6-8", C: "9-12"}
   ENFJ:
-    A: [job_ability:Warden/Aura_di_Sollievo, starter_bioma, PE, PE]
-    B: [trait_T1:Risonanza_di_Branco, cap_pt, guardia_situazionale]
-    C: [job_ability:Harvester/Taglia_Obiettivo, cap_pt, PE]
+    A: [job_ability:warden/aura_di_sollievo, starter_bioma, PE, PE]
+    B: [trait_T1:risonanza_di_branco, cap_pt, guardia_situazionale]
+    C: [job_ability:harvester/taglia_obiettivo, cap_pt, PE]
     bias_d12: {A: "1-6", B: "7-8", C: "9-12"}
   ENTJ:
-    A: [job_ability:Harvester/Blocco_Rifornimenti, cap_pt, PE]
-    B: [job_ability:Vanguard/Sfida, guardia_situazionale, PE]
-    C: [trait_T1:Pianificatore, sigillo_forma, starter_bioma, PE]
+    A: [job_ability:harvester/blocco_rifornimenti, cap_pt, PE]
+    B: [job_ability:vanguard/sfida, guardia_situazionale, PE]
+    C: [trait_T1:pianificatore, sigillo_forma, starter_bioma, PE]
     bias_d12: {A: "1-6", B: "7-9", C: "10-12"}
   NEUTRA:
-    A: [trait_T1:Random, job_ability:Random]
-    B: [trait_T1:Random, guardia_situazionale, cap_pt]
-    C: [job_ability:Random, starter_bioma, cap_pt]
+    A: [trait_T1:random, job_ability:random]
+    B: [trait_T1:random, guardia_situazionale, cap_pt]
+    C: [job_ability:random, starter_bioma, cap_pt]
     bias_d12: {A: "1-4", B: "5-8", C: "9-12"}

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -5859,7 +5859,7 @@
       ],
       "sinergie_pi": {
         "co_occorrenze": [
-          "job_ability:Warden/Scudo_di_Risonanza"
+          "job_ability:warden/scudo_di_risonanza"
         ],
         "combo_totale": 1,
         "forme": [
@@ -6829,7 +6829,7 @@
         "co_occorrenze": [
           "PE",
           "cap_pt",
-          "job_ability:Invoker/Sincronia",
+          "job_ability:invoker/sincronia",
           "sigillo_forma",
           "starter_bioma"
         ],
@@ -10302,7 +10302,7 @@
         "co_occorrenze": [
           "cap_pt",
           "guardia_situazionale",
-          "job_ability:Random"
+          "job_ability:random"
         ],
         "combo_totale": 2,
         "forme": [
@@ -11811,7 +11811,7 @@
         "co_occorrenze": [
           "cap_pt",
           "guardia_situazionale",
-          "job_ability:Skirmisher/Dash_Cut"
+          "job_ability:skirmisher/dash_cut"
         ],
         "combo_totale": 2,
         "forme": [

--- a/data/traits/locomotorio/zampe_a_molla.json
+++ b/data/traits/locomotorio/zampe_a_molla.json
@@ -39,7 +39,7 @@
     "co_occorrenze": [
       "cap_pt",
       "guardia_situazionale",
-      "job_ability:Skirmisher/Dash_Cut"
+      "job_ability:skirmisher/dash_cut"
     ],
     "combo_totale": 2,
     "forme": [

--- a/data/traits/strategia/focus_frazionato.json
+++ b/data/traits/strategia/focus_frazionato.json
@@ -40,7 +40,7 @@
     "co_occorrenze": [
       "PE",
       "cap_pt",
-      "job_ability:Invoker/Sincronia",
+      "job_ability:invoker/sincronia",
       "sigillo_forma",
       "starter_bioma"
     ],

--- a/data/traits/strategia/random.json
+++ b/data/traits/strategia/random.json
@@ -23,7 +23,7 @@
     "co_occorrenze": [
       "cap_pt",
       "guardia_situazionale",
-      "job_ability:Random"
+      "job_ability:random"
     ],
     "combo_totale": 2,
     "forme": [

--- a/data/traits/supporto/empatia_coordinativa.json
+++ b/data/traits/supporto/empatia_coordinativa.json
@@ -37,7 +37,7 @@
   ],
   "sinergie_pi": {
     "co_occorrenze": [
-      "job_ability:Warden/Scudo_di_Risonanza"
+      "job_ability:warden/scudo_di_risonanza"
     ],
     "combo_totale": 1,
     "forme": [

--- a/docs/PI-Pacchetti-Forme.md
+++ b/docs/PI-Pacchetti-Forme.md
@@ -1,64 +1,72 @@
 # PI, Pacchetti & Forme — Canvas B
 
 ## Struttura Economica
+
 - **Costo PI**: trait_T1 3 PE, trait_T2 6 PE, trait_T3 10 PE, job_ability 4 PE, ultimate_slot 6 PE, modulo_tattico 3 PE; cap acquisti su `cap_pt_max` e `starter_bioma_max` per evitare snowball precoce.【F:data/packs.yaml†L1-L8】
 - **Curve Budget**: baseline 7 → veteran 9 → elite 11, con sblocchi legati a optional e style bonus; i pack si basano su tiri `random_general_d20` con risultati speciali per bias Forma/Job e scelta manuale a 20.【F:data/packs.yaml†L9-L23】
 - **Shop Loop**: `pi_shop` alimenta companion app e HUD con suggerimenti di spesa coerenti con telemetria `pe_economy` (expected delta 6 PE, soft cap backlog 18).【F:data/core/telemetry.yaml†L63-L78】
 
 ## Pacchetti d20
-| Range d20 | Pack | Combo | Note |
-|-----------|------|-------|------|
-| 1-2 | A | job_ability + trait_T1 | Entry-level aggressivo per definire identità Forma. |
-| 3-4 | B | trait_T1 + guardia_situazionale + cap_pt | Rinforzo difensivo per squadre low guard. |
-| 5-6 | C | job_ability + cap_pt + starter_bioma | Seed tattico legato al bioma iniziale. |
-| 7-8 | D | job_ability + guardia_situazionale + PE | Combo offensiva con salvaguardia. |
-| 9-10 | E | trait_T1 + starter_bioma + cap_pt + PE | All-rounder multi-bioma. |
-| 11 | F | sigillo_forma + job_ability + starter_bioma | Spinge identità Forma esclusiva. |
-| 12 | G | sigillo_forma + trait_T1 + starter_bioma + PE | Prep evolutivo con investimento Forma. |
-| 13 | H | PE ×7 | Fondo accelerato per economie mirate. |
-| 14 | I | trait_T1 + guardia_situazionale + sigillo_forma | Difesa adattiva e crescita Forma. |
-| 15 | J | job_ability + PE ×3 | Spike abilità. |
-| 16-17 | Bias Forma | Rimanda alla tabella d12 della Forma scelta. |
-| 18-19 | Bias Job | Mappa preferenze per ruolo (Vanguard B/D, Skirmisher C/E, ecc.). |
-| 20 | Scelta | Qualsiasi pack disponibile; usato per correzioni bilanciamento o focus narrativo. |
+
+| Range d20 | Pack       | Combo                                                                             | Note                                                |
+| --------- | ---------- | --------------------------------------------------------------------------------- | --------------------------------------------------- |
+| 1-2       | A          | job_ability + trait_T1                                                            | Entry-level aggressivo per definire identità Forma. |
+| 3-4       | B          | trait_T1 + guardia_situazionale + cap_pt                                          | Rinforzo difensivo per squadre low guard.           |
+| 5-6       | C          | job_ability + cap_pt + starter_bioma                                              | Seed tattico legato al bioma iniziale.              |
+| 7-8       | D          | job_ability + guardia_situazionale + PE                                           | Combo offensiva con salvaguardia.                   |
+| 9-10      | E          | trait_T1 + starter_bioma + cap_pt + PE                                            | All-rounder multi-bioma.                            |
+| 11        | F          | sigillo_forma + job_ability + starter_bioma                                       | Spinge identità Forma esclusiva.                    |
+| 12        | G          | sigillo_forma + trait_T1 + starter_bioma + PE                                     | Prep evolutivo con investimento Forma.              |
+| 13        | H          | PE ×7                                                                             | Fondo accelerato per economie mirate.               |
+| 14        | I          | trait_T1 + guardia_situazionale + sigillo_forma                                   | Difesa adattiva e crescita Forma.                   |
+| 15        | J          | job_ability + PE ×3                                                               | Spike abilità.                                      |
+| 16-17     | Bias Forma | Rimanda alla tabella d12 della Forma scelta.                                      |
+| 18-19     | Bias Job   | Mappa preferenze per ruolo (Vanguard B/D, Skirmisher C/E, ecc.).                  |
+| 20        | Scelta     | Qualsiasi pack disponibile; usato per correzioni bilanciamento o focus narrativo. |
+
 【F:data/packs.yaml†L9-L23】
 
 ## Job Bias
+
 - Vanguard → preferenza B/D per tanking e controllo frontline.
 - Skirmisher → preferenza C/E per mobilità e danno a singolo bersaglio.
 - Warden → E/G per protezione e sustain.
 - Artificer → A/F per strumenti tattici e controllo area.
 - Invoker → A/J per poteri psionici burst.
 - Harvester → D/J per utility predatoria e economia risorse.
-【F:data/packs.yaml†L21-L32】
+  【F:data/packs.yaml†L21-L32】
 
 ## Forme Base (d12 bias)
-| Forma | Pack A | Pack B | Pack C | Bias d12 |
-|-------|--------|--------|--------|----------|
-| ISTJ | trait_T1:Pianificatore, guardia_situazionale, sigillo_forma | job_ability:Vanguard/Muraglia, cap_pt, PE | trait_T1:Pianificatore, cap_pt, starter_bioma, PE | A:1-5, B:6-9, C:10-12 |
-| ISFJ | trait_T1:Risonanza_di_Branco, guardia_situazionale, starter_bioma, PE | job_ability:Warden/Aura_di_Sollievo, cap_pt, PE | job_ability:Warden/Purga, guardia_situazionale, PE | A:1-4, B:5-9, C:10-12 |
-| INFJ | trait_T1:Focus_Frazionato, cap_pt, starter_bioma, PE | job_ability:Invoker/Vena_Psionica, guardia_situazionale, PE | job_ability:Artificer/Mina_a_Pressione, cap_pt, PE | A:1-4, B:5-8, C:9-12 |
-| INTJ | job_ability:Invoker/Varchi_di_Forza, cap_pt, PE | job_ability:Artificer/Mina_a_Pressione, guardia_situazionale, PE | trait_T1:Pianificatore, sigillo_forma, starter_bioma, PE | A:1-6, B:7-9, C:10-12 |
-| ISTP | trait_T1:Ghiandola_Caustica, guardia_situazionale, PE ×2 | job_ability:Skirmisher/Taglio_Opportunista, cap_pt, PE | job_ability:Artificer/Turret_Ematica, guardia_situazionale, PE | B:1-5, A:6-8, C:9-12 |
-| ISFP | job_ability:Skirmisher/Smoke_Step, starter_bioma, PE ×2 | trait_T1:Zampe_a_Molla, cap_pt, guardia_situazionale | job_ability:Skirmisher/Dash_Cut, cap_pt, PE | A:1-4, C:5-8, B:9-12 |
-| INFP | trait_T1:Empatia_Coordinativa, job_ability:Warden/Scudo_di_Risonanza | job_ability:Warden/Aura_di_Sollievo, starter_bioma, PE ×2 | trait_T1:Risonanza_di_Branco, cap_pt, guardia_situazionale | A:1-6, B:7-9, C:10-12 |
-| INTP | job_ability:Artificer/Turret_Ematica, cap_pt, PE | job_ability:Artificer/Neutralizzatore, guardia_situazionale, PE | trait_T1:Focus_Frazionato, sigillo_forma, starter_bioma, PE | A:1-5, B:6-9, C:10-12 |
-| ESTP | job_ability:Skirmisher/Dash_Cut, trait_T1:Zampe_a_Molla | job_ability:Skirmisher/Raffica, guardia_situazionale, PE | job_ability:Invoker/Sincronia, cap_pt, PE | A:1-6, B:7-9, C:10-12 |
-| ESFP | job_ability:Harvester/Taglia_Obiettivo, guardia_situazionale, PE | trait_T1:Tattiche_di_Branco, cap_pt, starter_bioma, PE | job_ability:Harvester/Rete_Predatoria, cap_pt, PE | A:1-5, B:6-8, C:9-12 |
-| ENFP | trait_T1:Pathfinder, cap_pt, starter_bioma, PE | job_ability:Invoker/Sincronia, guardia_situazionale, PE | job_ability:Skirmisher/Smoke_Step, cap_pt, PE | A:1-6, B:7-8, C:9-12 |
-| ENTP | job_ability:Invoker/Sincronia, trait_T1:Focus_Frazionato | job_ability:Artificer/Rete_Sincro, cap_pt, PE | trait_T1:Pianificatore, guardia_situazionale, sigillo_forma | A:1-6, B:7-9, C:10-12 |
-| ESTJ | job_ability:Vanguard/Muraglia, guardia_situazionale, PE | job_ability:Vanguard/Carica, cap_pt, PE | trait_T1:Pianificatore, sigillo_forma, starter_bioma, PE | A:1-5, B:6-9, C:10-12 |
-| ESFJ | job_ability:Warden/Scudo_di_Risonanza, cap_pt, PE | trait_T1:Tattiche_di_Branco, guardia_situazionale, sigillo_forma | job_ability:Warden/Aura_di_Sollievo, starter_bioma, PE ×2 | A:1-5, B:6-8, C:9-12 |
-| ENFJ | job_ability:Warden/Aura_di_Sollievo, starter_bioma, PE ×2 | trait_T1:Risonanza_di_Branco, cap_pt, guardia_situazionale | job_ability:Harvester/Taglia_Obiettivo, cap_pt, PE | A:1-6, B:7-8, C:9-12 |
-| ENTJ | job_ability:Harvester/Blocco_Rifornimenti, cap_pt, PE | job_ability:Vanguard/Sfida, guardia_situazionale, PE | trait_T1:Pianificatore, sigillo_forma, starter_bioma, PE | A:1-6, B:7-9, C:10-12 |
-| NEUTRA | trait_T1:Random, job_ability:Random | trait_T1:Random, guardia_situazionale, cap_pt | job_ability:Random, starter_bioma, cap_pt | A:1-4, B:5-8, C:9-12 |
+
+| Forma  | Pack A                                                                | Pack B                                                           | Pack C                                                         | Bias d12              |
+| ------ | --------------------------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------- | --------------------- |
+| ISTJ   | trait_T1:pianificatore, guardia_situazionale, sigillo_forma           | job_ability:vanguard/muraglia, cap_pt, PE                        | trait_T1:pianificatore, cap_pt, starter_bioma, PE              | A:1-5, B:6-9, C:10-12 |
+| ISFJ   | trait_T1:risonanza_di_branco, guardia_situazionale, starter_bioma, PE | job_ability:warden/aura_di_sollievo, cap_pt, PE                  | job_ability:warden/purga, guardia_situazionale, PE             | A:1-4, B:5-9, C:10-12 |
+| INFJ   | trait_T1:focus_frazionato, cap_pt, starter_bioma, PE                  | job_ability:invoker/vena_psionica, guardia_situazionale, PE      | job_ability:artificer/mina_a_pressione, cap_pt, PE             | A:1-4, B:5-8, C:9-12  |
+| INTJ   | job_ability:invoker/varchi_di_forza, cap_pt, PE                       | job_ability:artificer/mina_a_pressione, guardia_situazionale, PE | trait_T1:pianificatore, sigillo_forma, starter_bioma, PE       | A:1-6, B:7-9, C:10-12 |
+| ISTP   | trait_T1:ghiandola_caustica, guardia_situazionale, PE ×2              | job_ability:skirmisher/taglio_opportunista, cap_pt, PE           | job_ability:artificer/turret_ematica, guardia_situazionale, PE | B:1-5, A:6-8, C:9-12  |
+| ISFP   | job_ability:skirmisher/smoke_step, starter_bioma, PE ×2               | trait_T1:zampe_a_molla, cap_pt, guardia_situazionale             | job_ability:skirmisher/dash_cut, cap_pt, PE                    | A:1-4, C:5-8, B:9-12  |
+| INFP   | trait_T1:empatia_coordinativa, job_ability:warden/scudo_di_risonanza  | job_ability:warden/aura_di_sollievo, starter_bioma, PE ×2        | trait_T1:risonanza_di_branco, cap_pt, guardia_situazionale     | A:1-6, B:7-9, C:10-12 |
+| INTP   | job_ability:artificer/turret_ematica, cap_pt, PE                      | job_ability:artificer/neutralizzatore, guardia_situazionale, PE  | trait_T1:focus_frazionato, sigillo_forma, starter_bioma, PE    | A:1-5, B:6-9, C:10-12 |
+| ESTP   | job_ability:skirmisher/dash_cut, trait_T1:zampe_a_molla               | job_ability:skirmisher/raffica, guardia_situazionale, PE         | job_ability:invoker/sincronia, cap_pt, PE                      | A:1-6, B:7-9, C:10-12 |
+| ESFP   | job_ability:harvester/taglia_obiettivo, guardia_situazionale, PE      | trait_T1:tattiche_di_branco, cap_pt, starter_bioma, PE           | job_ability:harvester/rete_predatoria, cap_pt, PE              | A:1-5, B:6-8, C:9-12  |
+| ENFP   | trait_T1:pathfinder, cap_pt, starter_bioma, PE                        | job_ability:invoker/sincronia, guardia_situazionale, PE          | job_ability:skirmisher/smoke_step, cap_pt, PE                  | A:1-6, B:7-8, C:9-12  |
+| ENTP   | job_ability:invoker/sincronia, trait_T1:focus_frazionato              | job_ability:artificer/rete_sincro, cap_pt, PE                    | trait_T1:pianificatore, guardia_situazionale, sigillo_forma    | A:1-6, B:7-9, C:10-12 |
+| ESTJ   | job_ability:vanguard/muraglia, guardia_situazionale, PE               | job_ability:vanguard/carica, cap_pt, PE                          | trait_T1:pianificatore, sigillo_forma, starter_bioma, PE       | A:1-5, B:6-9, C:10-12 |
+| ESFJ   | job_ability:warden/scudo_di_risonanza, cap_pt, PE                     | trait_T1:tattiche_di_branco, guardia_situazionale, sigillo_forma | job_ability:warden/aura_di_sollievo, starter_bioma, PE ×2      | A:1-5, B:6-8, C:9-12  |
+| ENFJ   | job_ability:warden/aura_di_sollievo, starter_bioma, PE ×2             | trait_T1:risonanza_di_branco, cap_pt, guardia_situazionale       | job_ability:harvester/taglia_obiettivo, cap_pt, PE             | A:1-6, B:7-8, C:9-12  |
+| ENTJ   | job_ability:harvester/blocco_rifornimenti, cap_pt, PE                 | job_ability:vanguard/sfida, guardia_situazionale, PE             | trait_T1:pianificatore, sigillo_forma, starter_bioma, PE       | A:1-6, B:7-9, C:10-12 |
+| NEUTRA | trait_T1:random, job_ability:random                                   | trait_T1:random, guardia_situazionale, cap_pt                    | job_ability:random, starter_bioma, cap_pt                      | A:1-4, B:5-8, C:9-12  |
+
 【F:data/packs.yaml†L24-L90】
 
 ## Workflow Operativo
+
 1. Usa `tools/py/roll_pack.py <Forma> <Job> data/packs.yaml --seed <seed>` per generare simulazioni deterministiche; verifica parità con `node tools/ts/dist/roll_pack.js` usando lo stesso seed (workflow documentato in `docs/tool_run_report.md`).【F:docs/tool_run_report.md†L1-L25】
 2. Archivia gli output di riferimento in `docs/examples/` per ogni bioma e Forma testata; mantenere i seed condivisi (`demo`) per confronti cross-stack.【F:docs/checklist/action-items.md†L1-L35】
 3. Aggiorna `docs/Canvas/feature-updates.md` e `docs/piani/roadmap.md` con nuove sinergie o spostamenti budget dopo ogni tuning settimanale PR/telemetria.【F:docs/Canvas/feature-updates.md†L1-L40】【F:docs/piani/roadmap.md†L1-L90】
 
 ## Stato & Azioni
+
 - Tutte le Forme MBTI sono mappate; restano da estendere `compat_forme` e `base_scores` nel dataset `data/core/mating.yaml` per supportare romance e Nido (task Ondata 2).【F:data/core/mating.yaml†L1-L120】【F:docs/piani/roadmap.md†L43-L61】
 - Il workflow `daily-pr-summary` aggiorna automaticamente pack change log, evitando divergenze tra CLI TS/Python e documentazione PI.【F:docs/Canvas/feature-updates.md†L11-L20】【F:docs/tool_run_report.md†L1-L40】

--- a/docs/evo-tactics-pack/trait-reference.json
+++ b/docs/evo-tactics-pack/trait-reference.json
@@ -12,10 +12,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -52,10 +49,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -92,10 +86,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -132,10 +123,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -172,10 +160,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -212,10 +197,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -252,10 +234,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -323,13 +302,8 @@
           "bioma:cicloni_psionici"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Tempestarii",
-          "HUD:Fulcro_Tempesta"
-        ],
-        "tabelle_random": [
-          "tabella:fulmini_empatici"
-        ]
+        "forme": ["Forma:Tempestarii", "HUD:Fulcro_Tempesta"],
+        "tabelle_random": ["tabella:fulmini_empatici"]
       }
     },
     "antenne_reagenti": {
@@ -342,10 +316,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -382,10 +353,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -422,10 +390,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -462,10 +427,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -502,10 +464,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -542,10 +501,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -582,17 +538,11 @@
         "complementare": "strutturale",
         "core": "difesa"
       },
-      "sinergie": [
-        "carapace_fase_variabile"
-      ],
-      "conflitti": [
-        "frusta_fiammeggiante"
-      ],
+      "sinergie": ["carapace_fase_variabile"],
+      "conflitti": ["frusta_fiammeggiante"],
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "deploy_barrier"
-          ],
+          "capacita_richieste": ["deploy_barrier"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -625,10 +575,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -665,10 +612,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -705,10 +649,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -745,10 +686,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -816,13 +754,8 @@
           "hud:GripNode_Psion"
         ],
         "combo_totale": 4,
-        "forme": [
-          "Forma:Predatore_Tessuto",
-          "HUD:GrappleBurst"
-        ],
-        "tabelle_random": [
-          "tabella:predazione_multicanale"
-        ]
+        "forme": ["Forma:Predatore_Tessuto", "HUD:GrappleBurst"],
+        "tabelle_random": ["tabella:predazione_multicanale"]
       }
     },
     "artigli_sghiaccio_glaciale": {
@@ -865,12 +798,8 @@
           "hud:GlacierClaw_UI"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Assaltatore_Criogenico"
-        ],
-        "tabelle_random": [
-          "tabella:presa_criostatica"
-        ]
+        "forme": ["Forma:Assaltatore_Criogenico"],
+        "tabelle_random": ["tabella:presa_criostatica"]
       }
     },
     "artigli_vetrificati": {
@@ -883,10 +812,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -923,18 +849,11 @@
         "complementare": "difesa",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "conflitti": [
-        "mantello_meteoritico"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
+      "conflitti": ["mantello_meteoritico"],
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "flight"
-          ],
+          "capacita_richieste": ["flight"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -967,10 +886,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1007,10 +923,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1047,10 +960,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1087,10 +997,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1127,10 +1034,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1167,10 +1071,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1207,10 +1108,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1247,10 +1145,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1287,10 +1182,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1327,10 +1219,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1367,10 +1256,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1407,10 +1293,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1447,13 +1330,8 @@
         "complementare": "osmoregolazione",
         "core": "respiratorio"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "scheletro_idro_regolante"
-      ],
-      "conflitti": [
-        "polmoni_cristallini_alta_quota"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "scheletro_idro_regolante"],
+      "conflitti": ["polmoni_cristallini_alta_quota"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1478,12 +1356,8 @@
           "hud:EstuarioPsi"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Amfibio_Oracolare"
-        ],
-        "tabelle_random": [
-          "tabella:osmosi_psionica"
-        ]
+        "forme": ["Forma:Amfibio_Oracolare"],
+        "tabelle_random": ["tabella:osmosi_psionica"]
       }
     },
     "branchie_solfatiche": {
@@ -1496,10 +1370,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1536,10 +1407,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1606,13 +1474,8 @@
           "hud:RootMesh_Psi"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Archivio_Subglaciale",
-          "HUD:Radice_Proxy"
-        ],
-        "tabelle_random": [
-          "tabella:riserva_empatica"
-        ]
+        "forme": ["Forma:Archivio_Subglaciale", "HUD:Radice_Proxy"],
+        "tabelle_random": ["tabella:riserva_empatica"]
       }
     },
     "camere_anticorrosione": {
@@ -1625,10 +1488,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1665,10 +1525,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1705,10 +1562,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1745,10 +1599,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1785,10 +1636,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1825,10 +1673,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1865,10 +1710,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -1925,9 +1767,7 @@
         "armatura_pietra_planare",
         "mantello_meteoritico"
       ],
-      "conflitti": [
-        "struttura_elastica_amorfa"
-      ],
+      "conflitti": ["struttura_elastica_amorfa"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1965,13 +1805,8 @@
           "hud:PhaseShift_Plate"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Guardiano_Cangiante",
-          "HUD:Placca_Sintonica"
-        ],
-        "tabelle_random": [
-          "tabella:assetto_fase"
-        ]
+        "forme": ["Forma:Guardiano_Cangiante", "HUD:Placca_Sintonica"],
+        "tabelle_random": ["tabella:assetto_fase"]
       }
     },
     "carapace_luminiscente_abissale": {
@@ -1989,9 +1824,7 @@
         "risonanza_di_branco",
         "sinapsi_coraline_polifoniche"
       ],
-      "conflitti": [
-        "carapace_fase_variabile"
-      ],
+      "conflitti": ["carapace_fase_variabile"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2016,13 +1849,8 @@
           "hud:AbyssLight_Array"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Lanterna_Abissale",
-          "HUD:LuminaNet"
-        ],
-        "tabelle_random": [
-          "tabella:segnali_bioluminosi"
-        ]
+        "forme": ["Forma:Lanterna_Abissale", "HUD:LuminaNet"],
+        "tabelle_random": ["tabella:segnali_bioluminosi"]
       }
     },
     "carapace_segmenti_logici": {
@@ -2035,10 +1863,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2075,10 +1900,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2121,9 +1943,7 @@
         "sacche_galleggianti_ascensoriali",
         "zoccoli_risonanti_steppe"
       ],
-      "conflitti": [
-        "scheletro_idro_regolante"
-      ],
+      "conflitti": ["scheletro_idro_regolante"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2148,12 +1968,8 @@
           "hud:VentSplice_Halo"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Planatore_Psionico"
-        ],
-        "tabelle_random": [
-          "tabella:assetto_eolico"
-        ]
+        "forme": ["Forma:Planatore_Psionico"],
+        "tabelle_random": ["tabella:assetto_eolico"]
       }
     },
     "cartilagini_biofibre": {
@@ -2166,10 +1982,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2206,10 +2019,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2246,10 +2056,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2286,10 +2093,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2357,13 +2161,8 @@
           "hud:TundraPulse"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Cantore_Tundra",
-          "HUD:EchoGrid"
-        ],
-        "tabelle_random": [
-          "tabella:canti_ipersonici"
-        ]
+        "forme": ["Forma:Cantore_Tundra", "HUD:EchoGrid"],
+        "tabelle_random": ["tabella:canti_ipersonici"]
       }
     },
     "cervelletto_equilibrio_statico": {
@@ -2376,10 +2175,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2416,10 +2212,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2456,10 +2249,7 @@
         "complementare": "utility",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "bulbi_radici_permafrost",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["bulbi_radici_permafrost", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2495,10 +2285,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2535,12 +2322,8 @@
         "complementare": "resilienza",
         "core": "metabolico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie"
-      ],
-      "conflitti": [
-        "sangue_piroforico"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie"],
+      "conflitti": ["sangue_piroforico"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2575,10 +2358,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2615,10 +2395,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2655,10 +2432,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2695,10 +2469,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2735,10 +2506,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2775,10 +2543,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2815,10 +2580,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2855,10 +2617,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -2895,10 +2654,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3013,10 +2769,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3053,10 +2806,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3093,10 +2843,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3133,10 +2880,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3173,10 +2917,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3213,13 +2954,8 @@
         "complementare": "difensivo",
         "core": "metabolico"
       },
-      "sinergie": [
-        "cavita_risonanti_tundra"
-      ],
-      "conflitti": [
-        "sangue_piroforico",
-        "sacche_galleggianti_ascensoriali"
-      ],
+      "sinergie": ["cavita_risonanti_tundra"],
+      "conflitti": ["sangue_piroforico", "sacche_galleggianti_ascensoriali"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3267,10 +3003,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3307,10 +3040,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3347,10 +3077,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3387,10 +3114,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3427,10 +3151,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [],
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -3454,10 +3175,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3494,10 +3212,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3534,10 +3249,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3574,10 +3286,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3614,10 +3323,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3654,10 +3360,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3742,9 +3445,7 @@
       "famiglia_tipologia": "Supporto/Empatico",
       "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
       "tier": "T1",
-      "slot": [
-        "A"
-      ],
+      "slot": ["A"],
       "slot_profile": {
         "complementare": "coordinazione",
         "core": "supporto"
@@ -3773,13 +3474,9 @@
       "spinta_selettiva": "Turni lunghi con rischio alto in cui serve mitigare tilt e HP critici.",
       "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "job_ability:Warden/Scudo_di_Risonanza"
-        ],
+        "co_occorrenze": ["job_ability:warden/scudo_di_risonanza"],
         "combo_totale": 1,
-        "forme": [
-          "INFP"
-        ],
+        "forme": ["INFP"],
         "tabelle_random": []
       }
     },
@@ -3793,10 +3490,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3833,10 +3527,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3873,10 +3564,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [],
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -3900,10 +3588,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3940,10 +3625,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -3980,10 +3662,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4020,10 +3699,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4124,10 +3800,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4164,10 +3837,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4204,10 +3874,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4244,10 +3911,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4284,10 +3948,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4319,10 +3980,7 @@
       "famiglia_tipologia": "Strategico/Psionico",
       "fattore_mantenimento_energetico": "Medio (Dividere l'attenzione su più canali)",
       "tier": "T1",
-      "slot": [
-        "A",
-        "C"
-      ],
+      "slot": ["A", "C"],
       "slot_profile": {
         "complementare": "psionico",
         "core": "strategia"
@@ -4355,16 +4013,12 @@
         "co_occorrenze": [
           "PE",
           "cap_pt",
-          "job_ability:Invoker/Sincronia",
+          "job_ability:invoker/sincronia",
           "sigillo_forma",
           "starter_bioma"
         ],
         "combo_totale": 3,
-        "forme": [
-          "ENTP",
-          "INFJ",
-          "INTP"
-        ],
+        "forme": ["ENTP", "INFJ", "INTP"],
         "tabelle_random": []
       }
     },
@@ -4378,10 +4032,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4418,10 +4069,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4458,18 +4106,11 @@
         "complementare": "controllo",
         "core": "offensivo"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "mantello_meteoritico"
-      ],
-      "conflitti": [
-        "armatura_pietra_planare"
-      ],
+      "sinergie": ["focus_frazionato", "mantello_meteoritico"],
+      "conflitti": ["armatura_pietra_planare"],
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "void_stride"
-          ],
+          "capacita_richieste": ["void_stride"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -4502,10 +4143,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4537,9 +4175,7 @@
       "famiglia_tipologia": "Offensivo/Chimico",
       "fattore_mantenimento_energetico": "Medio (Produzione reagenti)",
       "tier": "T1",
-      "slot": [
-        "A"
-      ],
+      "slot": ["A"],
       "slot_profile": {
         "complementare": "assalto",
         "core": "offensivo"
@@ -4552,14 +4188,9 @@
       "spinta_selettiva": "Squadre che devono rispondere a guardie situazionali al turno 1-2.",
       "debolezza": "Gestione accurata delle riserve per non calare sotto i budget PE previsto.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "guardia_situazionale"
-        ],
+        "co_occorrenze": ["PE", "guardia_situazionale"],
         "combo_totale": 1,
-        "forme": [
-          "ISTP"
-        ],
+        "forme": ["ISTP"],
         "tabelle_random": []
       }
     },
@@ -4573,10 +4204,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4613,10 +4241,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4653,10 +4278,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4693,10 +4315,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4733,10 +4352,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4773,10 +4389,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4813,10 +4426,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4853,10 +4463,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4893,10 +4500,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4933,10 +4537,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -4973,10 +4574,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5013,10 +4611,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5053,10 +4648,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5093,10 +4685,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5133,10 +4722,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [],
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -5160,10 +4746,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5200,10 +4783,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5240,10 +4820,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5280,10 +4857,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5320,12 +4894,8 @@
         "complementare": "termoregolazione",
         "core": "respiratorio"
       },
-      "sinergie": [
-        "sangue_piroforico"
-      ],
-      "conflitti": [
-        "criostasi_adattiva"
-      ],
+      "sinergie": ["sangue_piroforico"],
+      "conflitti": ["criostasi_adattiva"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5360,10 +4930,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5400,10 +4967,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5440,10 +5004,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5480,10 +5041,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5520,9 +5078,7 @@
         "complementare": "alimentare",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "olfatto_risonanza_magnetica"
-      ],
+      "sinergie": ["olfatto_risonanza_magnetica"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5558,10 +5114,7 @@
         "complementare": "energia",
         "core": "metabolico"
       },
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5598,10 +5151,7 @@
         "complementare": "logistico",
         "core": "supporto"
       },
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5638,10 +5188,7 @@
         "complementare": "assalto",
         "core": "offensivo"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5678,18 +5225,11 @@
         "complementare": "termico",
         "core": "difesa"
       },
-      "sinergie": [
-        "frusta_fiammeggiante",
-        "carapace_fase_variabile"
-      ],
-      "conflitti": [
-        "aura_scudo_radianza"
-      ],
+      "sinergie": ["frusta_fiammeggiante", "carapace_fase_variabile"],
+      "conflitti": ["aura_scudo_radianza"],
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "fire_resist"
-          ],
+          "capacita_richieste": ["fire_resist"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -5722,10 +5262,7 @@
         "complementare": "tattico",
         "core": "strategia"
       },
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5762,10 +5299,7 @@
         "complementare": "protezione",
         "core": "respiratorio"
       },
-      "sinergie": [
-        "piume_solari_fotovoltaiche",
-        "polmoni_cristallini_alta_quota"
-      ],
+      "sinergie": ["piume_solari_fotovoltaiche", "polmoni_cristallini_alta_quota"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5801,10 +5335,7 @@
         "complementare": "cooperazione",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5841,10 +5372,7 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -5881,10 +5409,7 @@
         "complementare": "analitico",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6005,9 +5530,7 @@
         "membrane_planata_vectored",
         "nodi_micorrizici_oracolari"
       ],
-      "conflitti": [
-        "ghiandola_caustica"
-      ],
+      "conflitti": ["ghiandola_caustica"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6042,10 +5565,7 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6082,10 +5602,7 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6140,9 +5657,7 @@
         "membrane_planata_vectored",
         "mucillagine_simbionte_mangrovie"
       ],
-      "conflitti": [
-        "spore_psichiche_silenziate"
-      ],
+      "conflitti": ["spore_psichiche_silenziate"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6178,9 +5693,7 @@
         "core": "riproduttivo"
       },
       "sinergie": [],
-      "conflitti": [
-        "secrezione_rallentante_palmi"
-      ],
+      "conflitti": ["secrezione_rallentante_palmi"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6215,9 +5728,7 @@
         "complementare": "visivo",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "sonno_emisferico_alternato"
-      ],
+      "sinergie": ["sonno_emisferico_alternato"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6253,10 +5764,7 @@
         "complementare": "nervoso",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "eco_interno_riflesso",
-        "lingua_tattile_trama"
-      ],
+      "sinergie": ["eco_interno_riflesso", "lingua_tattile_trama"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6300,9 +5808,7 @@
       "famiglia_tipologia": "Esplorazione/Tattico",
       "fattore_mantenimento_energetico": "Basso (Sincronizzazione con HUD di esplorazione)",
       "tier": "T1",
-      "slot": [
-        "A"
-      ],
+      "slot": ["A"],
       "slot_profile": {
         "complementare": "ricognizione",
         "core": "strategia"
@@ -6315,15 +5821,9 @@
       "spinta_selettiva": "Missioni con indice explore alto e opzioni opzionali da capitalizzare.",
       "debolezza": "Valore ridotto in scenari a corridoio o con tilt già stabilizzato.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "starter_bioma"],
         "combo_totale": 1,
-        "forme": [
-          "ENFP"
-        ],
+        "forme": ["ENFP"],
         "tabelle_random": []
       }
     },
@@ -6332,10 +5832,7 @@
       "famiglia_tipologia": "Strategico/Tattico",
       "fattore_mantenimento_energetico": "Medio (Analisi continua di stato squadre)",
       "tier": "T1",
-      "slot": [
-        "A",
-        "C"
-      ],
+      "slot": ["A", "C"],
       "slot_profile": {
         "complementare": "tattico",
         "core": "strategia"
@@ -6362,21 +5859,9 @@
       "spinta_selettiva": "Squadre che devono mantenere priorità multiple su turni lunghi.",
       "debolezza": "Rigidità tattica se gli input di telemetria arrivano in ritardo.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "guardia_situazionale",
-          "sigillo_forma",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "guardia_situazionale", "sigillo_forma", "starter_bioma"],
         "combo_totale": 6,
-        "forme": [
-          "ENTJ",
-          "ENTP",
-          "ESTJ",
-          "INTJ",
-          "ISTJ"
-        ],
+        "forme": ["ENTJ", "ENTP", "ESTJ", "INTJ", "ISTJ"],
         "tabelle_random": []
       }
     },
@@ -6390,13 +5875,8 @@
         "complementare": "energetico",
         "core": "tegumentario"
       },
-      "sinergie": [
-        "membrane_eliofiltranti",
-        "sacche_spore_stratosferiche"
-      ],
-      "conflitti": [
-        "criostasi_adattiva"
-      ],
+      "sinergie": ["membrane_eliofiltranti", "sacche_spore_stratosferiche"],
+      "conflitti": ["criostasi_adattiva"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6431,12 +5911,8 @@
         "complementare": "aerobico",
         "core": "respiratorio"
       },
-      "sinergie": [
-        "membrane_eliofiltranti"
-      ],
-      "conflitti": [
-        "branchie_osmotiche_salmastra"
-      ],
+      "sinergie": ["membrane_eliofiltranti"],
+      "conflitti": ["branchie_osmotiche_salmastra"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6466,10 +5942,7 @@
       "famiglia_tipologia": "Flessibile/Generico",
       "fattore_mantenimento_energetico": "Variabile (Dipende dal tratto estratto)",
       "tier": "T1",
-      "slot": [
-        "A",
-        "B"
-      ],
+      "slot": ["A", "B"],
       "slot_profile": {
         "complementare": "adattivo",
         "core": "strategia"
@@ -6482,15 +5955,9 @@
       "spinta_selettiva": "Draft rapidi o recuperi quando il tavolo necessita sorprese adattive.",
       "debolezza": "Bassa affidabilità: richiede slot aggiuntivi per mitigare risultati sfavorevoli.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "cap_pt",
-          "guardia_situazionale",
-          "job_ability:Random"
-        ],
+        "co_occorrenze": ["cap_pt", "guardia_situazionale", "job_ability:random"],
         "combo_totale": 2,
-        "forme": [
-          "NEUTRA"
-        ],
+        "forme": ["NEUTRA"],
         "tabelle_random": []
       }
     },
@@ -6504,10 +5971,7 @@
         "complementare": "propulsivo",
         "core": "respiratorio"
       },
-      "sinergie": [
-        "sacche_galleggianti_ascensoriali",
-        "squame_rifrangenti_deserto"
-      ],
+      "sinergie": ["sacche_galleggianti_ascensoriali", "squame_rifrangenti_deserto"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6538,11 +6002,7 @@
       "famiglia_tipologia": "Supporto/Coordinativo",
       "fattore_mantenimento_energetico": "Basso (Richiede mantenimento empatico)",
       "tier": "T1",
-      "slot": [
-        "A",
-        "B",
-        "C"
-      ],
+      "slot": ["A", "B", "C"],
       "slot_profile": {
         "complementare": "coordinazione",
         "core": "supporto"
@@ -6573,18 +6033,9 @@
       "spinta_selettiva": "Forme che eccellono in difesa coordinata e scudi sovrapposti.",
       "debolezza": "Stress elevato se la coesione cala sotto i target di telemetria.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "guardia_situazionale",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "guardia_situazionale", "starter_bioma"],
         "combo_totale": 3,
-        "forme": [
-          "ENFJ",
-          "INFP",
-          "ISFJ"
-        ],
+        "forme": ["ENFJ", "INFP", "ISFJ"],
         "tabelle_random": []
       }
     },
@@ -6652,12 +6103,8 @@
         "complementare": "supporto",
         "core": "simbiotico"
       },
-      "sinergie": [
-        "piume_solari_fotovoltaiche"
-      ],
-      "conflitti": [
-        "respiro_a_scoppio"
-      ],
+      "sinergie": ["piume_solari_fotovoltaiche"],
+      "conflitti": ["respiro_a_scoppio"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6708,10 +6155,7 @@
         "lamelle_termoforetiche",
         "mantelli_geotermici"
       ],
-      "conflitti": [
-        "criostasi_adattiva",
-        "scheletro_idro_regolante"
-      ],
+      "conflitti": ["criostasi_adattiva", "scheletro_idro_regolante"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6764,9 +6208,7 @@
         "sacche_galleggianti_ascensoriali",
         "struttura_elastica_amorfa"
       ],
-      "conflitti": [
-        "sangue_piroforico"
-      ],
+      "conflitti": ["sangue_piroforico"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6802,10 +6244,7 @@
         "core": "tegumentario"
       },
       "sinergie": [],
-      "conflitti": [
-        "carapace_fase_variabile",
-        "nucleo_ovomotore_rotante"
-      ],
+      "conflitti": ["carapace_fase_variabile", "nucleo_ovomotore_rotante"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6840,10 +6279,7 @@
         "complementare": "navigazione",
         "core": "sensoriale"
       },
-      "sinergie": [
-        "carapace_fase_variabile",
-        "eco_interno_riflesso"
-      ],
+      "sinergie": ["carapace_fase_variabile", "eco_interno_riflesso"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6897,9 +6333,7 @@
         "lamine_scudo_silice",
         "midollo_antivibrazione"
       ],
-      "conflitti": [
-        "spore_psichiche_silenziate"
-      ],
+      "conflitti": ["spore_psichiche_silenziate"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6934,10 +6368,7 @@
         "complementare": "omeostatico",
         "core": "nervoso"
       },
-      "sinergie": [
-        "artigli_sghiaccio_glaciale",
-        "occhi_infrarosso_composti"
-      ],
+      "sinergie": ["artigli_sghiaccio_glaciale", "occhi_infrarosso_composti"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -6974,9 +6405,7 @@
         "core": "escretorio"
       },
       "sinergie": [],
-      "conflitti": [
-        "respiro_a_scoppio"
-      ],
+      "conflitti": ["respiro_a_scoppio"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -7011,12 +6440,8 @@
         "complementare": "difensivo",
         "core": "tegumentario"
       },
-      "sinergie": [
-        "respiro_a_scoppio"
-      ],
-      "conflitti": [
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["respiro_a_scoppio"],
+      "conflitti": ["mimetismo_cromatico_passivo"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -7113,9 +6538,7 @@
       "famiglia_tipologia": "Strategico/Tattico",
       "fattore_mantenimento_energetico": "Medio (Broadcast continuo di segnali)",
       "tier": "T1",
-      "slot": [
-        "B"
-      ],
+      "slot": ["B"],
       "slot_profile": {
         "complementare": "coordinazione",
         "core": "strategia"
@@ -7143,18 +6566,9 @@
       "spinta_selettiva": "Squadre che puntano a style bonus tramite assist e controllo spazio.",
       "debolezza": "Richiede formazione stabile; cala se la coesione precipita sotto il target.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "guardia_situazionale",
-          "sigillo_forma",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "guardia_situazionale", "sigillo_forma", "starter_bioma"],
         "combo_totale": 2,
-        "forme": [
-          "ESFJ",
-          "ESFP"
-        ],
+        "forme": ["ESFJ", "ESFP"],
         "tabelle_random": []
       }
     },
@@ -7168,9 +6582,7 @@
         "complementare": "idratazione",
         "core": "tegumentario"
       },
-      "sinergie": [
-        "bulbi_radici_permafrost"
-      ],
+      "sinergie": ["bulbi_radici_permafrost"],
       "conflitti": [],
       "requisiti_ambientali": [
         {
@@ -7252,10 +6664,7 @@
       "famiglia_tipologia": "Mobilità/Cinetico",
       "fattore_mantenimento_energetico": "Basso (Carica elastica a turni alterni)",
       "tier": "T1",
-      "slot": [
-        "A",
-        "B"
-      ],
+      "slot": ["A", "B"],
       "slot_profile": {
         "complementare": "propulsione",
         "core": "locomotorio"
@@ -7284,16 +6693,9 @@
       "spinta_selettiva": "Metagame con forte pressione di aggro e necessità di riposizionamento.",
       "debolezza": "Perdita di valore su mappe con spazi stretti o controllo setup elevato.",
       "sinergie_pi": {
-        "co_occorrenze": [
-          "cap_pt",
-          "guardia_situazionale",
-          "job_ability:Skirmisher/Dash_Cut"
-        ],
+        "co_occorrenze": ["cap_pt", "guardia_situazionale", "job_ability:skirmisher/dash_cut"],
         "combo_totale": 2,
-        "forme": [
-          "ESTP",
-          "ISFP"
-        ],
+        "forme": ["ESTP", "ISFP"],
         "tabelle_random": []
       }
     },
@@ -7307,12 +6709,8 @@
         "complementare": "supporto",
         "core": "locomotorio"
       },
-      "sinergie": [
-        "cartilagine_flessotermica_venti"
-      ],
-      "conflitti": [
-        "zampe_a_molla"
-      ],
+      "sinergie": ["cartilagine_flessotermica_venti"],
+      "conflitti": ["zampe_a_molla"],
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -7343,9 +6741,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "difensivo"
-          ]
+          "type": ["difensivo"]
         }
       },
       "traits": [
@@ -7370,67 +6766,47 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "difesa"
-          ]
+          "type": ["difesa"]
         }
       },
-      "traits": [
-        "armatura_pietra_planare",
-        "mantello_meteoritico"
-      ],
+      "traits": ["armatura_pietra_planare", "mantello_meteoritico"],
       "type": "difesa"
     },
     "digestivo": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "digestivo"
-          ]
+          "type": ["digestivo"]
         }
       },
-      "traits": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "traits": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "type": "digestivo"
     },
     "escretorio": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "escretorio"
-          ]
+          "type": ["escretorio"]
         }
       },
-      "traits": [
-        "spore_psichiche_silenziate"
-      ],
+      "traits": ["spore_psichiche_silenziate"],
       "type": "escretorio"
     },
     "idrostatico": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "idrostatico"
-          ]
+          "type": ["idrostatico"]
         }
       },
-      "traits": [
-        "sacche_galleggianti_ascensoriali"
-      ],
+      "traits": ["sacche_galleggianti_ascensoriali"],
       "type": "idrostatico"
     },
     "locomotorio": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "locomotorio"
-          ]
+          "type": ["locomotorio"]
         }
       },
       "traits": [
@@ -7461,9 +6837,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "metabolico"
-          ]
+          "type": ["metabolico"]
         }
       },
       "traits": [
@@ -7489,23 +6863,17 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "nervoso"
-          ]
+          "type": ["nervoso"]
         }
       },
-      "traits": [
-        "sonno_emisferico_alternato"
-      ],
+      "traits": ["sonno_emisferico_alternato"],
       "type": "nervoso"
     },
     "offensivo": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "offensivo"
-          ]
+          "type": ["offensivo"]
         }
       },
       "traits": [
@@ -7532,9 +6900,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "respiratorio"
-          ]
+          "type": ["respiratorio"]
         }
       },
       "traits": [
@@ -7550,23 +6916,17 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "riproduttivo"
-          ]
+          "type": ["riproduttivo"]
         }
       },
-      "traits": [
-        "nucleo_ovomotore_rotante"
-      ],
+      "traits": ["nucleo_ovomotore_rotante"],
       "type": "riproduttivo"
     },
     "sensoriale": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "sensoriale"
-          ]
+          "type": ["sensoriale"]
         }
       },
       "traits": [
@@ -7598,9 +6958,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "simbiotico"
-          ]
+          "type": ["simbiotico"]
         }
       },
       "traits": [
@@ -7630,9 +6988,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "strategia"
-          ]
+          "type": ["strategia"]
         }
       },
       "traits": [
@@ -7661,9 +7017,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "strutturale"
-          ]
+          "type": ["strutturale"]
         }
       },
       "traits": [
@@ -7691,9 +7045,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "supporto"
-          ]
+          "type": ["supporto"]
         }
       },
       "traits": [
@@ -7720,9 +7072,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "tegumentario"
-          ]
+          "type": ["tegumentario"]
         }
       },
       "traits": [

--- a/docs/evo-tactics-pack/traits/index.json
+++ b/docs/evo-tactics-pack/traits/index.json
@@ -23,10 +23,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -63,10 +60,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -103,10 +97,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -143,10 +134,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -183,10 +171,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -223,10 +208,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -263,10 +245,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -315,13 +294,8 @@
           "bioma:cicloni_psionici"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Tempestarii",
-          "HUD:Fulcro_Tempesta"
-        ],
-        "tabelle_random": [
-          "tabella:fulmini_empatici"
-        ]
+        "forme": ["Forma:Tempestarii", "HUD:Fulcro_Tempesta"],
+        "tabelle_random": ["tabella:fulmini_empatici"]
       },
       "slot": [],
       "slot_profile": {
@@ -353,10 +327,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -393,10 +364,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -433,10 +401,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -473,10 +438,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -513,10 +475,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -553,10 +512,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -573,9 +529,7 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
     },
     "armatura_pietra_planare": {
-      "conflitti": [
-        "frusta_fiammeggiante"
-      ],
+      "conflitti": ["frusta_fiammeggiante"],
       "debolezza": "Pesante: riduce mobilità in ambienti non supportati o a bassa gravità.",
       "famiglia_tipologia": "Difesa/Strutturale",
       "fattore_mantenimento_energetico": "Basso (Risonanza geodetica stabile)",
@@ -583,9 +537,7 @@
       "mutazione_indotta": "Cristallizza il dermascheletro con nodi rune che deviano energia.",
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "deploy_barrier"
-          ],
+          "capacita_richieste": ["deploy_barrier"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -597,9 +549,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile"
-      ],
+      "sinergie": ["carapace_fase_variabile"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -636,10 +586,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -676,10 +623,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -716,10 +660,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -756,10 +697,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -808,13 +746,8 @@
           "hud:GripNode_Psion"
         ],
         "combo_totale": 4,
-        "forme": [
-          "Forma:Predatore_Tessuto",
-          "HUD:GrappleBurst"
-        ],
-        "tabelle_random": [
-          "tabella:predazione_multicanale"
-        ]
+        "forme": ["Forma:Predatore_Tessuto", "HUD:GrappleBurst"],
+        "tabelle_random": ["tabella:predazione_multicanale"]
       },
       "slot": [],
       "slot_profile": {
@@ -857,12 +790,8 @@
           "hud:GlacierClaw_UI"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Assaltatore_Criogenico"
-        ],
-        "tabelle_random": [
-          "tabella:presa_criostatica"
-        ]
+        "forme": ["Forma:Assaltatore_Criogenico"],
+        "tabelle_random": ["tabella:presa_criostatica"]
       },
       "slot": [],
       "slot_profile": {
@@ -894,10 +823,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -914,9 +840,7 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
     },
     "aura_scudo_radianza": {
-      "conflitti": [
-        "mantello_meteoritico"
-      ],
+      "conflitti": ["mantello_meteoritico"],
       "debolezza": "Soffre saturazione se esposta a ombre gravitazionali o zone di antimagia.",
       "famiglia_tipologia": "Supporto/Difesa",
       "fattore_mantenimento_energetico": "Alto (Canalizzazione fotonica continua)",
@@ -924,9 +848,7 @@
       "mutazione_indotta": "Innesta organi fotoplasmatici che diffondono uno scudo radiante sugli alleati vicini.",
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "flight"
-          ],
+          "capacita_richieste": ["flight"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -938,10 +860,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -978,10 +897,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1018,10 +934,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1058,10 +971,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1098,10 +1008,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1138,10 +1045,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1178,10 +1082,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1218,10 +1119,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1258,10 +1156,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1298,10 +1193,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1338,10 +1230,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1378,10 +1267,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1418,10 +1304,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1438,9 +1321,7 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
     },
     "branchie_osmotiche_salmastra": {
-      "conflitti": [
-        "polmoni_cristallini_alta_quota"
-      ],
+      "conflitti": ["polmoni_cristallini_alta_quota"],
       "debolezza": "Richiede accesso costante ad acqua salmastra; ambienti d'acqua dolce provocano stress ionico.",
       "famiglia_tipologia": "Respiratorio/Osmoregolazione",
       "fattore_mantenimento_energetico": "Medio (Pompe ioniche attive)",
@@ -1459,10 +1340,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "scheletro_idro_regolante"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "scheletro_idro_regolante"],
       "sinergie_pi": {
         "co_occorrenze": [
           "boardgame:Evolution/Symbiosis",
@@ -1470,12 +1348,8 @@
           "hud:EstuarioPsi"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Amfibio_Oracolare"
-        ],
-        "tabelle_random": [
-          "tabella:osmosi_psionica"
-        ]
+        "forme": ["Forma:Amfibio_Oracolare"],
+        "tabelle_random": ["tabella:osmosi_psionica"]
       },
       "slot": [],
       "slot_profile": {
@@ -1507,10 +1381,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1547,10 +1418,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1598,13 +1466,8 @@
           "hud:RootMesh_Psi"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Archivio_Subglaciale",
-          "HUD:Radice_Proxy"
-        ],
-        "tabelle_random": [
-          "tabella:riserva_empatica"
-        ]
+        "forme": ["Forma:Archivio_Subglaciale", "HUD:Radice_Proxy"],
+        "tabelle_random": ["tabella:riserva_empatica"]
       },
       "slot": [],
       "slot_profile": {
@@ -1636,10 +1499,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1676,10 +1536,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1716,10 +1573,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1756,10 +1610,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1796,10 +1647,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1836,10 +1684,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1876,10 +1721,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -1896,9 +1738,7 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
     },
     "carapace_fase_variabile": {
-      "conflitti": [
-        "struttura_elastica_amorfa"
-      ],
+      "conflitti": ["struttura_elastica_amorfa"],
       "debolezza": "Debolezza strutturale durante la transizione tra le fasi di durezza.",
       "famiglia_tipologia": "Strutturale/Difensivo",
       "fattore_mantenimento_energetico": "Alto (Richiede energia per il cambio di fase)",
@@ -1957,13 +1797,8 @@
           "hud:PhaseShift_Plate"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Guardiano_Cangiante",
-          "HUD:Placca_Sintonica"
-        ],
-        "tabelle_random": [
-          "tabella:assetto_fase"
-        ]
+        "forme": ["Forma:Guardiano_Cangiante", "HUD:Placca_Sintonica"],
+        "tabelle_random": ["tabella:assetto_fase"]
       },
       "slot": [],
       "slot_profile": {
@@ -1975,9 +1810,7 @@
       "uso_funzione": "Durezza/densità del guscio modificabile rapidamente."
     },
     "carapace_luminiscente_abissale": {
-      "conflitti": [
-        "carapace_fase_variabile"
-      ],
+      "conflitti": ["carapace_fase_variabile"],
       "debolezza": "Luce intensa di superficie sovraccarica i biofotoni rendendo la corazza fragile.",
       "famiglia_tipologia": "Strutturale/Sensoriale",
       "fattore_mantenimento_energetico": "Alto (Bioluminescenza controllata)",
@@ -2008,13 +1841,8 @@
           "hud:AbyssLight_Array"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Lanterna_Abissale",
-          "HUD:LuminaNet"
-        ],
-        "tabelle_random": [
-          "tabella:segnali_bioluminosi"
-        ]
+        "forme": ["Forma:Lanterna_Abissale", "HUD:LuminaNet"],
+        "tabelle_random": ["tabella:segnali_bioluminosi"]
       },
       "slot": [],
       "slot_profile": {
@@ -2046,10 +1874,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2086,10 +1911,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2106,9 +1928,7 @@
       "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
     },
     "cartilagine_flessotermica_venti": {
-      "conflitti": [
-        "scheletro_idro_regolante"
-      ],
+      "conflitti": ["scheletro_idro_regolante"],
       "debolezza": "Temperature stabili riducono la reattività della cartilagine rendendo l'organismo lento.",
       "famiglia_tipologia": "Locomotorio/Adattivo",
       "fattore_mantenimento_energetico": "Medio (Richiede frequenti riallineamenti fibrosi)",
@@ -2140,12 +1960,8 @@
           "hud:VentSplice_Halo"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Planatore_Psionico"
-        ],
-        "tabelle_random": [
-          "tabella:assetto_eolico"
-        ]
+        "forme": ["Forma:Planatore_Psionico"],
+        "tabelle_random": ["tabella:assetto_eolico"]
       },
       "slot": [],
       "slot_profile": {
@@ -2177,10 +1993,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2217,10 +2030,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2257,10 +2067,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2297,10 +2104,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2349,13 +2153,8 @@
           "hud:TundraPulse"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Cantore_Tundra",
-          "HUD:EchoGrid"
-        ],
-        "tabelle_random": [
-          "tabella:canti_ipersonici"
-        ]
+        "forme": ["Forma:Cantore_Tundra", "HUD:EchoGrid"],
+        "tabelle_random": ["tabella:canti_ipersonici"]
       },
       "slot": [],
       "slot_profile": {
@@ -2387,10 +2186,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2427,10 +2223,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2466,10 +2259,7 @@
           }
         }
       ],
-      "sinergie": [
-        "bulbi_radici_permafrost",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["bulbi_radici_permafrost", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -2506,10 +2296,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2526,9 +2313,7 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
     },
     "circolazione_bifasica_palude": {
-      "conflitti": [
-        "sangue_piroforico"
-      ],
+      "conflitti": ["sangue_piroforico"],
       "debolezza": "Zone asciutte e calde causano stagnazione del circuito linfatico portando a tossicosi.",
       "famiglia_tipologia": "Metabolico/Resilienza",
       "fattore_mantenimento_energetico": "Medio (Doppio circuito emolinfa/linfa)",
@@ -2547,9 +2332,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -2586,10 +2369,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2626,10 +2406,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2666,10 +2443,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2706,10 +2480,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2746,10 +2517,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2786,10 +2554,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2826,10 +2591,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2866,10 +2628,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -2906,10 +2665,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3024,10 +2780,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3064,10 +2817,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3104,10 +2854,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3144,10 +2891,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3184,10 +2928,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3204,10 +2945,7 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
     },
     "criostasi_adattiva": {
-      "conflitti": [
-        "sangue_piroforico",
-        "sacche_galleggianti_ascensoriali"
-      ],
+      "conflitti": ["sangue_piroforico", "sacche_galleggianti_ascensoriali"],
       "debolezza": "Vulnerabilità estrema agli attacchi chimici (veleni) in fase Criostasi.",
       "famiglia_tipologia": "Metabolico/Difensivo",
       "fattore_mantenimento_energetico": "Alto (Fase di risveglio/inizio) / Basso (Fase Criostasi).",
@@ -3239,9 +2977,7 @@
           }
         }
       ],
-      "sinergie": [
-        "cavita_risonanti_tundra"
-      ],
+      "sinergie": ["cavita_risonanti_tundra"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -3278,10 +3014,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3318,10 +3051,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3358,10 +3088,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3398,10 +3125,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3425,10 +3149,7 @@
       "label": "Cuticole Cerose",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3465,10 +3186,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3505,10 +3223,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3545,10 +3260,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3585,10 +3297,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3625,10 +3334,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3665,10 +3371,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3763,18 +3466,12 @@
         "aura_scudo_radianza"
       ],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "job_ability:Warden/Scudo_di_Risonanza"
-        ],
+        "co_occorrenze": ["job_ability:warden/scudo_di_risonanza"],
         "combo_totale": 1,
-        "forme": [
-          "INFP"
-        ],
+        "forme": ["INFP"],
         "tabelle_random": []
       },
-      "slot": [
-        "A"
-      ],
+      "slot": ["A"],
       "slot_profile": {
         "complementare": "coordinazione",
         "core": "supporto"
@@ -3804,10 +3501,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3844,10 +3538,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3871,10 +3562,7 @@
       "label": "Enzimi Chelanti",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3911,10 +3599,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3951,10 +3636,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -3991,10 +3673,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4031,10 +3710,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4135,10 +3811,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4175,10 +3848,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4215,10 +3885,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4255,10 +3922,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4295,10 +3959,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4344,22 +4005,15 @@
         "co_occorrenze": [
           "PE",
           "cap_pt",
-          "job_ability:Invoker/Sincronia",
+          "job_ability:invoker/sincronia",
           "sigillo_forma",
           "starter_bioma"
         ],
         "combo_totale": 3,
-        "forme": [
-          "ENTP",
-          "INFJ",
-          "INTP"
-        ],
+        "forme": ["ENTP", "INFJ", "INTP"],
         "tabelle_random": []
       },
-      "slot": [
-        "A",
-        "C"
-      ],
+      "slot": ["A", "C"],
       "slot_profile": {
         "complementare": "psionico",
         "core": "strategia"
@@ -4389,10 +4043,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4429,10 +4080,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4449,9 +4097,7 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
     },
     "frusta_fiammeggiante": {
-      "conflitti": [
-        "armatura_pietra_planare"
-      ],
+      "conflitti": ["armatura_pietra_planare"],
       "debolezza": "Consumante: richiede costante dissipazione termica per non bruciare la matrice portante.",
       "famiglia_tipologia": "Offensivo/Controllo",
       "fattore_mantenimento_energetico": "Medio (Filamenti di plasma vincolato)",
@@ -4459,9 +4105,7 @@
       "mutazione_indotta": "Genera appendici tentacolari avvolte da plasma infernale controllato.",
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "void_stride"
-          ],
+          "capacita_richieste": ["void_stride"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -4473,10 +4117,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "mantello_meteoritico"
-      ],
+      "sinergie": ["focus_frazionato", "mantello_meteoritico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -4513,10 +4154,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4542,19 +4180,12 @@
       "requisiti_ambientali": [],
       "sinergie": [],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "guardia_situazionale"
-        ],
+        "co_occorrenze": ["PE", "guardia_situazionale"],
         "combo_totale": 1,
-        "forme": [
-          "ISTP"
-        ],
+        "forme": ["ISTP"],
         "tabelle_random": []
       },
-      "slot": [
-        "A"
-      ],
+      "slot": ["A"],
       "slot_profile": {
         "complementare": "assalto",
         "core": "offensivo"
@@ -4584,10 +4215,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4624,10 +4252,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4664,10 +4289,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4704,10 +4326,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4744,10 +4363,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4784,10 +4400,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4824,10 +4437,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4864,10 +4474,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4904,10 +4511,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4944,10 +4548,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -4984,10 +4585,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5024,10 +4622,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5064,10 +4659,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5104,10 +4696,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5131,10 +4720,7 @@
       "label": "Grassi Termici",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5171,10 +4757,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5211,10 +4794,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5251,10 +4831,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5291,10 +4868,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5311,9 +4885,7 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
     },
     "lamelle_termoforetiche": {
-      "conflitti": [
-        "criostasi_adattiva"
-      ],
+      "conflitti": ["criostasi_adattiva"],
       "debolezza": "Rende instabile la fisiologia in ambienti a gelo improvviso, con rischio di microfratture vascolari.",
       "famiglia_tipologia": "Respiratorio/Termoregolazione",
       "fattore_mantenimento_energetico": "Medio (Flusso continuo di fluidi caldi)",
@@ -5332,9 +4904,7 @@
           }
         }
       ],
-      "sinergie": [
-        "sangue_piroforico"
-      ],
+      "sinergie": ["sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -5371,10 +4941,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5411,10 +4978,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5451,10 +5015,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5491,10 +5052,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5530,9 +5088,7 @@
           }
         }
       ],
-      "sinergie": [
-        "olfatto_risonanza_magnetica"
-      ],
+      "sinergie": ["olfatto_risonanza_magnetica"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -5569,10 +5125,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5609,10 +5162,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5649,10 +5199,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5669,9 +5216,7 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
     },
     "mantello_meteoritico": {
-      "conflitti": [
-        "aura_scudo_radianza"
-      ],
+      "conflitti": ["aura_scudo_radianza"],
       "debolezza": "Vulnerabile a scariche di freddo gravitazionale che irrigidiscono il mantello.",
       "famiglia_tipologia": "Difesa/Termoregolazione",
       "fattore_mantenimento_energetico": "Alto (Rivestimento ablativo rigenerante)",
@@ -5679,9 +5224,7 @@
       "mutazione_indotta": "Deposita strati sovrapposti di materiale meteorico che vaporizzano l'impatto e rilasciano radianza.",
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "fire_resist"
-          ],
+          "capacita_richieste": ["fire_resist"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -5693,10 +5236,7 @@
           }
         }
       ],
-      "sinergie": [
-        "frusta_fiammeggiante",
-        "carapace_fase_variabile"
-      ],
+      "sinergie": ["frusta_fiammeggiante", "carapace_fase_variabile"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -5733,10 +5273,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5772,10 +5309,7 @@
           }
         }
       ],
-      "sinergie": [
-        "piume_solari_fotovoltaiche",
-        "polmoni_cristallini_alta_quota"
-      ],
+      "sinergie": ["piume_solari_fotovoltaiche", "polmoni_cristallini_alta_quota"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -5812,10 +5346,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5852,10 +5383,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5892,10 +5420,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -5978,9 +5503,7 @@
       "uso_funzione": "Assorbire e replicare il colore dell'ambiente circostante dopo contatto."
     },
     "mucillagine_simbionte_mangrovie": {
-      "conflitti": [
-        "ghiandola_caustica"
-      ],
+      "conflitti": ["ghiandola_caustica"],
       "debolezza": "Acque eccessivamente pure diluiscono la mucillagine riducendo la protezione.",
       "famiglia_tipologia": "Simbiotico/Difensivo",
       "fattore_mantenimento_energetico": "Medio (Coltura simbiotica costante)",
@@ -6053,10 +5576,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -6093,10 +5613,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -6113,9 +5630,7 @@
       "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
     },
     "nodi_micorrizici_oracolari": {
-      "conflitti": [
-        "spore_psichiche_silenziate"
-      ],
+      "conflitti": ["spore_psichiche_silenziate"],
       "debolezza": "Se la rete micorrizica viene recisa, l'organismo soffre crisi percettive e perdita di orientamento.",
       "famiglia_tipologia": "Simbiotico/Nervoso",
       "fattore_mantenimento_energetico": "Medio (Scambio continuo di segnali con simbionti)",
@@ -6168,9 +5683,7 @@
       "uso_funzione": "Riceve presagi e segnali tattici dalla rete fungina per coordinare manovre di squadra."
     },
     "nucleo_ovomotore_rotante": {
-      "conflitti": [
-        "secrezione_rallentante_palmi"
-      ],
+      "conflitti": ["secrezione_rallentante_palmi"],
       "debolezza": "Impossibilità di muoversi su superfici irregolari o in salita ripida.",
       "famiglia_tipologia": "Riproduttivo/Locomotorio",
       "fattore_mantenimento_energetico": "Alto (Rotolamento)",
@@ -6225,9 +5738,7 @@
           }
         }
       ],
-      "sinergie": [
-        "sonno_emisferico_alternato"
-      ],
+      "sinergie": ["sonno_emisferico_alternato"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -6276,10 +5787,7 @@
           }
         }
       ],
-      "sinergie": [
-        "eco_interno_riflesso",
-        "lingua_tattile_trama"
-      ],
+      "sinergie": ["eco_interno_riflesso", "lingua_tattile_trama"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -6305,20 +5813,12 @@
       "requisiti_ambientali": [],
       "sinergie": [],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "starter_bioma"],
         "combo_totale": 1,
-        "forme": [
-          "ENFP"
-        ],
+        "forme": ["ENFP"],
         "tabelle_random": []
       },
-      "slot": [
-        "A"
-      ],
+      "slot": ["A"],
       "slot_profile": {
         "complementare": "ricognizione",
         "core": "strategia"
@@ -6351,27 +5851,12 @@
         "membrane_captura_rugiada"
       ],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "guardia_situazionale",
-          "sigillo_forma",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "guardia_situazionale", "sigillo_forma", "starter_bioma"],
         "combo_totale": 6,
-        "forme": [
-          "ENTJ",
-          "ENTP",
-          "ESTJ",
-          "INTJ",
-          "ISTJ"
-        ],
+        "forme": ["ENTJ", "ENTP", "ESTJ", "INTJ", "ISTJ"],
         "tabelle_random": []
       },
-      "slot": [
-        "A",
-        "C"
-      ],
+      "slot": ["A", "C"],
       "slot_profile": {
         "complementare": "tattico",
         "core": "strategia"
@@ -6381,9 +5866,7 @@
       "uso_funzione": "Coordina finestre di danno e difesa, mantenendo la squadra allineata al piano PI."
     },
     "piume_solari_fotovoltaiche": {
-      "conflitti": [
-        "criostasi_adattiva"
-      ],
+      "conflitti": ["criostasi_adattiva"],
       "debolezza": "Ombre prolungate o polveri dense riducono drasticamente la produzione energetica.",
       "famiglia_tipologia": "Tegumentario/Energetico",
       "fattore_mantenimento_energetico": "Alto (Richiede manutenzione delle lamine fotoreattive)",
@@ -6402,10 +5885,7 @@
           }
         }
       ],
-      "sinergie": [
-        "membrane_eliofiltranti",
-        "sacche_spore_stratosferiche"
-      ],
+      "sinergie": ["membrane_eliofiltranti", "sacche_spore_stratosferiche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -6422,9 +5902,7 @@
       "uso_funzione": "Convertire la radiazione solare in riserve energetiche per abilità a lungo raggio."
     },
     "polmoni_cristallini_alta_quota": {
-      "conflitti": [
-        "branchie_osmotiche_salmastra"
-      ],
+      "conflitti": ["branchie_osmotiche_salmastra"],
       "debolezza": "Particolato pesante o sabbia vulcanica graffia i cristalli riducendo l'efficienza respiratoria.",
       "famiglia_tipologia": "Respiratorio/Aerobico",
       "fattore_mantenimento_energetico": "Medio (Pulizia periodica dei cristalli)",
@@ -6443,9 +5921,7 @@
           }
         }
       ],
-      "sinergie": [
-        "membrane_eliofiltranti"
-      ],
+      "sinergie": ["membrane_eliofiltranti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -6471,21 +5947,12 @@
       "requisiti_ambientali": [],
       "sinergie": [],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "cap_pt",
-          "guardia_situazionale",
-          "job_ability:Random"
-        ],
+        "co_occorrenze": ["cap_pt", "guardia_situazionale", "job_ability:random"],
         "combo_totale": 2,
-        "forme": [
-          "NEUTRA"
-        ],
+        "forme": ["NEUTRA"],
         "tabelle_random": []
       },
-      "slot": [
-        "A",
-        "B"
-      ],
+      "slot": ["A", "B"],
       "slot_profile": {
         "complementare": "adattivo",
         "core": "strategia"
@@ -6514,10 +5981,7 @@
           }
         }
       ],
-      "sinergie": [
-        "sacche_galleggianti_ascensoriali",
-        "squame_rifrangenti_deserto"
-      ],
+      "sinergie": ["sacche_galleggianti_ascensoriali", "squame_rifrangenti_deserto"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -6561,25 +6025,12 @@
         "aura_scudo_radianza"
       ],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "guardia_situazionale",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "guardia_situazionale", "starter_bioma"],
         "combo_totale": 3,
-        "forme": [
-          "ENFJ",
-          "INFP",
-          "ISFJ"
-        ],
+        "forme": ["ENFJ", "INFP", "ISFJ"],
         "tabelle_random": []
       },
-      "slot": [
-        "A",
-        "B",
-        "C"
-      ],
+      "slot": ["A", "B", "C"],
       "slot_profile": {
         "complementare": "coordinazione",
         "core": "supporto"
@@ -6643,9 +6094,7 @@
       "uso_funzione": "Controllo preciso della profondità e del movimento verticale."
     },
     "sacche_spore_stratosferiche": {
-      "conflitti": [
-        "respiro_a_scoppio"
-      ],
+      "conflitti": ["respiro_a_scoppio"],
       "debolezza": "Correnti ionizzate possono incendiare le sacche rendendo l'organismo instabile.",
       "famiglia_tipologia": "Simbiotico/Supporto",
       "fattore_mantenimento_energetico": "Alto (Coltura continua di spore portanti)",
@@ -6664,9 +6113,7 @@
           }
         }
       ],
-      "sinergie": [
-        "piume_solari_fotovoltaiche"
-      ],
+      "sinergie": ["piume_solari_fotovoltaiche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -6683,10 +6130,7 @@
       "uso_funzione": "Distribuisce simbionti di supporto e crea corridoi di movimento per la squadra."
     },
     "sangue_piroforico": {
-      "conflitti": [
-        "criostasi_adattiva",
-        "scheletro_idro_regolante"
-      ],
+      "conflitti": ["criostasi_adattiva", "scheletro_idro_regolante"],
       "debolezza": "Rischio di auto-combustione in caso di ferita profonda in atmosfera ricca di ossigeno.",
       "famiglia_tipologia": "Offensivo/Cinetico",
       "fattore_mantenimento_energetico": "Medio (Sintesi dei composti)",
@@ -6737,9 +6181,7 @@
       "uso_funzione": "Meccanismo di difesa termico o chimico che si attiva con l'aria."
     },
     "scheletro_idro_regolante": {
-      "conflitti": [
-        "sangue_piroforico"
-      ],
+      "conflitti": ["sangue_piroforico"],
       "debolezza": "Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio.",
       "famiglia_tipologia": "Strutturale/Omeostatico",
       "fattore_mantenimento_energetico": "Medio (Scambio rapido di fluidi)",
@@ -6792,10 +6234,7 @@
       "uso_funzione": "Assorbire o espellere rapidamente acqua dai tessuti ossei per modificare il peso."
     },
     "secrezione_rallentante_palmi": {
-      "conflitti": [
-        "carapace_fase_variabile",
-        "nucleo_ovomotore_rotante"
-      ],
+      "conflitti": ["carapace_fase_variabile", "nucleo_ovomotore_rotante"],
       "debolezza": "Esaurimento rapido delle riserve di liquido con tempo di ricarica prolungato.",
       "famiglia_tipologia": "Tegumentario/Difensivo",
       "fattore_mantenimento_energetico": "Medio (Produzione del liquido)",
@@ -6850,10 +6289,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "eco_interno_riflesso"
-      ],
+      "sinergie": ["carapace_fase_variabile", "eco_interno_riflesso"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -6870,9 +6306,7 @@
       "uso_funzione": "Traccia linee di campo e memorizza corridoi magnetici per la migrazione."
     },
     "sinapsi_coraline_polifoniche": {
-      "conflitti": [
-        "spore_psichiche_silenziate"
-      ],
+      "conflitti": ["spore_psichiche_silenziate"],
       "debolezza": "Vibrazioni sintonizzate male possono generare feedback dolorosi e perdita di coscienza.",
       "famiglia_tipologia": "Simbiotico/Comunicazione",
       "fattore_mantenimento_energetico": "Medio (Scambio continuo di impulsi corallini)",
@@ -6944,10 +6378,7 @@
           }
         }
       ],
-      "sinergie": [
-        "artigli_sghiaccio_glaciale",
-        "occhi_infrarosso_composti"
-      ],
+      "sinergie": ["artigli_sghiaccio_glaciale", "occhi_infrarosso_composti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -6964,9 +6395,7 @@
       "uso_funzione": "Vigilanza continua pur garantendo riposo."
     },
     "spore_psichiche_silenziate": {
-      "conflitti": [
-        "respiro_a_scoppio"
-      ],
+      "conflitti": ["respiro_a_scoppio"],
       "debolezza": "Funzionalità ridotta in presenza di vento forte o umidità elevata.",
       "famiglia_tipologia": "Escretorio/Psichico",
       "fattore_mantenimento_energetico": "Alto (Produzione e rilascio)",
@@ -7002,9 +6431,7 @@
       "uso_funzione": "Indurre uno stato di confusione o letargia negli individui vicini."
     },
     "squame_rifrangenti_deserto": {
-      "conflitti": [
-        "mimetismo_cromatico_passivo"
-      ],
+      "conflitti": ["mimetismo_cromatico_passivo"],
       "debolezza": "Soffre danni da feedback termico se colpito da raggi concentrati o laser.",
       "famiglia_tipologia": "Tegumentario/Difensivo",
       "fattore_mantenimento_energetico": "Medio (Richiede riallineamento delle placche)",
@@ -7023,9 +6450,7 @@
           }
         }
       ],
-      "sinergie": [
-        "respiro_a_scoppio"
-      ],
+      "sinergie": ["respiro_a_scoppio"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -7133,23 +6558,12 @@
         "membrane_captura_rugiada"
       ],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "guardia_situazionale",
-          "sigillo_forma",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "guardia_situazionale", "sigillo_forma", "starter_bioma"],
         "combo_totale": 2,
-        "forme": [
-          "ESFJ",
-          "ESFP"
-        ],
+        "forme": ["ESFJ", "ESFP"],
         "tabelle_random": []
       },
-      "slot": [
-        "B"
-      ],
+      "slot": ["B"],
       "slot_profile": {
         "complementare": "coordinazione",
         "core": "strategia"
@@ -7178,9 +6592,7 @@
           }
         }
       ],
-      "sinergie": [
-        "bulbi_radici_permafrost"
-      ],
+      "sinergie": ["bulbi_radici_permafrost"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -7273,22 +6685,12 @@
         "mucose_aderenza_sonica"
       ],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "cap_pt",
-          "guardia_situazionale",
-          "job_ability:Skirmisher/Dash_Cut"
-        ],
+        "co_occorrenze": ["cap_pt", "guardia_situazionale", "job_ability:skirmisher/dash_cut"],
         "combo_totale": 2,
-        "forme": [
-          "ESTP",
-          "ISFP"
-        ],
+        "forme": ["ESTP", "ISFP"],
         "tabelle_random": []
       },
-      "slot": [
-        "A",
-        "B"
-      ],
+      "slot": ["A", "B"],
       "slot_profile": {
         "complementare": "propulsione",
         "core": "locomotorio"
@@ -7298,9 +6700,7 @@
       "uso_funzione": "Dash esplosivi per mantenere il ritmo di ingaggio o disimpegno."
     },
     "zoccoli_risonanti_steppe": {
-      "conflitti": [
-        "zampe_a_molla"
-      ],
+      "conflitti": ["zampe_a_molla"],
       "debolezza": "Suoli cedevoli come sabbie mobili annullano la vibrazione e riducono la trazione.",
       "famiglia_tipologia": "Locomotorio/Supporto",
       "fattore_mantenimento_energetico": "Basso (Vibrazione passiva del suolo)",
@@ -7319,9 +6719,7 @@
           }
         }
       ],
-      "sinergie": [
-        "cartilagine_flessotermica_venti"
-      ],
+      "sinergie": ["cartilagine_flessotermica_venti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -7343,9 +6741,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "difensivo"
-          ]
+          "type": ["difensivo"]
         }
       },
       "traits": [
@@ -7370,67 +6766,47 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "difesa"
-          ]
+          "type": ["difesa"]
         }
       },
-      "traits": [
-        "armatura_pietra_planare",
-        "mantello_meteoritico"
-      ],
+      "traits": ["armatura_pietra_planare", "mantello_meteoritico"],
       "type": "difesa"
     },
     "digestivo": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "digestivo"
-          ]
+          "type": ["digestivo"]
         }
       },
-      "traits": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "traits": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "type": "digestivo"
     },
     "escretorio": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "escretorio"
-          ]
+          "type": ["escretorio"]
         }
       },
-      "traits": [
-        "spore_psichiche_silenziate"
-      ],
+      "traits": ["spore_psichiche_silenziate"],
       "type": "escretorio"
     },
     "idrostatico": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "idrostatico"
-          ]
+          "type": ["idrostatico"]
         }
       },
-      "traits": [
-        "sacche_galleggianti_ascensoriali"
-      ],
+      "traits": ["sacche_galleggianti_ascensoriali"],
       "type": "idrostatico"
     },
     "locomotorio": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "locomotorio"
-          ]
+          "type": ["locomotorio"]
         }
       },
       "traits": [
@@ -7461,9 +6837,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "metabolico"
-          ]
+          "type": ["metabolico"]
         }
       },
       "traits": [
@@ -7489,23 +6863,17 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "nervoso"
-          ]
+          "type": ["nervoso"]
         }
       },
-      "traits": [
-        "sonno_emisferico_alternato"
-      ],
+      "traits": ["sonno_emisferico_alternato"],
       "type": "nervoso"
     },
     "offensivo": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "offensivo"
-          ]
+          "type": ["offensivo"]
         }
       },
       "traits": [
@@ -7532,9 +6900,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "respiratorio"
-          ]
+          "type": ["respiratorio"]
         }
       },
       "traits": [
@@ -7550,23 +6916,17 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "riproduttivo"
-          ]
+          "type": ["riproduttivo"]
         }
       },
-      "traits": [
-        "nucleo_ovomotore_rotante"
-      ],
+      "traits": ["nucleo_ovomotore_rotante"],
       "type": "riproduttivo"
     },
     "sensoriale": {
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "sensoriale"
-          ]
+          "type": ["sensoriale"]
         }
       },
       "traits": [
@@ -7598,9 +6958,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "simbiotico"
-          ]
+          "type": ["simbiotico"]
         }
       },
       "traits": [
@@ -7630,9 +6988,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "strategia"
-          ]
+          "type": ["strategia"]
         }
       },
       "traits": [
@@ -7661,9 +7017,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "strutturale"
-          ]
+          "type": ["strutturale"]
         }
       },
       "traits": [
@@ -7691,9 +7045,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "supporto"
-          ]
+          "type": ["supporto"]
         }
       },
       "traits": [
@@ -7720,9 +7072,7 @@
       "query": {
         "source": "data/traits/index.json",
         "filters": {
-          "type": [
-            "tegumentario"
-          ]
+          "type": ["tegumentario"]
         }
       },
       "traits": [

--- a/docs/evo-tactics-pack/traits/locomotorio/index.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/index.json
@@ -23,10 +23,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -64,10 +61,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -117,13 +111,8 @@
           "hud:GripNode_Psion"
         ],
         "combo_totale": 4,
-        "forme": [
-          "Forma:Predatore_Tessuto",
-          "HUD:GrappleBurst"
-        ],
-        "tabelle_random": [
-          "tabella:predazione_multicanale"
-        ]
+        "forme": ["Forma:Predatore_Tessuto", "HUD:GrappleBurst"],
+        "tabelle_random": ["tabella:predazione_multicanale"]
       },
       "slot": [],
       "slot_profile": {
@@ -167,12 +156,8 @@
           "hud:GlacierClaw_UI"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Assaltatore_Criogenico"
-        ],
-        "tabelle_random": [
-          "tabella:presa_criostatica"
-        ]
+        "forme": ["Forma:Assaltatore_Criogenico"],
+        "tabelle_random": ["tabella:presa_criostatica"]
       },
       "slot": [],
       "slot_profile": {
@@ -205,10 +190,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -246,10 +228,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -287,10 +266,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -307,9 +283,7 @@
       "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
     },
     "cartilagine_flessotermica_venti": {
-      "conflitti": [
-        "scheletro_idro_regolante"
-      ],
+      "conflitti": ["scheletro_idro_regolante"],
       "debolezza": "Temperature stabili riducono la reattività della cartilagine rendendo l'organismo lento.",
       "famiglia_tipologia": "Locomotorio/Adattivo",
       "fattore_mantenimento_energetico": "Medio (Richiede frequenti riallineamenti fibrosi)",
@@ -342,12 +316,8 @@
           "hud:VentSplice_Halo"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Planatore_Psionico"
-        ],
-        "tabelle_random": [
-          "tabella:assetto_eolico"
-        ]
+        "forme": ["Forma:Planatore_Psionico"],
+        "tabelle_random": ["tabella:assetto_eolico"]
       },
       "slot": [],
       "slot_profile": {
@@ -380,10 +350,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -421,10 +388,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -541,10 +505,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -582,10 +543,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -623,10 +581,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -664,10 +619,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -705,10 +657,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -746,10 +695,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -787,10 +733,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -833,22 +776,12 @@
         "mucose_aderenza_sonica"
       ],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "cap_pt",
-          "guardia_situazionale",
-          "job_ability:Skirmisher/Dash_Cut"
-        ],
+        "co_occorrenze": ["cap_pt", "guardia_situazionale", "job_ability:skirmisher/dash_cut"],
         "combo_totale": 2,
-        "forme": [
-          "ESTP",
-          "ISFP"
-        ],
+        "forme": ["ESTP", "ISFP"],
         "tabelle_random": []
       },
-      "slot": [
-        "A",
-        "B"
-      ],
+      "slot": ["A", "B"],
       "slot_profile": {
         "complementare": "propulsione",
         "core": "locomotorio"
@@ -858,9 +791,7 @@
       "uso_funzione": "Dash esplosivi per mantenere il ritmo di ingaggio o disimpegno."
     },
     "zoccoli_risonanti_steppe": {
-      "conflitti": [
-        "zampe_a_molla"
-      ],
+      "conflitti": ["zampe_a_molla"],
       "debolezza": "Suoli cedevoli come sabbie mobili annullano la vibrazione e riducono la trazione.",
       "famiglia_tipologia": "Locomotorio/Supporto",
       "fattore_mantenimento_energetico": "Basso (Vibrazione passiva del suolo)",
@@ -880,9 +811,7 @@
           }
         }
       ],
-      "sinergie": [
-        "cartilagine_flessotermica_venti"
-      ],
+      "sinergie": ["cartilagine_flessotermica_venti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,

--- a/docs/evo-tactics-pack/traits/locomotorio/zampe_a_molla.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/zampe_a_molla.json
@@ -25,22 +25,12 @@
     "mucose_aderenza_sonica"
   ],
   "sinergie_pi": {
-    "co_occorrenze": [
-      "cap_pt",
-      "guardia_situazionale",
-      "job_ability:Skirmisher/Dash_Cut"
-    ],
+    "co_occorrenze": ["cap_pt", "guardia_situazionale", "job_ability:skirmisher/dash_cut"],
     "combo_totale": 2,
-    "forme": [
-      "ESTP",
-      "ISFP"
-    ],
+    "forme": ["ESTP", "ISFP"],
     "tabelle_random": []
   },
-  "slot": [
-    "A",
-    "B"
-  ],
+  "slot": ["A", "B"],
   "slot_profile": {
     "complementare": "propulsione",
     "core": "locomotorio"

--- a/docs/evo-tactics-pack/traits/strategia/focus_frazionato.json
+++ b/docs/evo-tactics-pack/traits/strategia/focus_frazionato.json
@@ -29,22 +29,15 @@
     "co_occorrenze": [
       "PE",
       "cap_pt",
-      "job_ability:Invoker/Sincronia",
+      "job_ability:invoker/sincronia",
       "sigillo_forma",
       "starter_bioma"
     ],
     "combo_totale": 3,
-    "forme": [
-      "ENTP",
-      "INFJ",
-      "INTP"
-    ],
+    "forme": ["ENTP", "INFJ", "INTP"],
     "tabelle_random": []
   },
-  "slot": [
-    "A",
-    "C"
-  ],
+  "slot": ["A", "C"],
   "slot_profile": {
     "complementare": "psionico",
     "core": "strategia"

--- a/docs/evo-tactics-pack/traits/strategia/index.json
+++ b/docs/evo-tactics-pack/traits/strategia/index.json
@@ -23,10 +23,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -64,10 +61,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -105,10 +99,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -146,10 +137,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -187,10 +175,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -228,10 +213,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -269,10 +251,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -310,10 +289,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -351,10 +327,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -401,22 +374,15 @@
         "co_occorrenze": [
           "PE",
           "cap_pt",
-          "job_ability:Invoker/Sincronia",
+          "job_ability:invoker/sincronia",
           "sigillo_forma",
           "starter_bioma"
         ],
         "combo_totale": 3,
-        "forme": [
-          "ENTP",
-          "INFJ",
-          "INTP"
-        ],
+        "forme": ["ENTP", "INFJ", "INTP"],
         "tabelle_random": []
       },
-      "slot": [
-        "A",
-        "C"
-      ],
+      "slot": ["A", "C"],
       "slot_profile": {
         "complementare": "psionico",
         "core": "strategia"
@@ -447,10 +413,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -488,10 +451,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -529,10 +489,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -570,10 +527,7 @@
           }
         }
       ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
+      "sinergie": ["pianificatore", "tattiche_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -600,20 +554,12 @@
       "requisiti_ambientali": [],
       "sinergie": [],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "starter_bioma"],
         "combo_totale": 1,
-        "forme": [
-          "ENFP"
-        ],
+        "forme": ["ENFP"],
         "tabelle_random": []
       },
-      "slot": [
-        "A"
-      ],
+      "slot": ["A"],
       "slot_profile": {
         "complementare": "ricognizione",
         "core": "strategia"
@@ -647,27 +593,12 @@
         "membrane_captura_rugiada"
       ],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "guardia_situazionale",
-          "sigillo_forma",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "guardia_situazionale", "sigillo_forma", "starter_bioma"],
         "combo_totale": 6,
-        "forme": [
-          "ENTJ",
-          "ENTP",
-          "ESTJ",
-          "INTJ",
-          "ISTJ"
-        ],
+        "forme": ["ENTJ", "ENTP", "ESTJ", "INTJ", "ISTJ"],
         "tabelle_random": []
       },
-      "slot": [
-        "A",
-        "C"
-      ],
+      "slot": ["A", "C"],
       "slot_profile": {
         "complementare": "tattico",
         "core": "strategia"
@@ -687,21 +618,12 @@
       "requisiti_ambientali": [],
       "sinergie": [],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "cap_pt",
-          "guardia_situazionale",
-          "job_ability:Random"
-        ],
+        "co_occorrenze": ["cap_pt", "guardia_situazionale", "job_ability:random"],
         "combo_totale": 2,
-        "forme": [
-          "NEUTRA"
-        ],
+        "forme": ["NEUTRA"],
         "tabelle_random": []
       },
-      "slot": [
-        "A",
-        "B"
-      ],
+      "slot": ["A", "B"],
       "slot_profile": {
         "complementare": "adattivo",
         "core": "strategia"
@@ -736,23 +658,12 @@
         "membrane_captura_rugiada"
       ],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "guardia_situazionale",
-          "sigillo_forma",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "guardia_situazionale", "sigillo_forma", "starter_bioma"],
         "combo_totale": 2,
-        "forme": [
-          "ESFJ",
-          "ESFP"
-        ],
+        "forme": ["ESFJ", "ESFP"],
         "tabelle_random": []
       },
-      "slot": [
-        "B"
-      ],
+      "slot": ["B"],
       "slot_profile": {
         "complementare": "coordinazione",
         "core": "strategia"

--- a/docs/evo-tactics-pack/traits/strategia/random.json
+++ b/docs/evo-tactics-pack/traits/strategia/random.json
@@ -9,21 +9,12 @@
   "requisiti_ambientali": [],
   "sinergie": [],
   "sinergie_pi": {
-    "co_occorrenze": [
-      "cap_pt",
-      "guardia_situazionale",
-      "job_ability:Random"
-    ],
+    "co_occorrenze": ["cap_pt", "guardia_situazionale", "job_ability:random"],
     "combo_totale": 2,
-    "forme": [
-      "NEUTRA"
-    ],
+    "forme": ["NEUTRA"],
     "tabelle_random": []
   },
-  "slot": [
-    "A",
-    "B"
-  ],
+  "slot": ["A", "B"],
   "slot_profile": {
     "complementare": "adattivo",
     "core": "strategia"

--- a/docs/evo-tactics-pack/traits/supporto/empatia_coordinativa.json
+++ b/docs/evo-tactics-pack/traits/supporto/empatia_coordinativa.json
@@ -25,18 +25,12 @@
     "aura_scudo_radianza"
   ],
   "sinergie_pi": {
-    "co_occorrenze": [
-      "job_ability:Warden/Scudo_di_Risonanza"
-    ],
+    "co_occorrenze": ["job_ability:warden/scudo_di_risonanza"],
     "combo_totale": 1,
-    "forme": [
-      "INFP"
-    ],
+    "forme": ["INFP"],
     "tabelle_random": []
   },
-  "slot": [
-    "A"
-  ],
+  "slot": ["A"],
   "slot_profile": {
     "complementare": "coordinazione",
     "core": "supporto"

--- a/docs/evo-tactics-pack/traits/supporto/index.json
+++ b/docs/evo-tactics-pack/traits/supporto/index.json
@@ -23,10 +23,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -64,10 +61,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -84,9 +78,7 @@
       "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
     },
     "aura_scudo_radianza": {
-      "conflitti": [
-        "mantello_meteoritico"
-      ],
+      "conflitti": ["mantello_meteoritico"],
       "debolezza": "Soffre saturazione se esposta a ombre gravitazionali o zone di antimagia.",
       "famiglia_tipologia": "Supporto/Difesa",
       "fattore_mantenimento_energetico": "Alto (Canalizzazione fotonica continua)",
@@ -95,9 +87,7 @@
       "mutazione_indotta": "Innesta organi fotoplasmatici che diffondono uno scudo radiante sugli alleati vicini.",
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "flight"
-          ],
+          "capacita_richieste": ["flight"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -109,10 +99,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -150,10 +137,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -191,10 +175,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -232,10 +213,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -273,10 +251,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -314,10 +289,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -355,10 +327,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -401,18 +370,12 @@
         "aura_scudo_radianza"
       ],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "job_ability:Warden/Scudo_di_Risonanza"
-        ],
+        "co_occorrenze": ["job_ability:warden/scudo_di_risonanza"],
         "combo_totale": 1,
-        "forme": [
-          "INFP"
-        ],
+        "forme": ["INFP"],
         "tabelle_random": []
       },
-      "slot": [
-        "A"
-      ],
+      "slot": ["A"],
       "slot_profile": {
         "complementare": "coordinazione",
         "core": "supporto"
@@ -443,10 +406,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -484,10 +444,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -525,10 +482,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -566,10 +520,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -607,10 +558,7 @@
           }
         }
       ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -655,25 +603,12 @@
         "aura_scudo_radianza"
       ],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "guardia_situazionale",
-          "starter_bioma"
-        ],
+        "co_occorrenze": ["PE", "cap_pt", "guardia_situazionale", "starter_bioma"],
         "combo_totale": 3,
-        "forme": [
-          "ENFJ",
-          "INFP",
-          "ISFJ"
-        ],
+        "forme": ["ENFJ", "INFP", "ISFJ"],
         "tabelle_random": []
       },
-      "slot": [
-        "A",
-        "B",
-        "C"
-      ],
+      "slot": ["A", "B", "C"],
       "slot_profile": {
         "complementare": "coordinazione",
         "core": "supporto"

--- a/docs/reports/trait-env-alignment.md
+++ b/docs/reports/trait-env-alignment.md
@@ -1,7 +1,7 @@
 # Allineamento tratti PI ↔ Regole ambientali
 
 ## Sintesi dati
-- **Tratti PI rilevati**: 8 identificatori (`T1`) usati nei pacchetti Forma (`Empatia_Coordinativa`, `Focus_Frazionato`, `Ghiandola_Caustica`, `Pathfinder`, `Pianificatore`, `Random`, `Risonanza_di_Branco`, `Tattiche_di_Branco`, `Zampe_a_Molla`).【F:data/derived/analysis/trait_env_mapping.json†L560-L573】
+- **Tratti PI rilevati**: 8 identificatori (`T1`) usati nei pacchetti Forma (`empatia_coordinativa`, `focus_frazionato`, `ghiandola_caustica`, `pathfinder`, `pianificatore`, `random`, `risonanza_di_branco`, `tattiche_di_branco`, `zampe_a_molla`).【F:data/derived/analysis/trait_env_mapping.json†L560-L573】
 - **Regole ambientali catalogate**: 210 tratti con suggerimenti ambientali dedicati (nessuna sovrapposizione diretta con i tratti PI → gap strutturale).【F:data/derived/analysis/trait_env_mapping.json†L2-L551】【F:data/derived/analysis/trait_env_mapping.json†L563-L573】
 - **Nuovo schema `trait_reference`**: ogni tratto espone ora `tier`, `slot`, `sinergie_pi` e `requisiti_ambientali`, consentendo di collegare i pacchetti PI ai contesti bioma/hazard laddove disponibili.【F:data/traits/index.json†L1-L36】【F:data/traits/index.json†L493-L530】
 
@@ -13,22 +13,22 @@
 | Sovrapposizioni attuali | 0 | Nessun tratto compare in entrambe le liste → occorrono mapping manuali o design di conversione futura.【F:data/derived/analysis/trait_env_mapping.json†L563-L573】 |
 
 ## Esempi applicativi per le squadre
-### Pianificatore + slot C controllato
-- Composizioni INTJ/ENTJ/ESTJ sfruttano `Pianificatore` nello slot C con `sigillo_forma` e `starter_bioma`, mantenendo budget PE equilibrato e garantendo capienza difensiva tramite `guardia_situazionale` negli slot A/B.【F:data/packs.yaml†L32-L110】
+### pianificatore + slot C controllato
+- Composizioni INTJ/ENTJ/ESTJ sfruttano `pianificatore` nello slot C con `sigillo_forma` e `starter_bioma`, mantenendo budget PE equilibrato e garantendo capienza difensiva tramite `guardia_situazionale` negli slot A/B.【F:data/packs.yaml†L32-L110】
 - Le telemetrie raccomandano pick-rate equilibrati fra Vanguard (22%) e Invoker (16%): il tratto supporta le rotazioni per entrambe le classi nelle finestre mid/late (phase weights 0.40).【F:data/core/telemetry.yaml†L5-L41】
 - Nota di design: usare `sinergie_pi.combo_totale` per valutare saturazione del tratto — 6 combinazioni già tracciate, suggerendo di limitarne l’accesso in nuove forme finché i target HUD restano stabili.【F:data/traits/index.json†L493-L517】【F:data/derived/analysis/trait_env_mapping.json†L574-L608】
 
 ### Focus Frazionato per doppio ingaggio
-- Le forme INFJ/INTP/ENTP aprono slot A/C con `Focus_Frazionato`, sfruttando co-occorrenze con `cap_pt`, `starter_bioma` e `sigillo_forma` per coprire scenari multi-fronta.【F:data/packs.yaml†L41-L90】
+- Le forme INFJ/INTP/ENTP aprono slot A/C con `focus_frazionato`, sfruttando co-occorrenze con `cap_pt`, `starter_bioma` e `sigillo_forma` per coprire scenari multi-fronta.【F:data/packs.yaml†L41-L90】
 - Telemetria: mantenere coesione ≥0.70 e setup bilanciato (indici `cohesion` e `setup`) riduce tilt e consente l’uso del tratto senza penalità — utile quando il team punta agli obiettivi opzionali (explore 0.45/0.30).【F:data/core/telemetry.yaml†L27-L48】
 - Nota di design: associare il tratto a squadre con invoker/artificer sopra i target di pick-rate per bilanciare telemetria e distribuire carico mentale; le sinergie PI segnalano 3 combinazioni già validate.【F:data/traits/index.json†L420-L458】【F:data/derived/analysis/trait_env_mapping.json†L591-L610】
 
-### Pathfinder e controllo exploro
-- `Pathfinder` appare nello slot A degli ENFP con `starter_bioma` e `cap_pt`, fornendo mobilità e scouting precoce per missioni con alti punteggi explore.【F:data/packs.yaml†L81-L85】
+### pathfinder e controllo exploro
+- `pathfinder` appare nello slot A degli ENFP con `starter_bioma` e `cap_pt`, fornendo mobilità e scouting precoce per missioni con alti punteggi explore.【F:data/packs.yaml†L81-L85】
 - L’indice explore (peso 0.45 per nuove caselle, 0.30 per opzionali) e i target HUD sulle classi di supporto evidenziano l’utilità del tratto per rispettare soglie di rischio/aggro durante missioni multi-bioma.【F:data/core/telemetry.yaml†L27-L41】
 - Nota di design: integrare log Forma con link telemetria (es. missione `skydock_siege` con finestre rischio) per estendere mapping ambientale futuro, sfruttando il nuovo campo `requisiti_ambientali` come punto di aggancio.【F:data/core/missions/skydock_siege.yaml†L1-L70】【F:data/traits/index.json†L493-L530】
 
 ## Prossimi passi suggeriti
-1. Derivare regole ambientali PI→bioma partendo dai tratti con co-occorrenze difensive (`Pianificatore`, `Risonanza_di_Branco`) per ridurre il gap di sovrapposizione (0 → X).
+1. Derivare regole ambientali PI→bioma partendo dai tratti con co-occorrenze difensive (`pianificatore`, `risonanza_di_branco`) per ridurre il gap di sovrapposizione (0 → X).
 2. Estendere la telemetria Forma includendo trigger automatici quando `sinergie_pi.combo_totale` supera soglie definite, così da alimentare design iterativo.
 3. Validare nel companion UI: il tooltip aggiornato mostra `Tier`, `Slot PI`, `Combo PI` e count dei `Requisiti ambientali`, aiutando il team a individuare subito lacune di coverage.

--- a/packs/evo_tactics_pack/docs/catalog/archive/trait_reference_legacy.json
+++ b/packs/evo_tactics_pack/docs/catalog/archive/trait_reference_legacy.json
@@ -3677,7 +3677,7 @@
       ],
       "sinergie_pi": {
         "co_occorrenze": [
-          "job_ability:Warden/Scudo_di_Risonanza"
+          "job_ability:warden/scudo_di_risonanza"
         ],
         "combo_totale": 1,
         "forme": [
@@ -4257,7 +4257,7 @@
         "co_occorrenze": [
           "PE",
           "cap_pt",
-          "job_ability:Invoker/Sincronia",
+          "job_ability:invoker/sincronia",
           "sigillo_forma",
           "starter_bioma"
         ],
@@ -6299,7 +6299,7 @@
         "co_occorrenze": [
           "cap_pt",
           "guardia_situazionale",
-          "job_ability:Random"
+          "job_ability:random"
         ],
         "combo_totale": 2,
         "forme": [
@@ -7101,7 +7101,7 @@
         "co_occorrenze": [
           "cap_pt",
           "guardia_situazionale",
-          "job_ability:Skirmisher/Dash_Cut"
+          "job_ability:skirmisher/dash_cut"
         ],
         "combo_totale": 2,
         "forme": [

--- a/packs/evo_tactics_pack/docs/catalog/trait_reference.json
+++ b/packs/evo_tactics_pack/docs/catalog/trait_reference.json
@@ -3774,7 +3774,7 @@
       "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
       "sinergie_pi": {
         "co_occorrenze": [
-          "job_ability:Warden/Scudo_di_Risonanza"
+          "job_ability:warden/scudo_di_risonanza"
         ],
         "combo_totale": 1,
         "forme": [
@@ -4355,7 +4355,7 @@
         "co_occorrenze": [
           "PE",
           "cap_pt",
-          "job_ability:Invoker/Sincronia",
+          "job_ability:invoker/sincronia",
           "sigillo_forma",
           "starter_bioma"
         ],
@@ -6485,7 +6485,7 @@
         "co_occorrenze": [
           "cap_pt",
           "guardia_situazionale",
-          "job_ability:Random"
+          "job_ability:random"
         ],
         "combo_totale": 2,
         "forme": [
@@ -7287,7 +7287,7 @@
         "co_occorrenze": [
           "cap_pt",
           "guardia_situazionale",
-          "job_ability:Skirmisher/Dash_Cut"
+          "job_ability:skirmisher/dash_cut"
         ],
         "combo_totale": 2,
         "forme": [

--- a/tools/py/command_outputs.txt
+++ b/tools/py/command_outputs.txt
@@ -3,7 +3,7 @@ python3 roll_pack.py ENTP invoker ../../data/packs.yaml
   "d20": 17,
   "pack": "C",
   "combo": [
-    "trait_T1:Pianificatore",
+    "trait_T1:pianificatore",
     "guardia_situazionale",
     "sigillo_forma"
   ]


### PR DESCRIPTION
## Summary
- convert PI job ability and trait identifiers to lower_snake_case across the trait registry and pack definitions
- propagate the updated slugs to supporting trait JSONs and Evo Tactics documentation catalogs
- reformat touched markdown/JSON docs to satisfy Prettier

## Testing
- python tools/py/validate_registry_naming.py
- python scripts/trait_audit.py --check

------
https://chatgpt.com/codex/tasks/task_b_6907fb1e74e8832ab1de771907107474