### PR TITLE
Refactor generator activity/export views

### DIFF
--- a/docs/evo-tactics-pack/views/activity.js
+++ b/docs/evo-tactics-pack/views/activity.js
@@ -1,0 +1,250 @@
+export function setup(state, elements, deps = {}) {
+  const triggerRender = () => {
+    if (typeof deps.render === 'function') {
+      deps.render(state, elements, deps);
+    } else {
+      render(state, elements, deps);
+    }
+  };
+
+  if (elements.activitySearch) {
+    elements.activitySearch.addEventListener('input', (event) => {
+      state.activityFilters = state.activityFilters ?? {};
+      state.activityFilters.query = String(event.target.value ?? '');
+      triggerRender();
+    });
+  }
+
+  if (elements.activityTagFilter && typeof deps.getSelectedValues === 'function') {
+    elements.activityTagFilter.addEventListener('change', () => {
+      const values = new Set(deps.getSelectedValues(elements.activityTagFilter));
+      state.activityFilters = state.activityFilters ?? {};
+      state.activityFilters.tags = values;
+      triggerRender();
+    });
+  }
+
+  if (elements.activityPinnedOnly) {
+    elements.activityPinnedOnly.addEventListener('change', (event) => {
+      state.activityFilters = state.activityFilters ?? {};
+      state.activityFilters.pinnedOnly = Boolean(event.target.checked);
+      triggerRender();
+    });
+  }
+
+  if (Array.isArray(elements.activityToneToggles)) {
+    elements.activityToneToggles.forEach((toggle) => {
+      if (!(toggle instanceof HTMLInputElement)) return;
+      toggle.addEventListener('change', (event) => {
+        const tone = event.target.value || event.target.dataset.activityTone;
+        if (!tone) return;
+        state.activityFilters = state.activityFilters ?? {};
+        if (!(state.activityFilters.tones instanceof Set)) {
+          state.activityFilters.tones = new Set(deps.defaultTones ?? []);
+        }
+        if (event.target.checked) {
+          state.activityFilters.tones.add(tone);
+        } else {
+          state.activityFilters.tones.delete(tone);
+        }
+        triggerRender();
+      });
+    });
+  }
+
+  if (elements.activityReset && typeof deps.resetFilters === 'function') {
+    elements.activityReset.addEventListener('click', (event) => {
+      event.preventDefault();
+      deps.resetFilters();
+    });
+  }
+
+  if (elements.logList && typeof deps.togglePin === 'function') {
+    elements.logList.addEventListener('click', (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return;
+      const button = target.closest('[data-action="toggle-activity-pin"]');
+      if (!(button instanceof HTMLElement)) return;
+      event.preventDefault();
+      const { eventId } = button.dataset;
+      if (!eventId) return;
+      deps.togglePin(eventId);
+    });
+  }
+
+  syncControls(state, elements, deps);
+}
+
+export function render(state, elements, deps = {}) {
+  const list = elements.logList;
+  const empty = elements.logEmpty;
+  if (!list) return;
+
+  list.innerHTML = '';
+  const entries = Array.isArray(state.activityLog) ? state.activityLog : [];
+  const filters = state.activityFilters ?? {};
+  const defaultTones = Array.isArray(deps.defaultTones) ? deps.defaultTones : [];
+  const toneFilterActive = filters.tones instanceof Set;
+  const toneSet = toneFilterActive ? filters.tones : new Set(defaultTones);
+  const tagSet = filters.tags instanceof Set ? filters.tags : new Set();
+  const query = String(filters.query ?? '')
+    .trim()
+    .toLowerCase();
+  const pinnedOnly = Boolean(filters.pinnedOnly);
+
+  const buildHaystack =
+    typeof deps.buildActivityHaystack === 'function' ? deps.buildActivityHaystack : () => '';
+  const toTitleCase = typeof deps.titleCase === 'function' ? deps.titleCase : (value) => value;
+  const toneLabels = deps.toneLabels && typeof deps.toneLabels === 'object' ? deps.toneLabels : {};
+
+  const filtered = entries.filter((entry) => {
+    const tone = entry.tone ?? 'info';
+    if (toneFilterActive) {
+      if (!toneSet.size) return false;
+      if (!toneSet.has(tone)) return false;
+    }
+    if (pinnedOnly && !entry.pinned) {
+      return false;
+    }
+    if (tagSet.size) {
+      const tagIds = (entry.tags ?? []).map((tag) => tag.id);
+      if (!tagIds.some((id) => tagSet.has(id))) {
+        return false;
+      }
+    }
+    if (query) {
+      const haystack = buildHaystack(entry);
+      if (!haystack.includes(query)) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  const hasEntries = filtered.length > 0;
+  list.hidden = !hasEntries;
+  if (empty) {
+    empty.hidden = hasEntries;
+    const filtersActive =
+      typeof deps.activityFiltersActive === 'function' ? deps.activityFiltersActive(state) : false;
+    empty.textContent =
+      hasEntries || !filtersActive
+        ? 'Nessuna attività registrata.'
+        : 'Nessun evento corrisponde ai filtri.';
+  }
+
+  if (!hasEntries) {
+    return;
+  }
+
+  filtered.forEach((entry) => {
+    const item = document.createElement('li');
+    item.className = 'generator-timeline__item';
+    item.dataset.tone = entry.tone ?? 'info';
+    item.dataset.pinned = entry.pinned ? 'true' : 'false';
+
+    const marker = document.createElement('div');
+    marker.className = 'generator-timeline__marker';
+    marker.setAttribute('aria-hidden', 'true');
+    item.appendChild(marker);
+
+    const content = document.createElement('div');
+    content.className = 'generator-timeline__content';
+    item.appendChild(content);
+
+    const header = document.createElement('header');
+    header.className = 'generator-timeline__header';
+    content.appendChild(header);
+
+    const time = document.createElement('time');
+    time.className = 'generator-timeline__time';
+    const stamp = entry.timestamp instanceof Date ? entry.timestamp : new Date(entry.timestamp);
+    const safeStamp = Number.isNaN(stamp.getTime()) ? new Date() : stamp;
+    time.dateTime = safeStamp.toISOString();
+    time.textContent = safeStamp.toLocaleString('it-IT', {
+      hour: '2-digit',
+      minute: '2-digit',
+      day: '2-digit',
+      month: '2-digit',
+    });
+    time.title = safeStamp.toLocaleString('it-IT');
+    header.appendChild(time);
+
+    const controls = document.createElement('div');
+    controls.className = 'generator-timeline__controls';
+    header.appendChild(controls);
+
+    const toneBadge = document.createElement('span');
+    toneBadge.className = `generator-timeline__tone generator-timeline__tone--${entry.tone ?? 'info'}`;
+    toneBadge.textContent = toneLabels[entry.tone ?? 'info'] ?? toTitleCase(entry.tone ?? 'info');
+    controls.appendChild(toneBadge);
+
+    const pinButton = document.createElement('button');
+    pinButton.type = 'button';
+    pinButton.className = 'generator-timeline__pin';
+    pinButton.dataset.action = 'toggle-activity-pin';
+    pinButton.dataset.eventId = entry.id;
+    pinButton.setAttribute('aria-pressed', entry.pinned ? 'true' : 'false');
+    pinButton.title = entry.pinned ? 'Rimuovi pin evento' : 'Pin evento';
+    pinButton.textContent = entry.pinned ? '📌' : '📍';
+    controls.appendChild(pinButton);
+
+    if (entry.action) {
+      const meta = document.createElement('p');
+      meta.className = 'generator-timeline__meta';
+      meta.textContent = toTitleCase(entry.action.replace(/[-_]/g, ' '));
+      content.appendChild(meta);
+    }
+
+    const messageText = document.createElement('p');
+    messageText.className = 'generator-timeline__message';
+    messageText.textContent = entry.message;
+    content.appendChild(messageText);
+
+    if (entry.tags?.length) {
+      const tagsContainer = document.createElement('div');
+      tagsContainer.className = 'chip-list chip-list--compact generator-timeline__tags';
+      entry.tags.forEach((tag) => {
+        if (!tag?.label) return;
+        const chip = document.createElement('span');
+        chip.className = 'chip';
+        chip.dataset.tagId = tag.id;
+        chip.textContent = tag.label;
+        tagsContainer.appendChild(chip);
+      });
+      if (tagsContainer.childElementCount) {
+        content.appendChild(tagsContainer);
+      }
+    }
+
+    list.appendChild(item);
+  });
+}
+
+export function syncControls(state, elements, deps = {}) {
+  state.activityFilters = state.activityFilters ?? {};
+  if (elements.activitySearch) {
+    elements.activitySearch.value = state.activityFilters.query ?? '';
+  }
+  if (elements.activityPinnedOnly) {
+    elements.activityPinnedOnly.checked = Boolean(state.activityFilters.pinnedOnly);
+  }
+  if (Array.isArray(elements.activityToneToggles)) {
+    const defaultTones = Array.isArray(deps.defaultTones) ? deps.defaultTones : [];
+    elements.activityToneToggles.forEach((toggle) => {
+      if (!(toggle instanceof HTMLInputElement)) return;
+      const tone = toggle.value || toggle.dataset.activityTone;
+      if (!tone) return;
+      if (!(state.activityFilters.tones instanceof Set)) {
+        state.activityFilters.tones = new Set(defaultTones);
+      }
+      toggle.checked = state.activityFilters.tones.has(tone);
+    });
+  }
+  if (elements.activityTagFilter) {
+    const selected = state.activityFilters.tags ?? new Set();
+    Array.from(elements.activityTagFilter.options).forEach((option) => {
+      option.selected = selected instanceof Set ? selected.has(option.value) : false;
+    });
+  }
+}

--- a/docs/evo-tactics-pack/views/export.js
+++ b/docs/evo-tactics-pack/views/export.js
@@ -1,0 +1,39 @@
+export function setup() {}
+
+export function render(state, elements, deps = {}) {
+  const container = elements.exportPreview;
+  const empty = elements.exportPreviewEmpty;
+  if (!container || !empty) return;
+
+  const payload = deps.payload ?? null;
+  const hasPayload = Boolean(payload);
+  container.hidden = !hasPayload;
+  empty.hidden = hasPayload;
+
+  if (!hasPayload) {
+    if (elements.exportPreviewJson) elements.exportPreviewJson.textContent = '';
+    if (elements.exportPreviewYaml) elements.exportPreviewYaml.textContent = '';
+    if (elements.exportPreviewJsonDetails) elements.exportPreviewJsonDetails.open = false;
+    if (elements.exportPreviewYamlDetails) elements.exportPreviewYamlDetails.open = false;
+    return;
+  }
+
+  const jsonDetails = elements.exportPreviewJsonDetails;
+  const yamlDetails = elements.exportPreviewYamlDetails;
+  const jsonWasOpen = Boolean(jsonDetails?.open);
+  const yamlWasOpen = Boolean(yamlDetails?.open);
+
+  if (elements.exportPreviewJson) {
+    elements.exportPreviewJson.textContent = JSON.stringify(payload, null, 2);
+  }
+  if (elements.exportPreviewYaml) {
+    if (typeof deps.toYAML === 'function') {
+      elements.exportPreviewYaml.textContent = deps.toYAML(payload);
+    } else {
+      elements.exportPreviewYaml.textContent = '';
+    }
+  }
+
+  if (jsonDetails) jsonDetails.open = jsonWasOpen;
+  if (yamlDetails) yamlDetails.open = yamlWasOpen;
+}

--- a/tests/docs-generator/integration/activity-view.integration.test.ts
+++ b/tests/docs-generator/integration/activity-view.integration.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as activityView from '../../../docs/evo-tactics-pack/views/activity.js';
+
+const DEFAULT_TONES = ['info', 'success', 'warn', 'error'];
+const TONE_LABELS = {
+  info: 'Info',
+  success: 'Successo',
+  warn: 'Avviso',
+  error: 'Errore',
+};
+
+function buildHaystack(entry) {
+  const parts = [entry.message, entry.action];
+  (entry.tags ?? []).forEach((tag) => {
+    if (tag?.label) parts.push(tag.label);
+  });
+  return parts
+    .filter((value) => value !== null && value !== undefined && value !== '')
+    .join(' ')
+    .toLowerCase();
+}
+
+function filtersActive(state) {
+  const filters = state.activityFilters ?? {};
+  if (filters.query) return true;
+  if (filters.pinnedOnly) return true;
+  if (filters.tags instanceof Set && filters.tags.size > 0) return true;
+  if (filters.tones instanceof Set) {
+    if (filters.tones.size !== DEFAULT_TONES.length) return true;
+    const missing = DEFAULT_TONES.some((tone) => !filters.tones.has(tone));
+    if (missing) return true;
+  }
+  return false;
+}
+
+function titleCase(value) {
+  return String(value)
+    .toLowerCase()
+    .replace(
+      /(^|\s|[._-])(\p{L})/gu,
+      (match, prefix, letter) => `${prefix}${letter.toUpperCase()}`,
+    );
+}
+
+describe('activity view', () => {
+  let state;
+  let elements;
+  let deps;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    state = {
+      activityLog: [
+        {
+          id: 'evt-1',
+          message: 'Evento principale',
+          tone: 'info',
+          pinned: true,
+          tags: [{ id: 'export', label: 'Export' }],
+          action: 'roll-ecos',
+          timestamp: new Date('2024-01-01T10:00:00Z'),
+        },
+        {
+          id: 'evt-2',
+          message: 'Evento secondario',
+          tone: 'error',
+          pinned: false,
+          tags: [{ id: 'misc', label: 'Misc' }],
+          action: 'reroll-biomi',
+          timestamp: new Date('2024-01-01T11:00:00Z'),
+        },
+      ],
+      activityFilters: {
+        query: '',
+        pinnedOnly: false,
+        tags: new Set(),
+        tones: new Set(DEFAULT_TONES),
+      },
+    };
+    elements = {
+      logList: document.createElement('ul'),
+      logEmpty: document.createElement('p'),
+      activitySearch: document.createElement('input'),
+      activityTagFilter: document.createElement('select'),
+      activityPinnedOnly: document.createElement('input'),
+      activityToneToggles: [document.createElement('input'), document.createElement('input')],
+      activityReset: document.createElement('button'),
+    };
+    elements.activitySearch.type = 'search';
+    elements.activityPinnedOnly.type = 'checkbox';
+    elements.activityToneToggles.forEach((toggle, index) => {
+      toggle.type = 'checkbox';
+      toggle.value = DEFAULT_TONES[index];
+      toggle.dataset.activityTone = DEFAULT_TONES[index];
+    });
+    const optionExport = document.createElement('option');
+    optionExport.value = 'export';
+    optionExport.textContent = 'Export';
+    optionExport.selected = true;
+    elements.activityTagFilter.appendChild(optionExport);
+    const optionMisc = document.createElement('option');
+    optionMisc.value = 'misc';
+    optionMisc.textContent = 'Misc';
+    elements.activityTagFilter.appendChild(optionMisc);
+
+    deps = {
+      defaultTones: DEFAULT_TONES,
+      toneLabels: TONE_LABELS,
+      buildActivityHaystack: buildHaystack,
+      activityFiltersActive: filtersActive,
+      titleCase,
+    };
+  });
+
+  it('renders filtered activity entries', () => {
+    state.activityFilters.query = 'export';
+    state.activityFilters.pinnedOnly = true;
+    state.activityFilters.tags = new Set(['export']);
+    state.activityFilters.tones = new Set(['info']);
+
+    activityView.render(state, elements, deps);
+
+    expect(elements.logList.hidden).toBe(false);
+    expect(elements.logList.children).toHaveLength(1);
+    const item = elements.logList.firstElementChild;
+    expect(item?.dataset.pinned).toBe('true');
+    expect(item?.querySelector('.generator-timeline__message')?.textContent).toBe(
+      'Evento principale',
+    );
+    expect(elements.logEmpty.hidden).toBe(true);
+  });
+
+  it('wires controls to the provided handlers', () => {
+    const renderSpy = vi.fn();
+    const resetSpy = vi.fn(() => {
+      state.activityFilters.query = '';
+      state.activityFilters.pinnedOnly = false;
+      state.activityFilters.tags = new Set();
+      state.activityFilters.tones = new Set(DEFAULT_TONES);
+    });
+    const togglePinSpy = vi.fn();
+    const getSelectedValues = vi.fn(() => ['export']);
+
+    activityView.setup(state, elements, {
+      ...deps,
+      render: renderSpy,
+      resetFilters: resetSpy,
+      togglePin: togglePinSpy,
+      getSelectedValues,
+    });
+
+    elements.activitySearch.value = 'alpha';
+    elements.activitySearch.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(state.activityFilters.query).toBe('alpha');
+
+    elements.activityPinnedOnly.checked = true;
+    elements.activityPinnedOnly.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(state.activityFilters.pinnedOnly).toBe(true);
+
+    elements.activityToneToggles[0].checked = false;
+    elements.activityToneToggles[0].dispatchEvent(new Event('change', { bubbles: true }));
+    expect(state.activityFilters.tones.has(DEFAULT_TONES[0])).toBe(false);
+
+    elements.activityTagFilter.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(getSelectedValues).toHaveBeenCalledTimes(1);
+    expect(state.activityFilters.tags.has('export')).toBe(true);
+
+    elements.activityReset.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(resetSpy).toHaveBeenCalledTimes(1);
+
+    const pinButton = document.createElement('button');
+    pinButton.dataset.action = 'toggle-activity-pin';
+    pinButton.dataset.eventId = 'evt-2';
+    elements.logList.appendChild(pinButton);
+    pinButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(togglePinSpy).toHaveBeenCalledWith('evt-2');
+
+    // Render should have been triggered for each change event above
+    expect(renderSpy.mock.calls.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/tests/docs-generator/integration/export-view.integration.test.ts
+++ b/tests/docs-generator/integration/export-view.integration.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import * as exportView from '../../../docs/evo-tactics-pack/views/export.js';
+
+describe('export view', () => {
+  it('renders payload preview preserving disclosure state', () => {
+    const elements = createElements();
+    const payload = { id: 'ecos-1', name: 'Ecosistema' };
+    elements.exportPreviewJsonDetails.open = true;
+    elements.exportPreviewYamlDetails.open = false;
+
+    exportView.render({}, elements, {
+      payload,
+      toYAML: () => 'id: ecos-1\nname: Ecosistema',
+    });
+
+    expect(elements.exportPreview.hidden).toBe(false);
+    expect(elements.exportPreviewEmpty.hidden).toBe(true);
+    expect(elements.exportPreviewJson?.textContent).toContain('"id": "ecos-1"');
+    expect(elements.exportPreviewYaml?.textContent).toContain('id: ecos-1');
+    expect(elements.exportPreviewJsonDetails.open).toBe(true);
+    expect(elements.exportPreviewYamlDetails.open).toBe(false);
+  });
+
+  it('clears preview when payload is missing', () => {
+    const elements = createElements();
+    elements.exportPreviewJson.textContent = 'stale';
+    elements.exportPreviewYaml.textContent = 'old';
+    elements.exportPreviewJsonDetails.open = true;
+    elements.exportPreviewYamlDetails.open = true;
+
+    exportView.render({}, elements, { payload: null, toYAML: () => 'unused' });
+
+    expect(elements.exportPreview.hidden).toBe(true);
+    expect(elements.exportPreviewEmpty.hidden).toBe(false);
+    expect(elements.exportPreviewJson.textContent).toBe('');
+    expect(elements.exportPreviewYaml.textContent).toBe('');
+    expect(elements.exportPreviewJsonDetails.open).toBe(false);
+    expect(elements.exportPreviewYamlDetails.open).toBe(false);
+  });
+});
+
+function createElements() {
+  const container = document.createElement('div');
+  const empty = document.createElement('div');
+  const json = document.createElement('pre');
+  const yaml = document.createElement('pre');
+  const jsonDetails = document.createElement('details');
+  const yamlDetails = document.createElement('details');
+  return {
+    exportPreview: container,
+    exportPreviewEmpty: empty,
+    exportPreviewJson: json,
+    exportPreviewYaml: yaml,
+    exportPreviewJsonDetails: jsonDetails,
+    exportPreviewYamlDetails: yamlDetails,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the generator activity log and export preview rendering logic into dedicated view modules with explicit dependency wiring
- update the generator bootstrap to delegate activity/export setup through the new modules while keeping state management in place
- add Vitest + JSDOM integration tests that cover activity filters/pin handling and export preview refresh behaviour

## Testing
- npm run test:docs-generator

------
https://chatgpt.com/codex/tasks/task_b_690a086878a4832a848434e17132b6af