### PR TITLE
Normalize job slug casing across trait assets

### DIFF
--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -5833,7 +5833,7 @@
       },
       "conflitti": [],
       "data_origin": "controllo_psionico",
-      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
+      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate warden scende.",
       "famiglia_tipologia": "Supporto/Empatico",
       "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
       "id": "empatia_coordinativa",

--- a/docs/DesignDoc-Overview.md
+++ b/docs/DesignDoc-Overview.md
@@ -1,17 +1,20 @@
 # Evo Tactics — Design Doc Overview
 
 ## Visione & Statement
+
 - **Visione** — Co-op tattico TV/app dove cellule di resistenza guidano forme bio-meccanoidi in campagne generate, alternando briefing, incursioni e fasi Nido per difendere habitat in mutazione costante.【F:appendici/A-CANVAS_ORIGINALE.txt†L10-L24】
 - **Statement** — "Trasformare l'ansia da tiro di dado in un'intesa condivisa": ogni scelta comunica impatto immediato (risk/cohesion) e conseguenze a lungo termine (stress, fiducia, reputazione) tramite HUD sincronizzato tra TV e companion.【F:appendici/A-CANVAS_ORIGINALE.txt†L26-L33】
 - **Esperienza target** — Gruppi da 3-4 giocatori in sessioni da ~90 minuti con onboarding <10 minuti supportato da preset di Forme e direttive assistite.【F:appendici/A-CANVAS_ORIGINALE.txt†L35-L41】
 
 ## Pilastri
+
 1. **Cooperazione situazionale** — Ruoli combinabili, scoreboard StressWave condiviso e strumenti per reagire ai picchi telemetrici.【F:appendici/A-CANVAS_ORIGINALE.txt†L43-L46】【F:docs/02-PILASTRI.md†L1-L6】
 2. **Mutazione significativa** — Progressione morfologica e narrativa legata a tratti, parti e mutazioni sbloccate da comportamento.【F:appendici/A-CANVAS_ORIGINALE.txt†L47-L52】【F:docs/20-SPECIE_E_PARTI.md†L1-L10】
 3. **Telemetria visibile** — Dashboard risk/cohesion, timeline eventi esportabile (`session-metrics.yaml`) e alert HUD condivisi.【F:appendici/A-CANVAS_ORIGINALE.txt†L53-L60】【F:data/core/telemetry.yaml†L1-L40】
 4. **Narrazione reattiva** — Il Director AI adatta missioni, spawn e ricompense in base a affinità, fiducia e scelte morali.【F:appendici/A-CANVAS_ORIGINALE.txt†L61-L73】【F:appendici/C-CANVAS_NPG_BIOMI.txt†L1-L31】
 
 ## Loop Principale
+
 1. **Briefing**: selezione missione, obiettivi, heatmap minacce e trend StressWave.【F:appendici/A-CANVAS_ORIGINALE.txt†L75-L86】
 2. **Setup Squad**: drafting Forme/Job, moduli PI, check sinergie tramite companion.【F:appendici/A-CANVAS_ORIGINALE.txt†L87-L92】【F:data/packs.yaml†L1-L23】
 3. **Incursione**: turni misti comando rapido + risoluzione d20 con combo cooperative e clock a segmenti.【F:appendici/A-CANVAS_ORIGINALE.txt†L93-L110】【F:docs/11-REGOLE_D20_TV.md†L1-L7】
@@ -20,22 +23,26 @@
 6. **Fase Nido**: investimenti infrastruttura, mutazioni e gestione comunità.【F:appendici/A-CANVAS_ORIGINALE.txt†L122-L124】【F:appendici/D-CANVAS_ACCOPPIAMENTO.txt†L1-L69】
 
 ## Progressione & Metriche Chiave
+
 - **Livello Squadra** 1-10: sblocca slot PI e missioni avanzate; bilanciato con `pi_shop` e budget curve baseline/veteran/elite.【F:appendici/A-CANVAS_ORIGINALE.txt†L126-L135】【F:data/packs.yaml†L1-L20】
 - **Prestigio Forma** (5 tier): concede tratti e mutazioni legate a Forme e Nido.【F:appendici/A-CANVAS_ORIGINALE.txt†L136-L141】【F:data/core/mating.yaml†L1-L101】
 - **Reputazione Fazioni** e **StressWave**: impattano spawn, ricompense e soglie di allerta HUD (>0.60).【F:appendici/A-CANVAS_ORIGINALE.txt†L142-L151】【F:data/core/telemetry.yaml†L1-L25】
 
 ## Sistema TV/d20 & Companion
+
 - **Risoluzione**: bande critico/successo/parziale/fallimento su d20 con modificatori PI, stance e Stress Mod legato a StressWave.【F:appendici/A-CANVAS_ORIGINALE.txt†L153-L164】【F:docs/11-REGOLE_D20_TV.md†L1-L7】
 - **Clock**: segmenti d6 per eventi a tempo (evacuazione, anomalie).【F:appendici/A-CANVAS_ORIGINALE.txt†L165-L168】
 - **Companion App**: drafting Forme/Job, macro azioni, chat tattica e upload telemetria JSON/YAML verso repo condiviso.【F:appendici/A-CANVAS_ORIGINALE.txt†L170-L184】
 - **HUD**: overlay risk/cohesion con indicatori mismatch ruoli e supporto second screen per mappa tattica e Nido.【F:appendici/A-CANVAS_ORIGINALE.txt†L186-L198】【F:docs/03-LOOP.md†L1-L5】
 
 ## Job & Trait di base
-- **Famiglie Job**: Vanguard, Skirmisher, Warden, Artificer, Invoker, Harvester — ciascuna con bias di pack (`job_bias`) e abilità signature documentate in `data/packs.yaml`.【F:data/packs.yaml†L21-L90】
+
+- **Famiglie Job**: vanguard, skirmisher, warden, artificer, invoker, harvester — ciascuna con bias di pack (`job_bias`) e abilità signature documentate in `data/packs.yaml`.【F:data/packs.yaml†L21-L90】
 - **Tratti**: `trait_T1`/`T2`/`T3` alimentano combo PI, sinergie e costi `pi_shop`; i validatori assicurano coerenza tra dataset e CLI (`tools/py` e `tools/ts`) e dipendono dall'inventario centralizzato (`docs/catalog/traits_inventory.json`) che viene aggiornato ad ogni commit.【F:data/packs.yaml†L1-L20】【F:docs/20-SPECIE_E_PARTI.md†L5-L10】【F:docs/catalog/traits_inventory.json†L1-L120】
 - **Prestigio/Mutazioni**: progressioni Forma sbloccano nuove combinazioni di parti e tratti, con telemetria MBTI/Ennea a supporto del seed temperamentale.【F:data/core/telemetry.yaml†L41-L73】【F:docs/22-FORME_BASE_16.md†L1-L6】
 
 ## Workflow tratti end-to-end
+
 1. **Allineare il glossario** — aggiungi/aggiorna l'entry in `data/core/traits/glossary.json` (label IT/EN, note sintetiche) e propaga la copia automatica in `docs/evo-tactics-pack/trait-glossary.json` / `packs/evo_tactics_pack/docs/catalog/trait_glossary.json` se necessario.【F:data/core/traits/glossary.json†L1-L118】【F:docs/evo-tactics-pack/trait-glossary.json†L1-L118】【F:packs/evo_tactics_pack/docs/catalog/trait_glossary.json†L1-L118】
 2. **Sincronizzare registri** — collega il nuovo tratto nelle regole ambientali e nel reference genetico (`env_traits.json` e `data/traits/index.json`, entrambi puntano al glossario condiviso).【F:packs/evo_tactics_pack/docs/catalog/env_traits.json†L1-L19】【F:data/traits/index.json†L1-L23】
 3. **Integrare nei biomi** — aggiorna `docs/catalog/species_trait_matrix.json` con le nuove associazioni Forma↔bioma↔tratto e usa `python tools/traits.py validate --matrix docs/catalog/species_trait_matrix.json` per assicurare che i mapping rispettino requisiti ambientali e morfotipi.【F:docs/catalog/species_trait_matrix.json†L1-L240】【F:tools/traits.py†L1-L236】
@@ -47,6 +54,7 @@
 9. **Gate CI & deploy** — conferma che `scripts/run_deploy_checks.sh` e il workflow `deploy-test-interface.yml` ereditino gli stessi controlli (inventario, registri generatore, audit) prima della pubblicazione web, così da mantenere allineati generator, dataset e bundle pubblico.【F:scripts/run_deploy_checks.sh†L1-L80】【F:.github/workflows/deploy-test-interface.yml†L1-L200】
 
 ## Quality Gates
+
 - **Audit tratti ↔ ambienti** — consulta `docs/reports/trait-env-alignment.md` per verificare coperture, lacune e note di bilanciamento tra tratti PI e regole ambientali; usalo prima dei playtest per pianificare i pick consigliati e dopo per registrare gap emersi.【F:docs/reports/trait-env-alignment.md†L1-L80】
 - **Matrice specie** — incrocia il report audit con `docs/catalog/species_trait_matrix.json` e il CSV generato (`data/derived/analysis/trait_coverage_matrix.csv`) per individuare rapidamente specie o biomi sottorappresentati; durante i playtest annota il diff tra comportamento atteso e osservato e ri-esegui `report_trait_coverage.py` per aggiornare la telemetria di riferimento.【F:docs/catalog/species_trait_matrix.json†L1-L240】【F:data/derived/analysis/trait_coverage_matrix.csv†L1-L40】
 - **Gate di bilanciamento** — prima del freeze build, assicurati che i pick-rate raccolti (`data/core/telemetry.yaml`) rispettino le soglie suggerite dall'audit e che eventuali deroghe siano documentate nel log playtest; un diff >5% rispetto al target impone un nuovo ciclo di QA con `scripts/cli_smoke.sh` e validazione trait coverage per confermare la stabilità dei dataset.【F:data/core/telemetry.yaml†L1-L73】【F:scripts/cli_smoke.sh†L1-L120】
@@ -54,5 +62,6 @@
   ![SquadSync canary novembre 2025](../assets/analytics/squadsync_mock.svg)
 
 ## Stato & Prossimi Passi
+
 - Vertical slice VC con 3 missioni giocabili, telemetria StressWave integrata e companion app v0.9 già in test interno.【F:appendici/A-CANVAS_ORIGINALE.txt†L200-L214】
 - Priorità correnti: migliorare onboarding, bilanciare pacchetti PI/EMA e ampliare contenuti Nido itinerante in linea con roadmap VC 2025.【F:appendici/A-CANVAS_ORIGINALE.txt†L215-L220】【F:docs/piani/roadmap.md†L1-L60】

--- a/docs/PI-Pacchetti-Forme.md
+++ b/docs/PI-Pacchetti-Forme.md
@@ -21,19 +21,19 @@
 | 14        | I          | trait_T1 + guardia_situazionale + sigillo_forma                                   | Difesa adattiva e crescita Forma.                   |
 | 15        | J          | job_ability + PE ×3                                                               | Spike abilità.                                      |
 | 16-17     | Bias Forma | Rimanda alla tabella d12 della Forma scelta.                                      |
-| 18-19     | Bias Job   | Mappa preferenze per ruolo (Vanguard B/D, Skirmisher C/E, ecc.).                  |
+| 18-19     | Bias Job   | Mappa preferenze per ruolo (vanguard B/D, skirmisher C/E, ecc.).                  |
 | 20        | Scelta     | Qualsiasi pack disponibile; usato per correzioni bilanciamento o focus narrativo. |
 
 【F:data/packs.yaml†L9-L23】
 
 ## Job Bias
 
-- Vanguard → preferenza B/D per tanking e controllo frontline.
-- Skirmisher → preferenza C/E per mobilità e danno a singolo bersaglio.
-- Warden → E/G per protezione e sustain.
-- Artificer → A/F per strumenti tattici e controllo area.
-- Invoker → A/J per poteri psionici burst.
-- Harvester → D/J per utility predatoria e economia risorse.
+- vanguard → preferenza B/D per tanking e controllo frontline.
+- skirmisher → preferenza C/E per mobilità e danno a singolo bersaglio.
+- warden → E/G per protezione e sustain.
+- artificer → A/F per strumenti tattici e controllo area.
+- invoker → A/J per poteri psionici burst.
+- harvester → D/J per utility predatoria e economia risorse.
   【F:data/packs.yaml†L21-L32】
 
 ## Forme Base (d12 bias)

--- a/docs/catalog/catalog_data.json
+++ b/docs/catalog/catalog_data.json
@@ -6571,7 +6571,7 @@
         "synergy": ["aurora-bridge-runner", "zephyr-spore-courier"]
       },
       "usage_tags": ["support"],
-      "weakness": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende."
+      "weakness": "Richiede squadra disciplinata; cade in efficacia se pick rate warden scende."
     },
     "enzimi_antifase_termica": {
       "completion_flags": {

--- a/docs/catalog/species_trait_matrix.json
+++ b/docs/catalog/species_trait_matrix.json
@@ -356,7 +356,7 @@
       "synergy_traits": ["focus_frazionato", "risonanza_di_branco", "empatia_coordinativa"]
     },
     "aurora-bridge-runner": {
-      "archetypes": ["Skirmisher"],
+      "archetypes": ["skirmisher"],
       "biomes": ["mezzanotte_orbitale"],
       "core_traits": [
         "sacche_galleggianti_ascensoriali",
@@ -383,11 +383,11 @@
       "required_capabilities": ["deploy_support_field", "long_range_scan"],
       "role": "dispersore_ponte",
       "source_files": ["packs/evo_tactics_pack/data/species/cryosteppe/aurora-bridge-runner.yaml"],
-      "synergy_hints": ["Support", "Skirmisher"],
-      "synergy_traits": ["Support"]
+      "synergy_hints": ["support", "skirmisher"],
+      "synergy_traits": ["support"]
     },
     "aurora-gull": {
-      "archetypes": ["Skirmisher", "Invoker"],
+      "archetypes": ["skirmisher", "invoker"],
       "biomes": ["mezzanotte_orbitale"],
       "core_traits": ["criostasi_adattiva", "eco_interno_riflesso", "sonno_emisferico_alternato"],
       "display_name": "Gabbiano d’Aurora",
@@ -543,7 +543,7 @@
       "synergy_traits": []
     },
     "cactus-weaver": {
-      "archetypes": ["Warden", "Artificer"],
+      "archetypes": ["warden", "artificer"],
       "biomes": ["abisso_vulcanico"],
       "core_traits": [
         "cuticole_cerose",
@@ -1005,7 +1005,7 @@
       "synergy_traits": ["focus_frazionato", "risonanza_di_branco", "tattiche_di_branco"]
     },
     "echo-wing": {
-      "archetypes": ["Skirmisher", "Invoker"],
+      "archetypes": ["skirmisher", "invoker"],
       "biomes": ["dorsale_termale_tropicale"],
       "core_traits": [
         "eco_interno_riflesso",
@@ -1072,7 +1072,7 @@
       "synergy_traits": []
     },
     "ferrocolonia-magnetotattica": {
-      "archetypes": ["Warden", "Artificer"],
+      "archetypes": ["warden", "artificer"],
       "biomes": ["dorsale_termale_tropicale"],
       "core_traits": [
         "mimetismo_cromatico_passivo",
@@ -1228,7 +1228,7 @@
       "required_capabilities": ["deploy_support_field"],
       "role": "ingegneri_ecosistema",
       "source_files": ["packs/evo_tactics_pack/data/species/foresta_temperata/glowcap-weaver.yaml"],
-      "synergy_hints": ["Support"],
+      "synergy_hints": ["support"],
       "synergy_traits": []
     },
     "gole-ventose-trait-keeper": {
@@ -1393,11 +1393,11 @@
       "source_files": [
         "packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/magnet-fathom-surveyor.yaml"
       ],
-      "synergy_hints": ["Warden", "Vanguard"],
+      "synergy_hints": ["warden", "vanguard"],
       "synergy_traits": []
     },
     "magneto-ridge-hunter": {
-      "archetypes": ["Vanguard"],
+      "archetypes": ["vanguard"],
       "biomes": ["dorsale_termale_tropicale"],
       "core_traits": ["coda_frusta_cinetica", "scheletro_idro_regolante", "artigli_sette_vie"],
       "display_name": "Magneto Ridge Hunter",
@@ -1420,7 +1420,7 @@
       "required_capabilities": ["build_cover", "dr_impact_cap", "non_metal_gear", "seal_vents"],
       "role": "predatore_terziario_apex",
       "source_files": ["packs/evo_tactics_pack/data/species/badlands/magneto-ridge-hunter.yaml"],
-      "synergy_hints": ["Vanguard", "Skirmisher"],
+      "synergy_hints": ["vanguard", "skirmisher"],
       "synergy_traits": ["tattiche_di_branco", "struttura_elastica_amorfa"]
     },
     "mangrovie-risonanti-trait-keeper": {
@@ -1515,14 +1515,14 @@
       "synergy_traits": []
     },
     "myco-spire-warden": {
-      "archetypes": ["Support"],
+      "archetypes": ["support"],
       "biomes": ["foresta_miceliale"],
       "core_traits": [
         "filamenti_digestivi_compattanti",
         "empatia_coordinativa",
         "struttura_elastica_amorfa"
       ],
-      "display_name": "Myco Spire Warden",
+      "display_name": "Myco Spire warden",
       "environment_focus": {
         "biome_class": "foresta_miceliale"
       },
@@ -1544,7 +1544,7 @@
       "source_files": [
         "packs/evo_tactics_pack/data/species/foresta_temperata/myco-spire-warden.yaml"
       ],
-      "synergy_hints": ["Support", "Strategist"],
+      "synergy_hints": ["support", "Strategist"],
       "synergy_traits": ["Strategist"]
     },
     "nano-rust-bloom": {
@@ -1576,7 +1576,7 @@
       "synergy_traits": []
     },
     "noctule-termico": {
-      "archetypes": ["Skirmisher", "Invoker"],
+      "archetypes": ["skirmisher", "invoker"],
       "biomes": ["abisso_vulcanico"],
       "core_traits": [
         "cuticole_cerose",
@@ -1669,7 +1669,7 @@
       "source_files": [
         "packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbital-ascendant.yaml"
       ],
-      "synergy_hints": ["Vanguard", "Invoker"],
+      "synergy_hints": ["vanguard", "invoker"],
       "synergy_traits": []
     },
     "otyugh-sentinella": {
@@ -1851,7 +1851,7 @@
       "source_files": [
         "packs/evo_tactics_pack/data/species/canopia_psionica_leggera/psionic-canopy-scout.yaml"
       ],
-      "synergy_hints": ["Support", "Invoker"],
+      "synergy_hints": ["support", "invoker"],
       "synergy_traits": []
     },
     "rakshasa-corte": {
@@ -1966,7 +1966,7 @@
       "synergy_traits": []
     },
     "rust-scavenger": {
-      "archetypes": ["Warden", "Artificer"],
+      "archetypes": ["warden", "artificer"],
       "biomes": ["dorsale_termale_tropicale"],
       "core_traits": [
         "ventriglio_gastroliti",
@@ -1993,7 +1993,7 @@
       "required_capabilities": ["build_cover", "dr_impact_cap", "non_metal_gear", "seal_vents"],
       "role": "ingegneri_ecosistema",
       "source_files": ["packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml"],
-      "synergy_hints": ["Vanguard", "Warden"],
+      "synergy_hints": ["vanguard", "warden"],
       "synergy_traits": []
     },
     "sand-burrower": {
@@ -2110,7 +2110,7 @@
       "required_capabilities": ["dr_impact_cap", "non_metal_gear"],
       "role": "predatore_terziario_apex",
       "source_files": ["packs/evo_tactics_pack/data/species/badlands/slag-veil-ambusher.yaml"],
-      "synergy_hints": ["Warden"],
+      "synergy_hints": ["warden"],
       "synergy_traits": ["tattiche_di_branco", "scheletro_idro_regolante"]
     },
     "sorgenti-geotermiche-trait-keeper": {
@@ -2170,7 +2170,7 @@
       "synergy_traits": []
     },
     "steppe-bison-mini": {
-      "archetypes": ["Warden", "Vanguard"],
+      "archetypes": ["warden", "vanguard"],
       "biomes": ["mezzanotte_orbitale"],
       "core_traits": ["ventriglio_gastroliti", "scheletro_idro_regolante", "respiro_a_scoppio"],
       "display_name": "Bisonte Nano della Steppa",
@@ -2407,7 +2407,7 @@
       "required_capabilities": ["long_range_scan"],
       "role": "dispersore_ponte",
       "source_files": ["packs/evo_tactics_pack/data/species/cryosteppe/zephyr-spore-courier.yaml"],
-      "synergy_hints": ["Support"],
+      "synergy_hints": ["support"],
       "synergy_traits": []
     }
   }

--- a/docs/catalog/traits_inventory.json
+++ b/docs/catalog/traits_inventory.json
@@ -400,7 +400,7 @@
       "type": "specie"
     },
     {
-      "notes": "Myco Spire Warden con core focalizzato su filamenti_digestivi_compattanti, empatia_coordinativa, struttura_elastica_amorfa.",
+      "notes": "Myco Spire warden con core focalizzato su filamenti_digestivi_compattanti, empatia_coordinativa, struttura_elastica_amorfa.",
       "path": "packs/evo_tactics_pack/data/species/foresta_temperata/myco-spire-warden.yaml",
       "state": "core",
       "type": "specie"

--- a/docs/evo-tactics-pack/env-traits.json
+++ b/docs/evo-tactics-pack/env-traits.json
@@ -7,29 +7,19 @@
         "biome_class": "foresta_temperata"
       },
       "suggest": {
-        "traits": [
-          "peli_idrofobici"
-        ],
+        "traits": ["peli_idrofobici"],
         "effects": {
           "res_cold": "+1"
         },
-        "jobs_bias": [
-          "Warden",
-          "Skirmisher"
-        ]
+        "jobs_bias": ["warden", "skirmisher"]
       }
     },
     {
       "when": {
-        "koppen_in": [
-          "Cfb",
-          "Cfa"
-        ]
+        "koppen_in": ["Cfb", "Cfa"]
       },
       "suggest": {
-        "traits": [
-          "pelli_fitte"
-        ],
+        "traits": ["pelli_fitte"],
         "effects": {
           "guard_stance": true
         }
@@ -37,36 +27,24 @@
     },
     {
       "when": {
-        "hazard_any": [
-          "pendenze_instabili"
-        ]
+        "hazard_any": ["pendenze_instabili"]
       },
-      "require_capability_any": [
-        "jump_bonus",
-        "pathing_bonus"
-      ]
+      "require_capability_any": ["jump_bonus", "pathing_bonus"]
     },
     {
       "when": {
         "morphotype": "ingegnere_radicante"
       },
       "suggest": {
-        "services_links": [
-          "regolazione:ritenzione_idrica",
-          "supporto:stabilizzazione_suolo"
-        ]
+        "services_links": ["regolazione:ritenzione_idrica", "supporto:stabilizzazione_suolo"]
       }
     },
     {
       "when": {
-        "salinita_in": [
-          "salina interna"
-        ]
+        "salinita_in": ["salina interna"]
       },
       "suggest": {
-        "traits": [
-          "cute_resistente_sali"
-        ],
+        "traits": ["cute_resistente_sali"],
         "effects": {
           "res_salt": "+1"
         }
@@ -77,94 +55,55 @@
         "biome_class": "badlands"
       },
       "suggest": {
-        "traits": [
-          "pelli_anti_ustione",
-          "pigmenti_termici",
-          "cute_resistente_sali"
-        ],
+        "traits": ["pelli_anti_ustione", "pigmenti_termici", "cute_resistente_sali"],
         "effects": {
           "res_fire": "+1"
         },
-        "jobs_bias": [
-          "Vanguard",
-          "Warden"
-        ]
+        "jobs_bias": ["vanguard", "warden"]
       }
     },
     {
       "when": {
-        "hazard_any": [
-          "iron_shards"
-        ]
+        "hazard_any": ["iron_shards"]
       },
-      "require_capability_any": [
-        "dr_impact_cap",
-        "build_cover"
-      ]
+      "require_capability_any": ["dr_impact_cap", "build_cover"]
     },
     {
       "when": {
-        "hazard_any": [
-          "magnetic_patches"
-        ]
+        "hazard_any": ["magnetic_patches"]
       },
       "suggest": {
-        "traits": [
-          "enzimi_chelanti"
-        ],
+        "traits": ["enzimi_chelanti"],
         "effects": {
           "trap_detect_ion": true
         }
       },
-      "require_capability_any": [
-        "non_metal_gear",
-        "seal_vents"
-      ]
+      "require_capability_any": ["non_metal_gear", "seal_vents"]
     },
     {
       "when": {
-        "koppen_any": [
-          "BWh",
-          "BSh"
-        ]
+        "koppen_any": ["BWh", "BSh"]
       },
       "suggest": {
-        "traits": [
-          "cuticole_cerose",
-          "reti_capillari_radici",
-          "proteine_shock_termico"
-        ],
+        "traits": ["cuticole_cerose", "reti_capillari_radici", "proteine_shock_termico"],
         "effects": {
           "res_fire": "+1",
           "res_salt": "+1"
         },
-        "jobs_bias": [
-          "Warden",
-          "Skirmisher"
-        ]
+        "jobs_bias": ["warden", "skirmisher"]
       }
     },
     {
       "when": {
-        "koppen_any": [
-          "BSk",
-          "Dfc"
-        ]
+        "koppen_any": ["BSk", "Dfc"]
       },
       "suggest": {
-        "traits": [
-          "pelli_cave",
-          "grassi_termici",
-          "pigmenti_aurorali"
-        ],
+        "traits": ["pelli_cave", "grassi_termici", "pigmenti_aurorali"],
         "effects": {
           "res_cold": "+1",
           "ignore_fog_penalty": true
         },
-        "jobs_bias": [
-          "Vanguard",
-          "Warden"
-        ]
+        "jobs_bias": ["vanguard", "warden"]
       }
     },
     {
@@ -174,10 +113,7 @@
       "meta": {
         "category": "biomi_estremi",
         "description": "Caldera vulcanica intrappolata in ghiacci iperpressurizzati.",
-        "hazard_profile": [
-          "shock_termici",
-          "geiser_criogenici"
-        ]
+        "hazard_profile": ["shock_termici", "geiser_criogenici"]
       },
       "suggest": {
         "traits": [
@@ -207,10 +143,7 @@
           "res_fire": "+1",
           "pressure_tolerance": true
         },
-        "jobs_bias": [
-          "Warden",
-          "Invoker"
-        ]
+        "jobs_bias": ["warden", "invoker"]
       }
     },
     {
@@ -220,10 +153,7 @@
       "meta": {
         "category": "biomi_estremi",
         "description": "Foresta pluviale satura di vapori acidi e precipitazioni caustiche.",
-        "hazard_profile": [
-          "piogge_acide",
-          "aerosol_solfurei"
-        ]
+        "hazard_profile": ["piogge_acide", "aerosol_solfurei"]
       },
       "suggest": {
         "traits": [
@@ -252,10 +182,7 @@
           "res_acid": "+2",
           "detox_cycle": true
         },
-        "jobs_bias": [
-          "Warden",
-          "Vanguard"
-        ]
+        "jobs_bias": ["warden", "vanguard"]
       }
     },
     {
@@ -265,10 +192,7 @@
       "meta": {
         "category": "biomi_estremi",
         "description": "Distese saline iperaride con evaporiti taglienti e miraggi termici.",
-        "hazard_profile": [
-          "tempeste_salate",
-          "miraggi_termici"
-        ]
+        "hazard_profile": ["tempeste_salate", "miraggi_termici"]
       },
       "suggest": {
         "traits": [
@@ -298,10 +222,7 @@
           "res_salt": "+2",
           "moisture_harvest": true
         },
-        "jobs_bias": [
-          "Skirmisher",
-          "Invoker"
-        ]
+        "jobs_bias": ["skirmisher", "invoker"]
       }
     },
     {
@@ -311,10 +232,7 @@
       "meta": {
         "category": "biomi_estremi",
         "description": "Corridoi stratosferici battuti da fulmini permanenti e venti a getto.",
-        "hazard_profile": [
-          "fulmini_perpetui",
-          "shearing_winds"
-        ]
+        "hazard_profile": ["fulmini_perpetui", "shearing_winds"]
       },
       "suggest": {
         "traits": [
@@ -344,10 +262,7 @@
           "res_electric": "+2",
           "wind_sense": true
         },
-        "jobs_bias": [
-          "Skirmisher",
-          "Invoker"
-        ]
+        "jobs_bias": ["skirmisher", "invoker"]
       }
     },
     {
@@ -357,10 +272,7 @@
       "meta": {
         "category": "biomi_estremi",
         "description": "Fosse abissali con sfiati vulcanici e pressioni titaniche.",
-        "hazard_profile": [
-          "sfiati_sulfurei",
-          "frane_abissali"
-        ]
+        "hazard_profile": ["sfiati_sulfurei", "frane_abissali"]
       },
       "suggest": {
         "traits": [
@@ -390,10 +302,7 @@
           "dark_vision": true,
           "res_heat": "+1"
         },
-        "jobs_bias": [
-          "Vanguard",
-          "Warden"
-        ]
+        "jobs_bias": ["vanguard", "warden"]
       }
     },
     {
@@ -432,10 +341,7 @@
           "tidal_sync": true,
           "res_salt": "+1"
         },
-        "jobs_bias": [
-          "Warden",
-          "Skirmisher"
-        ]
+        "jobs_bias": ["warden", "skirmisher"]
       }
     },
     {
@@ -474,10 +380,7 @@
           "climb_bonus": true,
           "mire_immunity": true
         },
-        "jobs_bias": [
-          "Vanguard",
-          "Skirmisher"
-        ]
+        "jobs_bias": ["vanguard", "skirmisher"]
       }
     },
     {
@@ -517,10 +420,7 @@
           "res_acid": "+1",
           "night_vision": true
         },
-        "jobs_bias": [
-          "Invoker",
-          "Skirmisher"
-        ]
+        "jobs_bias": ["invoker", "skirmisher"]
       }
     },
     {
@@ -559,10 +459,7 @@
           "res_heat": "+2",
           "pressure_tolerance": true
         },
-        "jobs_bias": [
-          "Vanguard",
-          "Warden"
-        ]
+        "jobs_bias": ["vanguard", "warden"]
       }
     },
     {
@@ -601,10 +498,7 @@
           "glide_bonus": true,
           "res_electric": "+2"
         },
-        "jobs_bias": [
-          "Skirmisher",
-          "Invoker"
-        ]
+        "jobs_bias": ["skirmisher", "invoker"]
       }
     },
     {
@@ -643,10 +537,7 @@
           "res_psionic": "+1",
           "initiative_bonus": true
         },
-        "jobs_bias": [
-          "Skirmisher",
-          "Vanguard"
-        ]
+        "jobs_bias": ["skirmisher", "vanguard"]
       }
     },
     {
@@ -686,10 +577,7 @@
           "stealth_bonus": true,
           "echolocation": true
         },
-        "jobs_bias": [
-          "Invoker",
-          "Warden"
-        ]
+        "jobs_bias": ["invoker", "warden"]
       }
     },
     {

--- a/docs/evo-tactics-pack/trait-reference.json
+++ b/docs/evo-tactics-pack/trait-reference.json
@@ -3472,7 +3472,7 @@
       "mutazione_indotta": "Circuiti sensorio-emotivi collegati al feed HUD PI.",
       "uso_funzione": "Collega cooldown difensivi e cura quando la squadra entra in finestra rischio.",
       "spinta_selettiva": "Turni lunghi con rischio alto in cui serve mitigare tilt e HP critici.",
-      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
+      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate warden scende.",
       "sinergie_pi": {
         "co_occorrenze": ["job_ability:warden/scudo_di_risonanza"],
         "combo_totale": 1,

--- a/docs/evo-tactics-pack/traits/index.json
+++ b/docs/evo-tactics-pack/traits/index.json
@@ -3442,7 +3442,7 @@
     },
     "empatia_coordinativa": {
       "conflitti": [],
-      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
+      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate warden scende.",
       "famiglia_tipologia": "Supporto/Empatico",
       "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
       "label": "Empatia Coordinativa",

--- a/docs/evo-tactics-pack/traits/supporto/empatia_coordinativa.json
+++ b/docs/evo-tactics-pack/traits/supporto/empatia_coordinativa.json
@@ -1,6 +1,6 @@
 {
   "conflitti": [],
-  "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
+  "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate warden scende.",
   "famiglia_tipologia": "Supporto/Empatico",
   "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
   "id": "empatia_coordinativa",

--- a/docs/evo-tactics-pack/traits/supporto/index.json
+++ b/docs/evo-tactics-pack/traits/supporto/index.json
@@ -345,7 +345,7 @@
     },
     "empatia_coordinativa": {
       "conflitti": [],
-      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
+      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate warden scende.",
       "famiglia_tipologia": "Supporto/Empatico",
       "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
       "id": "empatia_coordinativa",

--- a/docs/reports/trait-env-alignment.md
+++ b/docs/reports/trait-env-alignment.md
@@ -15,7 +15,7 @@
 ## Esempi applicativi per le squadre
 ### pianificatore + slot C controllato
 - Composizioni INTJ/ENTJ/ESTJ sfruttano `pianificatore` nello slot C con `sigillo_forma` e `starter_bioma`, mantenendo budget PE equilibrato e garantendo capienza difensiva tramite `guardia_situazionale` negli slot A/B.【F:data/packs.yaml†L32-L110】
-- Le telemetrie raccomandano pick-rate equilibrati fra Vanguard (22%) e Invoker (16%): il tratto supporta le rotazioni per entrambe le classi nelle finestre mid/late (phase weights 0.40).【F:data/core/telemetry.yaml†L5-L41】
+- Le telemetrie raccomandano pick-rate equilibrati fra vanguard (22%) e invoker (16%): il tratto supporta le rotazioni per entrambe le classi nelle finestre mid/late (phase weights 0.40).【F:data/core/telemetry.yaml†L5-L41】
 - Nota di design: usare `sinergie_pi.combo_totale` per valutare saturazione del tratto — 6 combinazioni già tracciate, suggerendo di limitarne l’accesso in nuove forme finché i target HUD restano stabili.【F:data/traits/index.json†L493-L517】【F:data/derived/analysis/trait_env_mapping.json†L574-L608】
 
 ### Focus Frazionato per doppio ingaggio

--- a/incoming/FEATURE_MAP_EVO_TACTICS.md
+++ b/incoming/FEATURE_MAP_EVO_TACTICS.md
@@ -5,9 +5,10 @@ Questa mappa riassume **tutte le feature** costruite finora, organizzate per are
 ---
 
 ## 0) Timeline versioni (macro)
-- **v1**: Pacchetto minimo (specie + morph base, ENTP, job Skirmisher, regole core, arma/tag/surge base, biomi starter, social/nest, telemetria).
+
+- **v1**: Pacchetto minimo (specie + morph base, ENTP, job skirmisher, regole core, arma/tag/surge base, biomi starter, social/nest, telemetria).
 - **v2**: Trait (Focus Frazionato, Backstab), 5 job extra, Mating & Regista, economia & preferenze & privacy, sinergie aggiornate.
-- **v3**: Biomi Desert/Cavern/Badlands espansi, template NPG + tabelle comportamento, MBTI↔Job micro-bonus, gear Invoker, checklist e validation.
+- **v3**: Biomi Desert/Cavern/Badlands espansi, template NPG + tabelle comportamento, MBTI↔Job micro-bonus, gear invoker, checklist e validation.
 - **v4**: 3 nuove specie + morph dedicati, preferenze social cross-biome, 6 one-pager NPG, encounter tables, reward tiers.
 - **v5**: MBTI Gates (soft), JSON Schemas (PG/NPG), Spawn Pack v1 (12 NPG), GM Quickstart, manifest.
 - **v6**: Patch “playtest-needed”: feint_step, proficiency, checks, stances, units_grid, mating_biome_links, tuning, surge SG, tag avanzati.
@@ -17,59 +18,68 @@ Questa mappa riassume **tutte le feature** costruite finora, organizzate per are
 ---
 
 ## 1) Sistemi Core
+
 - **Statistiche & Derivazioni**: `rules/stats.md` (HP, AC, Parry, Guardia, Move, Vel) → valide i valori di Klynn (13/13/+2/0/5/+1).
-- **Risorse**: `rules/resources.md` (PT, PP, PI, PE, SG) + `rules/tuning.md` (cap & ritmo, *playtest-needed*).  
-- **Prove & CD**: `rules/checks.md` (d20, CD guideline, vantaggio/svantaggio, TS) *(playtest-needed)*.
-- **Proficienze**: `rules/proficiency.md` *(playtest-needed)*.
-- **Stance/Guardie**: `rules/stances.yaml` (6 stance base) *(playtest-needed)*.
-- **Unità & Griglia**: `rules/units_grid.md` (1 casella = 1,5 m) *(playtest-needed)*.
+- **Risorse**: `rules/resources.md` (PT, PP, PI, PE, SG) + `rules/tuning.md` (cap & ritmo, _playtest-needed_).
+- **Prove & CD**: `rules/checks.md` (d20, CD guideline, vantaggio/svantaggio, TS) _(playtest-needed)_.
+- **Proficienze**: `rules/proficiency.md` _(playtest-needed)_.
+- **Stance/Guardie**: `rules/stances.yaml` (6 stance base) _(playtest-needed)_.
+- **Unità & Griglia**: `rules/units_grid.md` (1 casella = 1,5 m) _(playtest-needed)_.
 
 ## 2) Specie & Morph
+
 - **Specie**: `species/dune_stalker.yaml`, `species/sand_burrower.yaml`, `species/echo_wing.yaml`, `species/rust_scavenger.yaml`, `species/species_index.yaml`.
 - **Morph base**: `morph/spring_legs.yaml`, `acid_gland.yaml`, `elastomer_skin.yaml`, `echolocate.yaml`, `burst_anaerobic.yaml`.
 - **Morph extra**: `burrow_claws.yaml`, `ferrous_carapace.yaml`, `mag_sense.yaml`, `glide_wings.yaml`, `iron_spine.yaml`, `aero_exchange.yaml`, `rust_ingest.yaml`.
 
 ## 3) Forme, MBTI & Enneagramma
-- **Forme (MBTI)**: `form/ENTP.yaml` (assi 0–1, Baratto Tecnico, interazioni).  
+
+- **Forme (MBTI)**: `form/ENTP.yaml` (assi 0–1, Baratto Tecnico, interazioni).
 - **MBTI Affinity & Gates**: `form/mbti_job_affinities.yaml` (micro-bonus) + `form/mbti_gates.yaml` (soft-gating E/N/T/P con penalty primo turno).
 - **Enneagramma (temi)**: `ennea/themes.yaml` con **1..9** completi (trigger coerenti con gli hook).
-- **Add-on Enneagramma integrato**: `modules/personality/enneagram/`  
-  - `compat_map.json` (alias stat/eventi, incl. italiani),  
-  - `personality_module.v1.json` (hook meccanici per temi 1..9),  
-  - `enneagramma_dataset.json` & `enneagramma_schema.json`,  
-  - `hook_bindings.ts` (adapter eventi),  
-  - `role_theme_mappings.yaml` (**default** + **alt**), `role_theme_profile.yaml` (selettore),  
+- **Add-on Enneagramma integrato**: `modules/personality/enneagram/`
+  - `compat_map.json` (alias stat/eventi, incl. italiani),
+  - `personality_module.v1.json` (hook meccanici per temi 1..9),
+  - `enneagramma_dataset.json` & `enneagramma_schema.json`,
+  - `hook_bindings.ts` (adapter eventi),
+  - `role_theme_mappings.yaml` (**default** + **alt**), `role_theme_profile.yaml` (selettore),
   - `pg_enneagram_template.yaml`, `HOWTO_EVO_TACTICS.md`.
 - **Sinergie**: `rules/synergies.yaml` (echolocate+flank_mastery, echolocate+backstab).
 
 ## 4) Job & Trait
+
 - **Job**: `jobs/skirmisher.yaml` (+ `feint_step`), `vanguard.yaml`, `warden.yaml`, `artificer.yaml`, `invoker.yaml`, `harvester.yaml`.
 - **Trait**: `traits/focus_frazionato.yaml`, `traits/backstab.yaml`.
 - **Ultimate & SG**: introdotte nei job e supportate da `surge/overdrive.yaml` (consuma `sg:1`).
 
 ## 5) Gear, Tag, Surge
+
 - **Armi**: `gear/weapons/twin_blades.yaml`, `gear/weapons/arc_rod.yaml`.
-- **Tag**: `tags/weapon.yaml` (Tecnico, Impattante), `tags/weapon_extra.yaml` (Elettrico), `tags/weapon_advanced.yaml` (Vibrante, Cinetica, Ariosa, Bilanciata, Smorzata) *(playtest-needed)*.
+- **Tag**: `tags/weapon.yaml` (Tecnico, Impattante), `tags/weapon_extra.yaml` (Elettrico), `tags/weapon_advanced.yaml` (Vibrante, Cinetica, Ariosa, Bilanciata, Smorzata) _(playtest-needed)_.
 - **Surge**: `surge/pierce.yaml`, `surge/spin.yaml`, `surge/chain.yaml`, `surge/pulse.yaml`, `surge/overdrive.yaml` (SG).
 
 ## 6) Biomi, Social & Nest
+
 - **Biomi**: `biomes/starter_biomes.yaml`, `biomes/desert.yaml`, `biomes/cavern.yaml`, `biomes/badlands.yaml` (hazard, preferenze, modificatori).
 - **Social**: `social/affinity_trust.md`, `social/species_preferences.yaml` (Piace/Non Piace).
-- **Mating & Nest**: `social/mating.md`, `nest/requirements.yaml`, `rules/mating_biome_links.md` *(playtest-needed)*.
+- **Mating & Nest**: `social/mating.md`, `nest/requirements.yaml`, `rules/mating_biome_links.md` _(playtest-needed)_.
 
 ## 7) Telemetria & Sessione
+
 - **Telemetry VC**: `telemetry/vc.yaml` (aggiornamento aggro/risk/cohesion/setup/explore/tilt).
 - **PF_session**: `telemetry/pf_session.yaml` (proiezione assi E/N/T/P).
 
 ## 8) Regista / NPG
+
 - **Director**: `director/regista.md`, `director/behavior_tables.md`.
 - **NPG One-Pagers**: 8+ file (es.: `npg_skirmisher_desert.yaml`, `npg_warden_cavern.yaml`, `npg_vanguard_desert.yaml`, `npg_invoker_cavern.yaml`, `npg_artificer_badlands.yaml`, `npg_harvester_badlands.yaml`).
 - **Incontri & Ricompense**: `director/encounter_tables.yaml`, `director/regista_rewards.yaml`.
 
 ## 9) Exports, Schemi & Tools
-- **Spawn Packs**:  
-  - v1 (default): `exports/spawn_packs/pack_biome_jobs_v1.json` (12 NPG),  
-  - v7 (default temi): `exports/spawn_packs/pack_biome_jobs_v7.json`,  
+
+- **Spawn Packs**:
+  - v1 (default): `exports/spawn_packs/pack_biome_jobs_v1.json` (12 NPG),
+  - v7 (default temi): `exports/spawn_packs/pack_biome_jobs_v7.json`,
   - v8 (alt temi): `exports/spawn_packs/pack_biome_jobs_v8_alt.json`.
 - **Schemas**: `schemas/pg.schema.json`, `schemas/npg.schema.json` per validazioni.
 - **Tools**: `tools/validate_v7.py` (check integrazioni), `manifest.json` (versioning pacchetto).
@@ -78,22 +88,24 @@ Questa mappa riassume **tutte le feature** costruite finora, organizzate per are
 ---
 
 ## 10) Feature “beta / playtest-needed” (da bilanciare)
+
 - `rules/checks.md`, `rules/proficiency.md`, `rules/stances.yaml`, `rules/units_grid.md`, `rules/mating_biome_links.md`, `rules/tuning.md`, `tags/weapon_advanced.yaml`.
 - Numeriche hook temi (1..9) in `personality_module.v1.json`: **status: beta**.
 
 ---
 
 ## 11) Collegamenti chiave (cross-modulo)
-- **ENTP “Baratto Tecnico” ↔ Tag *Tecnico* ↔ Surge**: sconto PP + gestione PT/PP (prima Surge del turno).  
-- **Skirmisher** ↔ **flanking** ↔ `echolocate` **(sinergie)**.  
-- **Biomi** ↔ **specie/morph** (hazard/modifiers) ↔ **Regista** (incontri & premi).  
+
+- **ENTP “Baratto Tecnico” ↔ Tag _Tecnico_ ↔ Surge**: sconto PP + gestione PT/PP (prima Surge del turno).
+- **skirmisher** ↔ **flanking** ↔ `echolocate` **(sinergie)**.
+- **Biomi** ↔ **specie/morph** (hazard/modifiers) ↔ **Regista** (incontri & premi).
 - **MBTI Gates** + **Temi Enneagramma** ↔ **Telemetry/PF_session** (soft influence e micro-bonus).
 
 ---
 
 ## 12) Cosa manca / possibili next steps
-- **PDF Quickstart** impaginato /print.  
-- **Script switch profilo** e rigenerazione pack on-demand.  
-- **Spawn Pack v2** con varianti Rank/Elite/Boss.  
-- **Numeriche finali** post playtest (CD, bonus/malus, tag avanzati, stances).
 
+- **PDF Quickstart** impaginato /print.
+- **Script switch profilo** e rigenerazione pack on-demand.
+- **Spawn Pack v2** con varianti Rank/Elite/Boss.
+- **Numeriche finali** post playtest (CD, bonus/malus, tag avanzati, stances).

--- a/incoming/pack_biome_jobs_v8_alt.json
+++ b/incoming/pack_biome_jobs_v8_alt.json
@@ -2,10 +2,7 @@
   "generated": "2025-10-24",
   "count": 13,
   "profile": "alt",
-  "source": [
-    "pack_biome_jobs_v7.json",
-    "director/npg_*.yaml"
-  ],
+  "source": ["pack_biome_jobs_v7.json", "director/npg_*.yaml"],
   "items": [
     {
       "id": "npg_skirmisher_desert_01",
@@ -17,42 +14,23 @@
         "morph_budget": 11,
         "parts": {
           "locomotion": "spring_legs",
-          "offense": [
-            "acid_gland"
-          ],
-          "defense": [
-            "elastomer_skin"
-          ],
-          "senses": [
-            "echolocate"
-          ],
+          "offense": ["acid_gland"],
+          "defense": ["elastomer_skin"],
+          "senses": ["echolocate"],
           "metabolism": "burst_anaerobic"
         }
       },
       "job": {
         "id": "skirmisher",
         "rank": 1,
-        "actives": [
-          "dash_cut"
-        ],
-        "passives": [
-          "flank_mastery",
-          "backstab"
-        ]
+        "actives": ["dash_cut"],
+        "passives": ["flank_mastery", "backstab"]
       },
-      "traits": [
-        "focus_frazionato"
-      ],
+      "traits": ["focus_frazionato"],
       "gear": {
         "weapon": "twin_blades",
-        "tags": [
-          "Tecnico",
-          "Impattante"
-        ],
-        "surges": [
-          "pierce",
-          "spin"
-        ]
+        "tags": ["Tecnico", "Impattante"],
+        "surges": ["pierce", "spin"]
       },
       "tactics": {
         "opener": "Avvicinati da fuori adiacenza per attivare backstab, poi dash_cut.",
@@ -60,13 +38,8 @@
         "if_outnumbered": "Cerca flanking con alleati; evita terreno difficile."
       },
       "social_hooks": {
-        "likes": [
-          "flanking",
-          "preda isolata"
-        ],
-        "dislikes": [
-          "fuoco continuo"
-        ],
+        "likes": ["flanking", "preda isolata"],
+        "dislikes": ["fuoco continuo"],
         "recruit_threshold": "Affinity ≥ 0, Trust ≥ 2",
         "mating_threshold": "Trust ≥ 3 + Nest OK"
       },
@@ -104,35 +77,22 @@
         "parts": {
           "locomotion": "spring_legs",
           "offense": [],
-          "defense": [
-            "elastomer_skin"
-          ],
-          "senses": [
-            "echolocate"
-          ],
+          "defense": ["elastomer_skin"],
+          "senses": ["echolocate"],
           "metabolism": "burst_anaerobic"
         }
       },
       "job": {
         "id": "warden",
         "rank": 1,
-        "actives": [
-          "root_field",
-          "zone_denial"
-        ],
-        "passives": [
-          "sentinel_mark"
-        ]
+        "actives": ["root_field", "zone_denial"],
+        "passives": ["sentinel_mark"]
       },
       "traits": [],
       "gear": {
         "weapon": "twin_blades",
-        "tags": [
-          "Impattante"
-        ],
-        "surges": [
-          "spin"
-        ]
+        "tags": ["Impattante"],
+        "surges": ["spin"]
       },
       "tactics": {
         "opener": "Chiudi le strettoie con root_field; costringe a passaggi obbligati.",
@@ -140,13 +100,8 @@
         "if_outnumbered": "Zona di negazione e arretramento controllato."
       },
       "social_hooks": {
-        "likes": [
-          "strozzature naturali",
-          "difendere il territorio"
-        ],
-        "dislikes": [
-          "ponti instabili"
-        ]
+        "likes": ["strozzature naturali", "difendere il territorio"],
+        "dislikes": ["ponti instabili"]
       },
       "rewards": {
         "pe": 1,
@@ -179,38 +134,23 @@
         "morph_budget": 12,
         "parts": {
           "locomotion": "burrow_claws",
-          "offense": [
-            "iron_spine"
-          ],
-          "defense": [
-            "ferrous_carapace"
-          ],
-          "senses": [
-            "mag_sense"
-          ],
+          "offense": ["iron_spine"],
+          "defense": ["ferrous_carapace"],
+          "senses": ["mag_sense"],
           "metabolism": "burst_anaerobic"
         }
       },
       "job": {
         "id": "vanguard",
         "rank": 1,
-        "actives": [
-          "shoulder_rush",
-          "intercept"
-        ],
-        "passives": [
-          "guard_wall"
-        ]
+        "actives": ["shoulder_rush", "intercept"],
+        "passives": ["guard_wall"]
       },
       "traits": [],
       "gear": {
         "weapon": "twin_blades",
-        "tags": [
-          "Impattante"
-        ],
-        "surges": [
-          "pierce"
-        ]
+        "tags": ["Impattante"],
+        "surges": ["pierce"]
       },
       "tactics": {
         "opener": "Esci dalla sabbia con shoulder_rush per spingere dal bordo duna.",
@@ -248,40 +188,23 @@
         "morph_budget": 11,
         "parts": {
           "locomotion": "glide_wings",
-          "offense": [
-            "iron_spine"
-          ],
-          "defense": [
-            "elastomer_skin"
-          ],
-          "senses": [
-            "echolocate"
-          ],
+          "offense": ["iron_spine"],
+          "defense": ["elastomer_skin"],
+          "senses": ["echolocate"],
           "metabolism": "aero_exchange"
         }
       },
       "job": {
         "id": "invoker",
         "rank": 1,
-        "actives": [
-          "arc_bolt",
-          "pulse_cone"
-        ],
-        "passives": [
-          "disrupt_field"
-        ]
+        "actives": ["arc_bolt", "pulse_cone"],
+        "passives": ["disrupt_field"]
       },
       "traits": [],
       "gear": {
         "weapon": "arc_rod",
-        "tags": [
-          "Tecnico",
-          "Elettrico"
-        ],
-        "surges": [
-          "chain",
-          "pulse"
-        ]
+        "tags": ["Tecnico", "Elettrico"],
+        "surges": ["chain", "pulse"]
       },
       "tactics": {
         "opener": "Scendi da quota e lancia arc_bolt sfruttando rimbalzi sonori.",
@@ -321,38 +244,23 @@
         "morph_budget": 13,
         "parts": {
           "locomotion": "spring_legs",
-          "offense": [
-            "acid_gland"
-          ],
-          "defense": [
-            "ferrous_carapace"
-          ],
-          "senses": [
-            "mag_sense"
-          ],
+          "offense": ["acid_gland"],
+          "defense": ["ferrous_carapace"],
+          "senses": ["mag_sense"],
           "metabolism": "rust_ingest"
         }
       },
       "job": {
         "id": "artificer",
         "rank": 1,
-        "actives": [
-          "overclock",
-          "deploy_drone"
-        ],
-        "passives": [
-          "patchwork_armor"
-        ]
+        "actives": ["overclock", "deploy_drone"],
+        "passives": ["patchwork_armor"]
       },
       "traits": [],
       "gear": {
         "weapon": "twin_blades",
-        "tags": [
-          "Tecnico"
-        ],
-        "surges": [
-          "spin"
-        ]
+        "tags": ["Tecnico"],
+        "surges": ["spin"]
       },
       "tactics": {
         "opener": "Deploy_drone per vantaggio percezione; overclock all'alleato più mobile.",
@@ -390,38 +298,23 @@
         "morph_budget": 13,
         "parts": {
           "locomotion": "spring_legs",
-          "offense": [
-            "acid_gland"
-          ],
-          "defense": [
-            "ferrous_carapace"
-          ],
-          "senses": [
-            "mag_sense"
-          ],
+          "offense": ["acid_gland"],
+          "defense": ["ferrous_carapace"],
+          "senses": ["mag_sense"],
           "metabolism": "rust_ingest"
         }
       },
       "job": {
         "id": "harvester",
         "rank": 1,
-        "actives": [
-          "siphon_seed",
-          "scavenge_field"
-        ],
-        "passives": [
-          "graft_shift"
-        ]
+        "actives": ["siphon_seed", "scavenge_field"],
+        "passives": ["graft_shift"]
       },
       "traits": [],
       "gear": {
         "weapon": "twin_blades",
-        "tags": [
-          "Impattante"
-        ],
-        "surges": [
-          "pierce"
-        ]
+        "tags": ["Impattante"],
+        "surges": ["pierce"]
       },
       "tactics": {
         "opener": "Siphon_seed su bersagli <50% HP; priorità semina risorse.",
@@ -453,7 +346,7 @@
     },
     {
       "id": "npg_invoker_desert_02",
-      "name": "Invoker Desert 2",
+      "name": "invoker Desert 2",
       "biome": "desert",
       "role": "invoker",
       "attitude": "neutrale",
@@ -462,40 +355,23 @@
         "morph_budget": 12,
         "parts": {
           "locomotion": "glide_wings",
-          "offense": [
-            "iron_spine"
-          ],
-          "defense": [
-            "elastomer_skin"
-          ],
-          "senses": [
-            "echolocate"
-          ],
+          "offense": ["iron_spine"],
+          "defense": ["elastomer_skin"],
+          "senses": ["echolocate"],
           "metabolism": "aero_exchange"
         }
       },
       "job": {
         "id": "invoker",
         "rank": 1,
-        "actives": [
-          "arc_bolt",
-          "pulse_cone"
-        ],
-        "passives": [
-          "disrupt_field"
-        ]
+        "actives": ["arc_bolt", "pulse_cone"],
+        "passives": ["disrupt_field"]
       },
       "traits": [],
       "gear": {
         "weapon": "arc_rod",
-        "tags": [
-          "Tecnico",
-          "Elettrico"
-        ],
-        "surges": [
-          "chain",
-          "pulse"
-        ]
+        "tags": ["Tecnico", "Elettrico"],
+        "surges": ["chain", "pulse"]
       },
       "tactics": {
         "opener": "Usa la prima attiva coerente col terreno.",
@@ -526,7 +402,7 @@
     },
     {
       "id": "npg_skirmisher_cavern_03",
-      "name": "Skirmisher Cavern 3",
+      "name": "skirmisher Cavern 3",
       "biome": "cavern",
       "role": "skirmisher",
       "attitude": "ostile",
@@ -535,40 +411,23 @@
         "morph_budget": 12,
         "parts": {
           "locomotion": "spring_legs",
-          "offense": [
-            "acid_gland"
-          ],
-          "defense": [
-            "elastomer_skin"
-          ],
-          "senses": [
-            "echolocate"
-          ],
+          "offense": ["acid_gland"],
+          "defense": ["elastomer_skin"],
+          "senses": ["echolocate"],
           "metabolism": "burst_anaerobic"
         }
       },
       "job": {
         "id": "skirmisher",
         "rank": 1,
-        "actives": [
-          "dash_cut"
-        ],
-        "passives": [
-          "flank_mastery",
-          "backstab"
-        ]
+        "actives": ["dash_cut"],
+        "passives": ["flank_mastery", "backstab"]
       },
       "traits": [],
       "gear": {
         "weapon": "twin_blades",
-        "tags": [
-          "Tecnico",
-          "Impattante"
-        ],
-        "surges": [
-          "pierce",
-          "spin"
-        ]
+        "tags": ["Tecnico", "Impattante"],
+        "surges": ["pierce", "spin"]
       },
       "tactics": {
         "opener": "Usa la prima attiva coerente col terreno.",
@@ -599,7 +458,7 @@
     },
     {
       "id": "npg_warden_badlands_04",
-      "name": "Warden Badlands 4",
+      "name": "warden Badlands 4",
       "biome": "badlands",
       "role": "warden",
       "attitude": "ostile",
@@ -608,38 +467,23 @@
         "morph_budget": 12,
         "parts": {
           "locomotion": "spring_legs",
-          "offense": [
-            "acid_gland"
-          ],
-          "defense": [
-            "ferrous_carapace"
-          ],
-          "senses": [
-            "mag_sense"
-          ],
+          "offense": ["acid_gland"],
+          "defense": ["ferrous_carapace"],
+          "senses": ["mag_sense"],
           "metabolism": "rust_ingest"
         }
       },
       "job": {
         "id": "warden",
         "rank": 1,
-        "actives": [
-          "root_field",
-          "zone_denial"
-        ],
-        "passives": [
-          "sentinel_mark"
-        ]
+        "actives": ["root_field", "zone_denial"],
+        "passives": ["sentinel_mark"]
       },
       "traits": [],
       "gear": {
         "weapon": "twin_blades",
-        "tags": [
-          "Impattante"
-        ],
-        "surges": [
-          "spin"
-        ]
+        "tags": ["Impattante"],
+        "surges": ["spin"]
       },
       "tactics": {
         "opener": "Usa la prima attiva coerente col terreno.",
@@ -668,7 +512,7 @@
     },
     {
       "id": "npg_vanguard_cavern_05",
-      "name": "Vanguard Cavern 5",
+      "name": "vanguard Cavern 5",
       "biome": "cavern",
       "role": "vanguard",
       "attitude": "ostile",
@@ -677,38 +521,23 @@
         "morph_budget": 12,
         "parts": {
           "locomotion": "burrow_claws",
-          "offense": [
-            "iron_spine"
-          ],
-          "defense": [
-            "ferrous_carapace"
-          ],
-          "senses": [
-            "mag_sense"
-          ],
+          "offense": ["iron_spine"],
+          "defense": ["ferrous_carapace"],
+          "senses": ["mag_sense"],
           "metabolism": "burst_anaerobic"
         }
       },
       "job": {
         "id": "vanguard",
         "rank": 1,
-        "actives": [
-          "shoulder_rush",
-          "intercept"
-        ],
-        "passives": [
-          "guard_wall"
-        ]
+        "actives": ["shoulder_rush", "intercept"],
+        "passives": ["guard_wall"]
       },
       "traits": [],
       "gear": {
         "weapon": "twin_blades",
-        "tags": [
-          "Impattante"
-        ],
-        "surges": [
-          "pierce"
-        ]
+        "tags": ["Impattante"],
+        "surges": ["pierce"]
       },
       "tactics": {
         "opener": "Usa la prima attiva coerente col terreno.",
@@ -737,7 +566,7 @@
     },
     {
       "id": "npg_artificer_desert_06",
-      "name": "Artificer Desert 6",
+      "name": "artificer Desert 6",
       "biome": "desert",
       "role": "artificer",
       "attitude": "neutrale",
@@ -746,38 +575,23 @@
         "morph_budget": 12,
         "parts": {
           "locomotion": "spring_legs",
-          "offense": [
-            "acid_gland"
-          ],
-          "defense": [
-            "ferrous_carapace"
-          ],
-          "senses": [
-            "mag_sense"
-          ],
+          "offense": ["acid_gland"],
+          "defense": ["ferrous_carapace"],
+          "senses": ["mag_sense"],
           "metabolism": "rust_ingest"
         }
       },
       "job": {
         "id": "artificer",
         "rank": 1,
-        "actives": [
-          "overclock",
-          "deploy_drone"
-        ],
-        "passives": [
-          "patchwork_armor"
-        ]
+        "actives": ["overclock", "deploy_drone"],
+        "passives": ["patchwork_armor"]
       },
       "traits": [],
       "gear": {
         "weapon": "twin_blades",
-        "tags": [
-          "Tecnico"
-        ],
-        "surges": [
-          "spin"
-        ]
+        "tags": ["Tecnico"],
+        "surges": ["spin"]
       },
       "tactics": {
         "opener": "Usa la prima attiva coerente col terreno.",
@@ -806,7 +620,7 @@
     },
     {
       "id": "npg_harvester_desert_07",
-      "name": "Harvester Desert 7",
+      "name": "harvester Desert 7",
       "biome": "desert",
       "role": "harvester",
       "attitude": "neutrale",
@@ -815,38 +629,23 @@
         "morph_budget": 12,
         "parts": {
           "locomotion": "burrow_claws",
-          "offense": [
-            "iron_spine"
-          ],
-          "defense": [
-            "ferrous_carapace"
-          ],
-          "senses": [
-            "mag_sense"
-          ],
+          "offense": ["iron_spine"],
+          "defense": ["ferrous_carapace"],
+          "senses": ["mag_sense"],
           "metabolism": "burst_anaerobic"
         }
       },
       "job": {
         "id": "harvester",
         "rank": 1,
-        "actives": [
-          "siphon_seed",
-          "scavenge_field"
-        ],
-        "passives": [
-          "graft_shift"
-        ]
+        "actives": ["siphon_seed", "scavenge_field"],
+        "passives": ["graft_shift"]
       },
       "traits": [],
       "gear": {
         "weapon": "twin_blades",
-        "tags": [
-          "Impattante"
-        ],
-        "surges": [
-          "pierce"
-        ]
+        "tags": ["Impattante"],
+        "surges": ["pierce"]
       },
       "tactics": {
         "opener": "Usa la prima attiva coerente col terreno.",

--- a/locales/it/traits.json
+++ b/locales/it/traits.json
@@ -763,7 +763,7 @@
       "uso_funzione": "Utilizzo di onde sonore emesse internamente per mappare l'ambiente."
     },
     "empatia_coordinativa": {
-      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
+      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate warden scende.",
       "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
       "label": "Empatia Coordinativa",
       "mutazione_indotta": "Circuiti sensorio-emotivi collegati al feed HUD PI.",

--- a/packs/evo_tactics_pack/data/npg/foresta_temperata_npg.json
+++ b/packs/evo_tactics_pack/data/npg/foresta_temperata_npg.json
@@ -13,7 +13,7 @@
       }
     },
     "job": {
-      "id": "Skirmisher",
+      "id": "skirmisher",
       "rank": 1,
       "actives": [
         "dash"

--- a/packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml
@@ -67,8 +67,8 @@ derived_from_environment:
     - non_metal_gear
     - seal_vents
   jobs_bias:
-    - Vanguard
-    - Warden
+    - vanguard
+    - warden
 telemetry:
   expected_pick_rate: null
   spawn_weight: null

--- a/packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml
@@ -49,8 +49,8 @@ telemetry:
   expected_pick_rate: 0.18
   spawn_weight: 0.25
 jobs_synergy:
-  - Skirmisher
-  - Invoker
+  - skirmisher
+  - invoker
 environment_affinity:
   biome_class: dorsale_termale_tropicale
   koppen:
@@ -81,9 +81,9 @@ derived_from_environment:
     - non_metal_gear
     - seal_vents
   jobs_bias:
-    - Skirmisher
-    - Vanguard
-    - Warden
+    - skirmisher
+    - vanguard
+    - warden
 network_bridge_roles:
   - dispersore_ponte
   - impollinatore

--- a/packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml
@@ -66,8 +66,8 @@ derived_from_environment:
     - non_metal_gear
     - seal_vents
   jobs_bias:
-    - Vanguard
-    - Warden
+    - vanguard
+    - warden
 telemetry:
   expected_pick_rate: null
   spawn_weight: null

--- a/packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml
@@ -54,8 +54,8 @@ telemetry:
   expected_pick_rate: 0.1
   spawn_weight: 0.12
 jobs_synergy:
-  - Warden
-  - Artificer
+  - warden
+  - artificer
 mate_synergy:
   - sinergizzatore_team
   - architetto
@@ -98,8 +98,8 @@ derived_from_environment:
     - regolazione:ritenzione_idrica
     - supporto:stabilizzazione_suolo
   jobs_bias:
-    - Vanguard
-    - Warden
+    - vanguard
+    - warden
 network_bridge_roles:
   - ingegnere_ecosistema
   - sentinella

--- a/packs/evo_tactics_pack/data/species/badlands/magneto-ridge-hunter.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/magneto-ridge-hunter.yaml
@@ -71,8 +71,8 @@ derived_from_environment:
     - non_metal_gear
     - seal_vents
 jobs_bias:
-  - Vanguard
-  - Skirmisher
+  - vanguard
+  - skirmisher
 telemetry:
   expected_pick_rate: 0.42
   spawn_weight: 0.16
@@ -90,5 +90,5 @@ genetic_traits:
     - struttura_elastica_amorfa
 mate_synergy: []
 jobs_synergy:
-  - Vanguard
+  - vanguard
 description: i18n:species.magneto-ridge-hunter.description

--- a/packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml
@@ -68,8 +68,8 @@ derived_from_environment:
     - non_metal_gear
     - seal_vents
   jobs_bias:
-    - Vanguard
-    - Warden
+    - vanguard
+    - warden
 telemetry:
   expected_pick_rate: null
   spawn_weight: null

--- a/packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml
@@ -52,8 +52,8 @@ telemetry:
   expected_pick_rate: 0.15
   spawn_weight: 0.22
 jobs_synergy:
-  - Warden
-  - Artificer
+  - warden
+  - artificer
 environment_affinity:
   biome_class: dorsale_termale_tropicale
   koppen:
@@ -79,8 +79,8 @@ derived_from_environment:
     - non_metal_gear
     - seal_vents
 jobs_bias:
-  - Vanguard
-  - Warden
+  - vanguard
+  - warden
 genetic_traits:
   core:
     - ventriglio_gastroliti

--- a/packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml
@@ -63,8 +63,8 @@ derived_from_environment:
     - non_metal_gear
     - seal_vents
   jobs_bias:
-    - Vanguard
-    - Warden
+    - vanguard
+    - warden
 telemetry:
   expected_pick_rate: null
   spawn_weight: null

--- a/packs/evo_tactics_pack/data/species/badlands/slag-veil-ambusher.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/slag-veil-ambusher.yaml
@@ -61,7 +61,7 @@ derived_from_environment:
     - dr_impact_cap
     - non_metal_gear
 jobs_bias:
-  - Warden
+  - warden
 telemetry:
   expected_pick_rate: null
   spawn_weight: 0.08

--- a/packs/evo_tactics_pack/data/species/canopia_psionica_leggera/psionic-canopy-scout.yaml
+++ b/packs/evo_tactics_pack/data/species/canopia_psionica_leggera/psionic-canopy-scout.yaml
@@ -62,8 +62,8 @@ derived_from_environment:
   required_capabilities:
     - lift_control
 jobs_bias:
-  - Support
-  - Invoker
+  - support
+  - invoker
 telemetry:
   expected_pick_rate: null
   spawn_weight: 0.08

--- a/packs/evo_tactics_pack/data/species/caverna_risonante/resonant-claw-hunter.yaml
+++ b/packs/evo_tactics_pack/data/species/caverna_risonante/resonant-claw-hunter.yaml
@@ -63,8 +63,8 @@ derived_from_environment:
     - track_resonance
     - counter_burrow
   jobs_bias:
-    - Vanguard
-    - Invoker
+    - vanguard
+    - invoker
 telemetry:
   expected_pick_rate: null
   spawn_weight: null

--- a/packs/evo_tactics_pack/data/species/cryosteppe/aurora-bridge-runner.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/aurora-bridge-runner.yaml
@@ -69,15 +69,15 @@ derived_from_environment:
     - deploy_support_field
     - long_range_scan
 jobs_bias:
-  - Support
-  - Skirmisher
+  - support
+  - skirmisher
 telemetry:
   expected_pick_rate: 0.48
   spawn_weight: 0.14
 services_links: []
 genetic_traits: []
 mate_synergy:
-  - Support
+  - support
 jobs_synergy:
-  - Skirmisher
+  - skirmisher
 description: i18n:species.aurora-bridge-runner.description

--- a/packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml
@@ -43,8 +43,8 @@ telemetry:
   expected_pick_rate: 0.16
   spawn_weight: 0.24
 jobs_synergy:
-  - Skirmisher
-  - Invoker
+  - skirmisher
+  - invoker
 schema_version: 1.7
 receipt:
   source: PTPF.v1.0
@@ -67,9 +67,9 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-    - Skirmisher
-    - Vanguard
-    - Warden
+    - skirmisher
+    - vanguard
+    - warden
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml
@@ -56,9 +56,9 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-    - Skirmisher
-    - Vanguard
-    - Warden
+    - skirmisher
+    - vanguard
+    - warden
 telemetry:
   expected_pick_rate: null
   spawn_weight: null

--- a/packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml
@@ -60,9 +60,9 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-    - Skirmisher
-    - Vanguard
-    - Warden
+    - skirmisher
+    - vanguard
+    - warden
 telemetry:
   expected_pick_rate: null
   spawn_weight: null

--- a/packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml
@@ -47,8 +47,8 @@ telemetry:
   expected_pick_rate: 0.15
   spawn_weight: 0.22
 jobs_synergy:
-  - Warden
-  - Vanguard
+  - warden
+  - vanguard
 schema_version: 1.7
 receipt:
   source: PTPF.v1.0
@@ -71,9 +71,9 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-    - Skirmisher
-    - Vanguard
-    - Warden
+    - skirmisher
+    - vanguard
+    - warden
 genetic_traits: []
 mate_synergy: []
 description: i18n:species.steppe-bison-mini.description

--- a/packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml
@@ -60,9 +60,9 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-    - Skirmisher
-    - Vanguard
-    - Warden
+    - skirmisher
+    - vanguard
+    - warden
 telemetry:
   expected_pick_rate: null
   spawn_weight: null

--- a/packs/evo_tactics_pack/data/species/cryosteppe/zephyr-spore-courier.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/zephyr-spore-courier.yaml
@@ -60,7 +60,7 @@ derived_from_environment:
   required_capabilities:
     - long_range_scan
 jobs_bias:
-  - Support
+  - support
 telemetry:
   expected_pick_rate: null
   spawn_weight: 0.11

--- a/packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml
+++ b/packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml
@@ -47,8 +47,8 @@ telemetry:
   expected_pick_rate: 0.16
   spawn_weight: 0.24
 jobs_synergy:
-  - Warden
-  - Artificer
+  - warden
+  - artificer
 schema_version: 1.7
 receipt:
   source: PTPF.v1.0
@@ -73,9 +73,9 @@ derived_from_environment:
     - regolazione:ritenzione_idrica
     - supporto:stabilizzazione_suolo
   jobs_bias:
-    - Skirmisher
-    - Vanguard
-    - Warden
+    - skirmisher
+    - vanguard
+    - warden
 genetic_traits: []
 mate_synergy: []
 description: i18n:species.cactus-weaver.description

--- a/packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml
+++ b/packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml
@@ -59,9 +59,9 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-    - Skirmisher
-    - Vanguard
-    - Warden
+    - skirmisher
+    - vanguard
+    - warden
 telemetry:
   expected_pick_rate: null
   spawn_weight: null

--- a/packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml
+++ b/packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml
@@ -43,8 +43,8 @@ telemetry:
   expected_pick_rate: 0.17
   spawn_weight: 0.23
 jobs_synergy:
-  - Skirmisher
-  - Invoker
+  - skirmisher
+  - invoker
 schema_version: 1.7
 receipt:
   source: PTPF.v1.0
@@ -67,9 +67,9 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-    - Skirmisher
-    - Vanguard
-    - Warden
+    - skirmisher
+    - vanguard
+    - warden
 services_links: []
 genetic_traits: []
 mate_synergy: []

--- a/packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml
+++ b/packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml
@@ -60,9 +60,9 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-    - Skirmisher
-    - Vanguard
-    - Warden
+    - skirmisher
+    - vanguard
+    - warden
 telemetry:
   expected_pick_rate: null
   spawn_weight: null

--- a/packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml
+++ b/packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml
@@ -55,9 +55,9 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-    - Skirmisher
-    - Vanguard
-    - Warden
+    - skirmisher
+    - vanguard
+    - warden
 telemetry:
   expected_pick_rate: null
   spawn_weight: null

--- a/packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/magnet-fathom-surveyor.yaml
+++ b/packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/magnet-fathom-surveyor.yaml
@@ -62,8 +62,8 @@ derived_from_environment:
     - dr_impact_cap
     - seal_vents
 jobs_bias:
-  - Warden
-  - Vanguard
+  - warden
+  - vanguard
 telemetry:
   expected_pick_rate: null
   spawn_weight: 0.06

--- a/packs/evo_tactics_pack/data/species/foresta_temperata/glowcap-weaver.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_temperata/glowcap-weaver.yaml
@@ -59,7 +59,7 @@ derived_from_environment:
   required_capabilities:
     - deploy_support_field
 jobs_bias:
-  - Support
+  - support
 telemetry:
   expected_pick_rate: null
   spawn_weight: 0.1

--- a/packs/evo_tactics_pack/data/species/foresta_temperata/myco-spire-warden.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_temperata/myco-spire-warden.yaml
@@ -5,7 +5,7 @@ receipt:
   date: '2025-11-05'
   trace_hash: to-fill
 id: myco-spire-warden
-display_name: Myco Spire Warden
+display_name: Myco Spire warden
 biomes:
   - foresta_miceliale
 role_trofico: ingegneri_ecosistema
@@ -69,7 +69,7 @@ derived_from_environment:
     - seal_vents
     - deploy_support_field
 jobs_bias:
-  - Support
+  - support
   - Strategist
 telemetry:
   expected_pick_rate: 0.36
@@ -79,5 +79,5 @@ genetic_traits: []
 mate_synergy:
   - Strategist
 jobs_synergy:
-  - Support
+  - support
 description: i18n:species.myco-spire-warden.description

--- a/packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbital-ascendant.yaml
+++ b/packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbital-ascendant.yaml
@@ -61,8 +61,8 @@ derived_from_environment:
     - lift_control
     - res_psionic
 jobs_bias:
-  - Vanguard
-  - Invoker
+  - vanguard
+  - invoker
 telemetry:
   expected_pick_rate: null
   spawn_weight: 0.04

--- a/packs/evo_tactics_pack/data/species/rovine_planari/archon-solare.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/archon-solare.yaml
@@ -83,8 +83,8 @@ derived_from_environment:
     - supporto:rinforzo_barriere
     - culturale:guida_spirituale
   jobs_bias:
-    - Invoker
-    - Skirmisher
+    - invoker
+    - skirmisher
 genetic_traits:
   core:
     - ciclo_vitale_completo

--- a/packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml
@@ -66,8 +66,8 @@ derived_from_environment:
     - fire_resist
     - void_stride
   jobs_bias:
-    - Vanguard
-    - Warden
+    - vanguard
+    - warden
 genetic_traits:
   core:
     - ciclo_vitale_completo

--- a/packs/evo_tactics_pack/data/species/rovine_planari/banshee-risonante.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/banshee-risonante.yaml
@@ -67,8 +67,8 @@ derived_from_environment:
     - culturale:memorie_orali
     - regolazione:scarico_emozionale
   jobs_bias:
-    - Invoker
-    - Support
+    - invoker
+    - support
 genetic_traits:
   core:
     - ciclo_vitale_anomalo

--- a/packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml
@@ -66,8 +66,8 @@ derived_from_environment:
   services_links:
     - approvvigionamento:estrazione_fragili
   jobs_bias:
-    - Vanguard
-    - Warden
+    - vanguard
+    - warden
 genetic_traits:
   core:
     - ciclo_vitale_completo

--- a/packs/evo_tactics_pack/data/species/rovine_planari/couatl-aurora.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/couatl-aurora.yaml
@@ -79,8 +79,8 @@ derived_from_environment:
     - supporto:rituale_migrazione
     - culturale:memoria_delle_porte
   jobs_bias:
-    - Invoker
-    - Skirmisher
+    - invoker
+    - skirmisher
 genetic_traits:
   core:
     - ciclo_vitale_completo

--- a/packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml
@@ -68,8 +68,8 @@ derived_from_environment:
     - supporto:manutenzione_sigilli
     - regolazione:smaltimento_residui
   jobs_bias:
-    - Warden
-    - Artificer
+    - warden
+    - artificer
 genetic_traits:
   core:
     - ciclo_vitale_anomalo

--- a/packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml
@@ -68,8 +68,8 @@ derived_from_environment:
   services_links:
     - sicurezza:controllo_passaggi
   jobs_bias:
-    - Vanguard
-    - Skirmisher
+    - vanguard
+    - skirmisher
 genetic_traits:
   core:
     - ciclo_vitale_completo

--- a/packs/evo_tactics_pack/data/species/rovine_planari/otyugh-sentinella.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/otyugh-sentinella.yaml
@@ -70,8 +70,8 @@ derived_from_environment:
   services_links:
     - regolazione:purificazione_canali
   jobs_bias:
-    - Artificer
-    - Warden
+    - artificer
+    - warden
 genetic_traits:
   core:
     - ciclo_vitale_completo

--- a/packs/evo_tactics_pack/data/species/rovine_planari/rakshasa-corte.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/rakshasa-corte.yaml
@@ -67,8 +67,8 @@ derived_from_environment:
   services_links:
     - minaccia:propagazione_iconica
   jobs_bias:
-    - Invoker
-    - Skirmisher
+    - invoker
+    - skirmisher
 genetic_traits:
   core:
     - ciclo_vitale_completo

--- a/packs/evo_tactics_pack/data/species/rovine_planari/treant-portale.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/treant-portale.yaml
@@ -70,8 +70,8 @@ derived_from_environment:
     - supporto:rinforzo_strutturale
     - regolazione:depurazione_flussi
   jobs_bias:
-    - Artificer
-    - Warden
+    - artificer
+    - warden
 genetic_traits:
   core:
     - ciclo_vitale_completo

--- a/packs/evo_tactics_pack/docs/catalog/archive/trait_reference_legacy.json
+++ b/packs/evo_tactics_pack/docs/catalog/archive/trait_reference_legacy.json
@@ -3652,7 +3652,7 @@
     },
     "empatia_coordinativa": {
       "conflitti": [],
-      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
+      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate warden scende.",
       "famiglia_tipologia": "Supporto/Empatico",
       "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
       "label": "Empatia Coordinativa",

--- a/packs/evo_tactics_pack/docs/catalog/env_traits.json
+++ b/packs/evo_tactics_pack/docs/catalog/env_traits.json
@@ -14,8 +14,8 @@
           "res_cold": "+1"
         },
         "jobs_bias": [
-          "Warden",
-          "Skirmisher"
+          "warden",
+          "skirmisher"
         ]
       }
     },
@@ -86,8 +86,8 @@
           "res_fire": "+1"
         },
         "jobs_bias": [
-          "Vanguard",
-          "Warden"
+          "vanguard",
+          "warden"
         ]
       }
     },
@@ -139,8 +139,8 @@
           "res_salt": "+1"
         },
         "jobs_bias": [
-          "Warden",
-          "Skirmisher"
+          "warden",
+          "skirmisher"
         ]
       }
     },
@@ -162,8 +162,8 @@
           "ignore_fog_penalty": true
         },
         "jobs_bias": [
-          "Vanguard",
-          "Warden"
+          "vanguard",
+          "warden"
         ]
       }
     },
@@ -208,8 +208,8 @@
           "pressure_tolerance": true
         },
         "jobs_bias": [
-          "Warden",
-          "Invoker"
+          "warden",
+          "invoker"
         ]
       }
     },
@@ -253,8 +253,8 @@
           "detox_cycle": true
         },
         "jobs_bias": [
-          "Warden",
-          "Vanguard"
+          "warden",
+          "vanguard"
         ]
       }
     },
@@ -299,8 +299,8 @@
           "moisture_harvest": true
         },
         "jobs_bias": [
-          "Skirmisher",
-          "Invoker"
+          "skirmisher",
+          "invoker"
         ]
       }
     },
@@ -345,8 +345,8 @@
           "wind_sense": true
         },
         "jobs_bias": [
-          "Skirmisher",
-          "Invoker"
+          "skirmisher",
+          "invoker"
         ]
       }
     },
@@ -391,8 +391,8 @@
           "res_heat": "+1"
         },
         "jobs_bias": [
-          "Vanguard",
-          "Warden"
+          "vanguard",
+          "warden"
         ]
       }
     },
@@ -433,8 +433,8 @@
           "res_salt": "+1"
         },
         "jobs_bias": [
-          "Warden",
-          "Skirmisher"
+          "warden",
+          "skirmisher"
         ]
       }
     },
@@ -475,8 +475,8 @@
           "mire_immunity": true
         },
         "jobs_bias": [
-          "Vanguard",
-          "Skirmisher"
+          "vanguard",
+          "skirmisher"
         ]
       }
     },
@@ -518,8 +518,8 @@
           "night_vision": true
         },
         "jobs_bias": [
-          "Invoker",
-          "Skirmisher"
+          "invoker",
+          "skirmisher"
         ]
       }
     },
@@ -560,8 +560,8 @@
           "pressure_tolerance": true
         },
         "jobs_bias": [
-          "Vanguard",
-          "Warden"
+          "vanguard",
+          "warden"
         ]
       }
     },
@@ -602,8 +602,8 @@
           "res_electric": "+2"
         },
         "jobs_bias": [
-          "Skirmisher",
-          "Invoker"
+          "skirmisher",
+          "invoker"
         ]
       }
     },
@@ -644,8 +644,8 @@
           "initiative_bonus": true
         },
         "jobs_bias": [
-          "Skirmisher",
-          "Vanguard"
+          "skirmisher",
+          "vanguard"
         ]
       }
     },
@@ -687,8 +687,8 @@
           "echolocation": true
         },
         "jobs_bias": [
-          "Invoker",
-          "Warden"
+          "invoker",
+          "warden"
         ]
       }
     },
@@ -714,8 +714,8 @@
           "stealth_bonus": true
         },
         "jobs_bias": [
-          "Invoker",
-          "Support"
+          "invoker",
+          "support"
         ]
       }
     },
@@ -741,8 +741,8 @@
           "hazard_sense_magnetico": true
         },
         "jobs_bias": [
-          "Warden",
-          "Vanguard"
+          "warden",
+          "vanguard"
         ]
       }
     },
@@ -768,8 +768,8 @@
           "lift_control": true
         },
         "jobs_bias": [
-          "Invoker",
-          "Skirmisher"
+          "invoker",
+          "skirmisher"
         ]
       }
     },
@@ -794,8 +794,8 @@
           "struttura_elastica_amorfa"
         ],
         "jobs_bias": [
-          "Vanguard",
-          "Skirmisher"
+          "vanguard",
+          "skirmisher"
         ]
       }
     },
@@ -816,8 +816,8 @@
           "secrezione_rallentante_palmi"
         ],
         "jobs_bias": [
-          "Warden",
-          "Support"
+          "warden",
+          "support"
         ]
       }
     },
@@ -840,8 +840,8 @@
           "ventriglio_gastroliti"
         ],
         "jobs_bias": [
-          "Vanguard",
-          "Warden"
+          "vanguard",
+          "warden"
         ]
       }
     },
@@ -862,8 +862,8 @@
           "sonno_emisferico_alternato"
         ],
         "jobs_bias": [
-          "Invoker",
-          "Skirmisher"
+          "invoker",
+          "skirmisher"
         ]
       }
     },
@@ -891,9 +891,9 @@
           "struttura_elastica_amorfa"
         ],
         "jobs_bias": [
-          "Warden",
-          "Support",
-          "Invoker"
+          "warden",
+          "support",
+          "invoker"
         ]
       }
     },
@@ -917,8 +917,8 @@
           "ventriglio_gastroliti"
         ],
         "jobs_bias": [
-          "Vanguard",
-          "Skirmisher"
+          "vanguard",
+          "skirmisher"
         ]
       }
     },
@@ -939,8 +939,8 @@
           "spore_psichiche_silenziate"
         ],
         "jobs_bias": [
-          "Warden",
-          "Support"
+          "warden",
+          "support"
         ]
       }
     },
@@ -963,8 +963,8 @@
           "sacche_galleggianti_ascensoriali"
         ],
         "jobs_bias": [
-          "Invoker",
-          "Skirmisher"
+          "invoker",
+          "skirmisher"
         ]
       }
     }

--- a/packs/evo_tactics_pack/docs/catalog/trait_reference.json
+++ b/packs/evo_tactics_pack/docs/catalog/trait_reference.json
@@ -3771,7 +3771,7 @@
       "mutazione_indotta": "Circuiti sensorio-emotivi collegati al feed HUD PI.",
       "uso_funzione": "Collega cooldown difensivi e cura quando la squadra entra in finestra rischio.",
       "spinta_selettiva": "Turni lunghi con rischio alto in cui serve mitigare tilt e HP critici.",
-      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
+      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate warden scende.",
       "sinergie_pi": {
         "co_occorrenze": [
           "job_ability:warden/scudo_di_risonanza"

--- a/packs/evo_tactics_pack/out/patches/badlands/dune-stalker.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/badlands/dune-stalker.patch.yaml
@@ -38,6 +38,6 @@ derived_from_environment:
   - seal_vents
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+  - skirmisher
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/badlands/echo-wing.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/badlands/echo-wing.patch.yaml
@@ -24,5 +24,5 @@ derived_from_environment:
   - seal_vents
   services_links: []
   jobs_bias:
-  - Vanguard
-  - Warden
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/badlands/evento-tempesta-ferrosa.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/badlands/evento-tempesta-ferrosa.patch.yaml
@@ -24,5 +24,5 @@ derived_from_environment:
   - seal_vents
   services_links: []
   jobs_bias:
-  - Vanguard
-  - Warden
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/badlands/ferrocolonia-magnetotattica.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/badlands/ferrocolonia-magnetotattica.patch.yaml
@@ -26,5 +26,5 @@ derived_from_environment:
   - regolazione:ritenzione_idrica
   - supporto:stabilizzazione_suolo
   jobs_bias:
-  - Vanguard
-  - Warden
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/badlands/nano-rust-bloom.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/badlands/nano-rust-bloom.patch.yaml
@@ -24,5 +24,5 @@ derived_from_environment:
   - seal_vents
   services_links: []
   jobs_bias:
-  - Vanguard
-  - Warden
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/badlands/rust-scavenger.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/badlands/rust-scavenger.patch.yaml
@@ -24,5 +24,5 @@ derived_from_environment:
   - seal_vents
   services_links: []
   jobs_bias:
-  - Vanguard
-  - Warden
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/badlands/sand-burrower.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/badlands/sand-burrower.patch.yaml
@@ -24,5 +24,5 @@ derived_from_environment:
   - seal_vents
   services_links: []
   jobs_bias:
-  - Vanguard
-  - Warden
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/cryosteppe/aurora-gull.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/cryosteppe/aurora-gull.patch.yaml
@@ -17,6 +17,6 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+  - skirmisher
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/cryosteppe/cryo-lynx.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/cryosteppe/cryo-lynx.patch.yaml
@@ -17,6 +17,6 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+  - skirmisher
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/cryosteppe/evento-brinastorm.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/cryosteppe/evento-brinastorm.patch.yaml
@@ -17,6 +17,6 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+  - skirmisher
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/cryosteppe/steppe-bison-mini.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/cryosteppe/steppe-bison-mini.patch.yaml
@@ -17,6 +17,6 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+  - skirmisher
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/cryosteppe/thaw-rot.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/cryosteppe/thaw-rot.patch.yaml
@@ -17,6 +17,6 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+  - skirmisher
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/deserto_caldo/cactus-weaver.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/deserto_caldo/cactus-weaver.patch.yaml
@@ -19,6 +19,6 @@ derived_from_environment:
   - regolazione:ritenzione_idrica
   - supporto:stabilizzazione_suolo
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+  - skirmisher
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/deserto_caldo/evento-ondata-termica.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/deserto_caldo/evento-ondata-termica.patch.yaml
@@ -17,6 +17,6 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+  - skirmisher
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/deserto_caldo/noctule-termico.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/deserto_caldo/noctule-termico.patch.yaml
@@ -17,6 +17,6 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+  - skirmisher
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/deserto_caldo/silica-bloom.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/deserto_caldo/silica-bloom.patch.yaml
@@ -17,6 +17,6 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+  - skirmisher
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/deserto_caldo/thermo-raptor.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/deserto_caldo/thermo-raptor.patch.yaml
@@ -17,6 +17,6 @@ derived_from_environment:
   required_capabilities: []
   services_links: []
   jobs_bias:
-  - Skirmisher
-  - Vanguard
-  - Warden
+  - skirmisher
+  - vanguard
+  - warden

--- a/packs/evo_tactics_pack/out/patches/network/echo-wing.network.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/network/echo-wing.network.patch.yaml
@@ -7,7 +7,7 @@ environment_affinity:
   - FORESTA_TEMPERATA
 derived_from_environment:
   jobs_bias:
-  - Skirmisher
+  - skirmisher
 network_bridge_roles:
 - dispersore_ponte
 - impollinatore

--- a/packs/evo_tactics_pack/out/patches/network/ferrocolonia-magnetotattica.network.patch.yaml
+++ b/packs/evo_tactics_pack/out/patches/network/ferrocolonia-magnetotattica.network.patch.yaml
@@ -4,7 +4,7 @@ environment_affinity:
   - BADLANDS
 derived_from_environment:
   jobs_bias:
-  - Warden
+  - warden
 network_bridge_roles:
 - ingegnere_ecosistema
 - sentinella

--- a/packs/evo_tactics_pack/tools/config/ext_v1_5/validator_config.yaml
+++ b/packs/evo_tactics_pack/tools/config/ext_v1_5/validator_config.yaml
@@ -1,6 +1,6 @@
 schema_version: 1.5
 roles: [produttore, produttore_chemiotrofo, erbivoro_primario, erbivoro_primario_dispersore, filtratore_grazing, predatore_secondario, predatore_filtratore_secondario, predatore_regolatore_simbionte, predatore_terziario_apex, decompositore, impollinatore, impollinatore_notturno, commensale, commensale_opportunista, parassita, parassita_acquatico, detritivoro, ingegnere_ecosistema, onnivoro_invasivo, minaccia_microbica, evento_ecologico, dispersore_ponte]
-jobs: [Warden, Vanguard, Skirmisher, Artificer, Invoker]
+jobs: [warden, vanguard, skirmisher, artificer, invoker]
 encounter_roles: [minion, elite, boss, ambient]
 spawn: {orario: [diurno, notte, crepuscolo, continuo], meteo: [sereno_freddo, whiteout, whiteout_ionico, nebbia_ionica, caldo_pulsato]}
 budget_tiers: {default_max: 12, apex_or_keystone_max: 14, sentient_S2_plus_max: 13, enforce_mode: warn}
@@ -20,11 +20,11 @@ parts_capabilities:
   burst_anaerobic: [dash_free_once]
   claw_finesse: []
 jobs_pi_requirements:
-  Skirmisher: {require_any_capabilities: [jump_bonus, landing_on_ice, dash_free_once]}
-  Vanguard: {require_any_slots: [defense]}
-  Warden: {require_any_slots: [senses, defense]}
-  Artificer: {require_any_slots: [senses]}
-  Invoker: {require_any_slots: [senses]}
+  skirmisher: {require_any_capabilities: [jump_bonus, landing_on_ice, dash_free_once]}
+  vanguard: {require_any_slots: [defense]}
+  warden: {require_any_slots: [senses, defense]}
+  artificer: {require_any_slots: [senses]}
+  invoker: {require_any_slots: [senses]}
 telemetry_targets:
   pick_rate_by_role: {minion: [0.1, 0.3], elite: [0.05, 0.15], boss: [0.01, 0.05], ambient: [0.05, 0.2]}
   spawn_weight_by_rarity: {R1: [0.2, 0.4], R2: [0.1, 0.3], R3: [0.05, 0.2], R4: [0.01, 0.1], R5: [0.0, 0.05]}

--- a/packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml
+++ b/packs/evo_tactics_pack/tools/config/registries/env_to_traits.yaml
@@ -8,8 +8,8 @@ rules:
     effects:
       res_cold: '+1'
     jobs_bias:
-    - Warden
-    - Skirmisher
+    - warden
+    - skirmisher
 - when:
     koppen_in:
     - Cfb
@@ -49,8 +49,8 @@ rules:
     effects:
       res_fire: '+1'
     jobs_bias:
-    - Vanguard
-    - Warden
+    - vanguard
+    - warden
 - when:
     hazard_any:
     - iron_shards
@@ -81,8 +81,8 @@ rules:
       res_fire: '+1'
       res_salt: '+1'
     jobs_bias:
-    - Warden
-    - Skirmisher
+    - warden
+    - skirmisher
 - when:
     koppen_any:
     - BSk
@@ -96,8 +96,8 @@ rules:
       res_cold: '+1'
       ignore_fog_penalty: true
     jobs_bias:
-    - Vanguard
-    - Warden
+    - vanguard
+    - warden
 - when:
     biome_class: caldera_glaciale
   meta:
@@ -133,8 +133,8 @@ rules:
       res_fire: '+1'
       pressure_tolerance: true
     jobs_bias:
-    - Warden
-    - Invoker
+    - warden
+    - invoker
 - when:
     biome_class: foresta_acida
   meta:
@@ -169,8 +169,8 @@ rules:
       res_acid: '+2'
       detox_cycle: true
     jobs_bias:
-    - Warden
-    - Vanguard
+    - warden
+    - vanguard
 - when:
     biome_class: pianura_salina_iperarida
   meta:
@@ -206,8 +206,8 @@ rules:
       res_salt: '+2'
       moisture_harvest: true
     jobs_bias:
-    - Skirmisher
-    - Invoker
+    - skirmisher
+    - invoker
 - when:
     biome_class: stratosfera_tempestosa
   meta:
@@ -243,8 +243,8 @@ rules:
       res_electric: '+2'
       wind_sense: true
     jobs_bias:
-    - Skirmisher
-    - Invoker
+    - skirmisher
+    - invoker
 - when:
     biome_class: abisso_vulcanico
   meta:
@@ -280,8 +280,8 @@ rules:
       dark_vision: true
       res_heat: '+1'
     jobs_bias:
-    - Vanguard
-    - Warden
+    - vanguard
+    - warden
 - when:
     biome_class: laguna_bioreattiva
   meta:
@@ -314,8 +314,8 @@ rules:
       tidal_sync: true
       res_salt: '+1'
     jobs_bias:
-    - Warden
-    - Skirmisher
+    - warden
+    - skirmisher
 - when:
     biome_class: mangrovieto_cinetico
   meta:
@@ -348,8 +348,8 @@ rules:
       climb_bonus: true
       mire_immunity: true
     jobs_bias:
-    - Vanguard
-    - Skirmisher
+    - vanguard
+    - skirmisher
 - when:
     biome_class: reef_luminescente
   meta:
@@ -383,8 +383,8 @@ rules:
       res_acid: '+1'
       night_vision: true
     jobs_bias:
-    - Invoker
-    - Skirmisher
+    - invoker
+    - skirmisher
 - when:
     biome_class: dorsale_termale_tropicale
   meta:
@@ -417,8 +417,8 @@ rules:
       res_heat: '+2'
       pressure_tolerance: true
     jobs_bias:
-    - Vanguard
-    - Warden
+    - vanguard
+    - warden
 - when:
     biome_class: canopia_ionica
   meta:
@@ -451,8 +451,8 @@ rules:
       glide_bonus: true
       res_electric: '+2'
     jobs_bias:
-    - Skirmisher
-    - Invoker
+    - skirmisher
+    - invoker
 - when:
     biome_class: steppe_algoritmiche
   meta:
@@ -485,8 +485,8 @@ rules:
       res_psionic: '+1'
       initiative_bonus: true
     jobs_bias:
-    - Skirmisher
-    - Vanguard
+    - skirmisher
+    - vanguard
 - when:
     biome_class: caverna_risonante
   meta:
@@ -519,8 +519,8 @@ rules:
       stealth_bonus: true
       echolocation: true
     jobs_bias:
-    - Invoker
-    - Warden
+    - invoker
+    - warden
 - when:
     biome_class: caverna_risonante
   meta:
@@ -564,8 +564,8 @@ rules:
       res_psionic: '+1'
       stealth_bonus: true
     jobs_bias:
-    - Invoker
-    - Support
+    - invoker
+    - support
 - when:
     biome_class: falde_magnetiche_psioniche
   meta:
@@ -582,8 +582,8 @@ rules:
       res_psionic: '+2'
       hazard_sense_magnetico: true
     jobs_bias:
-    - Warden
-    - Vanguard
+    - warden
+    - vanguard
 - when:
     biome_class: orbita_psionica_inversa
   meta:
@@ -600,5 +600,5 @@ rules:
       res_psionic: '+2'
       lift_control: true
     jobs_bias:
-    - Invoker
-    - Skirmisher
+    - invoker
+    - skirmisher

--- a/packs/evo_tactics_pack/tools/config/registries/morphotypes.yaml
+++ b/packs/evo_tactics_pack/tools/config/registries/morphotypes.yaml
@@ -7,38 +7,38 @@ types:
       defense: 1
       senses: 1
     bias:
-    - Skirmisher
-    - Vanguard
+    - skirmisher
+    - vanguard
   volatore_planatore:
     default_slots:
       locomotion: 1
       offense: 1
       senses: 1
     bias:
-    - Skirmisher
-    - Invoker
+    - skirmisher
+    - invoker
   scavenger_corazzato:
     default_slots:
       defense: 2
       offense: 1
       senses: 1
     bias:
-    - Warden
-    - Vanguard
+    - warden
+    - vanguard
   ingegnere_radicante:
     default_slots:
       defense: 1
       senses: 1
     bias:
-    - Artificer
-    - Warden
+    - artificer
+    - warden
   anfibio_filtratore:
     default_slots:
       locomotion: 1
       senses: 1
     bias:
-    - Invoker
-    - Artificer
+    - invoker
+    - artificer
 slot_caps:
   defense: 3
   offense: 2

--- a/packs/evo_tactics_pack/tools/config/validator_config.yaml
+++ b/packs/evo_tactics_pack/tools/config/validator_config.yaml
@@ -23,11 +23,11 @@ roles:
 - evento_ecologico
 - dispersore_ponte
 jobs:
-- Warden
-- Vanguard
-- Skirmisher
-- Artificer
-- Invoker
+- warden
+- vanguard
+- skirmisher
+- artificer
+- invoker
 encounter_roles:
 - minion
 - elite
@@ -195,22 +195,22 @@ parts_capabilities:
   - dash_free_once
   claw_finesse: []
 jobs_pi_requirements:
-  Skirmisher:
+  skirmisher:
     require_any_capabilities:
     - jump_bonus
     - landing_on_ice
     - dash_free_once
-  Vanguard:
+  vanguard:
     require_any_slots:
     - defense
-  Warden:
+  warden:
     require_any_slots:
     - senses
     - defense
-  Artificer:
+  artificer:
     require_any_slots:
     - senses
-  Invoker:
+  invoker:
     require_any_slots:
     - senses
 telemetry_targets:

--- a/packs/evo_tactics_pack/tools/py/derive_crossbiome_traits_v1_0.py
+++ b/packs/evo_tactics_pack/tools/py/derive_crossbiome_traits_v1_0.py
@@ -31,7 +31,7 @@ def run(net_path, outdir):
                    'multibiome': sorted(list(present)),
                },
                'derived_from_environment': {
-                   'jobs_bias': sorted(list(set(['Warden' if 'sentinella' in roles else 'Skirmisher'])))
+                   'jobs_bias': sorted(list(set(['warden' if 'sentinella' in roles else 'skirmisher'])))
                },
                'network_bridge_roles': sorted(list(roles)),
                'biomes_add': []}

--- a/packs/evo_tactics_pack/tools/py/vtt/npg_pack.json
+++ b/packs/evo_tactics_pack/tools/py/vtt/npg_pack.json
@@ -16,7 +16,7 @@
       }
     },
     "job": {
-      "id": "Vanguard",
+      "id": "vanguard",
       "rank": 3,
       "actives": ["muraglia_termica", "carica_scintilla"],
       "passives": ["resistenza_termica", "guardia_pressurizzata"]
@@ -60,7 +60,7 @@
       }
     },
     "job": {
-      "id": "Artificer",
+      "id": "artificer",
       "rank": 2,
       "actives": ["torretta_prismi", "campo_lente"],
       "passives": ["stabilizzatori_sabbia"]
@@ -102,7 +102,7 @@
       }
     },
     "job": {
-      "id": "Harvester",
+      "id": "harvester",
       "rank": 2,
       "actives": ["rete_spinata", "sifone_sap"],
       "passives": ["raccolto_notturno"]
@@ -146,7 +146,7 @@
       }
     },
     "job": {
-      "id": "Invoker",
+      "id": "invoker",
       "rank": 2,
       "actives": ["risonanza_termica", "sciame_echolink"],
       "passives": ["sincronizza_branchi"]
@@ -188,7 +188,7 @@
       }
     },
     "job": {
-      "id": "Warden",
+      "id": "warden",
       "rank": 3,
       "actives": ["aura_dissonanza", "baluardo_risonante"],
       "passives": ["sentinella_caverna", "eco_vigil"]
@@ -232,7 +232,7 @@
       }
     },
     "job": {
-      "id": "Invoker",
+      "id": "invoker",
       "rank": 3,
       "actives": ["rituale_vibrante", "spira_convergenza"],
       "passives": ["mantello_risonante"]
@@ -274,7 +274,7 @@
       }
     },
     "job": {
-      "id": "Skirmisher",
+      "id": "skirmisher",
       "rank": 2,
       "actives": ["dash_fango", "colpo_vitale"],
       "passives": ["mimetismo_fungino"]
@@ -318,7 +318,7 @@
       }
     },
     "job": {
-      "id": "Harvester",
+      "id": "harvester",
       "rank": 1,
       "actives": ["drenaggio_luce", "trappola_silice"],
       "passives": ["raccolta_notturna"]
@@ -362,7 +362,7 @@
       }
     },
     "job": {
-      "id": "Vanguard",
+      "id": "vanguard",
       "rank": 3,
       "actives": ["assalto_valanga", "sfida_predatoria"],
       "passives": ["armatura_magnetica"]
@@ -406,7 +406,7 @@
       }
     },
     "job": {
-      "id": "Artificer",
+      "id": "artificer",
       "rank": 3,
       "actives": ["campo_magnetico", "mine_ferrose"],
       "passives": ["sinapsi_colla"]
@@ -450,7 +450,7 @@
       }
     },
     "job": {
-      "id": "Skirmisher",
+      "id": "skirmisher",
       "rank": 2,
       "actives": ["raffica_lame", "tuffo_sonico"],
       "passives": ["radar_stormo"]
@@ -492,7 +492,7 @@
       }
     },
     "job": {
-      "id": "Harvester",
+      "id": "harvester",
       "rank": 2,
       "actives": ["carico_sabbia", "drenaggio_metalli"],
       "passives": ["minatore_notturno"]

--- a/tools/py/trait_catalog_migrator.py
+++ b/tools/py/trait_catalog_migrator.py
@@ -114,7 +114,7 @@ PI_TRAIT_METADATA: Mapping[str, Mapping[str, str]] = {
         "mutazione_indotta": "Circuiti sensorio-emotivi collegati al feed HUD PI.",
         "spinta_selettiva": "Turni lunghi con rischio alto in cui serve mitigare tilt e HP critici.",
         "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
-        "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate Warden scende.",
+        "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate warden scende.",
     },
     "pathfinder": {
         "label": "Pathfinder",


### PR DESCRIPTION
## Summary
- convert job identifiers to lower_snake_case across evo tactics species data, registries, and generated patches
- align documentation, incoming pack assets, and locale strings with the new job slugs
- refresh helper scripts to emit lower_snake_case job bias values

## Testing
- python tools/py/validate_registry_naming.py
- python scripts/trait_audit.py --check

------
https://chatgpt.com/codex/tasks/task_b_690800215624832aabfa581e298f9930