### PR TITLE
docs: aggiorna Idea Engine hub e tutorial

### DIFF
--- a/README_IDEAS.md
+++ b/README_IDEAS.md
@@ -1,14 +1,18 @@
 # Idea Intake — Sezione sito (GitHub Pages)
 
-Questa cartella aggiunge **docs/ideas/** con un widget (JS) per inserire idee.
+> Support Hub / Docs / Idea Engine
+
+Questa cartella aggiunge **docs/ideas/** con un widget (JS) per inserire idee e instradare follow-up nel percorso condiviso con Support Hub.
 
 ## Novità widget & backend — 2025-12-01
+
 - **Richiamo feedback immediato** — Il report Codex pubblicato dal backend include una call to action verso il modulo espresso
   così da raccogliere rapidamente le note post-rilascio.
 - **Registro cambi dedicato** — I rilasci di widget/backend confluiscono in [`docs/ideas/changelog.md`](docs/ideas/changelog.md)
   per avere uno storico unico da citare in release note e retrospettive.
 
 ## Procedura feedback Idea Engine
+
 1. **Compila il modulo espresso** — Segnala regressioni o highlight dal playtest tramite il [modulo feedback immediato](https://forms.gle/evoTacticsIdeaFeedback).
 2. **Aggiungi note contestuali** — Usa il campo feedback mostrato dal widget dopo l'invio per collegare i commenti alla singola
    idea; l'informazione verrà riportata nel report Codex.
@@ -16,35 +20,42 @@ Questa cartella aggiunge **docs/ideas/** con un widget (JS) per inserire idee.
    `idea-engine-feedback` per raccolte più ampie.
 
 ## Link rapidi
+
+- [Tutorial Idea Engine end-to-end](docs/tutorials/idea-engine.md)
 - [Modulo feedback immediato](https://forms.gle/evoTacticsIdeaFeedback)
 - [Changelog widget/backend](docs/ideas/changelog.md)
 - [Indice idee generato dalla CI](IDEAS_INDEX.md)
 - [Support Hub Idea Engine](docs/ideas/index.html)
 
 ## Setup
+
 1. Copia tutto nella **radice del repo** (mantieni i percorsi).
 2. Apri `docs/ideas/index.html` e imposta:
    ```html
    <script>
      window.IDEA_WIDGET_CONFIG = {
-       apiBase: "https://<backend>/",   // lascia vuoto per usare solo export .md
-       apiToken: ""                     // opzionale
+       apiBase: 'https://<backend>/', // lascia vuoto per usare solo export .md
+       apiToken: '', // opzionale
      };
    </script>
    ```
 3. Pubblica GitHub Pages (branch `main`, cartella `/docs`).
 
-## Backend API (Node)
+## API backend Idea Engine
+
 - Installa le dipendenze del repository se non lo hai già fatto: `npm install`.
 - Avvia il servizio Idea Engine locale: `npm run start:api` (porta predefinita `3333`).
-- Il servizio usa un database persistente (`data/idea_engine.db`) basato su NeDB per catalogare tutte le idee.
+- Il servizio usa un database persistente (`data/idea_engine.db`) basato su NeDB per catalogare idee e output Codex.
 - Endpoints principali:
-  - `GET /api/health` per verificare lo stato del servizio.
-  - `POST /api/ideas` salva una nuova idea e restituisce il piano Codex GPT.
-  - `GET /api/ideas` e `GET /api/ideas/:id` per consultare l'archivio.
-  - `GET /api/ideas/:id/report` rigenera il brief incrementale per GPT.
+  - `GET /api/health` — verifica lo stato del servizio e la connessione ai dataset di supporto.
+  - `POST /api/ideas` — salva una nuova idea, valida la tassonomia e restituisce il piano Codex GPT.
+  - `GET /api/ideas` e `GET /api/ideas/:id` — consulta l'archivio e filtra per categoria o slug tassonomici.
+  - `GET /api/ideas/:id/report` — rigenera il brief incrementale per GPT mantenendo i riferimenti al Support Hub.
+  - `POST /api/ideas/:id/feedback` — aggiunge note contestuali al ciclo di revisione.
+- Per allineare gli slug usa la tassonomia ufficiale in [`config/idea_engine_taxonomy.json`](config/idea_engine_taxonomy.json) o il dump generato in [`docs/public/idea-taxonomy.json`](docs/public/idea-taxonomy.json).
 
 ## Uso
+
 - Apri la pagina **Idea Engine** dal Support Hub (`docs/ideas/index.html`) per utilizzare il form con lo stesso stile del
   sito pubblico.
 - Con `apiBase` configurato verso il servizio Node, il tasto **Invia al backend** registra l'idea nel database e mostra il
@@ -53,6 +64,7 @@ Questa cartella aggiunge **docs/ideas/** con un widget (JS) per inserire idee.
 - Il workflow `.github/workflows/idea-intake-index.yml` aggiorna `IDEAS_INDEX.md` ad ogni commit in `ideas/`.
 
 ## Campi del Reminder
+
 IDEA: <titolo breve>
 SOMMARIO: <2-4 righe secche>
 CATEGORIA: vedi `config/idea_engine_taxonomy.json`
@@ -63,18 +75,20 @@ SPECIE: <slug specie da data/core/species.yaml>
 TRATTI: <mutazioni/trait da data/core/traits/>
 FUNZIONI_GIOCO: <telemetria_vc, mating_nido, progressione_pe…>
 PRIORITÀ: P0 | P1 | P2 | P3
-AZIONI_NEXT: - [ ] azione 1  - [ ] azione 2
+AZIONI_NEXT: - [ ] azione 1 - [ ] azione 2
 LINK_DRIVE: <URL se esiste>
 GITHUB: <repo/percorso o URL se esiste>
 NOTE: <altro>
 
 ## Tassonomia categorie Idea Engine
+
 - La lista ufficiale delle categorie è definita in [`config/idea_engine_taxonomy.json`](config/idea_engine_taxonomy.json) e viene caricata sia dal backend Node (`server/app.js`) sia dal widget (`docs/public/embed.js`).
 - Quando aggiorni la tassonomia modifica il file JSON (mantieni la struttura `{ "categories": [] }`) e fai commit.
 - Per la versione pubblicata su GitHub Pages imposta `window.IDEA_WIDGET_CONFIG.categoriesUrl` verso l'asset JSON servito (esempio: `https://raw.githubusercontent.com/<org>/<repo>/main/config/idea_engine_taxonomy.json`). In locale puoi lasciare il valore di default `../config/idea_engine_taxonomy.json`.
 
 ## Suggerimenti e validazione slug
-- Il widget trasforma i campi Biomi/Ecosistemi/Specie/Tratti/Funzioni in multi-select con suggerimenti derivati dai dataset del repository.
+
+- Il widget trasforma i campi Biomi/Ecosistemi/Specie/Tratti/Funzioni in multi-select con suggerimenti derivati dai dataset del repository (con walkthrough nel tutorial Idea Engine).
 - Esegui `npm run build:idea-taxonomy` per rigenerare [`docs/public/idea-taxonomy.json`](docs/public/idea-taxonomy.json) a partire da:
   - `data/core/biomes.yaml` + alias in `data/core/biome_aliases.yaml`.
   - Datasets ecosistema/specie del pack (`packs/evo_tactics_pack/data/`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,20 +9,31 @@ Questi file sono scheletri collegati ai **Canvas** già creati in ChatGPT. Copia
 - `Mating-Reclutamento-Nido.md` — Attrazione, Affinità/Fiducia, standard di nido, eredità (Canvas D).
 
 ## Aggiornamenti rapidi
+
 - **Changelog** — la sintesi delle ultime release è integrata nel [README principale](../README.md#storico-aggiornamenti--archivio) e centralizzata in [`changelog.md`](changelog.md).
 - **Tutorial multimediali** — consulta `tutorials/` per schede SVG e passaggi rapidi dedicati a CLI, Idea Engine e dashboard (`docs/tutorials/*.md`).
 - **Feedback potenziato** — il modulo in `docs/public/embed.js` è attivo di default e rimanda al canale Slack `#feedback-enhancements` quando l'API non è configurata.
 
+## Idea Engine in breve
+
+- **Per iniziare** — segui il [tutorial Idea Engine](tutorials/idea-engine.md) per configurare widget, backend e percorso di approvazione.
+- **Ultimi rilasci** — consulta il [changelog dedicato](ideas/changelog.md) per aggiornamenti di widget e API.
+- **Raccogli feedback** — usa il [modulo espresso](https://forms.gle/evoTacticsIdeaFeedback) o la pagina Support Hub [Idea Engine](ideas/index.html) per convogliare note e follow-up.
+- **Tassonomia ufficiale** — verifica categorie e slug in [`config/idea_engine_taxonomy.json`](../config/idea_engine_taxonomy.json) prima di inviare proposte al backend.
+
 ## Settori operativi
+
 - **Flow** – orchestratore e validator (`services/generation/`, `tools/py`, `tools/ts`) sincronizzati con i dataset `data/core/`.
 - **Atlas** – webapp Vite (`webapp/`) e pannelli statici (`docs/test-interface/`) basati su snapshot `data/derived/` e fallback `webapp/public/data/`.
 - **Backend Idea Engine** – servizi Express (`server/`, `services/`) che espongono API consumate da Flow e Atlas e producono artefatti in `reports/`.
 - **Dataset & pack** – fonte unica (`data/`, `packs/`, `reports/`) che alimenta gli altri settori; ogni modifica richiede la verifica incrociata dei workflow (`npm run test:api`, `npm run webapp:deploy`).
 
 ## Procedure post-ottobre 2025
+
 Dal ciclo VC-2025-10 in avanti utilizziamo un flusso documentale condiviso con Support/QA e Telemetria. Con l'estensione di novembre 2025 il refactor della CLI introduce anche un percorso di approvazione per i profili `playtest`, `telemetry` e `support`.
 
 ### Decisioni architetturali
+
 - **ADR-XXX — Refactor CLI, determinismo e pipeline HUD**: `docs/adr/ADR-XXX-refactor-cli.md` raccoglie le motivazioni fornite dal team lead e formalizza le opzioni valutate, gli impatti sugli strumenti (`roll_pack`, `hud_alerts.ts`) e i follow-up richiesti.
 
 1. **Sync settimanale (martedì, 15:00 CET)** — raccogli log telemetrici e note playtest in `docs/chatgpt_changes/` (`sync-<AAAAMMGG>.md`) e annota la versione CLI attiva (`game-cli version --json`).

--- a/docs/ideas/changelog.md
+++ b/docs/ideas/changelog.md
@@ -3,17 +3,26 @@
 > Aggiorna questo file ad ogni promozione di widget/backend per mantenere una traccia unica delle novità. Duplica lo scheletro
 > qui sotto e collega sempre PR, issue o log operativi utili al review.
 
+## 2025-12-12 · Percorso Idea Engine unificato
+
+- Pubblicato il tutorial end-to-end in `docs/tutorials/idea-engine.md` con CTA condivise per onboarding, invio e raccolta feedback.
+- Aggiornati `docs/README.md` e `README_IDEAS.md` con sezione dedicata, link rapidi e riferimenti alla tassonomia ufficiale.
+- Allineati i link Support Hub per indirizzare i team verso `docs/ideas/index.html` e il modulo espresso.
+
 ## 2025-12-01 · Feedback sprint
+
 - Introdotta la call to action finale nel report Codex con link diretto al modulo di feedback immediato.
 - Allineati i README principali con procedura e link rapidi per l'ingestione del feedback.
 
 ## 2025-10-29 · Feedback nel widget
+
 - Il widget `docs/public/embed.js` mostra un modulo "Feedback" post-submit per raccogliere commenti contestuali.
 - Il backend accetta `POST /api/ideas/:id/feedback` e salva le note accanto alla proposta, includendole nel report Codex.
 
 ---
 
 ### Template per il prossimo rilascio
+
 ```
 ## AAAA-MM-GG · Nome rilascio
 - Punto 1

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -3,6 +3,7 @@
 Questa cartella raccoglie tutorial sintetici corredati da schede SVG per i flussi principali.
 
 - [CLI Evo Tactics](cli-quickstart.md)
+- [Idea Engine end-to-end](idea-engine.md)
 - [Feedback Idea Engine](idea-engine-feedback.md)
 - [Dashboard & Showcase](dashboard-tour.md)
 - [Overlay HUD canary](hud-overlay-quickstart.md)

--- a/docs/tutorials/idea-engine.md
+++ b/docs/tutorials/idea-engine.md
@@ -1,0 +1,29 @@
+# Tutorial rapido — Idea Engine end-to-end
+
+![Idea Engine overview](../../assets/tutorials/idea-engine-feedback.svg)
+
+## Obiettivo
+
+Attivare il percorso completo dall'ideazione alla raccolta feedback con il widget pubblico, il backend Node e la tassonomia condivisa.
+
+## Prerequisiti
+
+- Repository installato con dipendenze Node: `npm install` dalla root.
+- Accesso al file [`config/idea_engine_taxonomy.json`](../../config/idea_engine_taxonomy.json) per verificare slug e categorie.
+- Permessi per il canale Slack `#feedback-enhancements` e per il modulo espresso (Google Forms).
+
+## Passaggi
+
+1. **Avvia il backend** — esegui `npm run start:api` per esporre l'API su `http://0.0.0.0:3333` e verifica `GET /api/health` dal browser.
+2. **Configura il widget** — apri `docs/ideas/index.html`, imposta `window.IDEA_WIDGET_CONFIG.apiBase = "http://localhost:3333"` e, se necessario, `categoriesUrl` verso la tassonomia pubblicata.
+3. **Invia un'idea completa** — compila tutti i campi sfruttando i suggerimenti tassonomici; conferma l'invio con **Invia al backend** e salva il brief Codex generato.
+4. **Condividi feedback immediato** — utilizza il callout finale del report oppure apri direttamente il [modulo feedback](https://forms.gle/evoTacticsIdeaFeedback) per annotare follow-up.
+5. **Sincronizza con il Support Hub** — archivia l'idea in `IDEAS_INDEX.md` (workflow CI) e inoltra highlight nel canale `#feedback-enhancements` con link a `docs/ideas/index.html`.
+
+## Prossimi passi
+
+- Rigenera la tassonomia con `npm run build:idea-taxonomy` quando aggiorni biomi, specie o tratti.
+- Traccia le revisioni successive nel [changelog Idea Engine](../ideas/changelog.md) citando PR, issue e log di riferimento.
+- Mantieni allineati gli slug personalizzati aggiornando `docs/public/idea-taxonomy.json` e segnalando eccezioni nel Support Hub.
+
+👉 Apri subito la pagina [Support Hub Idea Engine](../ideas/index.html) per verificare che CTA e link siano correttamente instradati.


### PR DESCRIPTION
## Summary
- aggiunta una sezione "Idea Engine in breve" nell'indice della documentazione con collegamenti diretti a tutorial, changelog e feedback
- aggiornato README_IDEAS con breadcrumb, dettagli dell'API backend e riferimenti alla tassonomia condivisa
- creato il tutorial Idea Engine end-to-end, aggiornato l'indice dei tutorial e integrato il changelog dedicato

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_690904507188832a8f0e961c47e5b9fc