### PR TITLE
Fix: Convert Evo tactics doc utils to runtime-safe JavaScript

### DIFF
--- a/docs/evo-tactics-pack/utils/ids.ts
+++ b/docs/evo-tactics-pack/utils/ids.ts
@@ -1,6 +1,12 @@
-export function randomId(prefix = 'synt'): string {
+/**
+ * @typedef {import('./types.ts').RandomIdGenerator} RandomIdGenerator
+ */
+
+/**
+ * @param {string} [prefix='synt']
+ * @returns {string}
+ */
+export function randomId(prefix = 'synt') {
   const suffix = Math.random().toString(36).slice(2, 8);
   return `${prefix}-${suffix}`;
 }
-
-export type RandomIdGenerator = (prefix?: string) => string;

--- a/docs/evo-tactics-pack/utils/normalizers.ts
+++ b/docs/evo-tactics-pack/utils/normalizers.ts
@@ -1,32 +1,54 @@
-import { randomId, type RandomIdGenerator } from './ids.ts';
-import type { FilterSet, GenerationConstraints, HazardLevel, TagEntry, TagLike } from './types.ts';
+import { randomId } from './ids.ts';
 
-const ROLE_FLAGS_DEFAULT = ['apex', 'keystone', 'bridge', 'threat', 'event'] as const;
+/**
+ * @typedef {import('./types.ts').FilterSet} FilterSet
+ * @typedef {import('./types.ts').GenerationConstraints} GenerationConstraints
+ * @typedef {import('./types.ts').HazardLevel} HazardLevel
+ * @typedef {import('./types.ts').TagEntry} TagEntry
+ * @typedef {import('./types.ts').TagLike} TagLike
+ * @typedef {import('./types.ts').RandomIdGenerator} RandomIdGenerator
+ */
 
-const CLIMATE_HINTS = [
-  { pattern: /frost|criogen|ghiacci|ice/i, value: 'frozen' },
-  { pattern: /desert|sabbia|arid|dust/i, value: 'arid' },
-  { pattern: /tempesta|storm|ion|vento/i, value: 'storm' },
-  { pattern: /fung|micel|caver/i, value: 'subterranean' },
-  { pattern: /abiss|idro|mare|ocean/i, value: 'aquatic' },
-] as const;
+const ROLE_FLAGS_DEFAULT = Object.freeze(['apex', 'keystone', 'bridge', 'threat', 'event']);
 
-function filtersInclude(values: unknown, pattern: RegExp): boolean {
-  if (!Array.isArray(values) || !values.length) return false;
+const CLIMATE_HINTS = Object.freeze([
+  Object.freeze({ pattern: /frost|criogen|ghiacci|ice/i, value: 'frozen' }),
+  Object.freeze({ pattern: /desert|sabbia|arid|dust/i, value: 'arid' }),
+  Object.freeze({ pattern: /tempesta|storm|ion|vento/i, value: 'storm' }),
+  Object.freeze({ pattern: /fung|micel|caver/i, value: 'subterranean' }),
+  Object.freeze({ pattern: /abiss|idro|mare|ocean/i, value: 'aquatic' }),
+]);
+
+/**
+ * @param {unknown} values
+ * @param {RegExp} pattern
+ * @returns {boolean}
+ */
+function filtersInclude(values, pattern) {
+  if (!Array.isArray(values) || values.length === 0) return false;
   return values.some((value) => pattern.test(String(value)));
 }
 
-export function extractRequiredRoles(
-  filters: FilterSet = {},
-  roleFlags: readonly string[] = ROLE_FLAGS_DEFAULT,
-): string[] {
-  const roles = new Set<string>();
-  (Array.isArray(filters.flags) ? filters.flags : []).forEach((flag) => {
-    if (roleFlags.includes(String(flag))) {
-      roles.add(String(flag));
+/**
+ * @param {FilterSet | null | undefined} filters
+ * @param {readonly string[]} [roleFlags]
+ * @returns {string[]}
+ */
+export function extractRequiredRoles(filters = {}, roleFlags = ROLE_FLAGS_DEFAULT) {
+  const safeRoleFlags = Array.isArray(roleFlags) ? roleFlags : ROLE_FLAGS_DEFAULT;
+  const roles = new Set();
+  const safeFilters = filters && typeof filters === 'object' ? filters : {};
+  const flags = Array.isArray(safeFilters.flags) ? safeFilters.flags : [];
+  const roleTokens = Array.isArray(safeFilters.roles) ? safeFilters.roles : [];
+
+  flags.forEach((flag) => {
+    const value = String(flag);
+    if (safeRoleFlags.includes(value)) {
+      roles.add(value);
     }
   });
-  (Array.isArray(filters.roles) ? filters.roles : []).forEach((token) => {
+
+  roleTokens.forEach((token) => {
     const value = String(token).toLowerCase();
     if (/apic|predator|apex/i.test(value)) roles.add('apex');
     if (/chiav|custod|warden|keystone/i.test(value)) roles.add('keystone');
@@ -34,94 +56,129 @@ export function extractRequiredRoles(
     if (/minacc|threat|assalt|predator/i.test(value)) roles.add('threat');
     if (/evento|anomalia|event/i.test(value)) roles.add('event');
   });
+
   return Array.from(roles);
 }
 
-export function collectPreferredTags(filters: FilterSet = {}): string[] {
-  const tags = new Set<string>();
-  (Array.isArray(filters.tags) ? filters.tags : []).forEach((tag) => {
+/**
+ * @param {FilterSet | null | undefined} filters
+ * @returns {string[]}
+ */
+export function collectPreferredTags(filters = {}) {
+  const safeFilters = filters && typeof filters === 'object' ? filters : {};
+  const tags = new Set();
+  const tagTokens = Array.isArray(safeFilters.tags) ? safeFilters.tags : [];
+  const roleTokens = Array.isArray(safeFilters.roles) ? safeFilters.roles : [];
+
+  tagTokens.forEach((tag) => {
     if (tag) {
       tags.add(String(tag));
     }
   });
-  (Array.isArray(filters.roles) ? filters.roles : []).forEach((token) => {
+
+  roleTokens.forEach((token) => {
     const value = String(token).toLowerCase();
     if (/criogen|frost|ghiacci/i.test(value)) tags.add('criogenico');
     if (/desert|sabbia|arid/i.test(value)) tags.add('desertico');
     if (/idro|abiss|marino|ocean/i.test(value)) tags.add('abissale');
     if (/fung|micel/i.test(value)) tags.add('micelico');
   });
+
   return Array.from(tags);
 }
 
-export function inferHazardFromFilters(filters: FilterSet = {}): HazardLevel {
-  const flags = Array.isArray(filters.flags) ? filters.flags : [];
+/**
+ * @param {FilterSet | null | undefined} filters
+ * @returns {HazardLevel}
+ */
+export function inferHazardFromFilters(filters = {}) {
+  const safeFilters = filters && typeof filters === 'object' ? filters : {};
+  const flags = Array.isArray(safeFilters.flags) ? safeFilters.flags : [];
   if (flags.some((flag) => String(flag) === 'threat' || String(flag) === 'apex')) {
     return 'high';
   }
-  if (filtersInclude(filters.tags, /tempest|storm|pericolo|hazard|ferro/i)) {
+  if (filtersInclude(safeFilters.tags, /tempest|storm|pericolo|hazard|ferro/i)) {
     return 'high';
   }
-  if (filtersInclude(filters.tags, /rifug|tranquill|shelter|safe/i)) {
+  if (filtersInclude(safeFilters.tags, /rifug|tranquill|shelter|safe/i)) {
     return 'low';
   }
   return 'medium';
 }
 
-export function inferClimateFromFilters(filters: FilterSet = {}): string | null {
-  const tags = Array.isArray(filters.tags) ? filters.tags : [];
+/**
+ * @param {FilterSet | null | undefined} filters
+ * @returns {string | null}
+ */
+export function inferClimateFromFilters(filters = {}) {
+  const safeFilters = filters && typeof filters === 'object' ? filters : {};
+  const tags = Array.isArray(safeFilters.tags) ? safeFilters.tags : [];
   for (const hint of CLIMATE_HINTS) {
     if (filtersInclude(tags, hint.pattern)) {
       return hint.value;
     }
   }
-  if (filtersInclude(filters.roles, /criogen|ghiacci|frost/i)) return 'frozen';
-  if (filtersInclude(filters.roles, /fung|micel/i)) return 'subterranean';
-  if (filtersInclude(filters.roles, /idro|abiss|mare|ocean/i)) return 'aquatic';
+  if (filtersInclude(safeFilters.roles, /criogen|ghiacci|frost/i)) return 'frozen';
+  if (filtersInclude(safeFilters.roles, /fung|micel/i)) return 'subterranean';
+  if (filtersInclude(safeFilters.roles, /idro|abiss|mare|ocean/i)) return 'aquatic';
   return null;
 }
 
-export function inferMinSize(
-  filters: FilterSet = {},
-  roleFlags: readonly string[] = ROLE_FLAGS_DEFAULT,
-): number {
-  const roles = extractRequiredRoles(filters, roleFlags);
-  const tagCount = Array.isArray(filters.tags) ? filters.tags.length : 0;
+/**
+ * @param {FilterSet | null | undefined} filters
+ * @param {readonly string[]} [roleFlags]
+ * @returns {number}
+ */
+export function inferMinSize(filters = {}, roleFlags = ROLE_FLAGS_DEFAULT) {
+  const safeRoleFlags = Array.isArray(roleFlags) ? roleFlags : ROLE_FLAGS_DEFAULT;
+  const roles = extractRequiredRoles(filters, safeRoleFlags);
+  const safeFilters = filters && typeof filters === 'object' ? filters : {};
+  const tagCount = Array.isArray(safeFilters.tags) ? safeFilters.tags.length : 0;
   const base = roles.length >= 3 ? 4 : 3;
   const bonus = tagCount >= 4 ? 2 : tagCount >= 2 ? 1 : 0;
   return Math.min(6, base + bonus);
 }
 
-export interface BuildGenerationConstraintsOptions {
-  roleFlags?: readonly string[];
-}
+/**
+ * @typedef {Object} BuildGenerationConstraintsOptions
+ * @property {readonly string[]} [roleFlags]
+ */
 
-export function buildGenerationConstraints(
-  filters: FilterSet = {},
-  options: BuildGenerationConstraintsOptions = {},
-): GenerationConstraints {
-  const roleFlags = options.roleFlags ?? ROLE_FLAGS_DEFAULT;
+/**
+ * @param {FilterSet | null | undefined} filters
+ * @param {BuildGenerationConstraintsOptions} [options]
+ * @returns {GenerationConstraints}
+ */
+export function buildGenerationConstraints(filters = {}, options = {}) {
+  const roleFlags = Array.isArray(options.roleFlags) ? options.roleFlags : ROLE_FLAGS_DEFAULT;
   const requiredRoles = extractRequiredRoles(filters, roleFlags);
   const preferredTags = collectPreferredTags(filters);
   const hazard = inferHazardFromFilters(filters);
   const climate = inferClimateFromFilters(filters);
   const minSize = inferMinSize(filters, roleFlags);
-  const constraints: GenerationConstraints = {
+  /** @type {GenerationConstraints} */
+  const constraints = {
     requiredRoles,
     preferredTags,
     hazard,
     climate,
     minSize,
   };
-  if (!constraints.requiredRoles?.length) delete constraints.requiredRoles;
-  if (!constraints.preferredTags?.length) delete constraints.preferredTags;
+  if (!constraints.requiredRoles || constraints.requiredRoles.length === 0)
+    delete constraints.requiredRoles;
+  if (!constraints.preferredTags || constraints.preferredTags.length === 0)
+    delete constraints.preferredTags;
   if (!constraints.hazard) delete constraints.hazard;
   if (!constraints.climate) delete constraints.climate;
   if (!Number.isFinite(constraints.minSize)) delete constraints.minSize;
   return constraints;
 }
 
-export function normaliseTagId(value: unknown): string {
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normaliseTagId(value) {
   return String(value ?? '')
     .trim()
     .toLowerCase()
@@ -131,34 +188,38 @@ export function normaliseTagId(value: unknown): string {
     .replace(/^-+|-+$/g, '');
 }
 
-export function createTagEntry(
-  tag: TagLike,
-  generator: RandomIdGenerator = randomId,
-): TagEntry | null {
+/**
+ * @param {TagLike} tag
+ * @param {RandomIdGenerator} [generator]
+ * @returns {TagEntry | null}
+ */
+export function createTagEntry(tag, generator = randomId) {
   if (tag && typeof tag === 'object') {
+    const tagObject = /** @type {Record<string, unknown>} */ tag;
     const labelCandidate =
-      (tag as { label?: string | null }).label ??
-      (tag as { name?: string | null }).name ??
-      (tag as { title?: string | null }).title ??
-      (tag as { text?: string | null }).text ??
-      (tag as { value?: string | null }).value ??
-      (tag as { id?: string | null }).id ??
+      (typeof tagObject.label === 'string' ? tagObject.label : null) ??
+      (typeof tagObject.name === 'string' ? tagObject.name : null) ??
+      (typeof tagObject.title === 'string' ? tagObject.title : null) ??
+      (typeof tagObject.text === 'string' ? tagObject.text : null) ??
+      (typeof tagObject.value === 'string' ? tagObject.value : null) ??
+      (typeof tagObject.id === 'string' ? tagObject.id : null) ??
       '';
     const label = String(labelCandidate || '').trim();
     if (!label) {
       return null;
     }
     const idCandidate =
-      (tag as { id?: string | null }).id ??
-      (tag as { value?: string | null }).value ??
+      (typeof tagObject.id === 'string' ? tagObject.id : null) ??
+      (typeof tagObject.value === 'string' ? tagObject.value : null) ??
       normaliseTagId(label);
     const id = normaliseTagId(idCandidate || label) || normaliseTagId(label) || generator('tag');
     return { id: id || generator('tag'), label };
   }
-  const label = String(tag ?? '').trim();
-  if (!label) {
+  const label = typeof tag === 'string' ? tag : String(tag ?? '');
+  const trimmed = label.trim();
+  if (!trimmed) {
     return null;
   }
-  const id = normaliseTagId(label) || generator('tag');
-  return { id, label };
+  const id = normaliseTagId(trimmed) || generator('tag');
+  return { id, label: trimmed };
 }

--- a/docs/evo-tactics-pack/utils/types.ts
+++ b/docs/evo-tactics-pack/utils/types.ts
@@ -1,64 +1,78 @@
-export type FilterToken = string | number | boolean | null | undefined | { [key: string]: unknown };
+/**
+ * @typedef {string | number | boolean | null | undefined | Record<string, unknown>} FilterToken
+ */
 
-export interface FilterSet {
-  flags?: FilterToken[] | null;
-  roles?: FilterToken[] | null;
-  tags?: FilterToken[] | null;
-}
+/**
+ * @typedef {Object} FilterSet
+ * @property {(FilterToken[] | null | undefined)} [flags]
+ * @property {(FilterToken[] | null | undefined)} [roles]
+ * @property {(FilterToken[] | null | undefined)} [tags]
+ */
 
-export type HazardLevel = 'low' | 'medium' | 'high';
+/**
+ * @typedef {'low' | 'medium' | 'high'} HazardLevel
+ */
 
-export interface GenerationConstraints {
-  requiredRoles?: string[];
-  preferredTags?: string[];
-  hazard?: HazardLevel;
-  climate?: string | null;
-  minSize?: number;
-}
+/**
+ * @typedef {Object} GenerationConstraints
+ * @property {string[]} [requiredRoles]
+ * @property {string[]} [preferredTags]
+ * @property {HazardLevel} [hazard]
+ * @property {string | null} [climate]
+ * @property {number} [minSize]
+ */
 
-export interface TagEntry {
-  id: string;
-  label: string;
-}
+/**
+ * @typedef {Object} TagEntry
+ * @property {string} id
+ * @property {string} label
+ */
 
-export interface ActivityLogTag {
-  id: string | null;
-  label: string;
-}
+/**
+ * @typedef {Object} ActivityLogTag
+ * @property {string | null} id
+ * @property {string} label
+ */
 
-export type TagLike =
-  | TagEntry
-  | ActivityLogTag
-  | string
-  | {
-      id?: string | null;
-      value?: string | null;
-      label?: string | null;
-      name?: string | null;
-      title?: string | null;
-      text?: string | null;
-    }
-  | null
-  | undefined;
+/**
+ * @typedef {TagEntry | ActivityLogTag | string | {
+ *   id?: string | null,
+ *   value?: string | null,
+ *   label?: string | null,
+ *   name?: string | null,
+ *   title?: string | null,
+ *   text?: string | null,
+ * } | null | undefined} TagLike
+ */
 
-export interface ActivityLogEntryInput {
-  id?: string | null;
-  message?: string | null;
-  tone?: string | null;
-  timestamp?: string | number | Date | null;
-  tags?: TagLike[] | null;
-  action?: string | null;
-  pinned?: boolean | null;
-  metadata?: unknown;
-}
+/**
+ * @typedef {Object} ActivityLogEntryInput
+ * @property {string | null} [id]
+ * @property {string | null} [message]
+ * @property {string | null} [tone]
+ * @property {string | number | Date | null} [timestamp]
+ * @property {TagLike[] | null} [tags]
+ * @property {string | null} [action]
+ * @property {boolean | null} [pinned]
+ * @property {unknown} [metadata]
+ */
 
-export interface SerialisedActivityLogEntry {
-  id: string | null;
-  message: string;
-  tone: string;
-  timestamp: string;
-  tags: ActivityLogTag[];
-  action: string | null;
-  pinned: boolean;
-  metadata: unknown;
-}
+/**
+ * @typedef {Object} SerialisedActivityLogEntry
+ * @property {string | null} id
+ * @property {string} message
+ * @property {string} tone
+ * @property {string} timestamp
+ * @property {ActivityLogTag[]} tags
+ * @property {string | null} action
+ * @property {boolean} pinned
+ * @property {unknown} metadata
+ */
+
+/**
+ * @callback RandomIdGenerator
+ * @param {string} [prefix]
+ * @returns {string}
+ */
+
+export {};


### PR DESCRIPTION
## Summary
- rewrite the Evo tactics documentation utilities (ids, normalizers, serializers, types) using runtime-valid JavaScript with JSDoc typedefs
- ensure shared generator helpers no longer rely on TypeScript-only syntax so they can load directly in the browser

## Testing
- npm run lint --workspaces --if-present

------
https://chatgpt.com/codex/tasks/task_b_6909ecdfcf54832a8bd10e0c04dcbf7e