### PR TITLE
Refactor generator utilities into shared modules

### DIFF
--- a/docs/evo-tactics-pack/utils/ids.ts
+++ b/docs/evo-tactics-pack/utils/ids.ts
@@ -1,0 +1,6 @@
+export function randomId(prefix = 'synt'): string {
+  const suffix = Math.random().toString(36).slice(2, 8);
+  return `${prefix}-${suffix}`;
+}
+
+export type RandomIdGenerator = (prefix?: string) => string;

--- a/docs/evo-tactics-pack/utils/normalizers.ts
+++ b/docs/evo-tactics-pack/utils/normalizers.ts
@@ -1,0 +1,164 @@
+import { randomId, type RandomIdGenerator } from './ids.ts';
+import type { FilterSet, GenerationConstraints, HazardLevel, TagEntry, TagLike } from './types.ts';
+
+const ROLE_FLAGS_DEFAULT = ['apex', 'keystone', 'bridge', 'threat', 'event'] as const;
+
+const CLIMATE_HINTS = [
+  { pattern: /frost|criogen|ghiacci|ice/i, value: 'frozen' },
+  { pattern: /desert|sabbia|arid|dust/i, value: 'arid' },
+  { pattern: /tempesta|storm|ion|vento/i, value: 'storm' },
+  { pattern: /fung|micel|caver/i, value: 'subterranean' },
+  { pattern: /abiss|idro|mare|ocean/i, value: 'aquatic' },
+] as const;
+
+function filtersInclude(values: unknown, pattern: RegExp): boolean {
+  if (!Array.isArray(values) || !values.length) return false;
+  return values.some((value) => pattern.test(String(value)));
+}
+
+export function extractRequiredRoles(
+  filters: FilterSet = {},
+  roleFlags: readonly string[] = ROLE_FLAGS_DEFAULT,
+): string[] {
+  const roles = new Set<string>();
+  (Array.isArray(filters.flags) ? filters.flags : []).forEach((flag) => {
+    if (roleFlags.includes(String(flag))) {
+      roles.add(String(flag));
+    }
+  });
+  (Array.isArray(filters.roles) ? filters.roles : []).forEach((token) => {
+    const value = String(token).toLowerCase();
+    if (/apic|predator|apex/i.test(value)) roles.add('apex');
+    if (/chiav|custod|warden|keystone/i.test(value)) roles.add('keystone');
+    if (/ponte|bridge|logist|corridor/i.test(value)) roles.add('bridge');
+    if (/minacc|threat|assalt|predator/i.test(value)) roles.add('threat');
+    if (/evento|anomalia|event/i.test(value)) roles.add('event');
+  });
+  return Array.from(roles);
+}
+
+export function collectPreferredTags(filters: FilterSet = {}): string[] {
+  const tags = new Set<string>();
+  (Array.isArray(filters.tags) ? filters.tags : []).forEach((tag) => {
+    if (tag) {
+      tags.add(String(tag));
+    }
+  });
+  (Array.isArray(filters.roles) ? filters.roles : []).forEach((token) => {
+    const value = String(token).toLowerCase();
+    if (/criogen|frost|ghiacci/i.test(value)) tags.add('criogenico');
+    if (/desert|sabbia|arid/i.test(value)) tags.add('desertico');
+    if (/idro|abiss|marino|ocean/i.test(value)) tags.add('abissale');
+    if (/fung|micel/i.test(value)) tags.add('micelico');
+  });
+  return Array.from(tags);
+}
+
+export function inferHazardFromFilters(filters: FilterSet = {}): HazardLevel {
+  const flags = Array.isArray(filters.flags) ? filters.flags : [];
+  if (flags.some((flag) => String(flag) === 'threat' || String(flag) === 'apex')) {
+    return 'high';
+  }
+  if (filtersInclude(filters.tags, /tempest|storm|pericolo|hazard|ferro/i)) {
+    return 'high';
+  }
+  if (filtersInclude(filters.tags, /rifug|tranquill|shelter|safe/i)) {
+    return 'low';
+  }
+  return 'medium';
+}
+
+export function inferClimateFromFilters(filters: FilterSet = {}): string | null {
+  const tags = Array.isArray(filters.tags) ? filters.tags : [];
+  for (const hint of CLIMATE_HINTS) {
+    if (filtersInclude(tags, hint.pattern)) {
+      return hint.value;
+    }
+  }
+  if (filtersInclude(filters.roles, /criogen|ghiacci|frost/i)) return 'frozen';
+  if (filtersInclude(filters.roles, /fung|micel/i)) return 'subterranean';
+  if (filtersInclude(filters.roles, /idro|abiss|mare|ocean/i)) return 'aquatic';
+  return null;
+}
+
+export function inferMinSize(
+  filters: FilterSet = {},
+  roleFlags: readonly string[] = ROLE_FLAGS_DEFAULT,
+): number {
+  const roles = extractRequiredRoles(filters, roleFlags);
+  const tagCount = Array.isArray(filters.tags) ? filters.tags.length : 0;
+  const base = roles.length >= 3 ? 4 : 3;
+  const bonus = tagCount >= 4 ? 2 : tagCount >= 2 ? 1 : 0;
+  return Math.min(6, base + bonus);
+}
+
+export interface BuildGenerationConstraintsOptions {
+  roleFlags?: readonly string[];
+}
+
+export function buildGenerationConstraints(
+  filters: FilterSet = {},
+  options: BuildGenerationConstraintsOptions = {},
+): GenerationConstraints {
+  const roleFlags = options.roleFlags ?? ROLE_FLAGS_DEFAULT;
+  const requiredRoles = extractRequiredRoles(filters, roleFlags);
+  const preferredTags = collectPreferredTags(filters);
+  const hazard = inferHazardFromFilters(filters);
+  const climate = inferClimateFromFilters(filters);
+  const minSize = inferMinSize(filters, roleFlags);
+  const constraints: GenerationConstraints = {
+    requiredRoles,
+    preferredTags,
+    hazard,
+    climate,
+    minSize,
+  };
+  if (!constraints.requiredRoles?.length) delete constraints.requiredRoles;
+  if (!constraints.preferredTags?.length) delete constraints.preferredTags;
+  if (!constraints.hazard) delete constraints.hazard;
+  if (!constraints.climate) delete constraints.climate;
+  if (!Number.isFinite(constraints.minSize)) delete constraints.minSize;
+  return constraints;
+}
+
+export function normaliseTagId(value: unknown): string {
+  return String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function createTagEntry(
+  tag: TagLike,
+  generator: RandomIdGenerator = randomId,
+): TagEntry | null {
+  if (tag && typeof tag === 'object') {
+    const labelCandidate =
+      (tag as { label?: string | null }).label ??
+      (tag as { name?: string | null }).name ??
+      (tag as { title?: string | null }).title ??
+      (tag as { text?: string | null }).text ??
+      (tag as { value?: string | null }).value ??
+      (tag as { id?: string | null }).id ??
+      '';
+    const label = String(labelCandidate || '').trim();
+    if (!label) {
+      return null;
+    }
+    const idCandidate =
+      (tag as { id?: string | null }).id ??
+      (tag as { value?: string | null }).value ??
+      normaliseTagId(label);
+    const id = normaliseTagId(idCandidate || label) || normaliseTagId(label) || generator('tag');
+    return { id: id || generator('tag'), label };
+  }
+  const label = String(tag ?? '').trim();
+  if (!label) {
+    return null;
+  }
+  const id = normaliseTagId(label) || generator('tag');
+  return { id, label };
+}

--- a/docs/evo-tactics-pack/utils/serializers.ts
+++ b/docs/evo-tactics-pack/utils/serializers.ts
@@ -1,0 +1,148 @@
+import { normaliseTagId } from './normalizers.ts';
+import type { ActivityLogEntryInput, ActivityLogTag, SerialisedActivityLogEntry } from './types.ts';
+
+function toIsoTimestamp(value: ActivityLogEntryInput['timestamp']): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (value === null || value === undefined || value === '') {
+    return new Date().toISOString();
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return new Date().toISOString();
+  }
+  return date.toISOString();
+}
+
+export function serialiseActivityLogEntry(
+  entry: ActivityLogEntryInput,
+): SerialisedActivityLogEntry | null {
+  if (!entry) return null;
+  const tags: ActivityLogTag[] = Array.isArray(entry.tags)
+    ? entry.tags
+        .map((tag) => {
+          if (!tag) return null;
+          if (typeof tag === 'object') {
+            const id =
+              (tag as { id?: string | null; value?: string | null }).id ??
+              (tag as { value?: string | null }).value ??
+              null;
+            const label =
+              (tag as { label?: string | null }).label ??
+              (tag as { name?: string | null }).name ??
+              (tag as { value?: string | null }).value ??
+              (tag as { id?: string | null }).id ??
+              null;
+            if (!id && !label) return null;
+            return {
+              id: id ?? (label ? normaliseTagId(label) || null : null),
+              label: label ?? (id ? String(id) : ''),
+            } as ActivityLogTag;
+          }
+          const label = String(tag ?? '').trim();
+          if (!label) return null;
+          return { id: normaliseTagId(label) || null, label } as ActivityLogTag;
+        })
+        .filter((tag): tag is ActivityLogTag => Boolean(tag))
+    : [];
+
+  return {
+    id: entry.id ?? null,
+    message: entry.message ?? '',
+    tone: entry.tone ?? 'info',
+    timestamp: toIsoTimestamp(entry.timestamp ?? null),
+    tags,
+    action: entry.action ?? null,
+    pinned: Boolean(entry.pinned),
+    metadata: entry.metadata ?? null,
+  };
+}
+
+export function activityLogToCsv(entries: SerialisedActivityLogEntry[]): string {
+  const columns: (keyof SerialisedActivityLogEntry)[] = [
+    'id',
+    'timestamp',
+    'tone',
+    'message',
+    'tags',
+    'action',
+    'pinned',
+    'metadata',
+  ];
+
+  const escape = (value: unknown): string => {
+    if (value === null || value === undefined) return '';
+    const stringValue = String(value);
+    if (/[",\n]/.test(stringValue)) {
+      return `"${stringValue.replace(/"/g, '""')}"`;
+    }
+    return stringValue;
+  };
+
+  const header = columns.join(',');
+  if (!entries.length) {
+    return `${header}\n`;
+  }
+
+  const rows = entries.map((entry) => {
+    const tags = Array.isArray(entry.tags)
+      ? entry.tags
+          .map((tag) => {
+            if (!tag) return null;
+            const label = tag.label ?? tag.id ?? '';
+            return label ? String(label) : null;
+          })
+          .filter((value): value is string => Boolean(value))
+          .join('|')
+      : '';
+    const metadata =
+      entry.metadata === null || entry.metadata === undefined
+        ? ''
+        : typeof entry.metadata === 'string'
+          ? entry.metadata
+          : JSON.stringify(entry.metadata);
+    const record: Record<string, unknown> = {
+      id: entry.id ?? '',
+      timestamp: entry.timestamp ?? '',
+      tone: entry.tone ?? '',
+      message: entry.message ?? '',
+      tags,
+      action: entry.action ?? '',
+      pinned: entry.pinned ? 'true' : 'false',
+      metadata,
+    };
+    return columns.map((column) => escape(record[column])).join(',');
+  });
+
+  return [header, ...rows].join('\n');
+}
+
+export function toYAML(value: unknown, indent = 0): string {
+  const space = '  '.repeat(indent);
+  if (value === null || value === undefined) return 'null';
+  if (Array.isArray(value)) {
+    if (!value.length) return '[]';
+    return value
+      .map((item) => `${space}- ${toYAML(item, indent + 1).replace(/^\s*/, '')}`)
+      .join('\n');
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (!entries.length) return '{}';
+    return entries
+      .map(([key, val]) => {
+        const formatted = toYAML(val, indent + 1);
+        const needsBlock = typeof val === 'object' && val !== null;
+        return `${space}${key}: ${needsBlock ? `\n${formatted}` : formatted}`;
+      })
+      .join('\n');
+  }
+  if (typeof value === 'string') {
+    if (/[:#\-\[\]\{\}\n]/.test(value)) {
+      return JSON.stringify(value);
+    }
+    return value;
+  }
+  return String(value);
+}

--- a/docs/evo-tactics-pack/utils/types.ts
+++ b/docs/evo-tactics-pack/utils/types.ts
@@ -1,0 +1,64 @@
+export type FilterToken = string | number | boolean | null | undefined | { [key: string]: unknown };
+
+export interface FilterSet {
+  flags?: FilterToken[] | null;
+  roles?: FilterToken[] | null;
+  tags?: FilterToken[] | null;
+}
+
+export type HazardLevel = 'low' | 'medium' | 'high';
+
+export interface GenerationConstraints {
+  requiredRoles?: string[];
+  preferredTags?: string[];
+  hazard?: HazardLevel;
+  climate?: string | null;
+  minSize?: number;
+}
+
+export interface TagEntry {
+  id: string;
+  label: string;
+}
+
+export interface ActivityLogTag {
+  id: string | null;
+  label: string;
+}
+
+export type TagLike =
+  | TagEntry
+  | ActivityLogTag
+  | string
+  | {
+      id?: string | null;
+      value?: string | null;
+      label?: string | null;
+      name?: string | null;
+      title?: string | null;
+      text?: string | null;
+    }
+  | null
+  | undefined;
+
+export interface ActivityLogEntryInput {
+  id?: string | null;
+  message?: string | null;
+  tone?: string | null;
+  timestamp?: string | number | Date | null;
+  tags?: TagLike[] | null;
+  action?: string | null;
+  pinned?: boolean | null;
+  metadata?: unknown;
+}
+
+export interface SerialisedActivityLogEntry {
+  id: string | null;
+  message: string;
+  tone: string;
+  timestamp: string;
+  tags: ActivityLogTag[];
+  action: string | null;
+  pinned: boolean;
+  metadata: unknown;
+}


### PR DESCRIPTION
## Summary
- extract generator data utilities into dedicated utils modules
- add shared normalizer and serializer helpers for filters and exports
- update generator to consume the new utilities and shared random id helper

## Testing
- npm run lint --workspaces --if-present

------
https://chatgpt.com/codex/tasks/task_b_6909e3703b3c832a9b959289f99729f1