### PR TITLE
Refactor Evo pack generator panels into modular views

### DIFF
--- a/docs/evo-tactics-pack/views/biomes.js
+++ b/docs/evo-tactics-pack/views/biomes.js
@@ -1,0 +1,10 @@
+export function setup(state, elements, deps = {}) {
+  deps.attachComparisonHandlers?.(state, elements);
+}
+
+export function render(state, elements, deps = {}) {
+  const { context = {}, renderBiomes, currentFilters } = deps;
+  const filters =
+    context.filters ?? (typeof currentFilters === 'function' ? currentFilters() : undefined);
+  renderBiomes?.(filters);
+}

--- a/docs/evo-tactics-pack/views/composer.js
+++ b/docs/evo-tactics-pack/views/composer.js
@@ -1,0 +1,7 @@
+export function setup(state, elements, deps = {}) {
+  deps.attachComposerHandlers?.(state, elements);
+}
+
+export function render(state, elements, deps = {}) {
+  deps.renderComposerPanel?.(state, elements);
+}

--- a/docs/evo-tactics-pack/views/insights.js
+++ b/docs/evo-tactics-pack/views/insights.js
@@ -1,0 +1,11 @@
+export function setup(state, elements, deps = {}) {
+  deps.attachInsightHandlers?.(state, elements);
+}
+
+export function render(state, elements, deps = {}) {
+  const { context = {}, renderContextualInsights, getRecommendations } = deps;
+  const recommendations =
+    context.recommendations ??
+    (typeof getRecommendations === 'function' ? getRecommendations() : []);
+  renderContextualInsights?.(recommendations);
+}

--- a/docs/evo-tactics-pack/views/parameters.js
+++ b/docs/evo-tactics-pack/views/parameters.js
@@ -1,0 +1,35 @@
+export function setup(state, elements, deps = {}) {
+  deps.setupFilterChangeHandlers?.(state, elements);
+  deps.attachProfileHandlers?.(state, elements);
+  deps.setupExportControls?.(state, elements);
+}
+
+export function render(state, elements, deps = {}) {
+  const {
+    context = {},
+    renderProfileSlots,
+    renderExportManifest,
+    renderKpiSidebar,
+    currentFilters,
+  } = deps;
+
+  const refreshTargets = Array.isArray(context.refresh)
+    ? new Set(context.refresh)
+    : new Set(['profiles', 'export', 'kpi']);
+
+  if (refreshTargets.has('profiles') && typeof renderProfileSlots === 'function') {
+    renderProfileSlots(state, elements);
+  }
+
+  if (refreshTargets.has('export') && typeof renderExportManifest === 'function') {
+    const filters =
+      context.filters ??
+      (typeof context.getFilters === 'function' ? context.getFilters() : undefined) ??
+      (typeof currentFilters === 'function' ? currentFilters() : undefined);
+    renderExportManifest(filters);
+  }
+
+  if (refreshTargets.has('kpi') && typeof renderKpiSidebar === 'function') {
+    renderKpiSidebar(state, elements);
+  }
+}

--- a/docs/evo-tactics-pack/views/seeds.js
+++ b/docs/evo-tactics-pack/views/seeds.js
@@ -1,0 +1,5 @@
+export function setup() {}
+
+export function render(state, elements, deps = {}) {
+  deps.renderSeeds?.(state, elements);
+}

--- a/docs/evo-tactics-pack/views/traits.js
+++ b/docs/evo-tactics-pack/views/traits.js
@@ -1,0 +1,5 @@
+export function setup() {}
+
+export function render(state, elements, deps = {}) {
+  deps.renderTraitExpansions?.(state, elements);
+}


### PR DESCRIPTION
## Summary
- introduce a panel registry that orchestrates generator panel setup and rendering
- add view modules for each main generator panel exposing setup/render entry points
- update generator state updates to trigger the new panel renderers instead of direct DOM manipulation

## Testing
- npm run lint --workspaces --if-present

------
https://chatgpt.com/codex/tasks/task_b_6909f0a891f8832ab5cb5e43a6584170