### PR TITLE
Add biome tags to planar ruin path traits

### DIFF
--- a/data/traits/difesa/armatura_pietra_planare.json
+++ b/data/traits/difesa/armatura_pietra_planare.json
@@ -50,5 +50,8 @@
     "has_usage_tags": true,
     "has_data_origin": true
   },
+  "biome_tags": [
+    "rovine_planari"
+  ],
   "data_origin": "pathfinder_dataset"
 }

--- a/data/traits/difesa/mantello_meteoritico.json
+++ b/data/traits/difesa/mantello_meteoritico.json
@@ -52,5 +52,8 @@
     "has_usage_tags": true,
     "has_data_origin": true
   },
+  "biome_tags": [
+    "rovine_planari"
+  ],
   "data_origin": "pathfinder_dataset"
 }

--- a/data/traits/offensivo/frusta_fiammeggiante.json
+++ b/data/traits/offensivo/frusta_fiammeggiante.json
@@ -52,5 +52,8 @@
     "has_usage_tags": true,
     "has_data_origin": true
   },
+  "biome_tags": [
+    "rovine_planari"
+  ],
   "data_origin": "pathfinder_dataset"
 }

--- a/data/traits/supporto/aura_scudo_radianza.json
+++ b/data/traits/supporto/aura_scudo_radianza.json
@@ -52,5 +52,8 @@
     "has_usage_tags": true,
     "has_data_origin": true
   },
+  "biome_tags": [
+    "rovine_planari"
+  ],
   "data_origin": "pathfinder_dataset"
 }


### PR DESCRIPTION
## Summary
- add the missing `biome_tags` arrays for the planar ruin pathfinder traits

## Testing
- python tools/py/trait_template_validator.py --traits-dir data/traits --index data/traits/index.json

------
https://chatgpt.com/codex/tasks/task_b_690900725598832aad76a77049ab5f81