### PR TITLE
Add docs generator tests and flows coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "npm run build --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "test": "npm run test:api && npm run test --workspace tools/ts && npm run test --workspace webapp",
+    "test:docs-generator": "npx vitest run --config vitest.config.docs-generator.ts",
     "preview": "npm run preview --workspace webapp",
     "test:web": "npm run test:web --workspace tools/ts",
     "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && node --test tests/server/generationSnapshot.spec.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-latency.spec.ts && ./node_modules/.bin/tsx tests/scripts/tune_items.test.ts && ./node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts && node --test tests/tools/deploy-checks.spec.js",

--- a/tests/docs-generator/integration/generator.integration.test.ts
+++ b/tests/docs-generator/integration/generator.integration.test.ts
@@ -1,0 +1,471 @@
+/// <reference types="vitest" />
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+let elements: ReturnType<typeof createStubElements>;
+let anchorUi: ReturnType<typeof createAnchorUi>;
+const canvasContextStub = {
+  clearRect: vi.fn(),
+  fillRect: vi.fn(),
+  beginPath: vi.fn(),
+  arc: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+  stroke: vi.fn(),
+  fillText: vi.fn(),
+  closePath: vi.fn(),
+  save: vi.fn(),
+  restore: vi.fn(),
+  setLineDash: vi.fn(),
+  createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+};
+let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
+let originalScrollIntoView: typeof Element.prototype.scrollIntoView;
+let originalFocus: typeof HTMLElement.prototype.focus;
+
+const stubCatalog = {
+  species: [
+    {
+      id: 'synthetic-hunter',
+      display_name: 'Predatore sintetico',
+      role_trofico: 'predatore_apex',
+      functional_tags: ['criogenico', 'tempesta'],
+      flags: { apex: true, threat: true },
+    },
+  ],
+  biomi: [
+    {
+      id: 'frozen-ridge',
+      label: 'Cresta ghiacciata',
+      hazard: { severity: 'medium' },
+      traits: { ids: ['cryostasis'] },
+      manifest: { species_counts: { apex: 1, keystone: 0, bridge: 0, threat: 0, event: 0 } },
+      metrics: { zoneCount: 3 },
+      species: [
+        {
+          id: 'frost-scale',
+          display_name: 'Scala glaciale',
+          role_trofico: 'predatore_secondario',
+          functional_tags: ['criogenico'],
+          flags: { threat: true },
+          biomes: ['frozen-ridge'],
+        },
+      ],
+    },
+  ],
+  ecosistema: { biomi: [{ id: 'baseline', label: 'Bioma base' }] },
+  traits: {},
+};
+
+const fetchTraitRegistry = vi.fn(async () => ({
+  data: { rules: [] },
+  url: null,
+  fromFallback: false,
+}));
+const fetchTraitReference = vi.fn(async () => ({
+  data: { traits: {}, trait_glossary: null },
+  url: null,
+  fromFallback: false,
+}));
+const fetchTraitGlossary = vi.fn(async () => ({
+  data: { traits: {} },
+  url: null,
+  fromFallback: false,
+}));
+const fetchHazardRegistry = vi.fn(async () => ({
+  data: { hazards: {} },
+  url: null,
+  fromFallback: false,
+}));
+const fetchSpecies = vi.fn(async () => ({ data: [], url: null, fromFallback: false }));
+
+vi.mock('../../../docs/evo-tactics-pack/ui/elements.ts', () => ({
+  resolveGeneratorElements: () => elements,
+  resolveAnchorUi: () => anchorUi,
+}));
+
+vi.mock('../../../docs/evo-tactics-pack/pack-data.js', () => {
+  const candidates = ['https://example.test/packs/evo_tactics_pack/'];
+  const buildContext = () => ({
+    resolvedBase: candidates[0],
+    docsBase: `${candidates[0]}docs/`,
+    catalogUrl: `${candidates[0]}docs/catalog/catalog_data.json`,
+    apiBase: null,
+  });
+  const buildResult = () => ({ data: { ...stubCatalog }, context: buildContext() });
+  return {
+    PACK_PATH: 'packs/evo_tactics_pack/',
+    getPackRootCandidates: () => [...candidates],
+    loadPackCatalog: vi.fn(async () => buildResult()),
+    manualLoadCatalog: vi.fn(async () => buildResult()),
+  };
+});
+
+vi.mock('../../../services/api/generatorClient.ts', () => ({
+  fetchTraitRegistry,
+  fetchTraitReference,
+  fetchTraitGlossary,
+  fetchHazardRegistry,
+  fetchSpecies,
+}));
+
+vi.mock('../../../services/export/dossier.ts', () => ({
+  loadDossierTemplate: vi.fn(async () => '<div>Dossier</div>'),
+  generateDossierDocument: vi.fn(async () => ({ sections: [] })),
+  generateDossierHtml: vi.fn(async () => '<article></article>'),
+  generateDossierPdfBlob: vi.fn(async () => new Blob()),
+  buildPressKitMarkdown: vi.fn(async () => '# Press kit'),
+  generatePresetFileContents: vi.fn(async () => new Map()),
+}));
+
+vi.mock('../../../docs/evo-tactics-pack/views/parameters.js', () => ({
+  setup: vi.fn((state, els, deps) => {
+    deps?.setupFilterChangeHandlers?.(state, els);
+    deps?.attachProfileHandlers?.(state, els);
+    deps?.setupExportControls?.(state, els);
+  }),
+  render: vi.fn(),
+}));
+
+const noopViewModule = () => ({ setup: vi.fn(), render: vi.fn() });
+vi.mock('../../../docs/evo-tactics-pack/views/traits.js', () => noopViewModule());
+vi.mock('../../../docs/evo-tactics-pack/views/biomes.js', () => noopViewModule());
+vi.mock('../../../docs/evo-tactics-pack/views/seeds.js', () => noopViewModule());
+vi.mock('../../../docs/evo-tactics-pack/views/composer.js', () => noopViewModule());
+vi.mock('../../../docs/evo-tactics-pack/views/insights.js', () => noopViewModule());
+
+describe('docs generator — browser integration', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    document.body.innerHTML = '';
+    elements = createStubElements();
+    anchorUi = createAnchorUi();
+
+    globalThis.CSS = globalThis.CSS || { escape: (value: string) => String(value) };
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = vi.fn(async () => {
+      throw new Error('fetch unavailable in tests');
+    });
+
+    originalGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = vi.fn(() => canvasContextStub);
+
+    originalScrollIntoView = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = vi.fn();
+
+    originalFocus = HTMLElement.prototype.focus;
+    HTMLElement.prototype.focus = vi.fn();
+
+    globalThis.IntersectionObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as typeof IntersectionObserver;
+
+    globalThis.requestAnimationFrame = (callback: FrameRequestCallback) =>
+      setTimeout(() => callback(performance.now()), 0);
+    globalThis.cancelAnimationFrame = (handle: number) => clearTimeout(handle);
+
+    Object.assign(window, {
+      Chart: vi.fn(() => ({ destroy: vi.fn(), data: { datasets: [] }, update: vi.fn() })),
+      JSZip: class {
+        folder() {
+          return this;
+        }
+        file() {
+          return this;
+        }
+        async generateAsync() {
+          return new Uint8Array();
+        }
+      },
+      html2pdf: {
+        from() {
+          return this;
+        },
+        set() {
+          return this;
+        },
+        save: vi.fn(),
+        outputPdf: vi.fn(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    delete (window as { EvoPack?: unknown }).EvoPack;
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+    HTMLElement.prototype.focus = originalFocus;
+    vi.restoreAllMocks();
+  });
+
+  it('initialises the global generator state', async () => {
+    await import('../../../docs/evo-tactics-pack/generator.js');
+    await tick();
+
+    const generator = (window as { EvoPack?: { generator?: { state: unknown } } }).EvoPack
+      ?.generator;
+    expect(generator?.state).toBeDefined();
+    expect(generator?.state).toMatchObject({
+      activityLog: expect.any(Array),
+      preferences: { audioMuted: false, volume: 0.75 },
+    });
+    expect(Array.isArray(generator?.state?.activityLog)).toBe(true);
+  });
+
+  it('updates filters when multiselect change events fire', async () => {
+    await import('../../../docs/evo-tactics-pack/generator.js');
+    await tick();
+
+    const flagButton = elements.flags.querySelector(
+      '[data-multiselect-option]',
+    ) as HTMLButtonElement;
+    expect(flagButton).toBeTruthy();
+
+    flagButton.click();
+
+    const state = (window as { EvoPack?: { generator?: { state: any } } }).EvoPack?.generator
+      ?.state;
+    expect(state?.lastFilters?.flags).toEqual(['apex']);
+    expect(elements.filtersHint.textContent).toContain('Filtri attivi');
+  });
+});
+
+function createStubElements() {
+  const root = document.createElement('div');
+  root.id = 'generator-test-root';
+  document.body.appendChild(root);
+
+  const create = <K extends keyof HTMLElementTagNameMap>(tag: K) => {
+    const node = document.createElement(tag);
+    root.appendChild(node);
+    return node;
+  };
+
+  const form = create('form');
+  form.id = 'generator-form';
+
+  const flags = create('div');
+  const roles = create('div');
+  const tags = create('div');
+
+  const filtersHint = create('p');
+  filtersHint.id = 'generator-filters-hint';
+
+  const nBiomi = create('input');
+  nBiomi.id = 'nBiomi';
+  nBiomi.setAttribute('type', 'number');
+  nBiomi.value = '2';
+
+  const summaryContainer = create('section');
+  summaryContainer.id = 'generator-summary';
+
+  const summaryCounts = {
+    biomes: document.createElement('span'),
+    species: document.createElement('span'),
+    seeds: document.createElement('span'),
+  };
+  summaryCounts.biomes.dataset.summary = 'biomes';
+  summaryCounts.species.dataset.summary = 'species';
+  summaryCounts.seeds.dataset.summary = 'seeds';
+  summaryContainer.append(summaryCounts.biomes, summaryCounts.species, summaryCounts.seeds);
+
+  const makeButton = (label = '') => {
+    const button = create('button');
+    button.type = 'button';
+    button.textContent = label;
+    return button;
+  };
+
+  const audioControls = create('div');
+  const audioMute = makeButton('mute');
+  const audioVolume = create('input');
+  audioVolume.setAttribute('type', 'range');
+
+  const profileSlots = create('div');
+
+  const composerSynergySlider = create('input');
+  composerSynergySlider.setAttribute('type', 'range');
+  composerSynergySlider.value = '45';
+  const composerSynergyValue = create('span');
+
+  const composerRadarCanvas = create('canvas');
+  const composerHeatmap = create('div');
+  const compareCanvas = create('canvas');
+
+  const compareList = create('ul');
+  const pinnedList = create('ul');
+  const flowMapList = create('ul');
+  const historyList = create('ul');
+  const logList = create('ul');
+
+  const activitySearch = create('input');
+  activitySearch.setAttribute('type', 'search');
+  const activityTagFilter = document.createElement('select');
+  root.appendChild(activityTagFilter);
+  const activityPinnedOnly = create('input');
+  activityPinnedOnly.setAttribute('type', 'checkbox');
+
+  const activityToneToggles = [makeButton('info'), makeButton('warn')];
+  activityToneToggles.forEach((button, index) => {
+    button.dataset.activityTone = index === 0 ? 'info' : 'warn';
+  });
+
+  const activityReset = makeButton('reset');
+  activityReset.dataset.action = 'reset-activity-filters';
+
+  const exportPreset = document.createElement('select');
+  root.appendChild(exportPreset);
+  const exportPreviewJson = create('pre');
+  const exportPreviewYaml = create('pre');
+  const exportPreviewJsonDetails = create('details');
+  const exportPreviewYamlDetails = create('details');
+  const dossierPreview = create('div');
+
+  const flowNode = create('div');
+  flowNode.dataset.flowNode = 'onboarding';
+  const flowNodes = [flowNode];
+
+  const toneContainer = create('div');
+  toneContainer.append(...activityToneToggles);
+
+  const kpi = {
+    averageRoll: create('span'),
+    rerollCount: create('span'),
+    uniqueSpecies: create('span'),
+    profileReuses: create('span'),
+  };
+
+  const filters = {
+    form,
+    flags,
+    roles,
+    tags,
+    filtersHint,
+    nBiomi,
+    biomeGrid: create('div'),
+    traitGrid: create('div'),
+    seedGrid: create('div'),
+    status: create('p'),
+    summaryContainer,
+    summaryCounts,
+    narrativePanel: create('section'),
+    narrativeBriefing: create('p'),
+    narrativeHook: create('p'),
+    narrativeInsightPanel: create('section'),
+    narrativeInsightEmpty: create('div'),
+    narrativeInsightList: create('ul'),
+    briefingPanel: create('section'),
+    hookPanel: create('section'),
+    audioControls,
+    audioMute,
+    audioVolume,
+    profilePanel: create('section'),
+    profileSlots,
+    profileEmpty: create('div'),
+    composerPanel: create('section'),
+    composerPresetList: create('ul'),
+    composerPresetEmpty: create('div'),
+    composerSuggestions: create('ul'),
+    composerSuggestionsEmpty: create('div'),
+    composerRoleToggles: create('div'),
+    composerSynergySlider,
+    composerSynergyValue,
+    composerRadarCanvas,
+    composerHeatmap,
+    comparePanel: create('section'),
+    compareList,
+    compareEmpty: create('div'),
+    compareChartContainer: create('div'),
+    compareCanvas,
+    compareFallback: create('div'),
+    pinnedList,
+    pinnedEmpty: create('div'),
+    flowMapList,
+    flowNodes,
+    historyPanel: create('section'),
+    historyList,
+    historyEmpty: create('div'),
+    lastAction: create('p'),
+    logList,
+    logEmpty: create('div'),
+    activitySearch,
+    activityTagFilter,
+    activityPinnedOnly,
+    activityToneToggles,
+    activityReset,
+    exportMeta: create('div'),
+    exportList: create('ul'),
+    exportEmpty: create('div'),
+    exportActions: create('div'),
+    exportPreset,
+    exportPresetStatus: create('p'),
+    exportPreview: create('div'),
+    exportPreviewEmpty: create('div'),
+    exportPreviewJson,
+    exportPreviewYaml,
+    exportPreviewJsonDetails,
+    exportPreviewYamlDetails,
+    dossierPreview,
+    dossierEmpty: create('div'),
+    insightsPanel: create('section'),
+    insightsEmpty: create('div'),
+    insightsList: create('ul'),
+    kpi,
+  } as const;
+
+  return filters;
+}
+
+function createAnchorUi() {
+  const root = document.createElement('div');
+  root.dataset.anchorRoot = 'true';
+  document.body.appendChild(root);
+
+  const anchor = document.createElement('a');
+  anchor.dataset.anchorTarget = 'parameters';
+  anchor.href = '#generator-parameters';
+  document.body.appendChild(anchor);
+
+  const panel = document.createElement('section');
+  panel.dataset.panel = 'parameters';
+  document.body.appendChild(panel);
+
+  const breadcrumb = document.createElement('button');
+  breadcrumb.dataset.anchorBreadcrumb = 'parameters';
+  document.body.appendChild(breadcrumb);
+
+  const minimap = document.createElement('div');
+  minimap.dataset.anchorMinimap = 'parameters';
+  document.body.appendChild(minimap);
+
+  const overlay = document.createElement('div');
+  overlay.dataset.codexOverlay = 'true';
+  document.body.appendChild(overlay);
+
+  const toggle = document.createElement('button');
+  toggle.dataset.codexToggle = 'true';
+  document.body.appendChild(toggle);
+
+  const closer = document.createElement('button');
+  closer.dataset.codexClose = 'true';
+  document.body.appendChild(closer);
+
+  return {
+    root,
+    anchors: [anchor],
+    panels: [panel],
+    breadcrumbTargets: [breadcrumb],
+    minimapContainers: [minimap],
+    overlay,
+    codexToggles: [toggle],
+    codexClosers: [closer],
+  } as const;
+}
+
+async function tick() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}

--- a/tests/docs-generator/unit/utils.test.ts
+++ b/tests/docs-generator/unit/utils.test.ts
@@ -1,0 +1,158 @@
+/// <reference types="vitest" />
+import { describe, expect, it, vi } from 'vitest';
+
+import { randomId } from '../../../docs/evo-tactics-pack/utils/ids.ts';
+import {
+  buildGenerationConstraints,
+  collectPreferredTags,
+  createTagEntry,
+  extractRequiredRoles,
+  inferClimateFromFilters,
+  inferHazardFromFilters,
+  inferMinSize,
+  normaliseTagId,
+} from '../../../docs/evo-tactics-pack/utils/normalizers.ts';
+import {
+  activityLogToCsv,
+  serialiseActivityLogEntry,
+  toYAML,
+} from '../../../docs/evo-tactics-pack/utils/serializers.ts';
+
+describe('docs-generator utils — normalizers', () => {
+  it('extracts distinct required roles from flags and role tokens', () => {
+    const roles = extractRequiredRoles({
+      flags: ['apex', 'keystone', 'unsupported'],
+      roles: ['Predatore Apex', 'Custode logistico', 'Evento dinamico'],
+    });
+
+    expect(new Set(roles)).toEqual(new Set(['apex', 'keystone', 'bridge', 'event', 'threat']));
+  });
+
+  it('collects preferred tags from filters and role hints', () => {
+    const tags = collectPreferredTags({
+      tags: ['criogenico', null, ''],
+      roles: ['Predatore desertico', 'Micelico di caverna'],
+    });
+
+    expect(tags).toEqual(['criogenico', 'desertico', 'micelico']);
+  });
+
+  it('infers hazard and climate from filters', () => {
+    expect(inferHazardFromFilters({ flags: ['apex'] })).toBe('high');
+    expect(inferHazardFromFilters({ tags: ['rifugio sicuro'] })).toBe('low');
+    expect(inferHazardFromFilters({ tags: ['ambientale'] })).toBe('medium');
+
+    expect(inferClimateFromFilters({ tags: ['tempesta ionica'] })).toBe('storm');
+    expect(inferClimateFromFilters({ roles: ['fungoid subterraneo'] })).toBe('subterranean');
+    expect(inferClimateFromFilters({})).toBeNull();
+  });
+
+  it('infers minimum size based on roles and tags', () => {
+    expect(inferMinSize({ flags: ['apex', 'keystone'], tags: ['criogenico'] })).toBe(3);
+    expect(
+      inferMinSize({
+        roles: ['predatore apex', 'evento instabile'],
+        tags: ['criogenico', 'desertico'],
+      }),
+    ).toBe(5);
+    expect(inferMinSize({}, ['alpha'])).toBe(3);
+  });
+
+  it('builds generation constraints removing empty collections', () => {
+    const constraints = buildGenerationConstraints({
+      flags: ['apex'],
+      roles: ['Predatore apex'],
+      tags: ['criogenico'],
+    });
+
+    expect(constraints).toEqual({
+      requiredRoles: ['apex', 'threat'],
+      preferredTags: ['criogenico'],
+      hazard: 'high',
+      climate: 'frozen',
+      minSize: 3,
+    });
+  });
+
+  it('normalises tag identifiers with accents and spaces', () => {
+    expect(normaliseTagId('   Élite Operativo  ')).toBe('elite-operativo');
+  });
+
+  it('creates tag entries from primitives and objects', () => {
+    const fallback = vi.fn().mockReturnValue('tag-fallback');
+
+    expect(createTagEntry(' Nodo  ')).toEqual({ id: 'nodo', label: 'Nodo' });
+    expect(createTagEntry({ label: 'Risonanza', id: 'risonanza-interna' })).toEqual({
+      id: 'risonanza-interna',
+      label: 'Risonanza',
+    });
+    expect(createTagEntry({ value: 'Nuovo' }, fallback)).toEqual({ id: 'nuovo', label: 'Nuovo' });
+    expect(createTagEntry({ name: '  ' }, fallback)).toBeNull();
+    expect(createTagEntry('', fallback)).toBeNull();
+    expect(fallback).not.toHaveBeenCalled();
+  });
+});
+
+describe('docs-generator utils — serializers', () => {
+  it('serialises activity log entries applying defaults and tag normalisation', () => {
+    const entry = serialiseActivityLogEntry({
+      message: 'Catalogo pronto',
+      tags: [{ label: 'Catalogo' }, 'Ready', null],
+      tone: 'success',
+      metadata: { source: 'test' },
+      pinned: 1,
+    });
+
+    expect(entry).toMatchObject({
+      id: null,
+      message: 'Catalogo pronto',
+      tone: 'success',
+      pinned: true,
+      tags: [
+        { id: 'catalogo', label: 'Catalogo' },
+        { id: 'ready', label: 'Ready' },
+      ],
+      metadata: { source: 'test' },
+    });
+    expect(entry?.timestamp).toMatch(/\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('renders CSV output with escaped values and metadata serialisation', () => {
+    const csv = activityLogToCsv([
+      {
+        id: 'evt-1',
+        message: 'Evento "critico"',
+        tone: 'warn',
+        timestamp: '2024-01-01T10:00:00.000Z',
+        tags: [{ id: 'critical', label: 'Critical' }],
+        action: 'guard',
+        pinned: true,
+        metadata: { note: 'Check' },
+      },
+    ]);
+
+    expect(csv.split('\n')[0]).toBe('id,timestamp,tone,message,tags,action,pinned,metadata');
+    expect(csv).toContain('"Evento ""critico"""');
+    expect(csv).toContain('true');
+    expect(csv).toContain('"{""note"":""Check""}"');
+  });
+
+  it('converts nested structures to YAML-like strings', () => {
+    expect(
+      toYAML({
+        id: 'ecos-1',
+        metrics: { biomes: 3 },
+        tags: ['criogenico', 'desertico'],
+      }),
+    ).toBe('id: "ecos-1"\nmetrics: \n  biomes: 3\ntags: \n  - criogenico\n  - desertico');
+
+    expect(toYAML(['alpha', 'beta'])).toBe('- alpha\n- beta');
+  });
+});
+
+describe('docs-generator utils — ids', () => {
+  it('generates random identifiers with configurable prefix', () => {
+    const id = randomId('flow');
+    expect(id).toMatch(/^flow-[a-z0-9]{6}$/);
+  });
+});

--- a/tools/ts/tests/web/generator-flows.spec.ts
+++ b/tools/ts/tests/web/generator-flows.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Evo generator flows', () => {
+  test('loads catalog data and performs a roll workflow', async ({ page, baseURL }) => {
+    if (!baseURL) {
+      throw new Error('Base URL non disponibile per il test Playwright');
+    }
+    const packRoot = new URL('/packs/evo_tactics_pack/', baseURL).toString();
+    await page.goto(
+      `/docs/evo-tactics-pack/generator.html?pack-root=${encodeURIComponent(packRoot)}`,
+    );
+
+    await page.waitForSelector('#generator-status[data-tone="success"]', { timeout: 20000 });
+
+    const flagButton = await page.waitForSelector('#flags [data-multiselect-option]', {
+      timeout: 10000,
+    });
+    await flagButton.click();
+    await expect(page.locator('#generator-filters-hint')).toContainText('Filtri attivi');
+
+    await page.locator('[data-action="roll-ecos"]').click();
+
+    const summary = page.locator('#generator-summary');
+    await expect(summary).toHaveAttribute('data-has-results', 'true', { timeout: 20000 });
+    await expect(page.locator('[data-summary="biomes"]')).not.toHaveText('0', { timeout: 20000 });
+  });
+});

--- a/tools/ts/tests/web/generator-flows.spec.ts
+++ b/tools/ts/tests/web/generator-flows.spec.ts
@@ -10,7 +10,9 @@ test.describe('Evo generator flows', () => {
       `/docs/evo-tactics-pack/generator.html?pack-root=${encodeURIComponent(packRoot)}`,
     );
 
-    await page.waitForSelector('#generator-status[data-tone="success"]', { timeout: 20000 });
+    const status = page.locator('#generator-status');
+    await expect(status).toContainText("Catalogo pronto all'uso", { timeout: 45000 });
+    await expect(status).toHaveAttribute('data-tone', 'success');
 
     const flagButton = await page.waitForSelector('#flags [data-multiselect-option]', {
       timeout: 10000,

--- a/tools/ts/tests/web/generator-flows.spec.ts
+++ b/tools/ts/tests/web/generator-flows.spec.ts
@@ -5,6 +5,21 @@ test.describe('Evo generator flows', () => {
     if (!baseURL) {
       throw new Error('Base URL non disponibile per il test Playwright');
     }
+
+    await page.route('**/*.ts', async (route) => {
+      const response = await route.fetch();
+      const headers = {
+        ...response.headers(),
+        'content-type': 'text/javascript',
+      };
+      const body = await response.text();
+      await route.fulfill({
+        status: response.status(),
+        body,
+        headers,
+      });
+    });
+
     const packRoot = new URL('/packs/evo_tactics_pack/', baseURL).toString();
     await page.goto(
       `/docs/evo-tactics-pack/generator.html?pack-root=${encodeURIComponent(packRoot)}`,

--- a/tools/ts/tests/web/idea-engine.spec.ts
+++ b/tools/ts/tests/web/idea-engine.spec.ts
@@ -1,11 +1,11 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from '@playwright/test';
 
 test.beforeEach(async ({ context, page, baseURL }) => {
   await context.clearCookies();
   await context.clearPermissions();
-  page.on("console", (message) => {
+  page.on('console', (message) => {
     const type = message.type();
-    if (type === "error" || type === "warning") {
+    if (type === 'error' || type === 'warning') {
       console.log(`[console:${type}] ${message.text()}`);
     }
   });
@@ -14,51 +14,53 @@ test.beforeEach(async ({ context, page, baseURL }) => {
     window.sessionStorage?.clear();
   });
   if (!baseURL) {
-    throw new Error("BaseURL non configurato per i test Playwright.");
+    throw new Error('BaseURL non configurato per i test Playwright.');
   }
 });
 
-test("permette export markdown offline", async ({ page }) => {
-  await page.goto("/docs/ideas/index.html");
+test('permette export markdown offline', async ({ page }) => {
+  await page.goto('/docs/ideas/index.html');
 
-  await page.fill("#title", "Idea offline Playwright");
-  await page.fill("#summary", "Verifica del flusso di export in modalità offline.");
-  await page.fill("#tags", "#playwright #offline");
-  await page.fill("#biomes_input", "dorsale_termale_tropicale");
-  await page.press("#biomes_input", "Enter");
-  await page.fill("#ecosystems_input", "meta_ecosistema_alpha");
-  await page.press("#ecosystems_input", "Enter");
-  await page.fill("#species_input", "dune-stalker");
-  await page.press("#species_input", "Enter");
-  await page.fill("#traits_input", "focus_frazionato");
-  await page.press("#traits_input", "Enter");
-  await page.fill("#game_functions_input", "telemetria_vc");
-  await page.press("#game_functions_input", "Enter");
-  await page.fill("#actions_next", "- [ ] valida export\n- [ ] sincronizza reminder");
+  await page.waitForSelector('#idea-widget #title', { timeout: 20000 });
 
-  await page.getByRole("button", { name: "Anteprima / Export .md" }).click();
+  await page.fill('#title', 'Idea offline Playwright');
+  await page.fill('#summary', 'Verifica del flusso di export in modalità offline.');
+  await page.fill('#tags', '#playwright #offline');
+  await page.fill('#biomes_input', 'dorsale_termale_tropicale');
+  await page.press('#biomes_input', 'Enter');
+  await page.fill('#ecosystems_input', 'meta_ecosistema_alpha');
+  await page.press('#ecosystems_input', 'Enter');
+  await page.fill('#species_input', 'dune-stalker');
+  await page.press('#species_input', 'Enter');
+  await page.fill('#traits_input', 'focus_frazionato');
+  await page.press('#traits_input', 'Enter');
+  await page.fill('#game_functions_input', 'telemetria_vc');
+  await page.press('#game_functions_input', 'Enter');
+  await page.fill('#actions_next', '- [ ] valida export\n- [ ] sincronizza reminder');
 
-  const preview = page.locator("#result pre.preview");
-  await expect(preview).toContainText("IDEA: Idea offline Playwright");
-  await expect(preview).toContainText("## Suggested Next Actions");
-  await expect(preview).toContainText("- **Biomi:** dorsale_termale_tropicale");
+  await page.getByRole('button', { name: 'Anteprima / Export .md' }).click();
 
-  const reminder = page.locator("#result pre.preview");
-  await expect(reminder).toContainText("TAGS: #playwright #offline");
-  await expect(reminder).toContainText("BIOMI: dorsale_termale_tropicale");
-  await expect(reminder).toContainText("ECOSISTEMI: meta_ecosistema_alpha");
+  const preview = page.locator('#result pre.preview');
+  await expect(preview).toContainText('IDEA: Idea offline Playwright');
+  await expect(preview).toContainText('## Suggested Next Actions');
+  await expect(preview).toContainText('- **Biomi:** dorsale_termale_tropicale');
 
-  const note = page.locator("#result .note.small");
-  await expect(note).toContainText("Metti il file in  /ideas");
+  const reminder = page.locator('#result pre.preview');
+  await expect(reminder).toContainText('TAGS: #playwright #offline');
+  await expect(reminder).toContainText('BIOMI: dorsale_termale_tropicale');
+  await expect(reminder).toContainText('ECOSISTEMI: meta_ecosistema_alpha');
+
+  const note = page.locator('#result .note.small');
+  await expect(note).toContainText('Metti il file in  /ideas');
 });
 
-test("invia idea al backend configurato", async ({ page }) => {
+test('invia idea al backend configurato', async ({ page }) => {
   const requests: Array<{
     body: Record<string, unknown> | null;
     headers: Record<string, string>;
   }> = [];
 
-  await page.route("**/api/ideas", async (route) => {
+  await page.route('**/api/ideas', async (route) => {
     const request = route.request();
     requests.push({
       body: request.postDataJSON() as Record<string, unknown> | null,
@@ -66,54 +68,48 @@ test("invia idea al backend configurato", async ({ page }) => {
     });
     await route.fulfill({
       status: 200,
-      contentType: "application/json",
+      contentType: 'application/json',
       body: JSON.stringify({
-        exportPr: { pr_url: "https://github.com/example/repo/pull/42" },
-        ghIssue: { html_url: "https://github.com/example/repo/issues/99" },
-        driveDoc: { url: "https://drive.example/doc/alpha" },
+        exportPr: { pr_url: 'https://github.com/example/repo/pull/42' },
+        ghIssue: { html_url: 'https://github.com/example/repo/issues/99' },
+        driveDoc: { url: 'https://drive.example/doc/alpha' },
       }),
     });
   });
 
-  await page.goto(
-    "/docs/ideas/index.html?apiBase=https://api.example.test&apiToken=test-token"
-  );
+  await page.goto('/docs/ideas/index.html?apiBase=https://api.example.test&apiToken=test-token');
 
-  await page.fill("#title", "Idea backend Playwright");
-  await page.fill("#summary", "Simulazione invio con backend configurato.");
-  await page.fill("#github", "MasterDD-L34D/Game");
+  await page.waitForSelector('#idea-widget #title', { timeout: 20000 });
 
-  await page.getByRole("button", { name: "Invia al backend" }).click();
+  await page.fill('#title', 'Idea backend Playwright');
+  await page.fill('#summary', 'Simulazione invio con backend configurato.');
+  await page.fill('#github', 'MasterDD-L34D/Game');
 
-  const ok = page.locator("#result .ok");
-  await expect(ok).toHaveText("✅ Idea registrata.");
+  await page.getByRole('button', { name: 'Invia al backend' }).click();
 
-  const links = page.locator("#result a.linkish");
+  const ok = page.locator('#result .ok');
+  await expect(ok).toHaveText('✅ Idea registrata.');
+
+  const links = page.locator('#result a.linkish');
   await expect.poll(() => links.count()).toBeGreaterThanOrEqual(3);
   await expect(
-    page.locator(
-      '#result a.linkish[href="https://github.com/example/repo/pull/42"]'
-    )
+    page.locator('#result a.linkish[href="https://github.com/example/repo/pull/42"]'),
   ).toHaveCount(1);
   await expect(
-    page.locator(
-      '#result a.linkish[href="https://github.com/example/repo/issues/99"]'
-    )
+    page.locator('#result a.linkish[href="https://github.com/example/repo/issues/99"]'),
   ).toHaveCount(1);
   await expect(
-    page.locator(
-      '#result a.linkish[href="https://drive.example/doc/alpha"]'
-    )
+    page.locator('#result a.linkish[href="https://drive.example/doc/alpha"]'),
   ).toHaveCount(1);
 
   expect(requests).toHaveLength(1);
   const payload = (requests[0]?.body ?? {}) as Record<string, unknown>;
-  expect(payload && typeof payload === "object").toBeTruthy();
+  expect(payload && typeof payload === 'object').toBeTruthy();
   expect(payload).toMatchObject({
-    title: "Idea backend Playwright",
-    summary: "Simulazione invio con backend configurato.",
+    title: 'Idea backend Playwright',
+    summary: 'Simulazione invio con backend configurato.',
   });
 
-  const authHeader = requests[0]?.headers?.["authorization"];
-  expect(authHeader).toBe("Bearer test-token");
+  const authHeader = requests[0]?.headers?.['authorization'];
+  expect(authHeader).toBe('Bearer test-token');
 });

--- a/vitest.config.docs-generator.ts
+++ b/vitest.config.docs-generator.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['tests/docs-generator/**/*.{test,spec}.ts'],
+    environment: 'node',
+    environmentMatchGlobs: [['tests/docs-generator/integration/**', 'jsdom']],
+    setupFiles: [],
+    hookTimeout: 20000,
+  },
+});


### PR DESCRIPTION
## Summary
- add a standalone Vitest configuration and npm script for the docs-generator suite
- cover generator utilities with focused unit specs and a JSDOM integration harness that exercises state bootstrapping and filter handlers
- extend the Playwright suite with a generator workflow scenario served from the existing tools/ts infrastructure

## Testing
- npm run test:docs-generator
- npm run test:web --workspace tools/ts *(fails: Chromium system dependencies such as libatk-1.0 are not available in the container)*

------
https://chatgpt.com/codex/tasks/task_b_6909f425a050832a926aff1a3724fe74