### PR TITLE
Fix: re-export evo tactics typedefs

### DIFF
--- a/docs/evo-tactics-pack/utils/types.ts
+++ b/docs/evo-tactics-pack/utils/types.ts
@@ -75,4 +75,15 @@
  * @returns {string}
  */
 
-export {};
+export type {
+  ActivityLogEntryInput,
+  ActivityLogTag,
+  FilterSet,
+  FilterToken,
+  GenerationConstraints,
+  HazardLevel,
+  RandomIdGenerator,
+  SerialisedActivityLogEntry,
+  TagEntry,
+  TagLike,
+};


### PR DESCRIPTION
## Summary
- restore explicit exports for the Evo tactics JSDoc typedefs so downstream imports resolve
- keep RandomIdGenerator callback available alongside the other shared types

## Testing
- npm run lint --workspaces --if-present

------
https://chatgpt.com/codex/tasks/task_b_690a02b3da30832a81ceea61b7978272