### PR TITLE
Align Support Hub docs with design tokens

### DIFF
--- a/docs/assets/styles/components.css
+++ b/docs/assets/styles/components.css
@@ -19,10 +19,10 @@
   font-size: var(--type-md);
   cursor: pointer;
   transition:
-    transform 160ms ease,
-    box-shadow 160ms ease,
-    filter 160ms ease;
-  box-shadow: 0 14px 30px rgba(81, 101, 255, 0.35);
+    transform var(--transition-base),
+    box-shadow var(--transition-base),
+    filter var(--transition-base);
+  box-shadow: var(--shadow-button);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -39,9 +39,7 @@
 
 .button:focus-visible {
   outline: none;
-  box-shadow:
-    0 0 0 3px rgba(81, 101, 255, 0.35),
-    0 14px 30px rgba(81, 101, 255, 0.35);
+  box-shadow: var(--shadow-focus), var(--shadow-button);
 }
 
 .button:disabled {
@@ -58,18 +56,22 @@
   box-shadow: none;
 }
 
+.button--secondary:hover,
+.button--secondary:focus-visible {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
+}
+
 .button--ghost {
-  background: rgba(81, 101, 255, 0.1);
+  background: var(--color-accent-muted);
   color: var(--color-accent);
-  border-color: rgba(81, 101, 255, 0.3);
+  border-color: var(--color-accent-soft);
   box-shadow: none;
 }
 
-.button--secondary:hover,
 .button--ghost:hover,
-.button--secondary:focus-visible,
 .button--ghost:focus-visible {
-  background: rgba(81, 101, 255, 0.14);
+  background: var(--color-accent-soft);
   color: var(--color-accent-strong);
 }
 
@@ -97,8 +99,8 @@
   background: var(--color-surface);
   color: var(--color-text-primary);
   transition:
-    border-color 160ms ease,
-    box-shadow 160ms ease;
+    border-color var(--transition-base),
+    box-shadow var(--transition-base);
 }
 
 .form-field__input:focus-visible,
@@ -106,7 +108,7 @@
 .form-field__select:focus-visible {
   outline: none;
   border-color: var(--color-accent);
-  box-shadow: 0 0 0 3px rgba(81, 101, 255, 0.25);
+  box-shadow: var(--shadow-focus-strong);
 }
 
 .form-field__hint {
@@ -158,21 +160,27 @@
 }
 
 .banner--success {
-  border-color: rgba(26, 127, 59, 0.35);
-  background: rgba(26, 127, 59, 0.1);
+  border-color: var(--color-success-border);
+  background: var(--color-success-soft);
   color: var(--color-success);
 }
 
 .banner--warning {
-  border-color: rgba(180, 83, 9, 0.35);
-  background: rgba(180, 83, 9, 0.1);
+  border-color: var(--color-warning-border);
+  background: var(--color-warning-soft);
   color: var(--color-warning);
 }
 
 .banner--danger {
-  border-color: rgba(185, 28, 28, 0.35);
-  background: rgba(185, 28, 28, 0.1);
+  border-color: var(--color-danger-border);
+  background: var(--color-danger-soft);
   color: var(--color-danger);
+}
+
+.banner--info {
+  border-color: var(--color-info-border);
+  background: var(--color-info-soft);
+  color: var(--color-accent);
 }
 
 .tag,

--- a/docs/assets/styles/tokens.css
+++ b/docs/assets/styles/tokens.css
@@ -1,36 +1,88 @@
 :root {
+  /* Base palette */
   --color-bg: #0f172a;
   --color-surface: #ffffff;
   --color-surface-muted: #f3f5ff;
   --color-border: #d0d6e1;
   --color-border-strong: #94a3b8;
+  --color-border-subtle: rgba(208, 214, 225, 0.28);
+
+  /* Typography */
   --color-text-primary: #0b1120;
   --color-text-secondary: #334155;
   --color-text-inverse: #f8fafc;
+  --color-text-muted: rgba(248, 250, 252, 0.72);
+
+  /* Accent & feedback */
   --color-accent: #5165ff;
   --color-accent-strong: #3346d3;
+  --color-accent-soft: rgba(81, 101, 255, 0.16);
+  --color-accent-muted: rgba(81, 101, 255, 0.1);
+  --color-accent-glow: rgba(81, 101, 255, 0.35);
+
   --color-success: #1a7f3b;
+  --color-success-soft: rgba(26, 127, 59, 0.1);
+  --color-success-border: rgba(26, 127, 59, 0.35);
+  --color-success-backdrop: rgba(12, 46, 25, 0.9);
+  --color-success-foreground: rgba(229, 255, 238, 0.95);
+
   --color-warning: #b45309;
+  --color-warning-soft: rgba(180, 83, 9, 0.1);
+  --color-warning-border: rgba(180, 83, 9, 0.35);
+  --color-warning-backdrop: rgba(59, 29, 5, 0.9);
+  --color-warning-foreground: rgba(255, 243, 219, 0.95);
+
   --color-danger: #b91c1c;
+  --color-danger-soft: rgba(185, 28, 28, 0.1);
+  --color-danger-border: rgba(185, 28, 28, 0.35);
+  --color-danger-backdrop: rgba(64, 16, 16, 0.9);
+  --color-danger-foreground: rgba(255, 226, 226, 0.95);
+
+  --color-info-soft: rgba(81, 101, 255, 0.14);
+  --color-info-border: rgba(81, 101, 255, 0.5);
+  --color-info-backdrop: rgba(20, 30, 65, 0.92);
+  --color-info-foreground: rgba(224, 231, 255, 0.95);
+
+  /* Layered surfaces */
+  --layer-surface-low: rgba(15, 23, 42, 0.72);
+  --layer-surface-base: rgba(15, 23, 42, 0.82);
+  --layer-surface-raised: rgba(15, 23, 42, 0.9);
+  --layer-surface-overlay: rgba(15, 23, 42, 0.96);
+
+  /* Shadows & radii */
   --shadow-soft: 0 12px 32px rgba(15, 23, 42, 0.08);
+  --shadow-button: 0 14px 30px rgba(81, 101, 255, 0.35);
+  --shadow-focus: 0 0 0 3px rgba(81, 101, 255, 0.35);
+  --shadow-focus-strong: 0 0 0 3px rgba(81, 101, 255, 0.25);
+
   --radius-sm: 8px;
   --radius-md: 12px;
   --radius-lg: 20px;
+
+  /* Spacing scale */
   --space-2: 0.5rem;
   --space-3: 0.75rem;
   --space-4: 1rem;
   --space-6: 1.5rem;
   --space-8: 2rem;
+
+  /* Typography scale */
   --font-sans: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+
   --type-xs: 0.75rem;
   --type-sm: 0.875rem;
   --type-md: 1rem;
   --type-lg: 1.25rem;
   --type-xl: 1.5rem;
   --type-2xl: 2rem;
+
   --line-tight: 1.2;
   --line-normal: 1.5;
+
+  /* Layout */
   --container-max: 1120px;
   --container-wide: 1280px;
+
+  --transition-base: 160ms ease;
 }

--- a/docs/site.css
+++ b/docs/site.css
@@ -24,31 +24,31 @@
   --space-responsive-sm: clamp(var(--space-2), 0.6vw + 0.4rem, var(--space-3));
   --space-responsive-md: clamp(var(--space-3), 0.8vw + 0.55rem, var(--space-6));
   --color-canvas: var(--color-bg);
-  --color-surface-low: rgba(15, 23, 42, 0.72);
-  --color-surface-base: rgba(15, 23, 42, 0.82);
-  --color-surface-raised: rgba(15, 23, 42, 0.9);
-  --color-surface-overlay: rgba(15, 23, 42, 0.96);
-  --color-border-subtle: rgba(208, 214, 225, 0.28);
-  --color-border-glow: rgba(81, 101, 255, 0.35);
-  --color-text-muted: rgba(248, 250, 252, 0.72);
-  --color-accent-soft: rgba(81, 101, 255, 0.16);
-  --color-accent-muted: rgba(81, 101, 255, 0.1);
-  --tone-success-border: rgba(26, 127, 59, 0.5);
-  --tone-success-surface: rgba(26, 127, 59, 0.14);
-  --tone-success-backdrop: rgba(12, 46, 25, 0.9);
-  --tone-success-foreground: rgba(229, 255, 238, 0.95);
-  --tone-warn-border: rgba(180, 83, 9, 0.5);
-  --tone-warn-surface: rgba(180, 83, 9, 0.16);
-  --tone-warn-backdrop: rgba(59, 29, 5, 0.9);
-  --tone-warn-foreground: rgba(255, 243, 219, 0.95);
-  --tone-error-border: rgba(185, 28, 28, 0.55);
-  --tone-error-surface: rgba(185, 28, 28, 0.16);
-  --tone-error-backdrop: rgba(64, 16, 16, 0.9);
-  --tone-error-foreground: rgba(255, 226, 226, 0.95);
-  --tone-info-border: rgba(81, 101, 255, 0.5);
-  --tone-info-surface: rgba(81, 101, 255, 0.14);
-  --tone-info-backdrop: rgba(20, 30, 65, 0.92);
-  --tone-info-foreground: rgba(224, 231, 255, 0.95);
+  --color-surface-low: var(--layer-surface-low);
+  --color-surface-base: var(--layer-surface-base);
+  --color-surface-raised: var(--layer-surface-raised);
+  --color-surface-overlay: var(--layer-surface-overlay);
+  --color-border-subtle: var(--color-border-subtle);
+  --color-border-glow: var(--color-accent-glow);
+  --color-text-muted: var(--color-text-muted);
+  --color-accent-soft: var(--color-accent-soft);
+  --color-accent-muted: var(--color-accent-muted);
+  --tone-success-border: var(--color-success-border);
+  --tone-success-surface: var(--color-success-soft);
+  --tone-success-backdrop: var(--color-success-backdrop);
+  --tone-success-foreground: var(--color-success-foreground);
+  --tone-warn-border: var(--color-warning-border);
+  --tone-warn-surface: var(--color-warning-soft);
+  --tone-warn-backdrop: var(--color-warning-backdrop);
+  --tone-warn-foreground: var(--color-warning-foreground);
+  --tone-error-border: var(--color-danger-border);
+  --tone-error-surface: var(--color-danger-soft);
+  --tone-error-backdrop: var(--color-danger-backdrop);
+  --tone-error-foreground: var(--color-danger-foreground);
+  --tone-info-border: var(--color-info-border);
+  --tone-info-surface: var(--color-info-soft);
+  --tone-info-backdrop: var(--color-info-backdrop);
+  --tone-info-foreground: var(--color-info-foreground);
   --shadow-xs: 0 8px 18px rgba(15, 23, 42, 0.3);
   --shadow-sm: 0 12px 24px rgba(15, 23, 42, 0.35);
   --shadow-md: 0 18px 40px rgba(15, 23, 42, 0.4);
@@ -66,7 +66,6 @@
   --surface: var(--color-surface-base);
   --surface-strong: var(--color-surface-overlay);
   --transition: 200ms ease;
-
   font-family: var(--font-sans);
 }
 
@@ -79,8 +78,17 @@ body {
   margin: 0;
   padding: 0;
   background:
-    radial-gradient(circle at 20% 20%, rgba(81, 101, 255, 0.16), transparent 55%),
-    radial-gradient(circle at 80% 0%, rgba(51, 70, 211, 0.12), transparent 50%), var(--color-canvas);
+    radial-gradient(
+      circle at 20% 20%,
+      color-mix(in srgb, var(--color-accent) 24%, transparent),
+      transparent 55%
+    ),
+    radial-gradient(
+      circle at 80% 0%,
+      color-mix(in srgb, var(--color-accent-strong) 18%, transparent),
+      transparent 50%
+    ),
+    var(--color-canvas);
   color: var(--text);
   min-height: 100%;
 }
@@ -109,8 +117,17 @@ a:focus-visible {
   overflow: hidden;
   border-bottom: 1px solid var(--color-border-subtle);
   background:
-    radial-gradient(circle at 12% 18%, rgba(81, 101, 255, 0.28), transparent 58%),
-    radial-gradient(circle at 82% 8%, rgba(51, 70, 211, 0.24), transparent 48%), var(--color-canvas);
+    radial-gradient(
+      circle at 12% 18%,
+      color-mix(in srgb, var(--color-accent) 32%, transparent),
+      transparent 58%
+    ),
+    radial-gradient(
+      circle at 82% 8%,
+      color-mix(in srgb, var(--color-accent-strong) 28%, transparent),
+      transparent 48%
+    ),
+    var(--color-canvas);
   color: var(--text);
 }
 
@@ -119,8 +136,16 @@ a:focus-visible {
   position: absolute;
   inset: -160px;
   background:
-    radial-gradient(circle at 10% 20%, rgba(81, 101, 255, 0.4), transparent 58%),
-    radial-gradient(circle at 78% 14%, rgba(51, 70, 211, 0.32), transparent 46%);
+    radial-gradient(
+      circle at 10% 20%,
+      color-mix(in srgb, var(--color-accent) 40%, transparent),
+      transparent 58%
+    ),
+    radial-gradient(
+      circle at 78% 14%,
+      color-mix(in srgb, var(--color-accent-strong) 32%, transparent),
+      transparent 46%
+    );
   filter: blur(40px);
   opacity: 0.85;
   z-index: 0;


### PR DESCRIPTION
## Summary
- expand the shared token palette with accent, state, and transition utilities used by the Support Hub
- refactor component styles to read from the design tokens and add an info banner variant
- update site-level CSS so the hero, CTA, and navigation gradients rely on the shared variables

## Testing
- npx prettier --check docs/assets/styles

------
https://chatgpt.com/codex/tasks/task_b_6908ff6a3988832a9d10fa1f762a2f74