### PR TITLE
Ensure jsonschema stub defers to installed package

### DIFF
--- a/jsonschema/__init__.py
+++ b/jsonschema/__init__.py
@@ -3,70 +3,145 @@
 This stub provides only the limited surface used by scripts/trait_audit.py
 within this repository. It is **not** a full implementation and merely
 ensures that validation can run in environments without the jsonschema
-package installed. The validator intentionally performs no schema
-validation and yields no errors.
+package installed. When the real :mod:`jsonschema` package is present it is
+imported and re-exported so validation still occurs.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List
+import importlib
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
 
 
-class SchemaError(Exception):
-    """Placeholder schema error."""
+def _try_load_real_jsonschema() -> ModuleType | None:
+    """Attempt to import the real jsonschema module if it is installed.
+
+    The repository contains this lightweight stub at ``jsonschema/``. When
+    scripts are executed with ``PYTHONPATH=.`` (the recommended workflow), the
+    stub would normally shadow the third-party dependency. To avoid that, the
+    loader temporarily removes the repository path from the import search and
+    loads the actual package if available.
+    """
+
+    repo_root = Path(__file__).resolve().parent.parent
+    blocked_path = os.path.realpath(str(repo_root))
+
+    original_sys_path = list(sys.path)
+    filtered_paths = [
+        entry
+        for entry in original_sys_path
+        if os.path.realpath(entry or os.curdir) != blocked_path
+    ]
+
+    if len(filtered_paths) == len(original_sys_path):
+        # The repository path is not in sys.path, so importing normally is fine.
+        try:
+            return importlib.import_module(__name__)
+        except ModuleNotFoundError:
+            return None
+
+    stub_module = sys.modules.get(__name__)
+
+    try:
+        sys.path[:] = filtered_paths
+        sys.modules.pop(__name__, None)
+        try:
+            module = importlib.import_module(__name__)
+        except ModuleNotFoundError:
+            return None
+    finally:
+        sys.path[:] = original_sys_path
+        if stub_module is not None:
+            sys.modules[__name__] = stub_module
+
+    return module
 
 
-class ValidationError(Exception):
-    """Placeholder validation error used for compatibility."""
-
-    def __init__(self, message: str, absolute_path: Iterable[Any] | None = None) -> None:
-        super().__init__(message)
-        self.message = message
-        self.absolute_path = list(absolute_path or [])
+_REAL_JSONSCHEMA = _try_load_real_jsonschema()
 
 
-class _ExceptionsModule:
-    SchemaError = SchemaError
-    ValidationError = ValidationError
+if _REAL_JSONSCHEMA is not None:
+    Draft202012Validator = _REAL_JSONSCHEMA.Draft202012Validator
+    RefResolver = _REAL_JSONSCHEMA.RefResolver
+    SchemaError = _REAL_JSONSCHEMA.SchemaError
+    ValidationError = _REAL_JSONSCHEMA.ValidationError
+    exceptions = _REAL_JSONSCHEMA.exceptions
+    __all__ = getattr(_REAL_JSONSCHEMA, "__all__", [
+        "Draft202012Validator",
+        "RefResolver",
+        "SchemaError",
+        "ValidationError",
+        "exceptions",
+    ])
+else:
+    from dataclasses import dataclass
+    from typing import Any, Dict, Iterable, List
+
+    class SchemaError(Exception):
+        """Placeholder schema error."""
+
+    class ValidationError(Exception):
+        """Placeholder validation error used for compatibility."""
+
+        def __init__(
+            self, message: str, absolute_path: Iterable[Any] | None = None
+        ) -> None:
+            super().__init__(message)
+            self.message = message
+            self.absolute_path = list(absolute_path or [])
+
+    class _ExceptionsModule:
+        SchemaError = SchemaError
+        ValidationError = ValidationError
+
+    exceptions = _ExceptionsModule()
+
+    @dataclass
+    class RefResolver:
+        """Minimal resolver that stores the schema and reference store."""
+
+        schema: Dict[str, Any]
+        store: Dict[str, Any]
+
+        @classmethod
+        def from_schema(
+            cls, schema: Dict[str, Any], store: Dict[str, Any] | None = None
+        ) -> "RefResolver":
+            return cls(schema=schema, store=store or {})
+
+    class Draft202012Validator:
+        """No-op JSON schema validator."""
+
+        def __init__(
+            self, schema: Dict[str, Any], resolver: RefResolver | None = None
+        ) -> None:
+            self.schema = schema
+            self.resolver = resolver
+
+        @staticmethod
+        def check_schema(schema: Dict[str, Any]) -> None:
+            """Pretend to validate the schema structure."""
+            if not isinstance(schema, dict):
+                raise SchemaError("Schema must be a dictionary")
+
+        def iter_errors(self, instance: Any) -> List[ValidationError]:
+            """Return an empty list to indicate no validation errors."""
+            return []
+
+    __all__ = [
+        "Draft202012Validator",
+        "RefResolver",
+        "SchemaError",
+        "ValidationError",
+        "exceptions",
+    ]
 
 
-exceptions = _ExceptionsModule()
+def __getattr__(name: str) -> object:
+    """Delegate attribute access to the real package when available."""
 
-
-@dataclass
-class RefResolver:
-    """Minimal resolver that stores the schema and reference store."""
-
-    schema: Dict[str, Any]
-    store: Dict[str, Any]
-
-    @classmethod
-    def from_schema(cls, schema: Dict[str, Any], store: Dict[str, Any] | None = None) -> "RefResolver":
-        return cls(schema=schema, store=store or {})
-
-
-class Draft202012Validator:
-    """No-op JSON schema validator."""
-
-    def __init__(self, schema: Dict[str, Any], resolver: RefResolver | None = None) -> None:
-        self.schema = schema
-        self.resolver = resolver
-
-    @staticmethod
-    def check_schema(schema: Dict[str, Any]) -> None:
-        """Pretend to validate the schema structure."""
-        if not isinstance(schema, dict):
-            raise SchemaError("Schema must be a dictionary")
-
-    def iter_errors(self, instance: Any) -> List[ValidationError]:
-        """Return an empty list to indicate no validation errors."""
-        return []
-
-
-__all__ = [
-    "Draft202012Validator",
-    "RefResolver",
-    "SchemaError",
-    "ValidationError",
-    "exceptions",
-]
+    if _REAL_JSONSCHEMA is not None:
+        return getattr(_REAL_JSONSCHEMA, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- attempt to import the real jsonschema package by temporarily removing the repo path from sys.path
- reuse the real validators and exceptions when available, while keeping the previous lightweight fallback
- delegate attribute access to the actual package to preserve compatibility with additional APIs

## Testing
- PYTHONPATH=. python - <<'PY'
from jsonschema import Draft202012Validator
schema = {"type": "object"}
Draft202012Validator.check_schema(schema)
validator = Draft202012Validator(schema)
print(list(validator.iter_errors({"anything": 123})))
PY

------
https://chatgpt.com/codex/tasks/task_b_69089389d814832a8bec2a463075d9f6