### PR TITLE
Ensure data_origin coverage across evo tactics traits

### DIFF
--- a/data/derived/analysis/trait_coverage_report.json
+++ b/data/derived/analysis/trait_coverage_report.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-11-03T12:19:13+00:00",
+  "generated_at": "2025-11-03T19:52:37+00:00",
   "sources": {
     "env_traits": "packs/evo_tactics_pack/docs/catalog/env_traits.json",
     "trait_reference": "data/traits/index.json",

--- a/docs/evo-tactics-pack/traits/difensivo/ali_membrana_sonica.json
+++ b/docs/evo-tactics-pack/traits/difensivo/ali_membrana_sonica.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile",
-    "mimetismo_cromatico_passivo"
-  ],
+  "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/difensivo/appendici_risonanti_marea.json
+++ b/docs/evo-tactics-pack/traits/difensivo/appendici_risonanti_marea.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile",
-    "mimetismo_cromatico_passivo"
-  ],
+  "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/difensivo/barriere_miasma_glaciale.json
+++ b/docs/evo-tactics-pack/traits/difensivo/barriere_miasma_glaciale.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile",
-    "mimetismo_cromatico_passivo"
-  ],
+  "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/difensivo/branchie_microfiltri.json
+++ b/docs/evo-tactics-pack/traits/difensivo/branchie_microfiltri.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile",
-    "mimetismo_cromatico_passivo"
-  ],
+  "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/difensivo/capsule_paracadute.json
+++ b/docs/evo-tactics-pack/traits/difensivo/capsule_paracadute.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile",
-    "mimetismo_cromatico_passivo"
-  ],
+  "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/difensivo/circolazione_bifasica.json
+++ b/docs/evo-tactics-pack/traits/difensivo/circolazione_bifasica.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile",
-    "mimetismo_cromatico_passivo"
-  ],
+  "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/difensivo/coda_coppia_retroattiva.json
+++ b/docs/evo-tactics-pack/traits/difensivo/coda_coppia_retroattiva.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile",
-    "mimetismo_cromatico_passivo"
-  ],
+  "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/difensivo/cute_resistente_sali.json
+++ b/docs/evo-tactics-pack/traits/difensivo/cute_resistente_sali.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile",
-    "mimetismo_cromatico_passivo"
-  ],
+  "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T2",
-  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/difensivo/enzimi_antipredatori_algali.json
+++ b/docs/evo-tactics-pack/traits/difensivo/enzimi_antipredatori_algali.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile",
-    "mimetismo_cromatico_passivo"
-  ],
+  "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/difensivo/filtri_planctonici.json
+++ b/docs/evo-tactics-pack/traits/difensivo/filtri_planctonici.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile",
-    "mimetismo_cromatico_passivo"
-  ],
+  "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/difensivo/ghiandole_fango_coesivo.json
+++ b/docs/evo-tactics-pack/traits/difensivo/ghiandole_fango_coesivo.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile",
-    "mimetismo_cromatico_passivo"
-  ],
+  "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/difensivo/giunti_antitorsione.json
+++ b/docs/evo-tactics-pack/traits/difensivo/giunti_antitorsione.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile",
-    "mimetismo_cromatico_passivo"
-  ],
+  "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/difensivo/lingua_cristallina.json
+++ b/docs/evo-tactics-pack/traits/difensivo/lingua_cristallina.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile",
-    "mimetismo_cromatico_passivo"
-  ],
+  "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/difensivo/mucose_barofile.json
+++ b/docs/evo-tactics-pack/traits/difensivo/mucose_barofile.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile",
-    "mimetismo_cromatico_passivo"
-  ],
+  "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
   "tier": "T1",
-  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
+  "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/difesa/armatura_pietra_planare.json
+++ b/docs/evo-tactics-pack/traits/difesa/armatura_pietra_planare.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "frusta_fiammeggiante"
-  ],
+  "conflitti": ["frusta_fiammeggiante"],
   "debolezza": "Pesante: riduce mobilità in ambienti non supportati o a bassa gravità.",
   "famiglia_tipologia": "Difesa/Strutturale",
   "fattore_mantenimento_energetico": "Basso (Risonanza geodetica stabile)",
@@ -10,9 +8,7 @@
   "mutazione_indotta": "Cristallizza il dermascheletro con nodi rune che deviano energia.",
   "requisiti_ambientali": [
     {
-      "capacita_richieste": [
-        "deploy_barrier"
-      ],
+      "capacita_richieste": ["deploy_barrier"],
       "condizioni": {
         "biome_class": "rovine_planari"
       },
@@ -24,9 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile"
-  ],
+  "sinergie": ["carapace_fase_variabile"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -40,5 +34,6 @@
   },
   "spinta_selettiva": "Stabilizzare varchi e proteggere infrastrutture dalle onde d'urto.",
   "tier": "T2",
-  "uso_funzione": "Offre schermatura massiva e ancoraggio durante le aperture dimensionali."
+  "uso_funzione": "Offre schermatura massiva e ancoraggio durante le aperture dimensionali.",
+  "data_origin": "pathfinder_dataset"
 }

--- a/docs/evo-tactics-pack/traits/difesa/mantello_meteoritico.json
+++ b/docs/evo-tactics-pack/traits/difesa/mantello_meteoritico.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "aura_scudo_radianza"
-  ],
+  "conflitti": ["aura_scudo_radianza"],
   "debolezza": "Vulnerabile a scariche di freddo gravitazionale che irrigidiscono il mantello.",
   "famiglia_tipologia": "Difesa/Termoregolazione",
   "fattore_mantenimento_energetico": "Alto (Rivestimento ablativo rigenerante)",
@@ -10,9 +8,7 @@
   "mutazione_indotta": "Deposita strati sovrapposti di materiale meteorico che vaporizzano l'impatto e rilasciano radianza.",
   "requisiti_ambientali": [
     {
-      "capacita_richieste": [
-        "fire_resist"
-      ],
+      "capacita_richieste": ["fire_resist"],
       "condizioni": {
         "biome_class": "rovine_planari"
       },
@@ -24,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "frusta_fiammeggiante",
-    "carapace_fase_variabile"
-  ],
+  "sinergie": ["frusta_fiammeggiante", "carapace_fase_variabile"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -41,5 +34,6 @@
   },
   "spinta_selettiva": "Sopravvivere a bombardamenti planari e piogge di meteore dimensionali.",
   "tier": "T3",
-  "uso_funzione": "Assorbe colpi energetici estremi e converte il surplus in impulsi offensivi."
+  "uso_funzione": "Assorbe colpi energetici estremi e converte il surplus in impulsi offensivi.",
+  "data_origin": "pathfinder_dataset"
 }

--- a/docs/evo-tactics-pack/traits/digestivo/filamenti_digestivi_compattanti.json
+++ b/docs/evo-tactics-pack/traits/digestivo/filamenti_digestivi_compattanti.json
@@ -61,5 +61,6 @@
   },
   "spinta_selettiva": "Necessità di mantenere la pulizia del territorio/nido.",
   "tier": "T2",
-  "uso_funzione": "Espulsione compatta e ordinata di scorie."
+  "uso_funzione": "Espulsione compatta e ordinata di scorie.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/digestivo/ventriglio_gastroliti.json
+++ b/docs/evo-tactics-pack/traits/digestivo/ventriglio_gastroliti.json
@@ -48,5 +48,6 @@
   },
   "spinta_selettiva": "Dieta basata su semi, conchiglie o insetti corazzati.",
   "tier": "T1",
-  "uso_funzione": "Macinazione di cibo duro all'interno di un ventriglio."
+  "uso_funzione": "Macinazione di cibo duro all'interno di un ventriglio.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/escretorio/spore_psichiche_silenziate.json
+++ b/docs/evo-tactics-pack/traits/escretorio/spore_psichiche_silenziate.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "respiro_a_scoppio"
-  ],
+  "conflitti": ["respiro_a_scoppio"],
   "debolezza": "Funzionalità ridotta in presenza di vento forte o umidità elevata.",
   "famiglia_tipologia": "Escretorio/Psichico",
   "fattore_mantenimento_energetico": "Alto (Produzione e rilascio)",
@@ -35,5 +33,6 @@
   },
   "spinta_selettiva": "Neutralizzare gruppi di prede o predatori senza impegnare in combattimento.",
   "tier": "T1",
-  "uso_funzione": "Indurre uno stato di confusione o letargia negli individui vicini."
+  "uso_funzione": "Indurre uno stato di confusione o letargia negli individui vicini.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/idrostatico/sacche_galleggianti_ascensoriali.json
+++ b/docs/evo-tactics-pack/traits/idrostatico/sacche_galleggianti_ascensoriali.json
@@ -51,5 +51,6 @@
   },
   "spinta_selettiva": "Vivere in un ambiente acquatico con forti correnti verticali.",
   "tier": "T1",
-  "uso_funzione": "Controllo preciso della profondità e del movimento verticale."
+  "uso_funzione": "Controllo preciso della profondità e del movimento verticale.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/ali_ioniche.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/ali_ioniche.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "zampe_a_molla"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/antenne_wideband.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/antenne_wideband.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "zampe_a_molla"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/artigli_sette_vie.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/artigli_sette_vie.json
@@ -32,13 +32,8 @@
       "hud:GripNode_Psion"
     ],
     "combo_totale": 4,
-    "forme": [
-      "Forma:Predatore_Tessuto",
-      "HUD:GrappleBurst"
-    ],
-    "tabelle_random": [
-      "tabella:predazione_multicanale"
-    ]
+    "forme": ["Forma:Predatore_Tessuto", "HUD:GrappleBurst"],
+    "tabelle_random": ["tabella:predazione_multicanale"]
   },
   "slot": [],
   "slot_profile": {
@@ -47,5 +42,6 @@
   },
   "spinta_selettiva": "Arrampicarsi su pareti rocciose o vegetazione densa.",
   "tier": "T1",
-  "uso_funzione": "Afferrare superfici irregolari o oggetti multipli."
+  "uso_funzione": "Afferrare superfici irregolari o oggetti multipli.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/artigli_sghiaccio_glaciale.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/artigli_sghiaccio_glaciale.json
@@ -19,11 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "cartilagine_flessotermica_venti",
-    "sonno_emisferico_alternato",
-    "zampe_a_molla"
-  ],
+  "sinergie": ["cartilagine_flessotermica_venti", "sonno_emisferico_alternato", "zampe_a_molla"],
   "sinergie_pi": {
     "co_occorrenze": [
       "boardgame:DominantSpecies/Glaciation",
@@ -31,12 +27,8 @@
       "hud:GlacierClaw_UI"
     ],
     "combo_totale": 3,
-    "forme": [
-      "Forma:Assaltatore_Criogenico"
-    ],
-    "tabelle_random": [
-      "tabella:presa_criostatica"
-    ]
+    "forme": ["Forma:Assaltatore_Criogenico"],
+    "tabelle_random": ["tabella:presa_criostatica"]
   },
   "slot": [],
   "slot_profile": {
@@ -45,5 +37,6 @@
   },
   "spinta_selettiva": "Cacciare su superfici gelate e pareti verticali di ghiaccio vivo.",
   "tier": "T2",
-  "uso_funzione": "Scalza e immobilizza i bersagli congelandoli al contatto."
+  "uso_funzione": "Scalza e immobilizza i bersagli congelandoli al contatto.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/barbigli_sensori_plasma.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/barbigli_sensori_plasma.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "zampe_a_molla"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/branchie_metalloidi.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/branchie_metalloidi.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "zampe_a_molla"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/capillari_fotovoltaici.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/capillari_fotovoltaici.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "zampe_a_molla"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/cartilagine_flessotermica_venti.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/cartilagine_flessotermica_venti.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "scheletro_idro_regolante"
-  ],
+  "conflitti": ["scheletro_idro_regolante"],
   "debolezza": "Temperature stabili riducono la reattività della cartilagine rendendo l'organismo lento.",
   "famiglia_tipologia": "Locomotorio/Adattivo",
   "fattore_mantenimento_energetico": "Medio (Richiede frequenti riallineamenti fibrosi)",
@@ -34,12 +32,8 @@
       "hud:VentSplice_Halo"
     ],
     "combo_totale": 3,
-    "forme": [
-      "Forma:Planatore_Psionico"
-    ],
-    "tabelle_random": [
-      "tabella:assetto_eolico"
-    ]
+    "forme": ["Forma:Planatore_Psionico"],
+    "tabelle_random": ["tabella:assetto_eolico"]
   },
   "slot": [],
   "slot_profile": {
@@ -48,5 +42,6 @@
   },
   "spinta_selettiva": "Scalare falesie e planare tra correnti ascensionali turbolente.",
   "tier": "T2",
-  "uso_funzione": "Modula elasticità e rigidità muscolo-scheletrica per manovre evasive rapide."
+  "uso_funzione": "Modula elasticità e rigidità muscolo-scheletrica per manovre evasive rapide.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/chemiorecettori_bromuro.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/chemiorecettori_bromuro.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "zampe_a_molla"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/coda_contrappeso.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/coda_contrappeso.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "zampe_a_molla"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/coda_frusta_cinetica.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/coda_frusta_cinetica.json
@@ -75,5 +75,6 @@
   },
   "spinta_selettiva": "Necessità di un attacco di \"sfondamento\" dopo movimento preparatorio.",
   "tier": "T1",
-  "uso_funzione": "Immagazzinare energia da ogni movimento per un colpo finale potente."
+  "uso_funzione": "Immagazzinare energia da ogni movimento per un colpo finale potente.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/cuscinetti_elettrostatici.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/cuscinetti_elettrostatici.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "zampe_a_molla"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/enzimi_antifase_termica.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/enzimi_antifase_termica.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "zampe_a_molla"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/filamenti_termoconduzione.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/filamenti_termoconduzione.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "zampe_a_molla"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/ghiandole_fango_calde.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/ghiandole_fango_calde.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "zampe_a_molla"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/ghiandole_ventosa.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/ghiandole_ventosa.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "zampe_a_molla"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/linfa_tampone.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/linfa_tampone.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "zampe_a_molla"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/mucose_aderenza_sonica.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/mucose_aderenza_sonica.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "zampe_a_molla"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "zampe_a_molla"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
   "tier": "T1",
-  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/zampe_a_molla.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/zampe_a_molla.json
@@ -37,5 +37,6 @@
   },
   "spinta_selettiva": "Metagame con forte pressione di aggro e necessità di riposizionamento.",
   "tier": "T1",
-  "uso_funzione": "Dash esplosivi per mantenere il ritmo di ingaggio o disimpegno."
+  "uso_funzione": "Dash esplosivi per mantenere il ritmo di ingaggio o disimpegno.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/locomotorio/zoccoli_risonanti_steppe.json
+++ b/docs/evo-tactics-pack/traits/locomotorio/zoccoli_risonanti_steppe.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "zampe_a_molla"
-  ],
+  "conflitti": ["zampe_a_molla"],
   "debolezza": "Suoli cedevoli come sabbie mobili annullano la vibrazione e riducono la trazione.",
   "famiglia_tipologia": "Locomotorio/Supporto",
   "fattore_mantenimento_energetico": "Basso (Vibrazione passiva del suolo)",
@@ -21,9 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "cartilagine_flessotermica_venti"
-  ],
+  "sinergie": ["cartilagine_flessotermica_venti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -37,5 +33,6 @@
   },
   "spinta_selettiva": "Mantenere coesione di branchi su grandi distanze e rilevare predatori sotterranei.",
   "tier": "T1",
-  "uso_funzione": "Propaga segnali ritmici che sincronizzano movimenti e abilità di squadra."
+  "uso_funzione": "Propaga segnali ritmici che sincronizzano movimenti e abilità di squadra.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/metabolico/antenne_dustsense.json
+++ b/docs/evo-tactics-pack/traits/metabolico/antenne_dustsense.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "filamenti_digestivi_compattanti",
-    "ventriglio_gastroliti"
-  ],
+  "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/metabolico/appendici_thermotattiche.json
+++ b/docs/evo-tactics-pack/traits/metabolico/appendici_thermotattiche.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "filamenti_digestivi_compattanti",
-    "ventriglio_gastroliti"
-  ],
+  "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/metabolico/batteri_endosimbionti_chemio.json
+++ b/docs/evo-tactics-pack/traits/metabolico/batteri_endosimbionti_chemio.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "filamenti_digestivi_compattanti",
-    "ventriglio_gastroliti"
-  ],
+  "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/metabolico/branchie_solfatiche.json
+++ b/docs/evo-tactics-pack/traits/metabolico/branchie_solfatiche.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "filamenti_digestivi_compattanti",
-    "ventriglio_gastroliti"
-  ],
+  "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/metabolico/carapace_segmenti_logici.json
+++ b/docs/evo-tactics-pack/traits/metabolico/carapace_segmenti_logici.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "filamenti_digestivi_compattanti",
-    "ventriglio_gastroliti"
-  ],
+  "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/metabolico/circolazione_bifasica_palude.json
+++ b/docs/evo-tactics-pack/traits/metabolico/circolazione_bifasica_palude.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "sangue_piroforico"
-  ],
+  "conflitti": ["sangue_piroforico"],
   "debolezza": "Zone asciutte e calde causano stagnazione del circuito linfatico portando a tossicosi.",
   "famiglia_tipologia": "Metabolico/Resilienza",
   "fattore_mantenimento_energetico": "Medio (Doppio circuito emolinfa/linfa)",
@@ -21,9 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "mucillagine_simbionte_mangrovie"
-  ],
+  "sinergie": ["mucillagine_simbionte_mangrovie"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -37,5 +33,6 @@
   },
   "spinta_selettiva": "Resistere a tossine e anossia tipiche delle paludi psioniche.",
   "tier": "T2",
-  "uso_funzione": "Gestisce due circuiti circolatori per filtrare veleni e mantenere prestazioni elevate."
+  "uso_funzione": "Gestisce due circuiti circolatori per filtrare veleni e mantenere prestazioni elevate.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/metabolico/circolazione_cooling_loop.json
+++ b/docs/evo-tactics-pack/traits/metabolico/circolazione_cooling_loop.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "filamenti_digestivi_compattanti",
-    "ventriglio_gastroliti"
-  ],
+  "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/metabolico/coda_stabilizzatrice_filo.json
+++ b/docs/evo-tactics-pack/traits/metabolico/coda_stabilizzatrice_filo.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "filamenti_digestivi_compattanti",
-    "ventriglio_gastroliti"
-  ],
+  "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/metabolico/criostasi_adattiva.json
+++ b/docs/evo-tactics-pack/traits/metabolico/criostasi_adattiva.json
@@ -1,8 +1,5 @@
 {
-  "conflitti": [
-    "sangue_piroforico",
-    "sacche_galleggianti_ascensoriali"
-  ],
+  "conflitti": ["sangue_piroforico", "sacche_galleggianti_ascensoriali"],
   "debolezza": "Vulnerabilità estrema agli attacchi chimici (veleni) in fase Criostasi.",
   "famiglia_tipologia": "Metabolico/Difensivo",
   "fattore_mantenimento_energetico": "Alto (Fase di risveglio/inizio) / Basso (Fase Criostasi).",
@@ -35,9 +32,7 @@
       }
     }
   ],
-  "sinergie": [
-    "cavita_risonanti_tundra"
-  ],
+  "sinergie": ["cavita_risonanti_tundra"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -51,5 +46,6 @@
   },
   "spinta_selettiva": "Inverni prolungati o lunghi periodi di scarsità di cibo.",
   "tier": "T1",
-  "uso_funzione": "Sopravvivenza a condizioni ambientali estreme."
+  "uso_funzione": "Sopravvivenza a condizioni ambientali estreme.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/metabolico/cuticole_cerose.json
+++ b/docs/evo-tactics-pack/traits/metabolico/cuticole_cerose.json
@@ -7,10 +7,7 @@
   "label": "Cuticole Cerose",
   "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [],
-  "sinergie": [
-    "filamenti_digestivi_compattanti",
-    "ventriglio_gastroliti"
-  ],
+  "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -24,5 +21,6 @@
   },
   "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/metabolico/enzimi_chelanti.json
+++ b/docs/evo-tactics-pack/traits/metabolico/enzimi_chelanti.json
@@ -7,10 +7,7 @@
   "label": "Enzimi Chelanti",
   "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [],
-  "sinergie": [
-    "filamenti_digestivi_compattanti",
-    "ventriglio_gastroliti"
-  ],
+  "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -24,5 +21,6 @@
   },
   "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/metabolico/flagelli_ancoranti.json
+++ b/docs/evo-tactics-pack/traits/metabolico/flagelli_ancoranti.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "filamenti_digestivi_compattanti",
-    "ventriglio_gastroliti"
-  ],
+  "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/metabolico/ghiandole_grafene.json
+++ b/docs/evo-tactics-pack/traits/metabolico/ghiandole_grafene.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "filamenti_digestivi_compattanti",
-    "ventriglio_gastroliti"
-  ],
+  "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/metabolico/grassi_termici.json
+++ b/docs/evo-tactics-pack/traits/metabolico/grassi_termici.json
@@ -7,10 +7,7 @@
   "label": "Grassi Termici",
   "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
   "requisiti_ambientali": [],
-  "sinergie": [
-    "filamenti_digestivi_compattanti",
-    "ventriglio_gastroliti"
-  ],
+  "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -24,5 +21,6 @@
   },
   "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/metabolico/luminescenza_aurorale.json
+++ b/docs/evo-tactics-pack/traits/metabolico/luminescenza_aurorale.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "filamenti_digestivi_compattanti",
-    "ventriglio_gastroliti"
-  ],
+  "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
   "tier": "T1",
-  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
+  "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/nervoso/sonno_emisferico_alternato.json
+++ b/docs/evo-tactics-pack/traits/nervoso/sonno_emisferico_alternato.json
@@ -19,10 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "artigli_sghiaccio_glaciale",
-    "occhi_infrarosso_composti"
-  ],
+  "sinergie": ["artigli_sghiaccio_glaciale", "occhi_infrarosso_composti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -36,5 +33,6 @@
   },
   "spinta_selettiva": "Monitoraggio costante dei predatori in ambienti ad alto rischio.",
   "tier": "T1",
-  "uso_funzione": "Vigilanza continua pur garantendo riposo."
+  "uso_funzione": "Vigilanza continua pur garantendo riposo.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/antenne_flusso_mareale.json
+++ b/docs/evo-tactics-pack/traits/offensivo/antenne_flusso_mareale.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "sangue_piroforico"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/artigli_induzione.json
+++ b/docs/evo-tactics-pack/traits/offensivo/artigli_induzione.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "sangue_piroforico"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/biochip_memoria.json
+++ b/docs/evo-tactics-pack/traits/offensivo/biochip_memoria.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "sangue_piroforico"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/camere_anticorrosione.json
+++ b/docs/evo-tactics-pack/traits/offensivo/camere_anticorrosione.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "sangue_piroforico"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/cartilagini_biofibre.json
+++ b/docs/evo-tactics-pack/traits/offensivo/cartilagini_biofibre.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "sangue_piroforico"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/circolazione_supercritica.json
+++ b/docs/evo-tactics-pack/traits/offensivo/circolazione_supercritica.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "sangue_piroforico"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/coda_stabilizzatrice_vortex.json
+++ b/docs/evo-tactics-pack/traits/offensivo/coda_stabilizzatrice_vortex.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "sangue_piroforico"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/denti_chelatanti.json
+++ b/docs/evo-tactics-pack/traits/offensivo/denti_chelatanti.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "sangue_piroforico"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/enzimi_metanoossidanti.json
+++ b/docs/evo-tactics-pack/traits/offensivo/enzimi_metanoossidanti.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "sangue_piroforico"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/foliaggio_spugna.json
+++ b/docs/evo-tactics-pack/traits/offensivo/foliaggio_spugna.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "sangue_piroforico"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/frusta_fiammeggiante.json
+++ b/docs/evo-tactics-pack/traits/offensivo/frusta_fiammeggiante.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "armatura_pietra_planare"
-  ],
+  "conflitti": ["armatura_pietra_planare"],
   "debolezza": "Consumante: richiede costante dissipazione termica per non bruciare la matrice portante.",
   "famiglia_tipologia": "Offensivo/Controllo",
   "fattore_mantenimento_energetico": "Medio (Filamenti di plasma vincolato)",
@@ -10,9 +8,7 @@
   "mutazione_indotta": "Genera appendici tentacolari avvolte da plasma infernale controllato.",
   "requisiti_ambientali": [
     {
-      "capacita_richieste": [
-        "void_stride"
-      ],
+      "capacita_richieste": ["void_stride"],
       "condizioni": {
         "biome_class": "rovine_planari"
       },
@@ -24,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "focus_frazionato",
-    "mantello_meteoritico"
-  ],
+  "sinergie": ["focus_frazionato", "mantello_meteoritico"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -41,5 +34,6 @@
   },
   "spinta_selettiva": "Creare distanza di sicurezza contro predatori d'élite nelle zone instabili.",
   "tier": "T2",
-  "uso_funzione": "Afferra e disarma avversari o sigilla varchi planari con tagli di energia."
+  "uso_funzione": "Afferra e disarma avversari o sigilla varchi planari con tagli di energia.",
+  "data_origin": "pathfinder_dataset"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/ghiandola_caustica.json
+++ b/docs/evo-tactics-pack/traits/offensivo/ghiandola_caustica.json
@@ -9,24 +9,18 @@
   "requisiti_ambientali": [],
   "sinergie": [],
   "sinergie_pi": {
-    "co_occorrenze": [
-      "PE",
-      "guardia_situazionale"
-    ],
+    "co_occorrenze": ["PE", "guardia_situazionale"],
     "combo_totale": 1,
-    "forme": [
-      "ISTP"
-    ],
+    "forme": ["ISTP"],
     "tabelle_random": []
   },
-  "slot": [
-    "A"
-  ],
+  "slot": ["A"],
   "slot_profile": {
     "complementare": "assalto",
     "core": "offensivo"
   },
   "spinta_selettiva": "Squadre che devono rispondere a guardie situazionali al turno 1-2.",
   "tier": "T1",
-  "uso_funzione": "Sblocco early di danni da acido per rompere armature leggere."
+  "uso_funzione": "Sblocco early di danni da acido per rompere armature leggere.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/ghiandole_iodoattive.json
+++ b/docs/evo-tactics-pack/traits/offensivo/ghiandole_iodoattive.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "sangue_piroforico"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/gusci_magnesio.json
+++ b/docs/evo-tactics-pack/traits/offensivo/gusci_magnesio.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "sangue_piroforico"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/mantelli_geotermici.json
+++ b/docs/evo-tactics-pack/traits/offensivo/mantelli_geotermici.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "coda_frusta_cinetica",
-    "sangue_piroforico"
-  ],
+  "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
   "tier": "T1",
-  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+  "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/offensivo/sangue_piroforico.json
+++ b/docs/evo-tactics-pack/traits/offensivo/sangue_piroforico.json
@@ -1,8 +1,5 @@
 {
-  "conflitti": [
-    "criostasi_adattiva",
-    "scheletro_idro_regolante"
-  ],
+  "conflitti": ["criostasi_adattiva", "scheletro_idro_regolante"],
   "debolezza": "Rischio di auto-combustione in caso di ferita profonda in atmosfera ricca di ossigeno.",
   "famiglia_tipologia": "Offensivo/Cinetico",
   "fattore_mantenimento_energetico": "Medio (Sintesi dei composti)",
@@ -51,5 +48,6 @@
   },
   "spinta_selettiva": "Difesa contro predatori che tentano di estrarre fluidi corporei.",
   "tier": "T1",
-  "uso_funzione": "Meccanismo di difesa termico o chimico che si attiva con l'aria."
+  "uso_funzione": "Meccanismo di difesa termico o chimico che si attiva con l'aria.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/respiratorio/branchie_osmotiche_salmastra.json
+++ b/docs/evo-tactics-pack/traits/respiratorio/branchie_osmotiche_salmastra.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "polmoni_cristallini_alta_quota"
-  ],
+  "conflitti": ["polmoni_cristallini_alta_quota"],
   "debolezza": "Richiede accesso costante ad acqua salmastra; ambienti d'acqua dolce provocano stress ionico.",
   "famiglia_tipologia": "Respiratorio/Osmoregolazione",
   "fattore_mantenimento_energetico": "Medio (Pompe ioniche attive)",
@@ -21,10 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "mucillagine_simbionte_mangrovie",
-    "scheletro_idro_regolante"
-  ],
+  "sinergie": ["mucillagine_simbionte_mangrovie", "scheletro_idro_regolante"],
   "sinergie_pi": {
     "co_occorrenze": [
       "boardgame:Evolution/Symbiosis",
@@ -32,12 +27,8 @@
       "hud:EstuarioPsi"
     ],
     "combo_totale": 3,
-    "forme": [
-      "Forma:Amfibio_Oracolare"
-    ],
-    "tabelle_random": [
-      "tabella:osmosi_psionica"
-    ]
+    "forme": ["Forma:Amfibio_Oracolare"],
+    "tabelle_random": ["tabella:osmosi_psionica"]
   },
   "slot": [],
   "slot_profile": {
@@ -46,5 +37,6 @@
   },
   "spinta_selettiva": "Colonizzare mangrovie psioniche e barriere di estuario soggette a maree estreme.",
   "tier": "T2",
-  "uso_funzione": "Bilancia sali e tossine sfruttando microvalvole controllate psionicamente."
+  "uso_funzione": "Bilancia sali e tossine sfruttando microvalvole controllate psionicamente.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/respiratorio/lamelle_termoforetiche.json
+++ b/docs/evo-tactics-pack/traits/respiratorio/lamelle_termoforetiche.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "criostasi_adattiva"
-  ],
+  "conflitti": ["criostasi_adattiva"],
   "debolezza": "Rende instabile la fisiologia in ambienti a gelo improvviso, con rischio di microfratture vascolari.",
   "famiglia_tipologia": "Respiratorio/Termoregolazione",
   "fattore_mantenimento_energetico": "Medio (Flusso continuo di fluidi caldi)",
@@ -21,9 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "sangue_piroforico"
-  ],
+  "sinergie": ["sangue_piroforico"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -37,5 +33,6 @@
   },
   "spinta_selettiva": "Sopravvivere a fluidi tossici e temperature estreme nelle fumarole geotermiche.",
   "tier": "T2",
-  "uso_funzione": "Regola lo scambio gassoso sfruttando gradienti termici controllati."
+  "uso_funzione": "Regola lo scambio gassoso sfruttando gradienti termici controllati.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/respiratorio/membrane_eliofiltranti.json
+++ b/docs/evo-tactics-pack/traits/respiratorio/membrane_eliofiltranti.json
@@ -19,10 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "piume_solari_fotovoltaiche",
-    "polmoni_cristallini_alta_quota"
-  ],
+  "sinergie": ["piume_solari_fotovoltaiche", "polmoni_cristallini_alta_quota"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -36,5 +33,6 @@
   },
   "spinta_selettiva": "Proteggersi da radiazioni e agenti patogeni in altopiani ipersalini.",
   "tier": "T2",
-  "uso_funzione": "Filtra l'aria e i flussi luminosi rendendoli sicuri per tessuti delicati."
+  "uso_funzione": "Filtra l'aria e i flussi luminosi rendendoli sicuri per tessuti delicati.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/respiratorio/polmoni_cristallini_alta_quota.json
+++ b/docs/evo-tactics-pack/traits/respiratorio/polmoni_cristallini_alta_quota.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "branchie_osmotiche_salmastra"
-  ],
+  "conflitti": ["branchie_osmotiche_salmastra"],
   "debolezza": "Particolato pesante o sabbia vulcanica graffia i cristalli riducendo l'efficienza respiratoria.",
   "famiglia_tipologia": "Respiratorio/Aerobico",
   "fattore_mantenimento_energetico": "Medio (Pulizia periodica dei cristalli)",
@@ -21,9 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "membrane_eliofiltranti"
-  ],
+  "sinergie": ["membrane_eliofiltranti"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -37,5 +33,6 @@
   },
   "spinta_selettiva": "Operare in missioni d'alta quota senza supporto logistico esterno.",
   "tier": "T2",
-  "uso_funzione": "Massimizza l'assorbimento di ossigeno rarefatto e filtra agenti nocivi."
+  "uso_funzione": "Massimizza l'assorbimento di ossigeno rarefatto e filtra agenti nocivi.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/respiratorio/respiro_a_scoppio.json
+++ b/docs/evo-tactics-pack/traits/respiratorio/respiro_a_scoppio.json
@@ -19,10 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "sacche_galleggianti_ascensoriali",
-    "squame_rifrangenti_deserto"
-  ],
+  "sinergie": ["sacche_galleggianti_ascensoriali", "squame_rifrangenti_deserto"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -36,5 +33,6 @@
   },
   "spinta_selettiva": "Spostamento rapido tramite getto d'aria in ambienti a bassa resistenza.",
   "tier": "T1",
-  "uso_funzione": "Rilasciare grandi quantità d'aria o energia in un getto potente."
+  "uso_funzione": "Rilasciare grandi quantità d'aria o energia in un getto potente.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/riproduttivo/nucleo_ovomotore_rotante.json
+++ b/docs/evo-tactics-pack/traits/riproduttivo/nucleo_ovomotore_rotante.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "secrezione_rallentante_palmi"
-  ],
+  "conflitti": ["secrezione_rallentante_palmi"],
   "debolezza": "Impossibilità di muoversi su superfici irregolari o in salita ripida.",
   "famiglia_tipologia": "Riproduttivo/Locomotorio",
   "fattore_mantenimento_energetico": "Alto (Rotolamento)",
@@ -35,5 +33,6 @@
   },
   "spinta_selettiva": "Necessità di spostarsi rapidamente su terreni uniformi in assenza di arti.",
   "tier": "T1",
-  "uso_funzione": "Organo Motorio Rotante: usato come 'ruota' centrale per il rotolamento."
+  "uso_funzione": "Organo Motorio Rotante: usato come 'ruota' centrale per il rotolamento.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/ali_fulminee.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/ali_fulminee.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "focus_frazionato",
-    "sinapsi_coraline_polifoniche"
-  ],
+  "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/antenne_plasmatiche_tempesta.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/antenne_plasmatiche_tempesta.json
@@ -32,13 +32,8 @@
       "bioma:cicloni_psionici"
     ],
     "combo_totale": 3,
-    "forme": [
-      "Forma:Tempestarii",
-      "HUD:Fulcro_Tempesta"
-    ],
-    "tabelle_random": [
-      "tabella:fulmini_empatici"
-    ]
+    "forme": ["Forma:Tempestarii", "HUD:Fulcro_Tempesta"],
+    "tabelle_random": ["tabella:fulmini_empatici"]
   },
   "slot": [],
   "slot_profile": {
@@ -47,5 +42,6 @@
   },
   "spinta_selettiva": "Comandare fulmini e navigare in cieli turbolenti durante campagne aeree.",
   "tier": "T3",
-  "uso_funzione": "Canalizza scariche atmosferiche in attacchi direzionati o scudi ionici."
+  "uso_funzione": "Canalizza scariche atmosferiche in attacchi direzionati o scudi ionici.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/antenne_waveguide.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/antenne_waveguide.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "focus_frazionato",
-    "sinapsi_coraline_polifoniche"
-  ],
+  "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/baffi_mareomotori.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/baffi_mareomotori.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "focus_frazionato",
-    "sinapsi_coraline_polifoniche"
-  ],
+  "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/branchie_eoliche.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/branchie_eoliche.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "focus_frazionato",
-    "sinapsi_coraline_polifoniche"
-  ],
+  "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/capillari_fluoridici.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/capillari_fluoridici.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "focus_frazionato",
-    "sinapsi_coraline_polifoniche"
-  ],
+  "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/cavita_risonanti_tundra.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/cavita_risonanti_tundra.json
@@ -32,13 +32,8 @@
       "hud:TundraPulse"
     ],
     "combo_totale": 3,
-    "forme": [
-      "Forma:Cantore_Tundra",
-      "HUD:EchoGrid"
-    ],
-    "tabelle_random": [
-      "tabella:canti_ipersonici"
-    ]
+    "forme": ["Forma:Cantore_Tundra", "HUD:EchoGrid"],
+    "tabelle_random": ["tabella:canti_ipersonici"]
   },
   "slot": [],
   "slot_profile": {
@@ -47,5 +42,6 @@
   },
   "spinta_selettiva": "Coordinare branchi in lande aperte dove la visibilità è ridotta da bufere di ghiaccio.",
   "tier": "T1",
-  "uso_funzione": "Amplifica segnali acustici per comunicazioni a lungo raggio nel gelo."
+  "uso_funzione": "Amplifica segnali acustici per comunicazioni a lungo raggio nel gelo.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/cervelletto_equilibrio_statico.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/cervelletto_equilibrio_statico.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "focus_frazionato",
-    "sinapsi_coraline_polifoniche"
-  ],
+  "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/coda_balanciere.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/coda_balanciere.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "focus_frazionato",
-    "sinapsi_coraline_polifoniche"
-  ],
+  "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/cuore_multicamera_bassa_pressione.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/cuore_multicamera_bassa_pressione.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "focus_frazionato",
-    "sinapsi_coraline_polifoniche"
-  ],
+  "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/echi_risonanti.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/echi_risonanti.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "focus_frazionato",
-    "sinapsi_coraline_polifoniche"
-  ],
+  "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/eco_interno_riflesso.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/eco_interno_riflesso.json
@@ -32,11 +32,7 @@
       }
     }
   ],
-  "sinergie": [
-    "cavita_risonanti_tundra",
-    "olfatto_risonanza_magnetica",
-    "sensori_geomagnetici"
-  ],
+  "sinergie": ["cavita_risonanti_tundra", "olfatto_risonanza_magnetica", "sensori_geomagnetici"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -50,5 +46,6 @@
   },
   "spinta_selettiva": "Orientamento in ambienti completamente privi di luce.",
   "tier": "T2",
-  "uso_funzione": "Utilizzo di onde sonore emesse internamente per mappare l'ambiente."
+  "uso_funzione": "Utilizzo di onde sonore emesse internamente per mappare l'ambiente.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/filamenti_superconduttivi.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/filamenti_superconduttivi.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "focus_frazionato",
-    "sinapsi_coraline_polifoniche"
-  ],
+  "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/ghiandole_eco_mappanti.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/ghiandole_eco_mappanti.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "focus_frazionato",
-    "sinapsi_coraline_polifoniche"
-  ],
+  "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/ghiandole_resina_conduttiva.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/ghiandole_resina_conduttiva.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "focus_frazionato",
-    "sinapsi_coraline_polifoniche"
-  ],
+  "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/lamine_scudo_silice.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/lamine_scudo_silice.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "focus_frazionato",
-    "sinapsi_coraline_polifoniche"
-  ],
+  "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/lingua_tattile_trama.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/lingua_tattile_trama.json
@@ -19,9 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "olfatto_risonanza_magnetica"
-  ],
+  "sinergie": ["olfatto_risonanza_magnetica"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -35,5 +33,6 @@
   },
   "spinta_selettiva": "Individuare movimenti sismici o cibi sepolti.",
   "tier": "T1",
-  "uso_funzione": "\"Leggere\" la tessitura delle superfici per vibrazioni o micro-fratture."
+  "uso_funzione": "\"Leggere\" la tessitura delle superfici per vibrazioni o micro-fratture.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/midollo_antivibrazione.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/midollo_antivibrazione.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "focus_frazionato",
-    "sinapsi_coraline_polifoniche"
-  ],
+  "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
   "tier": "T1",
-  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/occhi_infrarosso_composti.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/occhi_infrarosso_composti.json
@@ -19,9 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "sonno_emisferico_alternato"
-  ],
+  "sinergie": ["sonno_emisferico_alternato"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -35,5 +33,6 @@
   },
   "spinta_selettiva": "Caccia notturna o nell'oscurità totale basata sul gradiente termico.",
   "tier": "T1",
-  "uso_funzione": "Vista specializzata che percepisce il calore corporeo."
+  "uso_funzione": "Vista specializzata che percepisce il calore corporeo.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/olfatto_risonanza_magnetica.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/olfatto_risonanza_magnetica.json
@@ -32,10 +32,7 @@
       }
     }
   ],
-  "sinergie": [
-    "eco_interno_riflesso",
-    "lingua_tattile_trama"
-  ],
+  "sinergie": ["eco_interno_riflesso", "lingua_tattile_trama"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -49,5 +46,6 @@
   },
   "spinta_selettiva": "Orientamento in ambienti sotterranei senza luce o caccia a prede metallifere.",
   "tier": "T2",
-  "uso_funzione": "Percepire la direzione e la composizione di metalli o campi energetici."
+  "uso_funzione": "Percepire la direzione e la composizione di metalli o campi energetici.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/sensoriale/sensori_geomagnetici.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/sensori_geomagnetici.json
@@ -19,10 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "carapace_fase_variabile",
-    "eco_interno_riflesso"
-  ],
+  "sinergie": ["carapace_fase_variabile", "eco_interno_riflesso"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -36,5 +33,6 @@
   },
   "spinta_selettiva": "Orientarsi in steppe polarizzate e tunnel sotterranei privi di riferimenti visivi.",
   "tier": "T1",
-  "uso_funzione": "Traccia linee di campo e memorizza corridoi magnetici per la migrazione."
+  "uso_funzione": "Traccia linee di campo e memorizza corridoi magnetici per la migrazione.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/antenne_reagenti.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/antenne_reagenti.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "mucillagine_simbionte_mangrovie",
-    "nodi_micorrizici_oracolari"
-  ],
+  "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/artigli_scivolo_silente.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/artigli_scivolo_silente.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "mucillagine_simbionte_mangrovie",
-    "nodi_micorrizici_oracolari"
-  ],
+  "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/biofilm_iperarido.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/biofilm_iperarido.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "mucillagine_simbionte_mangrovie",
-    "nodi_micorrizici_oracolari"
-  ],
+  "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/bulbi_radici_permafrost.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/bulbi_radici_permafrost.json
@@ -31,13 +31,8 @@
       "hud:RootMesh_Psi"
     ],
     "combo_totale": 3,
-    "forme": [
-      "Forma:Archivio_Subglaciale",
-      "HUD:Radice_Proxy"
-    ],
-    "tabelle_random": [
-      "tabella:riserva_empatica"
-    ]
+    "forme": ["Forma:Archivio_Subglaciale", "HUD:Radice_Proxy"],
+    "tabelle_random": ["tabella:riserva_empatica"]
   },
   "slot": [],
   "slot_profile": {
@@ -46,5 +41,6 @@
   },
   "spinta_selettiva": "Sostenere campagne lunghe in climi artici con riserve nutrizionali concentrate.",
   "tier": "T2",
-  "uso_funzione": "Rilascia energia e calore agli alleati radicati nella stessa rete subglaciale."
+  "uso_funzione": "Rilascia energia e calore agli alleati radicati nella stessa rete subglaciale.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/camere_nutrienti_vent.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/camere_nutrienti_vent.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "mucillagine_simbionte_mangrovie",
-    "nodi_micorrizici_oracolari"
-  ],
+  "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/cartilagini_flessoacustiche.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/cartilagini_flessoacustiche.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "mucillagine_simbionte_mangrovie",
-    "nodi_micorrizici_oracolari"
-  ],
+  "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/chioma_parassita_canopica.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/chioma_parassita_canopica.json
@@ -19,10 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "bulbi_radici_permafrost",
-    "nodi_micorrizici_oracolari"
-  ],
+  "sinergie": ["bulbi_radici_permafrost", "nodi_micorrizici_oracolari"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -36,5 +33,6 @@
   },
   "spinta_selettiva": "Stabilizzare piattaforme mobili e reti di trasporto tra gli alberi viventi.",
   "tier": "T1",
-  "uso_funzione": "Crea passaggi e nodi energetici condivisi nella canopia per movimenti rapidi."
+  "uso_funzione": "Crea passaggi e nodi energetici condivisi nella canopia per movimenti rapidi.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/ciste_salmastre.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/ciste_salmastre.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "mucillagine_simbionte_mangrovie",
-    "nodi_micorrizici_oracolari"
-  ],
+  "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/coralli_partner.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/coralli_partner.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "mucillagine_simbionte_mangrovie",
-    "nodi_micorrizici_oracolari"
-  ],
+  "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/denti_silice_termici.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/denti_silice_termici.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "mucillagine_simbionte_mangrovie",
-    "nodi_micorrizici_oracolari"
-  ],
+  "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/epitelio_fosforescente.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/epitelio_fosforescente.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "mucillagine_simbionte_mangrovie",
-    "nodi_micorrizici_oracolari"
-  ],
+  "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/ghiandole_cambio_salino.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/ghiandole_cambio_salino.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "mucillagine_simbionte_mangrovie",
-    "nodi_micorrizici_oracolari"
-  ],
+  "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/ghiandole_nebbia_acida.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/ghiandole_nebbia_acida.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "mucillagine_simbionte_mangrovie",
-    "nodi_micorrizici_oracolari"
-  ],
+  "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/lamelle_sincroniche.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/lamelle_sincroniche.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "mucillagine_simbionte_mangrovie",
-    "nodi_micorrizici_oracolari"
-  ],
+  "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/membrane_planata_vectored.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/membrane_planata_vectored.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "mucillagine_simbionte_mangrovie",
-    "nodi_micorrizici_oracolari"
-  ],
+  "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
   "tier": "T1",
-  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+  "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/mucillagine_simbionte_mangrovie.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/mucillagine_simbionte_mangrovie.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "ghiandola_caustica"
-  ],
+  "conflitti": ["ghiandola_caustica"],
   "debolezza": "Acque eccessivamente pure diluiscono la mucillagine riducendo la protezione.",
   "famiglia_tipologia": "Simbiotico/Difensivo",
   "fattore_mantenimento_energetico": "Medio (Coltura simbiotica costante)",
@@ -52,5 +50,6 @@
   },
   "spinta_selettiva": "Respinge tossine e predatori microbici tipici dei delta paludosi.",
   "tier": "T1",
-  "uso_funzione": "Forma una barriera viva che neutralizza veleni e sigilla ferite."
+  "uso_funzione": "Forma una barriera viva che neutralizza veleni e sigilla ferite.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/nodi_micorrizici_oracolari.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/nodi_micorrizici_oracolari.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "spore_psichiche_silenziate"
-  ],
+  "conflitti": ["spore_psichiche_silenziate"],
   "debolezza": "Se la rete micorrizica viene recisa, l'organismo soffre crisi percettive e perdita di orientamento.",
   "famiglia_tipologia": "Simbiotico/Nervoso",
   "fattore_mantenimento_energetico": "Medio (Scambio continuo di segnali con simbionti)",
@@ -52,5 +50,6 @@
   },
   "spinta_selettiva": "Anticipare frane psioniche e predatori guidati da reti vegetali senzienti.",
   "tier": "T3",
-  "uso_funzione": "Riceve presagi e segnali tattici dalla rete fungina per coordinare manovre di squadra."
+  "uso_funzione": "Riceve presagi e segnali tattici dalla rete fungina per coordinare manovre di squadra.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/sacche_spore_stratosferiche.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/sacche_spore_stratosferiche.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "respiro_a_scoppio"
-  ],
+  "conflitti": ["respiro_a_scoppio"],
   "debolezza": "Correnti ionizzate possono incendiare le sacche rendendo l'organismo instabile.",
   "famiglia_tipologia": "Simbiotico/Supporto",
   "fattore_mantenimento_energetico": "Alto (Coltura continua di spore portanti)",
@@ -21,9 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "piume_solari_fotovoltaiche"
-  ],
+  "sinergie": ["piume_solari_fotovoltaiche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -37,5 +33,6 @@
   },
   "spinta_selettiva": "Dispersone genetica rapida tra arcipelaghi aerei e piattaforme galleggianti.",
   "tier": "T3",
-  "uso_funzione": "Distribuisce simbionti di supporto e crea corridoi di movimento per la squadra."
+  "uso_funzione": "Distribuisce simbionti di supporto e crea corridoi di movimento per la squadra.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/simbiotico/sinapsi_coraline_polifoniche.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/sinapsi_coraline_polifoniche.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "spore_psichiche_silenziate"
-  ],
+  "conflitti": ["spore_psichiche_silenziate"],
   "debolezza": "Vibrazioni sintonizzate male possono generare feedback dolorosi e perdita di coscienza.",
   "famiglia_tipologia": "Simbiotico/Comunicazione",
   "fattore_mantenimento_energetico": "Medio (Scambio continuo di impulsi corallini)",
@@ -52,5 +50,6 @@
   },
   "spinta_selettiva": "Coordinare banchi e alleati in ambienti tridimensionali complessi.",
   "tier": "T2",
-  "uso_funzione": "Trasmette comandi e pattern tattici sfruttando armoniche subacquee."
+  "uso_funzione": "Trasmette comandi e pattern tattici sfruttando armoniche subacquee.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/strategia/antenne_microonde_cavernose.json
+++ b/docs/evo-tactics-pack/traits/strategia/antenne_microonde_cavernose.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "pianificatore",
-    "tattiche_di_branco"
-  ],
+  "sinergie": ["pianificatore", "tattiche_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strategia/artigli_radice.json
+++ b/docs/evo-tactics-pack/traits/strategia/artigli_radice.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "pianificatore",
-    "tattiche_di_branco"
-  ],
+  "sinergie": ["pianificatore", "tattiche_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strategia/biofilm_glow.json
+++ b/docs/evo-tactics-pack/traits/strategia/biofilm_glow.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "pianificatore",
-    "tattiche_di_branco"
-  ],
+  "sinergie": ["pianificatore", "tattiche_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strategia/camere_mirage.json
+++ b/docs/evo-tactics-pack/traits/strategia/camere_mirage.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "pianificatore",
-    "tattiche_di_branco"
-  ],
+  "sinergie": ["pianificatore", "tattiche_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strategia/cartilagini_desertiche.json
+++ b/docs/evo-tactics-pack/traits/strategia/cartilagini_desertiche.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "pianificatore",
-    "tattiche_di_branco"
-  ],
+  "sinergie": ["pianificatore", "tattiche_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strategia/ciste_riduttive.json
+++ b/docs/evo-tactics-pack/traits/strategia/ciste_riduttive.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "pianificatore",
-    "tattiche_di_branco"
-  ],
+  "sinergie": ["pianificatore", "tattiche_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strategia/colonne_vibromagnetiche.json
+++ b/docs/evo-tactics-pack/traits/strategia/colonne_vibromagnetiche.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "pianificatore",
-    "tattiche_di_branco"
-  ],
+  "sinergie": ["pianificatore", "tattiche_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strategia/denti_ossidoferro.json
+++ b/docs/evo-tactics-pack/traits/strategia/denti_ossidoferro.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "pianificatore",
-    "tattiche_di_branco"
-  ],
+  "sinergie": ["pianificatore", "tattiche_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strategia/epidermide_dielettrica.json
+++ b/docs/evo-tactics-pack/traits/strategia/epidermide_dielettrica.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "pianificatore",
-    "tattiche_di_branco"
-  ],
+  "sinergie": ["pianificatore", "tattiche_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strategia/focus_frazionato.json
+++ b/docs/evo-tactics-pack/traits/strategia/focus_frazionato.json
@@ -44,5 +44,6 @@
   },
   "spinta_selettiva": "Comunicazioni piatte dove occorre coprire minacce su più fronti.",
   "tier": "T1",
-  "uso_funzione": "Permette di gestire due ingaggi paralleli senza perdere efficienza."
+  "uso_funzione": "Permette di gestire due ingaggi paralleli senza perdere efficienza.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/strategia/ghiaccio_piezoelettrico.json
+++ b/docs/evo-tactics-pack/traits/strategia/ghiaccio_piezoelettrico.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "pianificatore",
-    "tattiche_di_branco"
-  ],
+  "sinergie": ["pianificatore", "tattiche_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strategia/ghiandole_minerali.json
+++ b/docs/evo-tactics-pack/traits/strategia/ghiandole_minerali.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "pianificatore",
-    "tattiche_di_branco"
-  ],
+  "sinergie": ["pianificatore", "tattiche_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strategia/lamelle_shear.json
+++ b/docs/evo-tactics-pack/traits/strategia/lamelle_shear.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "pianificatore",
-    "tattiche_di_branco"
-  ],
+  "sinergie": ["pianificatore", "tattiche_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strategia/membrane_captura_rugiada.json
+++ b/docs/evo-tactics-pack/traits/strategia/membrane_captura_rugiada.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "pianificatore",
-    "tattiche_di_branco"
-  ],
+  "sinergie": ["pianificatore", "tattiche_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
   "tier": "T1",
-  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
+  "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strategia/pathfinder.json
+++ b/docs/evo-tactics-pack/traits/strategia/pathfinder.json
@@ -9,25 +9,18 @@
   "requisiti_ambientali": [],
   "sinergie": [],
   "sinergie_pi": {
-    "co_occorrenze": [
-      "PE",
-      "cap_pt",
-      "starter_bioma"
-    ],
+    "co_occorrenze": ["PE", "cap_pt", "starter_bioma"],
     "combo_totale": 1,
-    "forme": [
-      "ENFP"
-    ],
+    "forme": ["ENFP"],
     "tabelle_random": []
   },
-  "slot": [
-    "A"
-  ],
+  "slot": ["A"],
   "slot_profile": {
     "complementare": "ricognizione",
     "core": "strategia"
   },
   "spinta_selettiva": "Missioni con indice explore alto e opzioni opzionali da capitalizzare.",
   "tier": "T1",
-  "uso_funzione": "Ottimizza esplorazione e controllo mappe multi-bioma."
+  "uso_funzione": "Ottimizza esplorazione e controllo mappe multi-bioma.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/strategia/pianificatore.json
+++ b/docs/evo-tactics-pack/traits/strategia/pianificatore.json
@@ -23,32 +23,18 @@
     "membrane_captura_rugiada"
   ],
   "sinergie_pi": {
-    "co_occorrenze": [
-      "PE",
-      "cap_pt",
-      "guardia_situazionale",
-      "sigillo_forma",
-      "starter_bioma"
-    ],
+    "co_occorrenze": ["PE", "cap_pt", "guardia_situazionale", "sigillo_forma", "starter_bioma"],
     "combo_totale": 6,
-    "forme": [
-      "ENTJ",
-      "ENTP",
-      "ESTJ",
-      "INTJ",
-      "ISTJ"
-    ],
+    "forme": ["ENTJ", "ENTP", "ESTJ", "INTJ", "ISTJ"],
     "tabelle_random": []
   },
-  "slot": [
-    "A",
-    "C"
-  ],
+  "slot": ["A", "C"],
   "slot_profile": {
     "complementare": "tattico",
     "core": "strategia"
   },
   "spinta_selettiva": "Squadre che devono mantenere priorità multiple su turni lunghi.",
   "tier": "T1",
-  "uso_funzione": "Coordina finestre di danno e difesa, mantenendo la squadra allineata al piano PI."
+  "uso_funzione": "Coordina finestre di danno e difesa, mantenendo la squadra allineata al piano PI.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/strategia/random.json
+++ b/docs/evo-tactics-pack/traits/strategia/random.json
@@ -21,5 +21,6 @@
   },
   "spinta_selettiva": "Draft rapidi o recuperi quando il tavolo necessita sorprese adattive.",
   "tier": "T1",
-  "uso_funzione": "Slot jolly per testing o pareggiare budget PI quando serve varietà."
+  "uso_funzione": "Slot jolly per testing o pareggiare budget PI quando serve varietà.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/strategia/tattiche_di_branco.json
+++ b/docs/evo-tactics-pack/traits/strategia/tattiche_di_branco.json
@@ -24,28 +24,18 @@
     "membrane_captura_rugiada"
   ],
   "sinergie_pi": {
-    "co_occorrenze": [
-      "PE",
-      "cap_pt",
-      "guardia_situazionale",
-      "sigillo_forma",
-      "starter_bioma"
-    ],
+    "co_occorrenze": ["PE", "cap_pt", "guardia_situazionale", "sigillo_forma", "starter_bioma"],
     "combo_totale": 2,
-    "forme": [
-      "ESFJ",
-      "ESFP"
-    ],
+    "forme": ["ESFJ", "ESFP"],
     "tabelle_random": []
   },
-  "slot": [
-    "B"
-  ],
+  "slot": ["B"],
   "slot_profile": {
     "complementare": "coordinazione",
     "core": "strategia"
   },
   "spinta_selettiva": "Squadre che puntano a style bonus tramite assist e controllo spazio.",
   "tier": "T1",
-  "uso_funzione": "Coordina prese e focus bersaglio condividendo segnali di priorità."
+  "uso_funzione": "Coordina prese e focus bersaglio condividendo segnali di priorità.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/antenne_tesla.json
+++ b/docs/evo-tactics-pack/traits/strutturale/antenne_tesla.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "scheletro_idro_regolante",
-    "struttura_elastica_amorfa"
-  ],
+  "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/artigli_vetrificati.json
+++ b/docs/evo-tactics-pack/traits/strutturale/artigli_vetrificati.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "scheletro_idro_regolante",
-    "struttura_elastica_amorfa"
-  ],
+  "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/branchie_dual_mode.json
+++ b/docs/evo-tactics-pack/traits/strutturale/branchie_dual_mode.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "scheletro_idro_regolante",
-    "struttura_elastica_amorfa"
-  ],
+  "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/capillari_criogenici.json
+++ b/docs/evo-tactics-pack/traits/strutturale/capillari_criogenici.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "scheletro_idro_regolante",
-    "struttura_elastica_amorfa"
-  ],
+  "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/carapace_fase_variabile.json
+++ b/docs/evo-tactics-pack/traits/strutturale/carapace_fase_variabile.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "struttura_elastica_amorfa"
-  ],
+  "conflitti": ["struttura_elastica_amorfa"],
   "debolezza": "Debolezza strutturale durante la transizione tra le fasi di durezza.",
   "famiglia_tipologia": "Strutturale/Difensivo",
   "fattore_mantenimento_energetico": "Alto (Richiede energia per il cambio di fase)",
@@ -61,13 +59,8 @@
       "hud:PhaseShift_Plate"
     ],
     "combo_totale": 3,
-    "forme": [
-      "Forma:Guardiano_Cangiante",
-      "HUD:Placca_Sintonica"
-    ],
-    "tabelle_random": [
-      "tabella:assetto_fase"
-    ]
+    "forme": ["Forma:Guardiano_Cangiante", "HUD:Placca_Sintonica"],
+    "tabelle_random": ["tabella:assetto_fase"]
   },
   "slot": [],
   "slot_profile": {
@@ -76,5 +69,6 @@
   },
   "spinta_selettiva": "Alternanza tra ambienti con attacchi cinetici pesanti e ambienti che richiedono velocità.",
   "tier": "T1",
-  "uso_funzione": "Durezza/densità del guscio modificabile rapidamente."
+  "uso_funzione": "Durezza/densità del guscio modificabile rapidamente.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/carapace_luminiscente_abissale.json
+++ b/docs/evo-tactics-pack/traits/strutturale/carapace_luminiscente_abissale.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "carapace_fase_variabile"
-  ],
+  "conflitti": ["carapace_fase_variabile"],
   "debolezza": "Luce intensa di superficie sovraccarica i biofotoni rendendo la corazza fragile.",
   "famiglia_tipologia": "Strutturale/Sensoriale",
   "fattore_mantenimento_energetico": "Alto (Bioluminescenza controllata)",
@@ -33,13 +31,8 @@
       "hud:AbyssLight_Array"
     ],
     "combo_totale": 3,
-    "forme": [
-      "Forma:Lanterna_Abissale",
-      "HUD:LuminaNet"
-    ],
-    "tabelle_random": [
-      "tabella:segnali_bioluminosi"
-    ]
+    "forme": ["Forma:Lanterna_Abissale", "HUD:LuminaNet"],
+    "tabelle_random": ["tabella:segnali_bioluminosi"]
   },
   "slot": [],
   "slot_profile": {
@@ -48,5 +41,6 @@
   },
   "spinta_selettiva": "Comunicare e mimetizzarsi nelle profondità prive di luce naturale.",
   "tier": "T3",
-  "uso_funzione": "Emette segnali di branco e devia attacchi grazie a pattern luminosi cangianti."
+  "uso_funzione": "Emette segnali di branco e devia attacchi grazie a pattern luminosi cangianti.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/cartilagini_pseudometalliche.json
+++ b/docs/evo-tactics-pack/traits/strutturale/cartilagini_pseudometalliche.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "scheletro_idro_regolante",
-    "struttura_elastica_amorfa"
-  ],
+  "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/cisti_iperbariche.json
+++ b/docs/evo-tactics-pack/traits/strutturale/cisti_iperbariche.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "scheletro_idro_regolante",
-    "struttura_elastica_amorfa"
-  ],
+  "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/cromofori_alert_acido.json
+++ b/docs/evo-tactics-pack/traits/strutturale/cromofori_alert_acido.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "scheletro_idro_regolante",
-    "struttura_elastica_amorfa"
-  ],
+  "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/denti_tuning_fork.json
+++ b/docs/evo-tactics-pack/traits/strutturale/denti_tuning_fork.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "scheletro_idro_regolante",
-    "struttura_elastica_amorfa"
-  ],
+  "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/filamenti_magnetotrofi.json
+++ b/docs/evo-tactics-pack/traits/strutturale/filamenti_magnetotrofi.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "scheletro_idro_regolante",
-    "struttura_elastica_amorfa"
-  ],
+  "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/ghiandole_condensa_ozono.json
+++ b/docs/evo-tactics-pack/traits/strutturale/ghiandole_condensa_ozono.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "scheletro_idro_regolante",
-    "struttura_elastica_amorfa"
-  ],
+  "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/ghiandole_nebbia_ionica.json
+++ b/docs/evo-tactics-pack/traits/strutturale/ghiandole_nebbia_ionica.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "scheletro_idro_regolante",
-    "struttura_elastica_amorfa"
-  ],
+  "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/lamine_filtranti_aeree.json
+++ b/docs/evo-tactics-pack/traits/strutturale/lamine_filtranti_aeree.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "scheletro_idro_regolante",
-    "struttura_elastica_amorfa"
-  ],
+  "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/membrane_pneumatofori.json
+++ b/docs/evo-tactics-pack/traits/strutturale/membrane_pneumatofori.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "scheletro_idro_regolante",
-    "struttura_elastica_amorfa"
-  ],
+  "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
   "tier": "T1",
-  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
+  "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/scheletro_idro_regolante.json
+++ b/docs/evo-tactics-pack/traits/strutturale/scheletro_idro_regolante.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "sangue_piroforico"
-  ],
+  "conflitti": ["sangue_piroforico"],
   "debolezza": "Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio.",
   "famiglia_tipologia": "Strutturale/Omeostatico",
   "fattore_mantenimento_energetico": "Medio (Scambio rapido di fluidi)",
@@ -52,5 +50,6 @@
   },
   "spinta_selettiva": "Alternare vita terrestre e vita acquatica/aerea.",
   "tier": "T1",
-  "uso_funzione": "Assorbire o espellere rapidamente acqua dai tessuti ossei per modificare il peso."
+  "uso_funzione": "Assorbire o espellere rapidamente acqua dai tessuti ossei per modificare il peso.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/strutturale/struttura_elastica_amorfa.json
+++ b/docs/evo-tactics-pack/traits/strutturale/struttura_elastica_amorfa.json
@@ -64,5 +64,6 @@
   },
   "spinta_selettiva": "Fuga rapida da predatori in spazi confinati.",
   "tier": "T1",
-  "uso_funzione": "Flessibilità estrema e capacità di assumere forme diverse."
+  "uso_funzione": "Flessibilità estrema e capacità di assumere forme diverse.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/supporto/antenne_eco_turbina.json
+++ b/docs/evo-tactics-pack/traits/supporto/antenne_eco_turbina.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "empatia_coordinativa",
-    "risonanza_di_branco"
-  ],
+  "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/supporto/artigli_acidofagi.json
+++ b/docs/evo-tactics-pack/traits/supporto/artigli_acidofagi.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "empatia_coordinativa",
-    "risonanza_di_branco"
-  ],
+  "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/supporto/aura_scudo_radianza.json
+++ b/docs/evo-tactics-pack/traits/supporto/aura_scudo_radianza.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "mantello_meteoritico"
-  ],
+  "conflitti": ["mantello_meteoritico"],
   "debolezza": "Soffre saturazione se esposta a ombre gravitazionali o zone di antimagia.",
   "famiglia_tipologia": "Supporto/Difesa",
   "fattore_mantenimento_energetico": "Alto (Canalizzazione fotonica continua)",
@@ -10,9 +8,7 @@
   "mutazione_indotta": "Innesta organi fotoplasmatici che diffondono uno scudo radiante sugli alleati vicini.",
   "requisiti_ambientali": [
     {
-      "capacita_richieste": [
-        "flight"
-      ],
+      "capacita_richieste": ["flight"],
       "condizioni": {
         "biome_class": "rovine_planari"
       },
@@ -24,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "empatia_coordinativa",
-    "risonanza_di_branco"
-  ],
+  "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -41,5 +34,6 @@
   },
   "spinta_selettiva": "Proteggere gli hub di evacuazione durante tempeste di energia planare.",
   "tier": "T3",
-  "uso_funzione": "Proietta schermature luminose sincronizzate con i segnali tattici della squadra."
+  "uso_funzione": "Proietta schermature luminose sincronizzate con i segnali tattici della squadra.",
+  "data_origin": "pathfinder_dataset"
 }

--- a/docs/evo-tactics-pack/traits/supporto/batteri_termofili_endosimbiosi.json
+++ b/docs/evo-tactics-pack/traits/supporto/batteri_termofili_endosimbiosi.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "empatia_coordinativa",
-    "risonanza_di_branco"
-  ],
+  "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/supporto/branchie_turbina.json
+++ b/docs/evo-tactics-pack/traits/supporto/branchie_turbina.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "empatia_coordinativa",
-    "risonanza_di_branco"
-  ],
+  "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/supporto/carapaci_ferruginosi.json
+++ b/docs/evo-tactics-pack/traits/supporto/carapaci_ferruginosi.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "empatia_coordinativa",
-    "risonanza_di_branco"
-  ],
+  "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/supporto/circolazione_doppia.json
+++ b/docs/evo-tactics-pack/traits/supporto/circolazione_doppia.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "empatia_coordinativa",
-    "risonanza_di_branco"
-  ],
+  "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/supporto/coda_stabilizzatrice_geiser.json
+++ b/docs/evo-tactics-pack/traits/supporto/coda_stabilizzatrice_geiser.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "empatia_coordinativa",
-    "risonanza_di_branco"
-  ],
+  "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/supporto/cuticole_neutralizzanti.json
+++ b/docs/evo-tactics-pack/traits/supporto/cuticole_neutralizzanti.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "empatia_coordinativa",
-    "risonanza_di_branco"
-  ],
+  "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/supporto/empatia_coordinativa.json
+++ b/docs/evo-tactics-pack/traits/supporto/empatia_coordinativa.json
@@ -37,5 +37,6 @@
   },
   "spinta_selettiva": "Turni lunghi con rischio alto in cui serve mitigare tilt e HP critici.",
   "tier": "T1",
-  "uso_funzione": "Collega cooldown difensivi e cura quando la squadra entra in finestra rischio."
+  "uso_funzione": "Collega cooldown difensivi e cura quando la squadra entra in finestra rischio.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/supporto/enzimi_chelatori_rapidi.json
+++ b/docs/evo-tactics-pack/traits/supporto/enzimi_chelatori_rapidi.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "empatia_coordinativa",
-    "risonanza_di_branco"
-  ],
+  "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/supporto/foliage_fotocatodico.json
+++ b/docs/evo-tactics-pack/traits/supporto/foliage_fotocatodico.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "empatia_coordinativa",
-    "risonanza_di_branco"
-  ],
+  "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/supporto/ghiandole_inchiostro_luce.json
+++ b/docs/evo-tactics-pack/traits/supporto/ghiandole_inchiostro_luce.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "empatia_coordinativa",
-    "risonanza_di_branco"
-  ],
+  "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/supporto/gusci_criovetro.json
+++ b/docs/evo-tactics-pack/traits/supporto/gusci_criovetro.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "empatia_coordinativa",
-    "risonanza_di_branco"
-  ],
+  "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/supporto/luminescenza_hydrotermica.json
+++ b/docs/evo-tactics-pack/traits/supporto/luminescenza_hydrotermica.json
@@ -20,10 +20,7 @@
       }
     }
   ],
-  "sinergie": [
-    "empatia_coordinativa",
-    "risonanza_di_branco"
-  ],
+  "sinergie": ["empatia_coordinativa", "risonanza_di_branco"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 2,
@@ -37,5 +34,6 @@
   },
   "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
   "tier": "T1",
-  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
+  "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione.",
+  "data_origin": "coverage_q4_2025"
 }

--- a/docs/evo-tactics-pack/traits/supporto/risonanza_di_branco.json
+++ b/docs/evo-tactics-pack/traits/supporto/risonanza_di_branco.json
@@ -27,30 +27,18 @@
     "aura_scudo_radianza"
   ],
   "sinergie_pi": {
-    "co_occorrenze": [
-      "PE",
-      "cap_pt",
-      "guardia_situazionale",
-      "starter_bioma"
-    ],
+    "co_occorrenze": ["PE", "cap_pt", "guardia_situazionale", "starter_bioma"],
     "combo_totale": 3,
-    "forme": [
-      "ENFJ",
-      "INFP",
-      "ISFJ"
-    ],
+    "forme": ["ENFJ", "INFP", "ISFJ"],
     "tabelle_random": []
   },
-  "slot": [
-    "A",
-    "B",
-    "C"
-  ],
+  "slot": ["A", "B", "C"],
   "slot_profile": {
     "complementare": "coordinazione",
     "core": "supporto"
   },
   "spinta_selettiva": "Forme che eccellono in difesa coordinata e scudi sovrapposti.",
   "tier": "T1",
-  "uso_funzione": "Amplifica buff condivisi sincronizzando i timer di squadra."
+  "uso_funzione": "Amplifica buff condivisi sincronizzando i timer di squadra.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/tegumentario/mimetismo_cromatico_passivo.json
+++ b/docs/evo-tactics-pack/traits/tegumentario/mimetismo_cromatico_passivo.json
@@ -63,5 +63,6 @@
   },
   "spinta_selettiva": "Ambiente con pattern cromatici molto variabili che cambiano lentamente.",
   "tier": "T1",
-  "uso_funzione": "Assorbire e replicare il colore dell'ambiente circostante dopo contatto."
+  "uso_funzione": "Assorbire e replicare il colore dell'ambiente circostante dopo contatto.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/tegumentario/piume_solari_fotovoltaiche.json
+++ b/docs/evo-tactics-pack/traits/tegumentario/piume_solari_fotovoltaiche.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "criostasi_adattiva"
-  ],
+  "conflitti": ["criostasi_adattiva"],
   "debolezza": "Ombre prolungate o polveri dense riducono drasticamente la produzione energetica.",
   "famiglia_tipologia": "Tegumentario/Energetico",
   "fattore_mantenimento_energetico": "Alto (Richiede manutenzione delle lamine fotoreattive)",
@@ -21,10 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "membrane_eliofiltranti",
-    "sacche_spore_stratosferiche"
-  ],
+  "sinergie": ["membrane_eliofiltranti", "sacche_spore_stratosferiche"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -38,5 +33,6 @@
   },
   "spinta_selettiva": "Massimizzare l'autonomia energetica per migrazioni aeree sopra deserti e oceani.",
   "tier": "T2",
-  "uso_funzione": "Convertire la radiazione solare in riserve energetiche per abilità a lungo raggio."
+  "uso_funzione": "Convertire la radiazione solare in riserve energetiche per abilità a lungo raggio.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/tegumentario/secrezione_rallentante_palmi.json
+++ b/docs/evo-tactics-pack/traits/tegumentario/secrezione_rallentante_palmi.json
@@ -1,8 +1,5 @@
 {
-  "conflitti": [
-    "carapace_fase_variabile",
-    "nucleo_ovomotore_rotante"
-  ],
+  "conflitti": ["carapace_fase_variabile", "nucleo_ovomotore_rotante"],
   "debolezza": "Esaurimento rapido delle riserve di liquido con tempo di ricarica prolungato.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
   "fattore_mantenimento_energetico": "Medio (Produzione del liquido)",
@@ -36,5 +33,6 @@
   },
   "spinta_selettiva": "Cattura di prede veloci o difesa da aggressori corpo a corpo.",
   "tier": "T1",
-  "uso_funzione": "Neutralizzare o immobilizzare prede/nemici."
+  "uso_funzione": "Neutralizzare o immobilizzare prede/nemici.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/tegumentario/squame_rifrangenti_deserto.json
+++ b/docs/evo-tactics-pack/traits/tegumentario/squame_rifrangenti_deserto.json
@@ -1,7 +1,5 @@
 {
-  "conflitti": [
-    "mimetismo_cromatico_passivo"
-  ],
+  "conflitti": ["mimetismo_cromatico_passivo"],
   "debolezza": "Soffre danni da feedback termico se colpito da raggi concentrati o laser.",
   "famiglia_tipologia": "Tegumentario/Difensivo",
   "fattore_mantenimento_energetico": "Medio (Richiede riallineamento delle placche)",
@@ -21,9 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "respiro_a_scoppio"
-  ],
+  "sinergie": ["respiro_a_scoppio"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -37,5 +33,6 @@
   },
   "spinta_selettiva": "Sopravvivere a intensi flare termici e accecanti miraggi desertici.",
   "tier": "T2",
-  "uso_funzione": "Rifrange la luce generando miraggi e dissipando attacchi energetici."
+  "uso_funzione": "Rifrange la luce generando miraggi e dissipando attacchi energetici.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/evo-tactics-pack/traits/tegumentario/vello_condensatore_nebbie.json
+++ b/docs/evo-tactics-pack/traits/tegumentario/vello_condensatore_nebbie.json
@@ -19,9 +19,7 @@
       }
     }
   ],
-  "sinergie": [
-    "bulbi_radici_permafrost"
-  ],
+  "sinergie": ["bulbi_radici_permafrost"],
   "sinergie_pi": {
     "co_occorrenze": [],
     "combo_totale": 0,
@@ -35,5 +33,6 @@
   },
   "spinta_selettiva": "Garantire idratazione in climi montani dove l'acqua liquida è scarsa ma la nebbia abbondante.",
   "tier": "T1",
-  "uso_funzione": "Condensa acqua atmosferica per supportare abilità metaboliche ad alto consumo."
+  "uso_funzione": "Condensa acqua atmosferica per supportare abilità metaboliche ad alto consumo.",
+  "data_origin": "controllo_psionico"
 }

--- a/docs/traits_template.md
+++ b/docs/traits_template.md
@@ -37,6 +37,7 @@ rispettare le regole indicate e sono validati automaticamente dal comando
 | `slot`                            | array[string] | ciascun elemento `^[A-Z]$`, array vuoto consentito   | Slot occupati.                                                           |
 | `sinergie`                        | array[string] | elementi `^[a-z0-9_]+$`                              | Trait compatibili.                                                       |
 | `conflitti`                       | array[string] | elementi `^[a-z0-9_]+$`                              | Trait incompatibili.                                                     |
+| `data_origin`                     | string        | `^[a-z0-9_]+$`                                       | Fonte editoriale/glossario (es. `controllo_psionico`).                   |
 | `mutazione_indotta`               | string        | non vuota                                            | Sintesi dell'adattamento.                                                |
 | `uso_funzione`                    | string        | non vuota                                            | Funzione in gioco.                                                       |
 | `spinta_selettiva`                | string        | non vuota                                            | Motivazione evolutiva/tattica.                                           |
@@ -57,6 +58,7 @@ per riflettere la modifica nelle localizzazioni.
   "slot": [],
   "sinergie": [],
   "conflitti": [],
+  "data_origin": "controllo_psionico",
   "mutazione_indotta": "Descrizione sintetica.",
   "uso_funzione": "Uso principale.",
   "spinta_selettiva": "Motivazione principale."
@@ -71,7 +73,6 @@ per riflettere la modifica nelle localizzazioni.
 | `requisiti_ambientali` | Array di vincoli contestuali. Ogni elemento include `condizioni.biome_class`, la sorgente (`fonte`) e facoltativamente `capacita_richieste` e `meta` (`expansion`, `tier`, `notes`). |
 | `biome_tags`           | Array di biomi affini (stringhe `^[a-z0-9_]+$`) usati per indicare ambienti secondari o sinergie narrative.                                                                          |
 | `usage_tags`           | Array di tag tattici (`scout`, `breaker`, `tank`, ecc.) normalizzati (`^[a-z0-9_]+$`) per filtri UI e analytics.                                                                     |
-| `data_origin`          | Stringa (`^[a-z0-9_]+$`) che identifica il pacchetto o la fonte editoriale (es. `controllo_psionico`, `coverage_q4_2025`).                                                           |
 | `completion_flags`     | Oggetto di flag booleani (es. `has_biome`, `has_species_link`) per tracciare rapidamente lacune editoriali.                                                                          |
 | `debolezza`            | Stringa opzionale per limiti intrinseci o vulnerabilità.                                                                                                                             |
 | `sinergie_pi`          | Oggetto con `co_occorrenze`, `forme`, `tabelle_random`, `combo_totale`. Serve per gli strumenti di pianificazione PI.                                                                |

--- a/logs/qa/latest-dashboard-metrics.json
+++ b/logs/qa/latest-dashboard-metrics.json
@@ -41,5 +41,65 @@
     "score": 0.0,
     "tolerance": 0.08,
     "snapshot": "logs/visual_runs/20251027T042511Z/generator.png"
-  }
+  },
+  "styleguide": {
+    "generated_at": "2025-11-03T19:52:35Z",
+    "kpi": {
+      "name_compliance": {
+        "label": "Nomi conformi",
+        "compliant": 174,
+        "total": 174,
+        "percent": 100.0,
+        "violations": [],
+        "sla_threshold": 0.95,
+        "status": "ok"
+      },
+      "description_completeness": {
+        "label": "Descrizioni complete",
+        "compliant": 174,
+        "total": 174,
+        "percent": 100.0,
+        "violations": [],
+        "sla_threshold": 0.95,
+        "status": "ok"
+      },
+      "ucum_presence": {
+        "label": "UCUM presenti",
+        "compliant": 174,
+        "total": 174,
+        "percent": 100.0,
+        "violations": [],
+        "sla_threshold": 0.8,
+        "status": "ok"
+      }
+    },
+    "summary": {
+      "breach_count": 0,
+      "breach_labels": [],
+      "overview": [
+        {
+          "metric": "name_compliance",
+          "label": "Nomi conformi",
+          "percent": 100.0,
+          "status": "ok",
+          "sla_threshold": 0.95
+        },
+        {
+          "metric": "description_completeness",
+          "label": "Descrizioni complete",
+          "percent": 100.0,
+          "status": "ok",
+          "sla_threshold": 0.95
+        },
+        {
+          "metric": "ucum_presence",
+          "label": "UCUM presenti",
+          "percent": 100.0,
+          "status": "ok",
+          "sla_threshold": 0.8
+        }
+      ]
+    }
+  },
+  "styleguide_generated_at": "2025-11-03T19:52:35Z"
 }

--- a/logs/trait_audit/styleguide_compliance_history.json
+++ b/logs/trait_audit/styleguide_compliance_history.json
@@ -30,5 +30,64 @@
         "status": "ok"
       }
     }
+  },
+  {
+    "generated_at": "2025-11-03T19:52:35Z",
+    "kpi": {
+      "name_compliance": {
+        "label": "Nomi conformi",
+        "compliant": 174,
+        "total": 174,
+        "percent": 100.0,
+        "violations": [],
+        "sla_threshold": 0.95,
+        "status": "ok"
+      },
+      "description_completeness": {
+        "label": "Descrizioni complete",
+        "compliant": 174,
+        "total": 174,
+        "percent": 100.0,
+        "violations": [],
+        "sla_threshold": 0.95,
+        "status": "ok"
+      },
+      "ucum_presence": {
+        "label": "UCUM presenti",
+        "compliant": 174,
+        "total": 174,
+        "percent": 100.0,
+        "violations": [],
+        "sla_threshold": 0.8,
+        "status": "ok"
+      }
+    },
+    "summary": {
+      "breach_count": 0,
+      "breach_labels": [],
+      "overview": [
+        {
+          "metric": "name_compliance",
+          "label": "Nomi conformi",
+          "percent": 100.0,
+          "status": "ok",
+          "sla_threshold": 0.95
+        },
+        {
+          "metric": "description_completeness",
+          "label": "Descrizioni complete",
+          "percent": 100.0,
+          "status": "ok",
+          "sla_threshold": 0.95
+        },
+        {
+          "metric": "ucum_presence",
+          "label": "UCUM presenti",
+          "percent": 100.0,
+          "status": "ok",
+          "sla_threshold": 0.8
+        }
+      ]
+    }
   }
 ]

--- a/logs/trait_audit/trait_progress_history.json
+++ b/logs/trait_audit/trait_progress_history.json
@@ -2,6 +2,16 @@
   {
     "timestamp": "2025-11-01T14:28:42.023736+00:00",
     "metrics": {
+      "completion_flags": {
+        "total_traits": 174,
+        "traits_with_value": 1,
+        "percent": 0.5747126436781609
+      },
+      "data_origin": {
+        "total_traits": 174,
+        "traits_with_value": 1,
+        "percent": 0.5747126436781609
+      },
       "species_affinity": {
         "total_traits": 174,
         "traits_with_value": 173,
@@ -16,16 +26,36 @@
         "total_traits": 174,
         "traits_with_value": 1,
         "percent": 0.5747126436781609
+      }
+    }
+  },
+  {
+    "timestamp": "2025-11-03T19:52:40.928056+00:00",
+    "metrics": {
+      "species_affinity": {
+        "total_traits": 174,
+        "traits_with_value": 174,
+        "percent": 100.0
+      },
+      "biome_tags": {
+        "total_traits": 174,
+        "traits_with_value": 1,
+        "percent": 0.5747126436781609
+      },
+      "usage_tags": {
+        "total_traits": 174,
+        "traits_with_value": 174,
+        "percent": 100.0
       },
       "completion_flags": {
         "total_traits": 174,
-        "traits_with_value": 1,
-        "percent": 0.5747126436781609
+        "traits_with_value": 174,
+        "percent": 100.0
       },
       "data_origin": {
         "total_traits": 174,
-        "traits_with_value": 1,
-        "percent": 0.5747126436781609
+        "traits_with_value": 174,
+        "percent": 100.0
       }
     }
   }

--- a/reports/styleguide_compliance.json
+++ b/reports/styleguide_compliance.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2025-11-02T14:11:27Z",
+  "generated_at": "2025-11-03T19:52:35Z",
   "kpi": {
     "name_compliance": {
       "label": "Nomi conformi",
@@ -28,5 +28,32 @@
       "sla_threshold": 0.8,
       "status": "ok"
     }
+  },
+  "summary": {
+    "breach_count": 0,
+    "breach_labels": [],
+    "overview": [
+      {
+        "metric": "name_compliance",
+        "label": "Nomi conformi",
+        "percent": 100.0,
+        "status": "ok",
+        "sla_threshold": 0.95
+      },
+      {
+        "metric": "description_completeness",
+        "label": "Descrizioni complete",
+        "percent": 100.0,
+        "status": "ok",
+        "sla_threshold": 0.95
+      },
+      {
+        "metric": "ucum_presence",
+        "label": "UCUM presenti",
+        "percent": 100.0,
+        "status": "ok",
+        "sla_threshold": 0.8
+      }
+    ]
   }
 }

--- a/reports/styleguide_compliance.md
+++ b/reports/styleguide_compliance.md
@@ -1,6 +1,6 @@
 # Styleguide Compliance
 
-_Aggiornato al 2025-11-02T20:15:42Z_
+_Aggiornato al 2025-11-03T19:52:35Z_
 
 ## KPI correnti
 
@@ -12,16 +12,19 @@ _Aggiornato al 2025-11-02T20:15:42Z_
 
 ## Anomalie principali
 
-Nessuna anomalia aperta: tutti i controlli risultano conformi alle soglie dello styleguide.
+- **Nomi conformi**: nessuna anomalia
+- **Descrizioni complete**: nessuna anomalia
+- **UCUM presenti**: nessuna anomalia
 
 ## Trend storico
 
 | Data | Nomi conformi | Descrizioni complete | UCUM presenti |
 | --- | ---: | ---: | ---: |
 | 2025-11-02 | 100.0% | 100.0% | 100.0% |
+| 2025-11-03 | 100.0% | 100.0% | 100.0% |
 
 ## Azioni consigliate
 
-- Continuare a validare i nuovi tratti con `trait_template_validator.py` per evitare regressioni.
-- Coordinare localization e narrativa per mantenere aggiornata la terminologia condivisa.
-- Integrare i controlli automatici nelle pipeline CI per garantire la copertura completa prima del rilascio.
+- Coordinare localization e narrativa per chiudere i gap di glossario quando segnalati.
+- Prioritizzare l'allineamento delle unità UCUM nelle metriche prima delle milestone di bilanciamento.
+- Validare i nuovi tratti con `trait_template_validator.py` per prevenire regressioni sullo styleguide.

--- a/reports/styleguide_status_review.md
+++ b/reports/styleguide_status_review.md
@@ -20,41 +20,28 @@ incompleti da colmare per considerare il progetto terminato.
 
 | Area | Stato attuale | Fonte |
 | --- | --- | --- |
-| **Specie collegate** | 1 tratto (`random`) privo di `species_affinity` | `data/traits/index.json`
+| **Specie collegate** | Copertura completa | `data/traits/index.json`
 | **Tag bioma** | 173 tratti ancora senza `biome_tags` | `reports/trait_progress.md`
-| **Tag d'uso** | 173 tratti privi di `usage_tags` | `reports/trait_progress.md`
-| **Origine dati** | 173 tratti senza `data_origin` | `reports/trait_progress.md`
+| **Tag d'uso** | Copertura completa | `reports/trait_progress.md`
+| **Origine dati** | Copertura completa | `reports/trait_progress.md`
 
 ## Piano di chiusura
 
-1. **Collegare i tratti orfani a specie specifiche**
-   - Aggiornare `data/traits/strategia/random.json` completando `species_affinity` e riflettere il
-     collegamento anche in `data/traits/index.json`.
-   - Rieseguire `python tools/py/build_species_trait_bridge.py` per validare che gli hook
-     specie ↔ tratto restino coerenti dopo l'aggiornamento.
+1. **Mantenere la copertura delle specie collegate**
+   - Verificare ogni nuovo tratto o revisione su `data/traits/` assicurandosi che `species_affinity` resti valorizzato.
+   - Rieseguire `python tools/py/build_species_trait_bridge.py` dopo inserimenti massivi per intercettare regressioni sugli hook specie ↔ tratto.
 
-2. **Popolare `biome_tags` e requisiti ambientali mancanti**
-   - Priorità ai tratti già utilizzati nei pacchetti (`coverage_q4_2025`, `controllo_psionico`).
-   - Usare `tools/py/normalize_trait_style.py --dry-run` per evidenziare i file privi di metadati
-     e aggiornare gradualmente le liste di bioma, seguendo le corrispondenze in
-     `packs/evo_tactics_pack/docs/catalog/env_traits.json`.
+2. **Popolare i `biome_tags` mancanti**
+   - Priorità ai 173 tratti privi di annotazioni, soprattutto quelli già presenti nei pacchetti (`coverage_q4_2025`, `controllo_psionico`).
+   - Usare `tools/py/normalize_trait_style.py --dry-run` per identificare i file scoperti e colmare gradualmente le liste di bioma con riferimento a `packs/evo_tactics_pack/docs/catalog/env_traits.json`.
 
-3. **Definire i `usage_tags` tattici**
-   - Adottare il vocabolario documentato in `docs/process/trait_data_reference.md` e annotare i ruoli
-     principali (es. `scout`, `breaker`, `support`).
-   - Automatizzare il controllo aggiungendo i tag mancanti alla checklist dell'editor (`webapp`)
-     e rieseguendo `npm run style:check` per assicurare la copertura completa.
+3. **Presidiare i `usage_tags` tattici**
+   - Continuare a usare il vocabolario in `docs/process/trait_data_reference.md` e validare che ogni nuovo tratto mantenga i tag esistenti.
+   - Integrare il controllo nella checklist editoriale e rieseguire `npm run style:check` quando vengono introdotte nuove tipologie.
 
-4. **Compilare `data_origin` per il catalogo canonico**
-   - Creare una mappa sorgenti → slug (`controllo_psionico`, `coverage_q4_2025`, ecc.) nel
-     glossario editoriale e applicarla batch con `tools/py/normalize_trait_style.py`.
-   - Aggiornare `docs/traits_template.md` con una nota rapida che ricordi di impostare sempre
-     `data_origin` durante la creazione di nuovi tratti.
-
-5. **Report di chiusura**
-   - Dopo aver popolato i campi, rigenerare `reports/trait_progress.md` e `reports/styleguide_compliance.md`
-     per ottenere un'istantanea finale.
-   - Allegare gli output ai prossimi PR insieme alla checklist di conformità.
+4. **Consolidare `data_origin` nel catalogo**
+   - Riutilizzare la mappa sorgenti → slug del glossario editoriale e applicarla immediatamente ai nuovi tratti o alle revisioni.
+   - Programmare verifiche periodiche con `tools/py/normalize_trait_style.py` per assicurare che la copertura resti completa dopo merge multipli.
 
 Seguendo il piano sopra, la style guide risulterà completamente applicata a dati, workflow e
 strumenti, chiudendo le ultime lacune operative.

--- a/reports/trait_fields_by_type.json
+++ b/reports/trait_fields_by_type.json
@@ -2,8 +2,10 @@
   "Difesa/Strutturale": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -17,14 +19,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Difesa/Termoregolazione": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -38,14 +43,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Digestivo/Alimentare": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -59,14 +67,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Digestivo/Escretorio": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -80,14 +91,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Digestivo/Metabolico": {
     "trait_count": 13,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -101,14 +115,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Escretorio/Psichico": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -122,6 +139,7 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
@@ -152,8 +170,10 @@
   "Flessibile/Generico": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -165,16 +185,20 @@
       "sinergie_pi",
       "slot",
       "slot_profile",
+      "species_affinity",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Idrostatico/Locomotorio": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -188,14 +212,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Locomotorio/Adattivo": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -209,14 +236,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Locomotorio/Difensivo": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -230,14 +260,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Locomotorio/Mobilità": {
     "trait_count": 14,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -251,14 +284,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Locomotorio/Predatorio": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -272,14 +308,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Locomotorio/Prensile": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -293,14 +332,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Locomotorio/Supporto": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -314,14 +356,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Metabolico/Difensivo": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -335,14 +380,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Metabolico/Resilienza": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -356,14 +404,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Mobilità/Cinetico": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -377,14 +428,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Nervoso/Omeostatico": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -398,14 +452,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Offensivo/Assalto": {
     "trait_count": 13,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -419,14 +476,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Offensivo/Chimico": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -440,14 +500,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Offensivo/Cinetico": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -461,14 +524,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Offensivo/Controllo": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -482,14 +548,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Respiratorio/Aerobico": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -503,14 +572,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Respiratorio/Osmoregolazione": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -524,14 +596,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Respiratorio/Propulsivo": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -545,14 +620,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Respiratorio/Protezione": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -566,14 +644,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Respiratorio/Termoregolazione": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -587,14 +668,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Riproduttivo/Locomotorio": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -608,14 +692,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Sensoriale/Alimentare": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -629,14 +716,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Sensoriale/Analitico": {
     "trait_count": 14,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -650,14 +740,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Sensoriale/Navigazione": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -671,14 +764,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Sensoriale/Nervoso": {
     "trait_count": 2,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -692,14 +788,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Sensoriale/Offensivo": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -713,14 +812,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Sensoriale/Supporto": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -734,14 +836,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Sensoriale/Visivo": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -755,14 +860,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Simbiotico/Comunicazione": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -776,14 +884,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Simbiotico/Cooperativo": {
     "trait_count": 13,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -797,14 +908,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Simbiotico/Difensivo": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -818,14 +932,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Simbiotico/Nervoso": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -839,14 +956,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Simbiotico/Nutrizione": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -860,14 +980,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Simbiotico/Supporto": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -881,14 +1004,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Simbiotico/Utility": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -902,14 +1028,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Strategico/Psionico": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -923,14 +1052,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Strategico/Tattico": {
     "trait_count": 15,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -944,14 +1076,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Strutturale/Adattivo": {
     "trait_count": 13,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -965,14 +1100,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Strutturale/Difensivo": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -986,14 +1124,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Strutturale/Locomotorio": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -1007,14 +1148,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Strutturale/Omeostatico": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -1028,14 +1172,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Strutturale/Sensoriale": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -1049,14 +1196,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Supporto/Coordinativo": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -1070,14 +1220,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Supporto/Difesa": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -1091,14 +1244,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Supporto/Empatico": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -1112,14 +1268,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Supporto/Logistico": {
     "trait_count": 13,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -1133,6 +1292,7 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
@@ -1158,8 +1318,10 @@
   "Tegumentario/Difensivo": {
     "trait_count": 17,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -1173,14 +1335,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Tegumentario/Energetico": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -1194,14 +1359,17 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   },
   "Tegumentario/Idratazione": {
     "trait_count": 1,
     "fields": [
+      "biome_tags",
       "completion_flags",
       "conflitti",
+      "data_origin",
       "debolezza",
       "famiglia_tipologia",
       "fattore_mantenimento_energetico",
@@ -1215,6 +1383,7 @@
       "slot_profile",
       "spinta_selettiva",
       "tier",
+      "usage_tags",
       "uso_funzione"
     ]
   }

--- a/reports/trait_progress.md
+++ b/reports/trait_progress.md
@@ -1,27 +1,31 @@
 # Trait Completion Dashboard
 
-_Aggiornato al 2025-11-02 20:15 UTC, totale tratti: 174_
+_Aggiornato al 2025-11-03 19:52 UTC, totale tratti: 174_
 
 ## KPI principali
 
 | Indicatore | Tratti con dato | Totale | Copertura |
 | --- | ---: | ---: | --- |
 | Specie collegate | 174 | 174 | 100.0% |
-| Tag bioma | 174 | 174 | 100.0% |
+| Tag bioma | 1 | 174 | 0.6% |
 | Tag d'uso | 174 | 174 | 100.0% |
 | Flag completamento | 174 | 174 | 100.0% |
 | Origine dati | 174 | 174 | 100.0% |
 
 ### Gap principali
 
-Nessun gap aperto: tutte le metriche hanno raggiunto il 100% di copertura.
+- **Specie collegate**: copertura completa ✅
+- **Tag bioma**: 173 tratti senza dato → `ali_fulminee, ali_ioniche, ali_membrana_sonica, antenne_dustsense, antenne_eco_turbina` … (+168 altri)
+- **Tag d'uso**: copertura completa ✅
+- **Flag completamento**: copertura completa ✅
+- **Origine dati**: copertura completa ✅
 
 ## Trend storico
 
 | Data | Specie collegate | Tag bioma | Tag d'uso | Flag completamento | Origine dati |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | 2025-11-01 | 99.4% | 0.6% | 0.6% | 0.6% | 0.6% |
-| 2025-11-02 | 100.0% | 100.0% | 100.0% | 100.0% | 100.0% |
+| 2025-11-03 | 100.0% | 0.6% | 100.0% | 100.0% | 100.0% |
 
 ## Styleguide compliance
 
@@ -35,6 +39,7 @@ _Dettagli completi nel report `reports/styleguide_compliance.md`._
 
 ## Interpretazione
 
-- L'allineamento con il bestiario è completo: ogni tratto ha le specie collegate.
-- La tassonomia dei tag bioma e dei tag d'uso è stata completata e verificata.
-- Flag di completamento e origine dati sono mappati su tutto l'inventario, indicando una copertura totale e consistente.
+- **Specie collegate** misura quante mutazioni hanno già un'ancora con il bestiario.
+- **Tag bioma** e **Tag d'uso** sono ancora sperimentali: il dashboard aiuta a individuare i tratti da prioritizzare per completare la tassonomia.
+- **Flag completamento** e **Origine dati** sono pensati per segnalare la qualità dell'inventario: una copertura bassa suggerisce di allineare i registri di editing.
+

--- a/reports/trait_texts.json
+++ b/reports/trait_texts.json
@@ -1,0 +1,1742 @@
+{
+  "antenne_plasmatiche_tempesta": {
+    "en": {
+      "label": "Storm Plasma Antennae",
+      "description": "Channels storm lightning into psionic strikes or shields."
+    },
+    "it": {
+      "label": "Antenne Plasmatiche di Tempesta",
+      "description": "Convoglia fulmini atmosferici in attacchi mirati o scudi ionici."
+    }
+  },
+  "artigli_sette_vie": {
+    "en": {
+      "label": "Seven-Way Talons",
+      "description": "Multi-hook talons locking a steady grip on irregular surfaces."
+    },
+    "it": {
+      "label": "Artigli a Sette Vie",
+      "description": "Artigli multipli che assicurano presa stabile su superfici irregolari."
+    }
+  },
+  "artigli_sghiaccio_glaciale": {
+    "en": {
+      "label": "Artigli Sghiaccio Glaciale",
+      "description": "Cryogenic claws that freeze and pin targets on contact."
+    },
+    "it": {
+      "label": "Artigli Sghiaccio Glaciale",
+      "description": "Falangi criogeniche che congelano e fissano il bersaglio al contatto."
+    }
+  },
+  "branchie_osmotiche_salmastra": {
+    "en": {
+      "label": "Branchie Osmotiche Salmastre",
+      "description": "Psionic gills filtering salts and toxins in shifting waters."
+    },
+    "it": {
+      "label": "Branchie Osmotiche Salmastre",
+      "description": "Branchie psioniche che filtrano sali e tossine in acque variabili."
+    }
+  },
+  "bulbi_radici_permafrost": {
+    "en": {
+      "label": "Bulbi Radici del Permafrost",
+      "description": "Root bulbs releasing heat and stores to linked allies."
+    },
+    "it": {
+      "label": "Bulbi Radici del Permafrost",
+      "description": "Bulbi radice che rilasciano calore e nutrimento alle unità connesse."
+    }
+  },
+  "carapace_fase_variabile": {
+    "en": {
+      "label": "Phase-Shifting Carapace",
+      "description": "Shell shifts density to balance defense and mobility."
+    },
+    "it": {
+      "label": "Carapace a Variazione di Fase",
+      "description": "Corazza che varia densità per bilanciare difesa e mobilità."
+    }
+  },
+  "carapace_luminiscente_abissale": {
+    "en": {
+      "label": "Carapace Luminiscente Abissale",
+      "description": "Bioluminescent shell confusing predators in abyssal dark."
+    },
+    "it": {
+      "label": "Carapace Luminiscente Abissale",
+      "description": "Guscio bioluminescente che confonde i predatori nelle profondità."
+    }
+  },
+  "cartilagine_flessotermica_venti": {
+    "en": {
+      "label": "Cartilagine Flessotermica dei Venti",
+      "description": "Thermo-reactive cartilage optimizing aerial turns."
+    },
+    "it": {
+      "label": "Cartilagine Flessotermica dei Venti",
+      "description": "Cartilagine termoreattiva che ottimizza virate e planate aeree."
+    }
+  },
+  "cavita_risonanti_tundra": {
+    "en": {
+      "label": "Cavità Risonanti della Tundra",
+      "description": "Chest chambers projecting long-range calls through tundra frost."
+    },
+    "it": {
+      "label": "Cavità Risonanti della Tundra",
+      "description": "Camere toraciche che proiettano richiami a lunga distanza nel gelo."
+    }
+  },
+  "chioma_parassita_canopica": {
+    "en": {
+      "label": "Chioma Parassita Canopica",
+      "description": "Parasitic tendrils weaving energy lanes through canopy."
+    },
+    "it": {
+      "label": "Chioma Parassita Canopica",
+      "description": "Filamenti parassiti che creano corsie energetiche nella canopia."
+    }
+  },
+  "circolazione_bifasica_palude": {
+    "en": {
+      "label": "Swamp Biphase Circulation",
+      "description": "Dual blood circuits separating oxygen flow from toxins in stagnant wetlands."
+    },
+    "it": {
+      "label": "Circolazione Bifasica di Palude",
+      "description": "Doppio circuito sanguigno che separa ossigeno e agenti tossici in ambienti stagnanti."
+    }
+  },
+  "coda_frusta_cinetica": {
+    "en": {
+      "label": "Kinetic Lash Tail",
+      "description": "Elastic tail storing momentum for a devastating lash."
+    },
+    "it": {
+      "label": "Coda a Frusta Cinetica",
+      "description": "Coda elastica che accumula slancio per un colpo cinetico devastante."
+    }
+  },
+  "criostasi_adattiva": {
+    "en": {
+      "label": "Adaptive Cryostasis",
+      "description": "Suspended metabolism surviving protracted extreme seasons."
+    },
+    "it": {
+      "label": "Criostasi",
+      "description": "Metabolismo sospeso che sopravvive a stagioni estreme prolungate."
+    }
+  },
+  "eco_interno_riflesso": {
+    "en": {
+      "label": "Internal Echo Reflex",
+      "description": "Internal sonar mapping surroundings via body reverbs."
+    },
+    "it": {
+      "label": "Riflesso dell'Eco Interno",
+      "description": "Sonar interno che mappa l'ambiente attraverso vibrazioni corporee."
+    }
+  },
+  "empatia_coordinativa": {
+    "en": {
+      "label": "Coordinated Empathy",
+      "description": "Empathic mesh synchronizing team-wide heals and defenses."
+    },
+    "it": {
+      "label": "Empatia Coordinativa",
+      "description": "Rete empatica che sincronizza cure e difese dell'intera squadra."
+    }
+  },
+  "filamenti_digestivi_compattanti": {
+    "en": {
+      "label": "Digestive Compaction Filaments",
+      "description": "Digestive filaments compact waste to free vital space."
+    },
+    "it": {
+      "label": "Filamenti Digestivi Compattanti",
+      "description": "Filamenti digestivi che compattano scarti e liberano spazio vitale."
+    }
+  },
+  "focus_frazionato": {
+    "en": {
+      "label": "Fractional Focus",
+      "description": "Split cortex keeps two threats under active surveillance."
+    },
+    "it": {
+      "label": "Focus Frazionato",
+      "description": "Cortex biforcato che mantiene due minacce in sorveglianza attiva."
+    }
+  },
+  "ghiandola_caustica": {
+    "en": {
+      "label": "Caustic Gland",
+      "description": "Offensive gland spraying quick acid against light armor."
+    },
+    "it": {
+      "label": "Ghiandola Caustica",
+      "description": "Ghiandola offensiva che spruzza acidi rapidi contro corazze leggere."
+    }
+  },
+  "lamelle_termoforetiche": {
+    "en": {
+      "label": "Thermophoretic Lamellae",
+      "description": "Respiratory lamellae deflect extreme gases via heat gradients."
+    },
+    "it": {
+      "label": "Lamelle Termoforetiche",
+      "description": "Lamelle respiratorie che deviano gas estremi con gradienti termici."
+    }
+  },
+  "lingua_tattile_trama": {
+    "en": {
+      "label": "Texture-Sensing Tongue",
+      "description": "Sensory tongue reading hidden vibrations and fractures."
+    },
+    "it": {
+      "label": "Lingua Tattile Trama-Sensibile",
+      "description": "Lingua sensoriale che legge vibrazioni e fratture nascoste."
+    }
+  },
+  "membrane_eliofiltranti": {
+    "en": {
+      "label": "Membrane Eliofiltranti",
+      "description": "Translucent membranes screening radiation and airborne pathogens."
+    },
+    "it": {
+      "label": "Membrane Eliofiltranti",
+      "description": "Membrane traslucide che schermano radiazioni e patogeni sospesi."
+    }
+  },
+  "mimetismo_cromatico_passivo": {
+    "en": {
+      "label": "Passive Chromatic Mimicry",
+      "description": "Passive chromatophores slowly mirroring surrounding hues."
+    },
+    "it": {
+      "label": "Ghiandole di Mimetismo Cromatico Passivo",
+      "description": "Cromatofori passivi che replicano lentamente i colori circostanti."
+    }
+  },
+  "mucillagine_simbionte_mangrovie": {
+    "en": {
+      "label": "Mucillagine Simbionte delle Mangrovie",
+      "description": "Symbiotic mucus absorbing poisons and sealing swamp wounds."
+    },
+    "it": {
+      "label": "Mucillagine Simbionte delle Mangrovie",
+      "description": "Mucosa simbionte che assorbe veleni e sigilla ferite palustri."
+    }
+  },
+  "nodi_micorrizici_oracolari": {
+    "en": {
+      "label": "Nodi Micorrizici Oracolari",
+      "description": "Mycorrhizal nodes foreseeing threats via fungal signals."
+    },
+    "it": {
+      "label": "Nodi Micorrizici Oracolari",
+      "description": "Nodi micorrizici che anticipano minacce tramite segnali fungini."
+    }
+  },
+  "nucleo_ovomotore_rotante": {
+    "en": {
+      "label": "Rotating Ovomotor Core",
+      "description": "Rotating core turning the body into a driving wheel."
+    },
+    "it": {
+      "label": "Uovo rotaia, uovo grande e uova piccole dentro...",
+      "description": "Nucleo rotante che trasforma il corpo in una ruota motrice."
+    }
+  },
+  "occhi_infrarosso_composti": {
+    "en": {
+      "label": "Infrared Compound Eyes",
+      "description": "Infrared ommatidia tracking thermal trails in darkness."
+    },
+    "it": {
+      "label": "Occhi Composti ad Infrarosso",
+      "description": "Ommatidi infrarossi che seguono scie termiche nell'oscurità."
+    }
+  },
+  "olfatto_risonanza_magnetica": {
+    "en": {
+      "label": "Magnetic Resonance Scent",
+      "description": "Olfactory nodes tracing magnetic fields and metal veins."
+    },
+    "it": {
+      "label": "Olfatto di Risonanza Magnetica",
+      "description": "Bulbi olfattivi che tracciano campi magnetici e vene metalliche."
+    }
+  },
+  "pathfinder": {
+    "en": {
+      "label": "Pathfinder",
+      "description": "Exploration suite highlighting safe routes across shifting biomes."
+    },
+    "it": {
+      "label": "Pathfinder",
+      "description": "Suite esplorativa che evidenzia rotte sicure tra biomi imprevedibili."
+    }
+  },
+  "pianificatore": {
+    "en": {
+      "label": "Strategic Planner",
+      "description": "Strategic module keeping priorities and attack windows aligned."
+    },
+    "it": {
+      "label": "Pianificatore",
+      "description": "Modulo strategico che mantiene priorità e finestre d'attacco allineate."
+    }
+  },
+  "piume_solari_fotovoltaiche": {
+    "en": {
+      "label": "Piume Solari Fotovoltaiche",
+      "description": "Photovoltaic plumage storing sunlight for long sorties."
+    },
+    "it": {
+      "label": "Piume Solari Fotovoltaiche",
+      "description": "Piumaggio fotovoltaico che immagazzina luce per lunghe missioni."
+    }
+  },
+  "polmoni_cristallini_alta_quota": {
+    "en": {
+      "label": "Polmoni Cristallini d'Alta Quota",
+      "description": "Crystalline lungs concentrating thin high-altitude oxygen."
+    },
+    "it": {
+      "label": "Polmoni Cristallini d'Alta Quota",
+      "description": "Polmoni cristallini che concentrano ossigeno rarefatto in quota."
+    }
+  },
+  "random": {
+    "en": {
+      "label": "Trait Random",
+      "description": "Experimental slot drawing random traits from a curated pool."
+    },
+    "it": {
+      "label": "Trait Random",
+      "description": "Slot sperimentale che estrae tratti casuali dal pool controllato."
+    }
+  },
+  "respiro_a_scoppio": {
+    "en": {
+      "label": "Burst Breath Propulsion",
+      "description": "Thoracic valves unleashing instantaneous propulsion bursts."
+    },
+    "it": {
+      "label": "Respiro a scoppio",
+      "description": "Valvole toraciche che rilasciano getti propulsivi istantanei."
+    }
+  },
+  "risonanza_di_branco": {
+    "en": {
+      "label": "Pack Resonance",
+      "description": "Resonant lattice amplifying the pack's shared buffs."
+    },
+    "it": {
+      "label": "Risonanza di Branco",
+      "description": "Rete risonante che amplifica buff condivisi del branco."
+    }
+  },
+  "sacche_galleggianti_ascensoriali": {
+    "en": {
+      "label": "Elevating Buoyancy Sacs",
+      "description": "Adjustable gas sacs controlling buoyancy and depth."
+    },
+    "it": {
+      "label": "Sacche galleggianti ascensoriali",
+      "description": "Sacche gassose regolabili per controllare assetto e profondità."
+    }
+  },
+  "sacche_spore_stratosferiche": {
+    "en": {
+      "label": "Sacche di Spore Stratosferiche",
+      "description": "Stratospheric vesicles dispersing long-range support spores."
+    },
+    "it": {
+      "label": "Sacche di Spore Stratosferiche",
+      "description": "Vescicole stratosferiche che disperdono spore di supporto a lungo."
+    }
+  },
+  "sangue_piroforico": {
+    "en": {
+      "label": "Pyrophoric Blood",
+      "description": "Blood ignites on air contact, burning would-be piercers."
+    },
+    "it": {
+      "label": "Sangue che prende fuoco a contatto con l'ossigeno",
+      "description": "Fluido ematico che incendia l'aria colpendo chi perfora la corazza."
+    }
+  },
+  "scheletro_idro_regolante": {
+    "en": {
+      "label": "Hydro-Regulating Skeleton",
+      "description": "Porous bones modulate water content to shift body mass."
+    },
+    "it": {
+      "label": "Scheletro Idro-Regolante",
+      "description": "Ossa porose che modulano il contenuto idrico per mutare massa."
+    }
+  },
+  "secrezione_rallentante_palmi": {
+    "en": {
+      "label": "Retarding Palm Secretions",
+      "description": "Palms exude slowing gel to snare fast targets."
+    },
+    "it": {
+      "label": "Mani secernano liquido rallentante",
+      "description": "Palmi che rilasciano gel rallentante per bloccare bersagli rapidi."
+    }
+  },
+  "sensori_geomagnetici": {
+    "en": {
+      "label": "Geomagnetic Resonance Sensors",
+      "description": "Cranial crystals mapping invisible geomagnetic corridors."
+    },
+    "it": {
+      "label": "Sensori a Risonanza Geomagnetica",
+      "description": "Cristalli cranici che mappano corridoi geomagnetici invisibili."
+    }
+  },
+  "sinapsi_coraline_polifoniche": {
+    "en": {
+      "label": "Sinapsi Coraline Polifoniche",
+      "description": "Coralline synapses relaying orders through marine harmonics."
+    },
+    "it": {
+      "label": "Sinapsi Coraline Polifoniche",
+      "description": "Sinapsi coralline che trasmettono ordini tramite armoniche marine."
+    }
+  },
+  "sonno_emisferico_alternato": {
+    "en": {
+      "label": "Unihemispheric Sleep",
+      "description": "Alternating hemispheres keep watch while the other sleeps."
+    },
+    "it": {
+      "label": "Dormire con solo metà cervello alla volta",
+      "description": "Cervello alternato che veglia con un emisfero mentre l'altro riposa."
+    }
+  },
+  "spore_psichiche_silenziate": {
+    "en": {
+      "label": "Silent Psychic Spores",
+      "description": "Psionic spores that lull and confuse nearby targets."
+    },
+    "it": {
+      "label": "Spora Psichica Silenziosa",
+      "description": "Spore psioniche che sedano e confondono i bersagli vicini."
+    }
+  },
+  "squame_rifrangenti_deserto": {
+    "en": {
+      "label": "Squame Rifrangenti del Deserto",
+      "description": "Crystal scales diffusing heat and casting mirages."
+    },
+    "it": {
+      "label": "Squame Rifrangenti del Deserto",
+      "description": "Scaglie cristalline che diffondono calore e creano miraggi."
+    }
+  },
+  "struttura_elastica_amorfa": {
+    "en": {
+      "label": "Elastic Amorphous Frame",
+      "description": "Amorphous frame stretching or compressing to escape binds."
+    },
+    "it": {
+      "label": "Struttura elastica, allungabile, amorfa, retrattile",
+      "description": "Corpo amorfo che si estende e si compatta per evadere vincoli."
+    }
+  },
+  "tattiche_di_branco": {
+    "en": {
+      "label": "Pack Tactics",
+      "description": "Tactical protocol coordinating shared focus and grapples."
+    },
+    "it": {
+      "label": "Tattiche di Branco",
+      "description": "Protocollo tattico che coordina focus e prese condivise."
+    }
+  },
+  "vello_condensatore_nebbie": {
+    "en": {
+      "label": "Vello Condensatore di Nebbie",
+      "description": "Capillary fleece condensing fog into mobile water reserves."
+    },
+    "it": {
+      "label": "Vello Condensatore di Nebbie",
+      "description": "Vello capillare che condensa nebbia in riserve idriche mobili."
+    }
+  },
+  "ventriglio_gastroliti": {
+    "en": {
+      "label": "Gastrolith Grinding Gizzard",
+      "description": "Muscular gizzard grinding hard food with gastroliths."
+    },
+    "it": {
+      "label": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
+      "description": "Ventriglio muscoloso che macina cibi duri con gastroliti."
+    }
+  },
+  "zampe_a_molla": {
+    "en": {
+      "label": "Spring-Loaded Limbs",
+      "description": "Spring-loaded limbs storing energy for repositioning leaps."
+    },
+    "it": {
+      "label": "Zampe a Molla",
+      "description": "Arti a molla che accumulano energia per balzi di riposizionamento."
+    }
+  },
+  "zoccoli_risonanti_steppe": {
+    "en": {
+      "label": "Zoccoli Risonanti delle Steppe",
+      "description": "Hollow hooves sending rhythmic waves across the steppe pack."
+    },
+    "it": {
+      "label": "Zoccoli Risonanti delle Steppe",
+      "description": "Zoccoli cavi che inviano onde ritmiche al branco sulle steppe."
+    }
+  },
+  "ali_fulminee": {
+    "en": {
+      "label": "Ali Fulminee",
+      "description": "Ali Fulminee allow squads to interpret minute signals and unstable psionic patterns within stratosfera tempestosa."
+    },
+    "it": {
+      "label": "Ali Fulminee",
+      "description": "Ali Fulminee permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di stratosfera tempestosa."
+    }
+  },
+  "ali_ioniche": {
+    "en": {
+      "label": "Ionic Wings",
+      "description": "Propulsive membranes that pulse micro-discharges for controlled bursts."
+    },
+    "it": {
+      "label": "Ali Ioniche",
+      "description": "Membrane propulsive che rilasciano micro-scariche per scatti controllati."
+    }
+  },
+  "ali_membrana_sonica": {
+    "en": {
+      "label": "Sonic Membrane Wings",
+      "description": "Vibrating plates that dissipate energy and blunt corrosive impacts."
+    },
+    "it": {
+      "label": "Ali a Membrana Sonica",
+      "description": "Piastre vibranti che dissipano energia e attenuano impatti corrosivi."
+    }
+  },
+  "antenne_dustsense": {
+    "en": {
+      "label": "Dustsense Antennae",
+      "description": "Layered receptors stabilising multi-source absorption across ionic deserts."
+    },
+    "it": {
+      "label": "Antenne Dustsense",
+      "description": "Ricettori stratificati che stabilizzano l’assorbimento multi-fonte in deserti ionici."
+    }
+  },
+  "antenne_eco_turbina": {
+    "en": {
+      "label": "Antenne Eco Turbina",
+      "description": "Antenne Eco Turbina allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale."
+    },
+    "it": {
+      "label": "Antenne Eco Turbina",
+      "description": "Antenne Eco Turbina permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale."
+    }
+  },
+  "antenne_flusso_mareale": {
+    "en": {
+      "label": "Antenne Flusso Mareale",
+      "description": "Antenne Flusso Mareale allow squads to channel kinetic or elemental energy into targeted strikes within laguna bioreattiva."
+    },
+    "it": {
+      "label": "Antenne Flusso Mareale",
+      "description": "Antenne Flusso Mareale permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di laguna bioreattiva."
+    }
+  },
+  "antenne_microonde_cavernose": {
+    "en": {
+      "label": "Antenne Microonde Cavernose",
+      "description": "Antenne Microonde Cavernose allow squads to predict trajectories and orchestrate multilayered setups within caverna risonante."
+    },
+    "it": {
+      "label": "Antenne Microonde Cavernose",
+      "description": "Antenne Microonde Cavernose permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caverna risonante."
+    }
+  },
+  "antenne_reagenti": {
+    "en": {
+      "label": "Antenne Reagenti",
+      "description": "Antenne Reagenti allow squads to synchronise allied organisms and mutualistic flows within foresta acida."
+    },
+    "it": {
+      "label": "Antenne Reagenti",
+      "description": "Antenne Reagenti permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di foresta acida."
+    }
+  },
+  "antenne_tesla": {
+    "en": {
+      "label": "Antenne Tesla",
+      "description": "Antenne Tesla allow squads to redistribute load and modulate structural rigidity within canopia ionica."
+    },
+    "it": {
+      "label": "Antenne Tesla",
+      "description": "Antenne Tesla permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di canopia ionica."
+    }
+  },
+  "antenne_waveguide": {
+    "en": {
+      "label": "Antenne Waveguide",
+      "description": "Antenne Waveguide allow squads to interpret minute signals and unstable psionic patterns within reef luminescente."
+    },
+    "it": {
+      "label": "Antenne Waveguide",
+      "description": "Antenne Waveguide permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di reef luminescente."
+    }
+  },
+  "antenne_wideband": {
+    "en": {
+      "label": "Antenne Wideband",
+      "description": "Antenne Wideband allow squads to gain grip and controlled acceleration across extreme terrain within steppe algoritmiche."
+    },
+    "it": {
+      "label": "Antenne Wideband",
+      "description": "Antenne Wideband permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di steppe algoritmiche."
+    }
+  },
+  "appendici_risonanti_marea": {
+    "en": {
+      "label": "Appendici Risonanti Marea",
+      "description": "Appendici Risonanti Marea allow squads to disperse energy and attenuate corrosive or thermal impacts within laguna bioreattiva."
+    },
+    "it": {
+      "label": "Appendici Risonanti Marea",
+      "description": "Appendici Risonanti Marea permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di laguna bioreattiva."
+    }
+  },
+  "appendici_thermotattiche": {
+    "en": {
+      "label": "Appendici Thermotattiche",
+      "description": "Appendici Thermotattiche allow squads to stabilise multi-source energy absorption and conversion within abisso vulcanico."
+    },
+    "it": {
+      "label": "Appendici Thermotattiche",
+      "description": "Appendici Thermotattiche permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di abisso vulcanico."
+    }
+  },
+  "artigli_acidofagi": {
+    "en": {
+      "label": "Artigli Acidofagi",
+      "description": "Artigli Acidofagi allow squads to coordinate resource exchange and squad stabilisation parameters within foresta acida."
+    },
+    "it": {
+      "label": "Artigli Acidofagi",
+      "description": "Artigli Acidofagi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida."
+    }
+  },
+  "artigli_induzione": {
+    "en": {
+      "label": "Artigli Induzione",
+      "description": "Artigli Induzione allow squads to channel kinetic or elemental energy into targeted strikes within canopia ionica."
+    },
+    "it": {
+      "label": "Artigli Induzione",
+      "description": "Artigli Induzione permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di canopia ionica."
+    }
+  },
+  "artigli_radice": {
+    "en": {
+      "label": "Artigli Radice",
+      "description": "Artigli Radice allow squads to predict trajectories and orchestrate multilayered setups within mangrovieto cinetico."
+    },
+    "it": {
+      "label": "Artigli Radice",
+      "description": "Artigli Radice permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di mangrovieto cinetico."
+    }
+  },
+  "artigli_scivolo_silente": {
+    "en": {
+      "label": "Artigli Scivolo Silente",
+      "description": "Artigli Scivolo Silente allow squads to synchronise allied organisms and mutualistic flows within caverna risonante."
+    },
+    "it": {
+      "label": "Artigli Scivolo Silente",
+      "description": "Artigli Scivolo Silente permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di caverna risonante."
+    }
+  },
+  "artigli_vetrificati": {
+    "en": {
+      "label": "Artigli Vetrificati",
+      "description": "Artigli Vetrificati allow squads to redistribute load and modulate structural rigidity within caldera glaciale."
+    },
+    "it": {
+      "label": "Artigli Vetrificati",
+      "description": "Artigli Vetrificati permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caldera glaciale."
+    }
+  },
+  "baffi_mareomotori": {
+    "en": {
+      "label": "Baffi Mareomotori",
+      "description": "Baffi Mareomotori allow squads to interpret minute signals and unstable psionic patterns within mangrovieto cinetico."
+    },
+    "it": {
+      "label": "Baffi Mareomotori",
+      "description": "Baffi Mareomotori permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di mangrovieto cinetico."
+    }
+  },
+  "barbigli_sensori_plasma": {
+    "en": {
+      "label": "Barbigli Sensori Plasma",
+      "description": "Barbigli Sensori Plasma allow squads to gain grip and controlled acceleration across extreme terrain within stratosfera tempestosa."
+    },
+    "it": {
+      "label": "Barbigli Sensori Plasma",
+      "description": "Barbigli Sensori Plasma permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di stratosfera tempestosa."
+    }
+  },
+  "barriere_miasma_glaciale": {
+    "en": {
+      "label": "Barriere Miasma Glaciale",
+      "description": "Barriere Miasma Glaciale allow squads to disperse energy and attenuate corrosive or thermal impacts within caldera glaciale."
+    },
+    "it": {
+      "label": "Barriere Miasma Glaciale",
+      "description": "Barriere Miasma Glaciale permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di caldera glaciale."
+    }
+  },
+  "batteri_endosimbionti_chemio": {
+    "en": {
+      "label": "Batteri Endosimbionti Chemio",
+      "description": "Batteri Endosimbionti Chemio allow squads to stabilise multi-source energy absorption and conversion within abisso vulcanico."
+    },
+    "it": {
+      "label": "Batteri Endosimbionti Chemio",
+      "description": "Batteri Endosimbionti Chemio permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di abisso vulcanico."
+    }
+  },
+  "batteri_termofili_endosimbiosi": {
+    "en": {
+      "label": "Batteri Termofili Endosimbiosi",
+      "description": "Batteri Termofili Endosimbiosi allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale."
+    },
+    "it": {
+      "label": "Batteri Termofili Endosimbiosi",
+      "description": "Batteri Termofili Endosimbiosi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale."
+    }
+  },
+  "biochip_memoria": {
+    "en": {
+      "label": "Biochip Memoria",
+      "description": "Biochip Memoria allow squads to channel kinetic or elemental energy into targeted strikes within steppe algoritmiche."
+    },
+    "it": {
+      "label": "Biochip Memoria",
+      "description": "Biochip Memoria permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di steppe algoritmiche."
+    }
+  },
+  "biofilm_glow": {
+    "en": {
+      "label": "Biofilm Glow",
+      "description": "Biofilm Glow allow squads to predict trajectories and orchestrate multilayered setups within reef luminescente."
+    },
+    "it": {
+      "label": "Biofilm Glow",
+      "description": "Biofilm Glow permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di reef luminescente."
+    }
+  },
+  "biofilm_iperarido": {
+    "en": {
+      "label": "Biofilm Iperarido",
+      "description": "Biofilm Iperarido allow squads to synchronise allied organisms and mutualistic flows within pianura salina iperarida."
+    },
+    "it": {
+      "label": "Biofilm Iperarido",
+      "description": "Biofilm Iperarido permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di pianura salina iperarida."
+    }
+  },
+  "branchie_dual_mode": {
+    "en": {
+      "label": "Branchie Dual Mode",
+      "description": "Branchie Dual Mode allow squads to redistribute load and modulate structural rigidity within laguna bioreattiva."
+    },
+    "it": {
+      "label": "Branchie Dual Mode",
+      "description": "Branchie Dual Mode permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di laguna bioreattiva."
+    }
+  },
+  "branchie_eoliche": {
+    "en": {
+      "label": "Branchie Eoliche",
+      "description": "Branchie Eoliche allow squads to interpret minute signals and unstable psionic patterns within stratosfera tempestosa."
+    },
+    "it": {
+      "label": "Branchie Eoliche",
+      "description": "Branchie Eoliche permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di stratosfera tempestosa."
+    }
+  },
+  "branchie_metalloidi": {
+    "en": {
+      "label": "Branchie Metalloidi",
+      "description": "Branchie Metalloidi allow squads to gain grip and controlled acceleration across extreme terrain within abisso vulcanico."
+    },
+    "it": {
+      "label": "Branchie Metalloidi",
+      "description": "Branchie Metalloidi permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di abisso vulcanico."
+    }
+  },
+  "branchie_microfiltri": {
+    "en": {
+      "label": "Branchie Microfiltri",
+      "description": "Branchie Microfiltri allow squads to disperse energy and attenuate corrosive or thermal impacts within reef luminescente."
+    },
+    "it": {
+      "label": "Branchie Microfiltri",
+      "description": "Branchie Microfiltri permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di reef luminescente."
+    }
+  },
+  "branchie_solfatiche": {
+    "en": {
+      "label": "Branchie Solfatiche",
+      "description": "Branchie Solfatiche allow squads to stabilise multi-source energy absorption and conversion within caldera glaciale."
+    },
+    "it": {
+      "label": "Branchie Solfatiche",
+      "description": "Branchie Solfatiche permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di caldera glaciale."
+    }
+  },
+  "branchie_turbina": {
+    "en": {
+      "label": "Branchie Turbina",
+      "description": "Branchie Turbina allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale."
+    },
+    "it": {
+      "label": "Branchie Turbina",
+      "description": "Branchie Turbina permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale."
+    }
+  },
+  "camere_anticorrosione": {
+    "en": {
+      "label": "Camere Anticorrosione",
+      "description": "Camere Anticorrosione allow squads to channel kinetic or elemental energy into targeted strikes within foresta acida."
+    },
+    "it": {
+      "label": "Camere Anticorrosione",
+      "description": "Camere Anticorrosione permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di foresta acida."
+    }
+  },
+  "camere_mirage": {
+    "en": {
+      "label": "Camere Mirage",
+      "description": "Camere Mirage allow squads to predict trajectories and orchestrate multilayered setups within pianura salina iperarida."
+    },
+    "it": {
+      "label": "Camere Mirage",
+      "description": "Camere Mirage permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida."
+    }
+  },
+  "camere_nutrienti_vent": {
+    "en": {
+      "label": "Camere Nutrienti Vent",
+      "description": "Camere Nutrienti Vent allow squads to synchronise allied organisms and mutualistic flows within dorsale termale tropicale."
+    },
+    "it": {
+      "label": "Camere Nutrienti Vent",
+      "description": "Camere Nutrienti Vent permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di dorsale termale tropicale."
+    }
+  },
+  "capillari_criogenici": {
+    "en": {
+      "label": "Capillari Criogenici",
+      "description": "Capillari Criogenici allow squads to redistribute load and modulate structural rigidity within caldera glaciale."
+    },
+    "it": {
+      "label": "Capillari Criogenici",
+      "description": "Capillari Criogenici permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caldera glaciale."
+    }
+  },
+  "capillari_fluoridici": {
+    "en": {
+      "label": "Capillari Fluoridici",
+      "description": "Capillari Fluoridici allow squads to interpret minute signals and unstable psionic patterns within foresta acida."
+    },
+    "it": {
+      "label": "Capillari Fluoridici",
+      "description": "Capillari Fluoridici permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di foresta acida."
+    }
+  },
+  "capillari_fotovoltaici": {
+    "en": {
+      "label": "Capillari Fotovoltaici",
+      "description": "Capillari Fotovoltaici allow squads to gain grip and controlled acceleration across extreme terrain within canopia ionica."
+    },
+    "it": {
+      "label": "Capillari Fotovoltaici",
+      "description": "Capillari Fotovoltaici permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di canopia ionica."
+    }
+  },
+  "capsule_paracadute": {
+    "en": {
+      "label": "Capsule Paracadute",
+      "description": "Capsule Paracadute allow squads to disperse energy and attenuate corrosive or thermal impacts within stratosfera tempestosa."
+    },
+    "it": {
+      "label": "Capsule Paracadute",
+      "description": "Capsule Paracadute permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di stratosfera tempestosa."
+    }
+  },
+  "carapace_segmenti_logici": {
+    "en": {
+      "label": "Carapace Segmenti Logici",
+      "description": "Carapace Segmenti Logici allow squads to stabilise multi-source energy absorption and conversion within steppe algoritmiche."
+    },
+    "it": {
+      "label": "Carapace Segmenti Logici",
+      "description": "Carapace Segmenti Logici permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di steppe algoritmiche."
+    }
+  },
+  "carapaci_ferruginosi": {
+    "en": {
+      "label": "Carapaci Ferruginosi",
+      "description": "Carapaci Ferruginosi allow squads to coordinate resource exchange and squad stabilisation parameters within abisso vulcanico."
+    },
+    "it": {
+      "label": "Carapaci Ferruginosi",
+      "description": "Carapaci Ferruginosi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di abisso vulcanico."
+    }
+  },
+  "cartilagini_biofibre": {
+    "en": {
+      "label": "Cartilagini Biofibre",
+      "description": "Cartilagini Biofibre allow squads to channel kinetic or elemental energy into targeted strikes within reef luminescente."
+    },
+    "it": {
+      "label": "Cartilagini Biofibre",
+      "description": "Cartilagini Biofibre permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di reef luminescente."
+    }
+  },
+  "cartilagini_desertiche": {
+    "en": {
+      "label": "Cartilagini Desertiche",
+      "description": "Cartilagini Desertiche allow squads to predict trajectories and orchestrate multilayered setups within pianura salina iperarida."
+    },
+    "it": {
+      "label": "Cartilagini Desertiche",
+      "description": "Cartilagini Desertiche permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida."
+    }
+  },
+  "cartilagini_flessoacustiche": {
+    "en": {
+      "label": "Cartilagini Flessoacustiche",
+      "description": "Cartilagini Flessoacustiche allow squads to synchronise allied organisms and mutualistic flows within caverna risonante."
+    },
+    "it": {
+      "label": "Cartilagini Flessoacustiche",
+      "description": "Cartilagini Flessoacustiche permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di caverna risonante."
+    }
+  },
+  "cartilagini_pseudometalliche": {
+    "en": {
+      "label": "Cartilagini Pseudometalliche",
+      "description": "Cartilagini Pseudometalliche allow squads to redistribute load and modulate structural rigidity within abisso vulcanico."
+    },
+    "it": {
+      "label": "Cartilagini Pseudometalliche",
+      "description": "Cartilagini Pseudometalliche permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico."
+    }
+  },
+  "cervelletto_equilibrio_statico": {
+    "en": {
+      "label": "Cervelletto Equilibrio Statico",
+      "description": "Cervelletto Equilibrio Statico allow squads to interpret minute signals and unstable psionic patterns within canopia ionica."
+    },
+    "it": {
+      "label": "Cervelletto Equilibrio Statico",
+      "description": "Cervelletto Equilibrio Statico permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di canopia ionica."
+    }
+  },
+  "chemiorecettori_bromuro": {
+    "en": {
+      "label": "Chemiorecettori Bromuro",
+      "description": "Chemiorecettori Bromuro allow squads to gain grip and controlled acceleration across extreme terrain within pianura salina iperarida."
+    },
+    "it": {
+      "label": "Chemiorecettori Bromuro",
+      "description": "Chemiorecettori Bromuro permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di pianura salina iperarida."
+    }
+  },
+  "circolazione_bifasica": {
+    "en": {
+      "label": "Circolazione Bifasica",
+      "description": "Circolazione Bifasica allow squads to disperse energy and attenuate corrosive or thermal impacts within caldera glaciale."
+    },
+    "it": {
+      "label": "Circolazione Bifasica",
+      "description": "Circolazione Bifasica permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di caldera glaciale."
+    }
+  },
+  "circolazione_cooling_loop": {
+    "en": {
+      "label": "Circolazione Cooling Loop",
+      "description": "Circolazione Cooling Loop allow squads to stabilise multi-source energy absorption and conversion within steppe algoritmiche."
+    },
+    "it": {
+      "label": "Circolazione Cooling Loop",
+      "description": "Circolazione Cooling Loop permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di steppe algoritmiche."
+    }
+  },
+  "circolazione_doppia": {
+    "en": {
+      "label": "Circolazione Doppia",
+      "description": "Circolazione Doppia allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale."
+    },
+    "it": {
+      "label": "Circolazione Doppia",
+      "description": "Circolazione Doppia permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale."
+    }
+  },
+  "circolazione_supercritica": {
+    "en": {
+      "label": "Circolazione Supercritica",
+      "description": "Circolazione Supercritica allow squads to channel kinetic or elemental energy into targeted strikes within abisso vulcanico."
+    },
+    "it": {
+      "label": "Circolazione Supercritica",
+      "description": "Circolazione Supercritica permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di abisso vulcanico."
+    }
+  },
+  "ciste_riduttive": {
+    "en": {
+      "label": "Ciste Riduttive",
+      "description": "Ciste Riduttive allow squads to predict trajectories and orchestrate multilayered setups within laguna bioreattiva."
+    },
+    "it": {
+      "label": "Ciste Riduttive",
+      "description": "Ciste Riduttive permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di laguna bioreattiva."
+    }
+  },
+  "ciste_salmastre": {
+    "en": {
+      "label": "Ciste Salmastre",
+      "description": "Ciste Salmastre allow squads to synchronise allied organisms and mutualistic flows within pianura salina iperarida."
+    },
+    "it": {
+      "label": "Ciste Salmastre",
+      "description": "Ciste Salmastre permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di pianura salina iperarida."
+    }
+  },
+  "cisti_iperbariche": {
+    "en": {
+      "label": "Cisti Iperbariche",
+      "description": "Cisti Iperbariche allow squads to redistribute load and modulate structural rigidity within abisso vulcanico."
+    },
+    "it": {
+      "label": "Cisti Iperbariche",
+      "description": "Cisti Iperbariche permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico."
+    }
+  },
+  "coda_balanciere": {
+    "en": {
+      "label": "Coda Balanciere",
+      "description": "Coda Balanciere allow squads to interpret minute signals and unstable psionic patterns within caverna risonante."
+    },
+    "it": {
+      "label": "Coda Balanciere",
+      "description": "Coda Balanciere permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante."
+    }
+  },
+  "coda_contrappeso": {
+    "en": {
+      "label": "Coda Contrappeso",
+      "description": "Coda Contrappeso allow squads to gain grip and controlled acceleration across extreme terrain within mangrovieto cinetico."
+    },
+    "it": {
+      "label": "Coda Contrappeso",
+      "description": "Coda Contrappeso permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di mangrovieto cinetico."
+    }
+  },
+  "coda_coppia_retroattiva": {
+    "en": {
+      "label": "Coda Coppia Retroattiva",
+      "description": "Coda Coppia Retroattiva allow squads to disperse energy and attenuate corrosive or thermal impacts within steppe algoritmiche."
+    },
+    "it": {
+      "label": "Coda Coppia Retroattiva",
+      "description": "Coda Coppia Retroattiva permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di steppe algoritmiche."
+    }
+  },
+  "coda_stabilizzatrice_filo": {
+    "en": {
+      "label": "Coda Stabilizzatrice Filo",
+      "description": "Coda Stabilizzatrice Filo allow squads to stabilise multi-source energy absorption and conversion within canopia ionica."
+    },
+    "it": {
+      "label": "Coda Stabilizzatrice Filo",
+      "description": "Coda Stabilizzatrice Filo permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di canopia ionica."
+    }
+  },
+  "coda_stabilizzatrice_geiser": {
+    "en": {
+      "label": "Coda Stabilizzatrice Geiser",
+      "description": "Coda Stabilizzatrice Geiser allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale."
+    },
+    "it": {
+      "label": "Coda Stabilizzatrice Geiser",
+      "description": "Coda Stabilizzatrice Geiser permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale."
+    }
+  },
+  "coda_stabilizzatrice_vortex": {
+    "en": {
+      "label": "Coda Stabilizzatrice Vortex",
+      "description": "Coda Stabilizzatrice Vortex allow squads to channel kinetic or elemental energy into targeted strikes within stratosfera tempestosa."
+    },
+    "it": {
+      "label": "Coda Stabilizzatrice Vortex",
+      "description": "Coda Stabilizzatrice Vortex permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di stratosfera tempestosa."
+    }
+  },
+  "colonne_vibromagnetiche": {
+    "en": {
+      "label": "Colonne Vibromagnetiche",
+      "description": "Colonne Vibromagnetiche allow squads to predict trajectories and orchestrate multilayered setups within caverna risonante."
+    },
+    "it": {
+      "label": "Colonne Vibromagnetiche",
+      "description": "Colonne Vibromagnetiche permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caverna risonante."
+    }
+  },
+  "coralli_partner": {
+    "en": {
+      "label": "Coralli Partner",
+      "description": "Coralli Partner allow squads to synchronise allied organisms and mutualistic flows within reef luminescente."
+    },
+    "it": {
+      "label": "Coralli Partner",
+      "description": "Coralli Partner permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di reef luminescente."
+    }
+  },
+  "cromofori_alert_acido": {
+    "en": {
+      "label": "Cromofori Alert Acido",
+      "description": "Cromofori Alert Acido allow squads to redistribute load and modulate structural rigidity within foresta acida."
+    },
+    "it": {
+      "label": "Cromofori Alert Acido",
+      "description": "Cromofori Alert Acido permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di foresta acida."
+    }
+  },
+  "cuore_multicamera_bassa_pressione": {
+    "en": {
+      "label": "Cuore Multicamera Bassa Pressione",
+      "description": "Cuore Multicamera Bassa Pressione allow squads to interpret minute signals and unstable psionic patterns within stratosfera tempestosa."
+    },
+    "it": {
+      "label": "Cuore Multicamera Bassa Pressione",
+      "description": "Cuore Multicamera Bassa Pressione permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di stratosfera tempestosa."
+    }
+  },
+  "cuscinetti_elettrostatici": {
+    "en": {
+      "label": "Cuscinetti Elettrostatici",
+      "description": "Cuscinetti Elettrostatici allow squads to gain grip and controlled acceleration across extreme terrain within pianura salina iperarida."
+    },
+    "it": {
+      "label": "Cuscinetti Elettrostatici",
+      "description": "Cuscinetti Elettrostatici permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di pianura salina iperarida."
+    }
+  },
+  "cute_resistente_sali": {
+    "en": {
+      "label": "Cute Resistente Sali",
+      "description": "Cute Resistente Sali allow squads to disperse energy and attenuate corrosive or thermal impacts within badlands."
+    },
+    "it": {
+      "label": "Cute Resistente Sali",
+      "description": "Cute Resistente Sali permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di badlands."
+    }
+  },
+  "cuticole_cerose": {
+    "en": {
+      "label": "Cuticole Cerose",
+      "description": "Cuticole Cerose allow squads to stabilise multi-source energy absorption and conversion within ambienti dinamici."
+    },
+    "it": {
+      "label": "Cuticole Cerose",
+      "description": "Cuticole Cerose permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici."
+    }
+  },
+  "cuticole_neutralizzanti": {
+    "en": {
+      "label": "Cuticole Neutralizzanti",
+      "description": "Cuticole Neutralizzanti allow squads to coordinate resource exchange and squad stabilisation parameters within foresta acida."
+    },
+    "it": {
+      "label": "Cuticole Neutralizzanti",
+      "description": "Cuticole Neutralizzanti permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida."
+    }
+  },
+  "denti_chelatanti": {
+    "en": {
+      "label": "Denti Chelatanti",
+      "description": "Denti Chelatanti allow squads to channel kinetic or elemental energy into targeted strikes within foresta acida."
+    },
+    "it": {
+      "label": "Denti Chelatanti",
+      "description": "Denti Chelatanti permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di foresta acida."
+    }
+  },
+  "denti_ossidoferro": {
+    "en": {
+      "label": "Denti Ossidoferro",
+      "description": "Denti Ossidoferro allow squads to predict trajectories and orchestrate multilayered setups within abisso vulcanico."
+    },
+    "it": {
+      "label": "Denti Ossidoferro",
+      "description": "Denti Ossidoferro permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di abisso vulcanico."
+    }
+  },
+  "denti_silice_termici": {
+    "en": {
+      "label": "Denti Silice Termici",
+      "description": "Denti Silice Termici allow squads to synchronise allied organisms and mutualistic flows within dorsale termale tropicale."
+    },
+    "it": {
+      "label": "Denti Silice Termici",
+      "description": "Denti Silice Termici permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di dorsale termale tropicale."
+    }
+  },
+  "denti_tuning_fork": {
+    "en": {
+      "label": "Denti Tuning Fork",
+      "description": "Denti Tuning Fork allow squads to redistribute load and modulate structural rigidity within caverna risonante."
+    },
+    "it": {
+      "label": "Denti Tuning Fork",
+      "description": "Denti Tuning Fork permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caverna risonante."
+    }
+  },
+  "echi_risonanti": {
+    "en": {
+      "label": "Echi Risonanti",
+      "description": "Echi Risonanti allow squads to interpret minute signals and unstable psionic patterns within caverna risonante."
+    },
+    "it": {
+      "label": "Echi Risonanti",
+      "description": "Echi Risonanti permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante."
+    }
+  },
+  "enzimi_antifase_termica": {
+    "en": {
+      "label": "Enzimi Antifase Termica",
+      "description": "Enzimi Antifase Termica allow squads to gain grip and controlled acceleration across extreme terrain within caldera glaciale."
+    },
+    "it": {
+      "label": "Enzimi Antifase Termica",
+      "description": "Enzimi Antifase Termica permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di caldera glaciale."
+    }
+  },
+  "enzimi_antipredatori_algali": {
+    "en": {
+      "label": "Enzimi Antipredatori Algali",
+      "description": "Enzimi Antipredatori Algali allow squads to disperse energy and attenuate corrosive or thermal impacts within reef luminescente."
+    },
+    "it": {
+      "label": "Enzimi Antipredatori Algali",
+      "description": "Enzimi Antipredatori Algali permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di reef luminescente."
+    }
+  },
+  "enzimi_chelanti": {
+    "en": {
+      "label": "Enzimi Chelanti",
+      "description": "Enzimi Chelanti allow squads to stabilise multi-source energy absorption and conversion within ambienti dinamici."
+    },
+    "it": {
+      "label": "Enzimi Chelanti",
+      "description": "Enzimi Chelanti permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici."
+    }
+  },
+  "enzimi_chelatori_rapidi": {
+    "en": {
+      "label": "Enzimi Chelatori Rapidi",
+      "description": "Enzimi Chelatori Rapidi allow squads to coordinate resource exchange and squad stabilisation parameters within foresta acida."
+    },
+    "it": {
+      "label": "Enzimi Chelatori Rapidi",
+      "description": "Enzimi Chelatori Rapidi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida."
+    }
+  },
+  "enzimi_metanoossidanti": {
+    "en": {
+      "label": "Enzimi Metanoossidanti",
+      "description": "Enzimi Metanoossidanti allow squads to channel kinetic or elemental energy into targeted strikes within abisso vulcanico."
+    },
+    "it": {
+      "label": "Enzimi Metanoossidanti",
+      "description": "Enzimi Metanoossidanti permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di abisso vulcanico."
+    }
+  },
+  "epidermide_dielettrica": {
+    "en": {
+      "label": "Epidermide Dielettrica",
+      "description": "Epidermide Dielettrica allow squads to predict trajectories and orchestrate multilayered setups within stratosfera tempestosa."
+    },
+    "it": {
+      "label": "Epidermide Dielettrica",
+      "description": "Epidermide Dielettrica permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di stratosfera tempestosa."
+    }
+  },
+  "epitelio_fosforescente": {
+    "en": {
+      "label": "Epitelio Fosforescente",
+      "description": "Epitelio Fosforescente allow squads to synchronise allied organisms and mutualistic flows within reef luminescente."
+    },
+    "it": {
+      "label": "Epitelio Fosforescente",
+      "description": "Epitelio Fosforescente permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di reef luminescente."
+    }
+  },
+  "filamenti_magnetotrofi": {
+    "en": {
+      "label": "Filamenti Magnetotrofi",
+      "description": "Filamenti Magnetotrofi allow squads to redistribute load and modulate structural rigidity within abisso vulcanico."
+    },
+    "it": {
+      "label": "Filamenti Magnetotrofi",
+      "description": "Filamenti Magnetotrofi permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico."
+    }
+  },
+  "filamenti_superconduttivi": {
+    "en": {
+      "label": "Filamenti Superconduttivi",
+      "description": "Filamenti Superconduttivi allow squads to interpret minute signals and unstable psionic patterns within caldera glaciale."
+    },
+    "it": {
+      "label": "Filamenti Superconduttivi",
+      "description": "Filamenti Superconduttivi permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caldera glaciale."
+    }
+  },
+  "filamenti_termoconduzione": {
+    "en": {
+      "label": "Filamenti Termoconduzione",
+      "description": "Filamenti Termoconduzione allow squads to gain grip and controlled acceleration across extreme terrain within dorsale termale tropicale."
+    },
+    "it": {
+      "label": "Filamenti Termoconduzione",
+      "description": "Filamenti Termoconduzione permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di dorsale termale tropicale."
+    }
+  },
+  "filtri_planctonici": {
+    "en": {
+      "label": "Filtri Planctonici",
+      "description": "Filtri Planctonici allow squads to disperse energy and attenuate corrosive or thermal impacts within laguna bioreattiva."
+    },
+    "it": {
+      "label": "Filtri Planctonici",
+      "description": "Filtri Planctonici permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di laguna bioreattiva."
+    }
+  },
+  "flagelli_ancoranti": {
+    "en": {
+      "label": "Flagelli Ancoranti",
+      "description": "Flagelli Ancoranti allow squads to stabilise multi-source energy absorption and conversion within laguna bioreattiva."
+    },
+    "it": {
+      "label": "Flagelli Ancoranti",
+      "description": "Flagelli Ancoranti permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di laguna bioreattiva."
+    }
+  },
+  "foliage_fotocatodico": {
+    "en": {
+      "label": "Foliage Fotocatodico",
+      "description": "Foliage Fotocatodico allow squads to coordinate resource exchange and squad stabilisation parameters within foresta acida."
+    },
+    "it": {
+      "label": "Foliage Fotocatodico",
+      "description": "Foliage Fotocatodico permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida."
+    }
+  },
+  "foliaggio_spugna": {
+    "en": {
+      "label": "Foliaggio Spugna",
+      "description": "Foliaggio Spugna allow squads to channel kinetic or elemental energy into targeted strikes within mangrovieto cinetico."
+    },
+    "it": {
+      "label": "Foliaggio Spugna",
+      "description": "Foliaggio Spugna permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di mangrovieto cinetico."
+    }
+  },
+  "ghiaccio_piezoelettrico": {
+    "en": {
+      "label": "Ghiaccio Piezoelettrico",
+      "description": "Ghiaccio Piezoelettrico allow squads to predict trajectories and orchestrate multilayered setups within caldera glaciale."
+    },
+    "it": {
+      "label": "Ghiaccio Piezoelettrico",
+      "description": "Ghiaccio Piezoelettrico permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caldera glaciale."
+    }
+  },
+  "ghiandole_cambio_salino": {
+    "en": {
+      "label": "Ghiandole Cambio Salino",
+      "description": "Ghiandole Cambio Salino allow squads to synchronise allied organisms and mutualistic flows within laguna bioreattiva."
+    },
+    "it": {
+      "label": "Ghiandole Cambio Salino",
+      "description": "Ghiandole Cambio Salino permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di laguna bioreattiva."
+    }
+  },
+  "ghiandole_condensa_ozono": {
+    "en": {
+      "label": "Ghiandole Condensa Ozono",
+      "description": "Ghiandole Condensa Ozono allow squads to redistribute load and modulate structural rigidity within stratosfera tempestosa."
+    },
+    "it": {
+      "label": "Ghiandole Condensa Ozono",
+      "description": "Ghiandole Condensa Ozono permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di stratosfera tempestosa."
+    }
+  },
+  "ghiandole_eco_mappanti": {
+    "en": {
+      "label": "Ghiandole Eco Mappanti",
+      "description": "Ghiandole Eco Mappanti allow squads to interpret minute signals and unstable psionic patterns within caverna risonante."
+    },
+    "it": {
+      "label": "Ghiandole Eco Mappanti",
+      "description": "Ghiandole Eco Mappanti permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante."
+    }
+  },
+  "ghiandole_fango_calde": {
+    "en": {
+      "label": "Ghiandole Fango Calde",
+      "description": "Ghiandole Fango Calde allow squads to gain grip and controlled acceleration across extreme terrain within abisso vulcanico."
+    },
+    "it": {
+      "label": "Ghiandole Fango Calde",
+      "description": "Ghiandole Fango Calde permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di abisso vulcanico."
+    }
+  },
+  "ghiandole_fango_coesivo": {
+    "en": {
+      "label": "Ghiandole Fango Coesivo",
+      "description": "Ghiandole Fango Coesivo allow squads to disperse energy and attenuate corrosive or thermal impacts within mangrovieto cinetico."
+    },
+    "it": {
+      "label": "Ghiandole Fango Coesivo",
+      "description": "Ghiandole Fango Coesivo permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di mangrovieto cinetico."
+    }
+  },
+  "ghiandole_grafene": {
+    "en": {
+      "label": "Ghiandole Grafene",
+      "description": "Ghiandole Grafene allow squads to stabilise multi-source energy absorption and conversion within steppe algoritmiche."
+    },
+    "it": {
+      "label": "Ghiandole Grafene",
+      "description": "Ghiandole Grafene permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di steppe algoritmiche."
+    }
+  },
+  "ghiandole_inchiostro_luce": {
+    "en": {
+      "label": "Ghiandole Inchiostro Luce",
+      "description": "Ghiandole Inchiostro Luce allow squads to coordinate resource exchange and squad stabilisation parameters within reef luminescente."
+    },
+    "it": {
+      "label": "Ghiandole Inchiostro Luce",
+      "description": "Ghiandole Inchiostro Luce permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di reef luminescente."
+    }
+  },
+  "ghiandole_iodoattive": {
+    "en": {
+      "label": "Ghiandole Iodoattive",
+      "description": "Ghiandole Iodoattive allow squads to channel kinetic or elemental energy into targeted strikes within pianura salina iperarida."
+    },
+    "it": {
+      "label": "Ghiandole Iodoattive",
+      "description": "Ghiandole Iodoattive permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di pianura salina iperarida."
+    }
+  },
+  "ghiandole_minerali": {
+    "en": {
+      "label": "Ghiandole Minerali",
+      "description": "Ghiandole Minerali allow squads to predict trajectories and orchestrate multilayered setups within dorsale termale tropicale."
+    },
+    "it": {
+      "label": "Ghiandole Minerali",
+      "description": "Ghiandole Minerali permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di dorsale termale tropicale."
+    }
+  },
+  "ghiandole_nebbia_acida": {
+    "en": {
+      "label": "Ghiandole Nebbia Acida",
+      "description": "Ghiandole Nebbia Acida allow squads to synchronise allied organisms and mutualistic flows within foresta acida."
+    },
+    "it": {
+      "label": "Ghiandole Nebbia Acida",
+      "description": "Ghiandole Nebbia Acida permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di foresta acida."
+    }
+  },
+  "ghiandole_nebbia_ionica": {
+    "en": {
+      "label": "Ghiandole Nebbia Ionica",
+      "description": "Ghiandole Nebbia Ionica allow squads to redistribute load and modulate structural rigidity within canopia ionica."
+    },
+    "it": {
+      "label": "Ghiandole Nebbia Ionica",
+      "description": "Ghiandole Nebbia Ionica permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di canopia ionica."
+    }
+  },
+  "ghiandole_resina_conduttiva": {
+    "en": {
+      "label": "Ghiandole Resina Conduttiva",
+      "description": "Ghiandole Resina Conduttiva allow squads to interpret minute signals and unstable psionic patterns within canopia ionica."
+    },
+    "it": {
+      "label": "Ghiandole Resina Conduttiva",
+      "description": "Ghiandole Resina Conduttiva permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di canopia ionica."
+    }
+  },
+  "ghiandole_ventosa": {
+    "en": {
+      "label": "Ghiandole Ventosa",
+      "description": "Ghiandole Ventosa allow squads to gain grip and controlled acceleration across extreme terrain within caldera glaciale."
+    },
+    "it": {
+      "label": "Ghiandole Ventosa",
+      "description": "Ghiandole Ventosa permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di caldera glaciale."
+    }
+  },
+  "giunti_antitorsione": {
+    "en": {
+      "label": "Giunti Antitorsione",
+      "description": "Giunti Antitorsione allow squads to disperse energy and attenuate corrosive or thermal impacts within mangrovieto cinetico."
+    },
+    "it": {
+      "label": "Giunti Antitorsione",
+      "description": "Giunti Antitorsione permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di mangrovieto cinetico."
+    }
+  },
+  "grassi_termici": {
+    "en": {
+      "label": "Grassi Termici",
+      "description": "Grassi Termici allow squads to stabilise multi-source energy absorption and conversion within ambienti dinamici."
+    },
+    "it": {
+      "label": "Grassi Termici",
+      "description": "Grassi Termici permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici."
+    }
+  },
+  "gusci_criovetro": {
+    "en": {
+      "label": "Gusci Criovetro",
+      "description": "Gusci Criovetro allow squads to coordinate resource exchange and squad stabilisation parameters within caldera glaciale."
+    },
+    "it": {
+      "label": "Gusci Criovetro",
+      "description": "Gusci Criovetro permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di caldera glaciale."
+    }
+  },
+  "gusci_magnesio": {
+    "en": {
+      "label": "Gusci Magnesio",
+      "description": "Gusci Magnesio allow squads to channel kinetic or elemental energy into targeted strikes within dorsale termale tropicale."
+    },
+    "it": {
+      "label": "Gusci Magnesio",
+      "description": "Gusci Magnesio permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di dorsale termale tropicale."
+    }
+  },
+  "lamelle_shear": {
+    "en": {
+      "label": "Lamelle Shear",
+      "description": "Lamelle Shear allow squads to predict trajectories and orchestrate multilayered setups within stratosfera tempestosa."
+    },
+    "it": {
+      "label": "Lamelle Shear",
+      "description": "Lamelle Shear permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di stratosfera tempestosa."
+    }
+  },
+  "lamelle_sincroniche": {
+    "en": {
+      "label": "Lamelle Sincroniche",
+      "description": "Lamelle Sincroniche allow squads to synchronise allied organisms and mutualistic flows within steppe algoritmiche."
+    },
+    "it": {
+      "label": "Lamelle Sincroniche",
+      "description": "Lamelle Sincroniche permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di steppe algoritmiche."
+    }
+  },
+  "lamine_filtranti_aeree": {
+    "en": {
+      "label": "Lamine Filtranti Aeree",
+      "description": "Lamine Filtranti Aeree allow squads to redistribute load and modulate structural rigidity within mangrovieto cinetico."
+    },
+    "it": {
+      "label": "Lamine Filtranti Aeree",
+      "description": "Lamine Filtranti Aeree permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di mangrovieto cinetico."
+    }
+  },
+  "lamine_scudo_silice": {
+    "en": {
+      "label": "Lamine Scudo Silice",
+      "description": "Lamine Scudo Silice allow squads to interpret minute signals and unstable psionic patterns within dorsale termale tropicale."
+    },
+    "it": {
+      "label": "Lamine Scudo Silice",
+      "description": "Lamine Scudo Silice permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di dorsale termale tropicale."
+    }
+  },
+  "linfa_tampone": {
+    "en": {
+      "label": "Linfa Tampone",
+      "description": "Linfa Tampone allow squads to gain grip and controlled acceleration across extreme terrain within foresta acida."
+    },
+    "it": {
+      "label": "Linfa Tampone",
+      "description": "Linfa Tampone permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di foresta acida."
+    }
+  },
+  "lingua_cristallina": {
+    "en": {
+      "label": "Lingua Cristallina",
+      "description": "Lingua Cristallina allow squads to disperse energy and attenuate corrosive or thermal impacts within pianura salina iperarida."
+    },
+    "it": {
+      "label": "Lingua Cristallina",
+      "description": "Lingua Cristallina permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di pianura salina iperarida."
+    }
+  },
+  "luminescenza_aurorale": {
+    "en": {
+      "label": "Luminescenza Aurorale",
+      "description": "Luminescenza Aurorale allow squads to stabilise multi-source energy absorption and conversion within caldera glaciale."
+    },
+    "it": {
+      "label": "Luminescenza Aurorale",
+      "description": "Luminescenza Aurorale permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di caldera glaciale."
+    }
+  },
+  "luminescenza_hydrotermica": {
+    "en": {
+      "label": "Luminescenza Hydrotermica",
+      "description": "Luminescenza Hydrotermica allow squads to coordinate resource exchange and squad stabilisation parameters within abisso vulcanico."
+    },
+    "it": {
+      "label": "Luminescenza Hydrotermica",
+      "description": "Luminescenza Hydrotermica permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di abisso vulcanico."
+    }
+  },
+  "mantelli_geotermici": {
+    "en": {
+      "label": "Mantelli Geotermici",
+      "description": "Mantelli Geotermici allow squads to channel kinetic or elemental energy into targeted strikes within caldera glaciale."
+    },
+    "it": {
+      "label": "Mantelli Geotermici",
+      "description": "Mantelli Geotermici permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di caldera glaciale."
+    }
+  },
+  "membrane_captura_rugiada": {
+    "en": {
+      "label": "Membrane Captura Rugiada",
+      "description": "Membrane Captura Rugiada allow squads to predict trajectories and orchestrate multilayered setups within pianura salina iperarida."
+    },
+    "it": {
+      "label": "Membrane Captura Rugiada",
+      "description": "Membrane Captura Rugiada permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida."
+    }
+  },
+  "membrane_planata_vectored": {
+    "en": {
+      "label": "Membrane Planata Vectored",
+      "description": "Membrane Planata Vectored allow squads to synchronise allied organisms and mutualistic flows within canopia ionica."
+    },
+    "it": {
+      "label": "Membrane Planata Vectored",
+      "description": "Membrane Planata Vectored permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di canopia ionica."
+    }
+  },
+  "membrane_pneumatofori": {
+    "en": {
+      "label": "Membrane Pneumatofori",
+      "description": "Membrane Pneumatofori allow squads to redistribute load and modulate structural rigidity within mangrovieto cinetico."
+    },
+    "it": {
+      "label": "Membrane Pneumatofori",
+      "description": "Membrane Pneumatofori permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di mangrovieto cinetico."
+    }
+  },
+  "midollo_antivibrazione": {
+    "en": {
+      "label": "Midollo Antivibrazione",
+      "description": "Midollo Antivibrazione allow squads to interpret minute signals and unstable psionic patterns within caverna risonante."
+    },
+    "it": {
+      "label": "Midollo Antivibrazione",
+      "description": "Midollo Antivibrazione permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante."
+    }
+  },
+  "mucose_aderenza_sonica": {
+    "en": {
+      "label": "Mucose Aderenza Sonica",
+      "description": "Mucose Aderenza Sonica allow squads to gain grip and controlled acceleration across extreme terrain within caverna risonante."
+    },
+    "it": {
+      "label": "Mucose Aderenza Sonica",
+      "description": "Mucose Aderenza Sonica permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di caverna risonante."
+    }
+  },
+  "mucose_barofile": {
+    "en": {
+      "label": "Mucose Barofile",
+      "description": "Mucose Barofile allow squads to disperse energy and attenuate corrosive or thermal impacts within abisso vulcanico."
+    },
+    "it": {
+      "label": "Mucose Barofile",
+      "description": "Mucose Barofile permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di abisso vulcanico."
+    }
+  },
+  "aura_scudo_radianza": {
+    "en": {
+      "label": "Radiant Shield Aura",
+      "description": "Photoplasmic field that deflects planar damage while syncing squad vitals."
+    },
+    "it": {
+      "label": "Aura Scudo di Radianza",
+      "description": "Campo fotoplasmatico che devia danni planari e sincronizza i battiti della squadra."
+    }
+  },
+  "frusta_fiammeggiante": {
+    "en": {
+      "label": "Flame Lash",
+      "description": "Bound plasma appendage that can hook and ignite targets."
+    },
+    "it": {
+      "label": "Frusta Fiammeggiante",
+      "description": "Appendice di plasma vincolato capace di arpionare e incendiare bersagli."
+    }
+  },
+  "mantello_meteoritico": {
+    "en": {
+      "label": "Meteoric Mantle",
+      "description": "Regenerating ablative layers that vaporize impacts into thermal pulses."
+    },
+    "it": {
+      "label": "Mantello Meteoritico",
+      "description": "Strati ablativi rigeneranti che vaporizzano l'impatto convertendolo in impulso termico."
+    }
+  },
+  "armatura_pietra_planare": {
+    "en": {
+      "label": "Planar Stone Plating",
+      "description": "Resonant plating carved from extradimensional stone that dampens shockwaves."
+    },
+    "it": {
+      "label": "Armatura di Pietra Planare",
+      "description": "Corazza risonante scolpita da roccia extradimensionale che smorza onde d'urto."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- make `data_origin` part of the mandatory trait fields and document it in the starter JSON skeleton
- ensure every evo tactics trait JSON carries an editorial `data_origin` slug and regenerate coverage/styleguide artifacts
- refresh dashboards and the styleguide status review so species, usage tags, and data-origin coverage reflect the new baseline

## Testing
- python tools/py/collect_trait_fields.py --output reports/trait_fields_by_type.json --glossary-output reports/trait_texts.json
- python tools/py/styleguide_compliance_report.py --strict
- python tools/py/report_trait_coverage.py --strict
- python tools/py/trait_completion_dashboard.py --out-markdown reports/trait_progress.md
- ./.husky/pre-commit


------
https://chatgpt.com/codex/tasks/task_b_690904aa8bbc832a8617b6788f8b72fc