### PR TITLE
Add cache isolation regression test for matchmaking summaries

### DIFF
--- a/tests/matchmaking/filters.spec.ts
+++ b/tests/matchmaking/filters.spec.ts
@@ -108,11 +108,20 @@ describe('Matchmaking — combinazione filtri', () => {
 
     const first = await client.fetchSummaries(filters);
     assert.strictEqual(fetchCount, 1, 'la prima chiamata deve interrogare la rete');
-    first[0].playersInQueue = 9999;
+
+    const firstEntry = first[0];
+    assert.ok(firstEntry, 'la risposta iniziale deve contenere un elemento');
+    first.pop();
+    firstEntry.playersInQueue = 9999;
 
     const second = await client.fetchSummaries(filters);
     assert.strictEqual(fetchCount, 1, 'la seconda chiamata deve usare la cache');
     assert.notStrictEqual(second, first, 'la cache deve restituire un nuovo array');
+    assert.strictEqual(
+      second.length,
+      responsePayload.length,
+      'la risposta cache deve mantenere la stessa cardinalità dei dati originali',
+    );
     assert.strictEqual(
       second[0].playersInQueue,
       responsePayload[0].playersInQueue,


### PR DESCRIPTION
## Descrizione
- estende il test sull'immutabilità della cache del matchmaking verificando che mutazioni dell'array restituito non influenzino i dati memorizzati
- aggiunge un controllo esplicito sulla cardinalità dei risultati cache per garantire l'isolamento dei dati originali

## Checklist guida stile & QA
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato
- [ ] Documentazione/processi aggiornati ove necessario

## Testing
- [ ] `npm run style:check`
- [x] Altro: `node --test tests/matchmaking/filters.spec.ts` (fallito: modulo /src/api/matchmaking non risolto in questo ambiente)

## Note
- n/d


------
https://chatgpt.com/codex/tasks/task_b_6907fb96f3f8832a8038a2721a94212c