### PR TITLE
Refactor generator persistence and audio into services

### DIFF
--- a/docs/evo-tactics-pack/services/audio.ts
+++ b/docs/evo-tactics-pack/services/audio.ts
@@ -1,0 +1,381 @@
+import { StoredPreferences } from './storage.ts';
+
+type AudioLogger = {
+  warn?: (...args: unknown[]) => void;
+};
+
+type AudioElementLike = {
+  volume: number;
+  currentTime: number;
+  play?: () => void | Promise<void>;
+  pause?: () => void;
+  preload?: string;
+};
+
+type AudioElementFactory = (src: string) => AudioElementLike | null;
+
+type ClassListLike = {
+  toggle?: (className: string, force?: boolean) => void;
+};
+
+type EventListenerLike = (event: unknown) => void;
+
+type EventTargetLike = {
+  addEventListener?: (type: string, listener: EventListenerLike) => void;
+};
+
+type ButtonElementLike = EventTargetLike & {
+  classList?: ClassListLike;
+  setAttribute?: (name: string, value: string) => void;
+  textContent?: string;
+};
+
+type InputElementLike = EventTargetLike & {
+  value: string;
+};
+
+type ControlsElementLike = {
+  hidden?: boolean;
+  setAttribute?: (name: string, value: string) => void;
+};
+
+export interface AudioControlElements {
+  controls?: ControlsElementLike | null;
+  mute?: ButtonElementLike | null;
+  volume?: InputElementLike | null;
+}
+
+export interface AudioPreferencesState {
+  audioMuted: boolean;
+  volume: number;
+}
+
+export interface AudioCueFactoryOptions {
+  cues?: Record<string, string>;
+  createAudioElement?: AudioElementFactory;
+  logger?: AudioLogger;
+  initialVolume?: number;
+}
+
+export interface AudioCueFactory {
+  ensure(key: string): AudioElementLike | null;
+  setVolume(volume: number): void;
+}
+
+export interface AudioServiceOptions {
+  cues?: Record<string, string>;
+  preferences: AudioPreferencesState;
+  elements?: AudioControlElements;
+  loadPreferences?: () => StoredPreferences;
+  savePreferences?: (preferences: StoredPreferences) => void;
+  createAudioElement?: AudioElementFactory;
+  logger?: AudioLogger;
+  defaultVolume?: number;
+}
+
+export interface AudioService {
+  applyPreferences(): void;
+  playCue(key: string): void;
+  setupControls(): void;
+  restorePreferences(): void;
+}
+
+export const RARE_CUE_SOURCE =
+  'data:audio/wav;base64,UklGRiYfAABXQVZFZm10IBAAAAABAAEAIlYAAESsAAACABAAZGF0YQIfAAAAALwL+hZBISMqQTFONhM5d' +
+  'DlsNxEzkSwzJFAaUg+wA+j3dezU4XfYw9AKy4rH' +
+  'aMawx1XLMNEC2XbiJ+2j+G0ECBD3GsUkCC1nM543gDn5OA023jChKaYgTBYCC0P/jPNa6CbeXdVeznXJ1cabxsnISM3o02HcWeZk8Q390wg9FMweESioLz81' +
+  'mziWOSc4XTRhLnIm5xwmEqEG1/pD72LkqtqD0kXMMsh2xiTHNcqHz+LW999j6rj1egEtDVIYcyIhKwEyxzZBOVU5ADddMp4rCiP9GOQNNwJy9hPrleBo1+/P' +
+  'espEx2/GBMjzyxDSG9q9447uG/rlBXIRQxzlJfAtDTT8N5E5vDiGNREwmChrH+0UjgnJ/RzyA+f23GLUo80AyavGv8Y5yf/N39SN3a7n0/KG/kgKnRUJIB4p' +
+  'eTDLNdw4ijnON7szfS1WJZ4bvRApBV/52u0Z447Zn9Gjy9nHasZlx8HKWNDv1zThw+st9/MCnA6nGZ8jGCy4Mjc3ZTkrOYs2ojGjKtohphd0DL0A/vS06Vrf' +
+  'X9Yiz/PJB8eAxmLImcz40jvbCeX475P7XQfZEood/ibQLqs0UDiYOXY49jQ9L4knLB6LExgIUPyu8LDlzdtv0+/MlMiMxu3Gssm/zt3Vv94G6UT0AAC8C/oW' +
+  'QSEjKkExTjYTOXQ5bDcRM5EsMyRQGlIPsAPo93Xs1OF32MPQCsuKx2jGsMdVyzDRAtl24ifto/htBAgQ9xrFJAgtZzOeN4A5+TgNNt4woSmmIEwWAgtD/4zz' +
+  'Wugm3l3VXs51ydXGm8bJyEjN6NNh3FnmZPEN/dMIPRTMHhEoqC8/NZs4ljknOF00YS5yJuccJhKhBtf6Q+9i5Krag9JFzDLIdsYkxzXKh8/i1vffY+q49XoB' +
+  'LQ1SGHMiISsBMsc2QTlVOQA3XTKeKwoj/RjkDTcCcvYT65XgaNfvz3rKRMdvxgTI88sQ0hvaveOO7hv65QVyEUMc5SXwLQ00/DeRObw4hjURMJgoax/tFI4J' +
+  'yf0c8gPn9txi1KPNAMmrxr/GOcn/zd/Ujd2u59Pyhv5ICp0VCSAeKXkwyzXcOIo5zje7M30tViWeG70QKQVf+drtGeOO2Z/Ro8vZx2rGZcfByljQ79c04cPr' +
+  'LffzApwOpxmfIxgsuDI3N2U5KzmLNqIxoyraIaYXdAy9AP70tOla31/WIs/zyQfHgMZiyJnM+NI72wnl+O+T+10H2RKKHf4m0C6rNFA4mDl2OPY0PS+JJywe' +
+  'ixMYCFD8rvCw5c3bb9PvzJTIjMbtxrLJv87d1b/eBulE9AAAvAv6FkEhIypBMU42Ezl0OWw3ETORLDMkUBpSD7AD6Pd17NThd9jD0ArLisdoxrDHVcsw0QLZ' +
+  'duIn7aP4bQQIEPcaxSQILWcznjeAOfk4DTbeMKEppiBMFgILQ/+M81roJt5d1V7OdcnVxpvGychIzejTYdxZ5mTxDf3TCD0UzB4RKKgvPzWbOJY5JzhdNGEu' +
+  'cibnHCYSoQbX+kPvYuSq2oPSRcwyyHbGJMc1yofP4tb332PquPV6AS0NUhhzIiErATLHNkE5VTkAN10ynisKI/0Y5A03AnL2E+uV4GjX7896ykTHb8YEyPPL' +
+  'ENIb2r3jju4b+uUFchFDHOUl8C0NNPw3kTm8OIY1ETCYKGsf7RSOCcn9HPID5/bcYtSjzQDJq8a/xjnJ/83f1I3drufT8ob+SAqdFQkgHil5MMs13DiKOc43' +
+  'uzN9LVYlnhu9ECkFX/na7Rnjjtmf0aPL2cdqxmXHwcpY0O/XNOHD6y338wKcDqcZnyMYLLgyNzdlOSs5izaiMaMq2iGmF3QMvQD+9LTpWt9f1iLP88kHx4DG' +
+  'YsiZzPjSO9sJ5fjvk/tdB9kSih3+JtAuqzRQOJg5djj2ND0viScsHosTGAhQ/K7wsOXN22/T78yUyIzG7cayyb/O3dW/3gbpRPQAALwL+hZBISMqQTFONhM5' +
+  'dDlsNxEzkSwzJFAaUg+wA+j3dezU4XfYw9AKy4rHaMawx1XLMNEC2XbiJ+2j+G0ECBD3GsUkCC1nM543gDn5OA023jChKaYgTBYCC0P/jPNa6CbeXdVeznXJ' +
+  '1cabxsnISM3o02HcWeZk8Q390wg9FMweESioLz81mziWOSc4XTRhLnIm5xwmEqEG1/pD72LkqtqD0kXMMsh2xiTHNcqHz+LW999j6rj1egEtDVIYcyIhKwEy' +
+  'xzZBOVU5ADddMp4rCiP9GOQNNwJy9hPrleBo1+/PespEx2/GBMjzyxDSG9q9447uG/rlBXIRQxzlJfAtDTT8N5E5vDiGNREwmChrH+0UjgnJ/RzyA+f23GLU' +
+  'o80AyavGv8Y5yf/N39SN3a7n0/KG/kgKnRUJIB4peTDLNdw4ijnON7szfS1WJZ4bvRApBV/52u0Z447Zn9Gjy9nHasZlx8HKWNDv1zThw+st9/MCnA6nGZ8j' +
+  'GCy4Mjc3ZTkrOYs2ojGjKtohphd0DL0A/vS06VrfX9Yiz/PJB8eAxmLImcz40jvbCeX475P7XQfZEood/ibQLqs0UDiYOXY49jQ9L4knLB6LExgIUPyu8LDl' +
+  'zdtv0+/MlMiMxu3Gssm/zt3Vv94G6UT0AAC8C/oWQSEjKkExTjYTOXQ5bDcRM5EsMyRQGlIPsAPo93Xs1OF32MPQCsuKx2jGsMdVyzDRAtl24ifto/htBAgQ' +
+  '9xrFJAgtZzOeN4A5+TgNNt4woSmmIEwWAgtD/4zzWugm3l3VXs51ydXGm8bJyEjN6NNh3FnmZPEN/dMIPRTMHhEoqC8/NZs4ljknOF00YS5yJuccJhKhBtf6' +
+  'Q+9i5Krag9JFzDLIdsYkxzXKh8/i1vffY+q49XoBLQ1SGHMiISsBMsc2QTlVOQA3XTKeKwoj/RjkDTcCcvYT65XgaNfvz3rKRMdvxgTI88sQ0hvaveOO7hv6' +
+  '5QVyEUMc5SXwLQ00/DeRObw4hjURMJgoax/tFI4Jyf0c8gPn9txi1KPNAMmrxr/GOcn/zd/Ujd2u59Pyhv5ICp0VCSAeKXkwyzXcOIo5zje7M30tViWeG70Q' +
+  'KQVf+drtGeOO2Z/Ro8vZx2rGZcfByljQ79c04cPrLffzApwOpxmfIxgsuDI3N2U5KzmLNqIxoyraIaYXdAy9AP70tOla31/WIs/zyQfHgMZiyJnM+NI72wnl' +
+  '+O+T+10H2RKKHf4m0C6rNFA4mDl2OPY0PS+JJyweixMYCFD8rvCw5c3bb9PvzJTIjMbtxrLJv87d1b/eBulE9AAAvAv6FkEhIypBMU42Ezl0OWw3ETORLDMk' +
+  'UBpSD7AD6Pd17NThd9jD0ArLisdoxrDHVcsw0QLZduIn7aP4bQQIEPcaxSQILWcznjeAOfk4DTbeMKEppiBMFgILQ/+M81roJt5d1V7OdcnVxpvGychIzejT' +
+  'YdxZ5mTxDf3TCD0UzB4RKKgvPzWbOJY5JzhdNGEucibnHCYSoQbX+kPvYuSq2oPSRcwyyHbGJMc1yofP4tb332PquPV6AS0NUhhzIiErATLHNkE5VTkAN10y' +
+  'nisKI/0Y5A03AnL2E+uV4GjX7896ykTHb8YEyPPLENIb2r3jju4b+uUFchFDHOUl8C0NNPw3kTm8OIY1ETCYKGsf7RSOCcn9HPID5/bcYtSjzQDJq8a/xjnJ' +
+  '/83f1I3drufT8ob+SAqdFQkgHil5MMs13DiKOc43uzN9LVYlnhu9ECkFX/na7Rnjjtmf0aPL2cdqxmXHwcpY0O/XNOHD6y338wKcDqcZnyMYLLgyNzdlOSs5' +
+  'izaiMaMq2iGmF3QMvQD+9LTpWt9f1iLP88kHx4DGYsiZzPjSO9sJ5fjvk/tdB9kSih3+JtAuqzRQOJg5djj2ND0viScsHosTGAhQ/K7wsOXN22/T78yUyIzG' +
+  '7cayyb/O3dW/3gbpRPQAALwL+hZBISMqQTFONhM5dDlsNxEzkSwzJFAaUg+wA+j3dezU4XfYw9AKy4rHaMawx1XLMNEC2XbiJ+2j+G0ECBD3GsUkCC1nM543' +
+  'gDn5OA023jChKaYgTBYCC0P/jPNa6CbeXdVeznXJ1cabxsnISM3o02HcWeZk8Q390wg9FMweESioLz81mziWOSc4XTRhLnIm5xwmEqEG1/pD72LkqtqD0kXM' +
+  'Msh2xiTHNcqHz+LW999j6rj1egEtDVIYcyIhKwEyxzZBOVU5ADddMp4rCiP9GOQNNwJy9hPrleBo1+/PespEx2/GBMjzyxDSG9q9447uG/rlBXIRQxzlJfAt' +
+  'DTT8N5E5vDiGNREwmChrH+0UjgnJ/RzyA+f23GLUo80AyavGv8Y5yf/N39SN3a7n0/KG/kgKnRUJIB4peTDLNdw4ijnON7szfS1WJZ4bvRApBV/52u0Z447Z' +
+  'n9Gjy9nHasZlx8HKWNDv1zThw+st9/MCnA6nGZ8jGCy4Mjc3ZTkrOYs2ojGjKtohphd0DL0A/vS06VrfX9Yiz/PJB8eAxmLImcz40jvbCeX475P7XQfZEood' +
+  '/ibQLqs0UDiYOXY49jQ9L4knLB6LExgIUPyu8LDlzdtv0+/MlMiMxu3Gssm/zt3Vv94G6UT0AAC8C/oWQSEjKkExTjYTOXQ5bDcRM5EsMyRQGlIPsAPo93Xs' +
+  '1OF32MPQCsuKx2jGsMdVyzDRAtl24ifto/htBAgQ9xrFJAgtZzOeN4A5+TgNNt4woSmmIEwWAgtD/4zzWugm3l3VXs51ydXGm8bJyEjN6NNh3FnmZPEN/dMI' +
+  'PRTMHhEoqC8/NZs4ljknOF00YS5yJuccJhKhBtf6Q+9i5Krag9JFzDLIdsYkxzXKh8/i1vffY+q49XoBLQ1SGHMiISsBMsc2QTlVOQA3XTKeKwoj/RjkDTcC' +
+  'cvYT65XgaNfvz3rKRMdvxgTI88sQ0hvaveOO7hv65QVyEUMc5SXwLQ00/DeRObw4hjURMJgoax/tFI4Jyf0c8gPn9txi1KPNAMmrxr/GOcn/zd/Ujd2u59Py' +
+  'hv5ICp0VCSAeKXkwyzXcOIo5zje7M30tViWeG70QKQVf+drtGeOO2Z/Ro8vZx2rGZcfByljQ79c04cPrLffzApwOpxmfIxgsuDI3N2U5KzmLNqIxoyraIaYX' +
+  'dAy9AP70tOla31/WIs/zyQfHgMZiyJnM+NI72wnl+O+T+10H2RKKHf4m0C6rNFA4mDl2OPY0PS+JJyweixMYCFD8rvCw5c3bb9PvzJTIjMbtxrLJv87d1b/e' +
+  'BulE9AAAvAv6FkEhIypBMU42Ezl0OWw3ETORLDMkUBpSD7AD6Pd17NThd9jD0ArLisdoxrDHVcsw0QLZduIn7aP4bQQIEPcaxSQILWcznjeAOfk4DTbeMKEp' +
+  'piBMFgILQ/+M81roJt5d1V7OdcnVxpvGychIzejTYdxZ5mTxDf3TCD0UzB4RKKgvPzWbOJY5JzhdNGEucibnHCYSoQbX+kPvYuSq2oPSRcwyyHbGJMc1yofP' +
+  '4tb332PquPV6AS0NUhhzIiErATLHNkE5VTkAN10ynisKI/0Y5A03AnL2E+uV4GjX7896ykTHb8YEyPPLENIb2r3jju4b+uUFchFDHOUl8C0NNPw3kTm8OIY1' +
+  'ETCYKGsf7RSOCcn9HPID5/bcYtSjzQDJq8a/xjnJ/83f1I3drufT8ob+SAqdFQkgHil5MMs13DiKOc43uzN9LVYlnhu9ECkFX/na7Rnjjtmf0aPL2cdqxmXH' +
+  'wcpY0O/XNOHD6y338wKcDqcZnyMYLLgyNzdlOSs5izaiMaMq2iGmF3QMvQD+9LTpWt9f1iLP88kHx4DGYsiZzPjSO9sJ5fjvk/tdB9kSih3+JtAuqzRQOJg5' +
+  'djj2ND0viScsHosTGAhQ/K7wsOXN22/T78yUyIzG7cayyb/O3dW/3gbpRPQAALwL+hZBISMqQTFONhM5dDlsNxEzkSwzJFAaUg+wA+j3dezU4XfYw9AKy4rH' +
+  'aMawx1XLMNEC2XbiJ+2j+G0ECBD3GsUkCC1nM543gDn5OA023jChKaYgTBYCC0P/jPNa6CbeXdVeznXJ1cabxsnISM3o02HcWeZk8Q390wg9FMweESioLz81' +
+  'mziWOSc4XTRhLnIm5xwmEqEG1/pD72LkqtqD0kXMMsh2xiTHNcqHz+LW999j6rj1egEtDVIYcyIhKwEyxzZBOVU5ADddMp4rCiP9GOQNNwJy9hPrleBo1+/P' +
+  'espEx2/GBMjzyxDSG9q9447uG/rlBXIRQxzlJfAtDTT8N5E5vDiGNREwmChrH+0UjgnJ/RzyA+f23GLUo80AyavGv8Y5yf/N39SN3a7n0/KG/kgKnRUJIB4p' +
+  'eTDLNdw4ijnON7szfS1WJZ4bvRApBV/52u0Z447Zn9Gjy9nHasZlx8HKWNDv1zThw+st9/MCnA6nGZ8jGCy4Mjc3ZTkrOYs2ojGjKtohphd0DL0A/vS06Vrf' +
+  'X9Yiz/PJB8eAxmLImcz40jvbCeX475P7XQfZEood/ibQLqs0UDiYOXY49jQ9L4knLB6LExgIUPyu8LDlzdtv0+/MlMiMxu3Gssm/zt3Vv94G6UT0AAC8C/oW' +
+  'QSEjKkExTjYTOXQ5bDcRM5EsMyRQGlIPsAPo93Xs1OF32MPQCsuKx2jGsMdVyzDRAtl24ifto/htBAgQ9xrFJAgtZzOeN4A5+TgNNt4woSmmIEwWAgtD/4zz' +
+  'Wug=';
+
+export const DEFAULT_AUDIO_CUES = {
+  rare: RARE_CUE_SOURCE,
+} as const;
+
+export function clampVolume(value: unknown, fallback = 0.5): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return fallback;
+  if (numeric < 0) return 0;
+  if (numeric > 1) return 1;
+  return numeric;
+}
+
+function defaultCreateAudioElement(
+  src: string,
+  initialVolume: number,
+  logger?: AudioLogger,
+): AudioElementLike | null {
+  if (typeof Audio === 'undefined') {
+    return null;
+  }
+  try {
+    const audio = new Audio(src);
+    audio.preload = 'auto';
+    audio.volume = clampVolume(initialVolume);
+    return audio as unknown as AudioElementLike;
+  } catch (error) {
+    logger?.warn?.('Impossibile inizializzare il cue audio', error);
+    return null;
+  }
+}
+
+export function createAudioCueFactory(options: AudioCueFactoryOptions = {}): AudioCueFactory {
+  const { cues = {}, createAudioElement, logger, initialVolume = 0.5 } = options;
+  const cache = new Map<string, AudioElementLike>();
+  const factory: AudioElementFactory =
+    createAudioElement ?? ((src) => defaultCreateAudioElement(src, initialVolume, logger));
+
+  return {
+    ensure(key: string) {
+      if (!key) return null;
+      if (cache.has(key)) {
+        return cache.get(key) ?? null;
+      }
+      const src = cues[key];
+      if (!src) return null;
+      try {
+        const element = factory(src);
+        if (!element) {
+          return null;
+        }
+        if (typeof element.volume === 'number') {
+          element.volume = clampVolume(initialVolume);
+        }
+        cache.set(key, element);
+        return element;
+      } catch (error) {
+        logger?.warn?.('Impossibile inizializzare il cue audio', error);
+        return null;
+      }
+    },
+    setVolume(volume: number) {
+      const target = clampVolume(volume);
+      cache.forEach((audio) => {
+        try {
+          audio.volume = target;
+        } catch (error) {
+          logger?.warn?.('Impossibile aggiornare il volume del cue audio', error);
+        }
+      });
+    },
+  };
+}
+
+export function createAudioService(options: AudioServiceOptions): AudioService {
+  const {
+    cues = DEFAULT_AUDIO_CUES,
+    preferences,
+    elements = {},
+    loadPreferences,
+    savePreferences,
+    createAudioElement,
+    logger,
+    defaultVolume = 0.5,
+  } = options;
+
+  const cueFactory = createAudioCueFactory({
+    cues,
+    createAudioElement,
+    logger,
+    initialVolume: defaultVolume,
+  });
+
+  const controlElements: AudioControlElements = {
+    controls: elements.controls ?? null,
+    mute: elements.mute ?? null,
+    volume: elements.volume ?? null,
+  };
+
+  function persist() {
+    savePreferences?.({
+      audioMuted: Boolean(preferences.audioMuted),
+      volume: clampVolume(preferences.volume, defaultVolume),
+    });
+  }
+
+  function applyPreferences() {
+    const muted = Boolean(preferences.audioMuted);
+    const volume = clampVolume(preferences.volume, defaultVolume);
+    preferences.volume = volume;
+
+    cueFactory.setVolume(muted ? 0 : volume);
+
+    const muteButton = controlElements.mute;
+    if (muteButton?.classList?.toggle) {
+      muteButton.classList.toggle('is-muted', muted);
+    }
+    muteButton?.setAttribute?.('aria-pressed', muted ? 'true' : 'false');
+    if (typeof muteButton?.textContent === 'string') {
+      muteButton.textContent = muted ? '🔇 Audio disattivato' : '🔈 Audio attivo';
+    }
+
+    const volumeInput = controlElements.volume;
+    if (volumeInput) {
+      const targetValue = String(Math.round(volume * 100));
+      if (volumeInput.value !== targetValue) {
+        volumeInput.value = targetValue;
+      }
+    }
+  }
+
+  function playCue(key: string) {
+    const audio = cueFactory.ensure(key);
+    if (!audio) return;
+    const volume = clampVolume(preferences.volume, defaultVolume);
+    if (preferences.audioMuted || volume <= 0) {
+      if (typeof audio.pause === 'function') {
+        try {
+          audio.pause();
+        } catch (error) {
+          logger?.warn?.('Impossibile mettere in pausa il cue audio', error);
+        }
+      }
+      return;
+    }
+    try {
+      audio.currentTime = 0;
+      audio.volume = volume;
+      const playback = audio.play?.();
+      if (playback && typeof (playback as Promise<void>).catch === 'function') {
+        (playback as Promise<void>).catch((error) => {
+          if (!error || (error as { name?: string }).name === 'NotAllowedError') {
+            return;
+          }
+          logger?.warn?.('Riproduzione audio non riuscita', error);
+        });
+      }
+    } catch (error) {
+      logger?.warn?.(`Impossibile riprodurre il cue audio ${key}`, error);
+    }
+  }
+
+  function setupControls() {
+    const supported = Boolean(cueFactory.ensure('rare'));
+    const controls = controlElements.controls;
+    if (!supported) {
+      if (controls) {
+        controls.hidden = true;
+        controls.setAttribute?.('aria-hidden', 'true');
+      }
+      return;
+    }
+    if (controls) {
+      controls.hidden = false;
+      controls.setAttribute?.('aria-hidden', 'false');
+    }
+
+    const muteButton = controlElements.mute;
+    if (muteButton?.addEventListener) {
+      muteButton.addEventListener('click', (event) => {
+        const evt = event as { preventDefault?: () => void };
+        evt?.preventDefault?.();
+        const nextMuted = !preferences.audioMuted;
+        preferences.audioMuted = nextMuted;
+        if (!nextMuted && clampVolume(preferences.volume, defaultVolume) <= 0) {
+          preferences.volume = defaultVolume;
+        }
+        applyPreferences();
+        persist();
+      });
+    }
+
+    const volumeInput = controlElements.volume;
+    if (volumeInput?.addEventListener) {
+      const handleVolume = (value: unknown) => {
+        const numeric = clampVolume(Number(value) / 100, defaultVolume);
+        preferences.volume = numeric;
+        if (numeric > 0 && preferences.audioMuted) {
+          preferences.audioMuted = false;
+        }
+        if (numeric === 0) {
+          preferences.audioMuted = true;
+        }
+        applyPreferences();
+      };
+
+      volumeInput.addEventListener('input', (event) => {
+        const target =
+          (event as { target?: { value?: string } }).target?.value ?? volumeInput.value;
+        handleVolume(target);
+      });
+
+      volumeInput.addEventListener('change', () => {
+        persist();
+      });
+    }
+
+    applyPreferences();
+  }
+
+  function restorePreferences() {
+    const stored = loadPreferences?.();
+    if (stored && typeof stored === 'object') {
+      if (typeof stored.audioMuted === 'boolean') {
+        preferences.audioMuted = stored.audioMuted;
+      }
+      if (typeof stored.volume === 'number') {
+        preferences.volume = clampVolume(stored.volume, defaultVolume);
+      }
+    }
+    applyPreferences();
+  }
+
+  return {
+    applyPreferences,
+    playCue,
+    setupControls,
+    restorePreferences,
+  };
+}

--- a/docs/evo-tactics-pack/services/storage.ts
+++ b/docs/evo-tactics-pack/services/storage.ts
@@ -1,0 +1,231 @@
+type StorageLike = {
+  getItem(key: string): string | null | undefined;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+};
+
+type WindowLike = {
+  localStorage?: StorageLike | null;
+};
+
+type StorageLogger = {
+  warn?: (...args: unknown[]) => void;
+};
+
+export const STORAGE_KEYS = {
+  activityLog: 'evo-generator-activity-log',
+  filterProfiles: 'evo-generator-filter-profiles',
+  history: 'evo-generator-history',
+  pinned: 'evo-generator-pinned',
+  locks: 'evo-generator-locks',
+  preferences: 'evo-generator-preferences',
+} as const;
+
+export type StoredPreferences = {
+  audioMuted?: boolean;
+  volume?: number;
+} | null;
+
+export type StoredLocks = {
+  biomes: unknown[];
+  species: unknown[];
+};
+
+export interface StorageService {
+  isPersistent(): boolean;
+  loadActivityLog(): unknown[];
+  saveActivityLog(entries: unknown[]): void;
+  loadFilterProfiles(): unknown[];
+  saveFilterProfiles(profiles: unknown[]): void;
+  loadPreferences(): StoredPreferences;
+  savePreferences(preferences: StoredPreferences): void;
+  loadPinnedState(): unknown[];
+  savePinnedState(payload: unknown[]): void;
+  loadLocks(): StoredLocks;
+  saveLocks(payload: StoredLocks): void;
+  loadHistory(): unknown[];
+  saveHistory(entries: unknown[]): void;
+}
+
+export interface CreateStorageServiceOptions {
+  windowRef?: WindowLike | null;
+  storage?: StorageLike | null;
+  logger?: StorageLogger;
+}
+
+function createMemoryStorage(): StorageLike {
+  const store = new Map<string, string>();
+  return {
+    getItem(key: string) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+  };
+}
+
+function detectLocalStorage(
+  windowRef?: WindowLike | null,
+  logger?: StorageLogger,
+): StorageLike | null {
+  const storage = windowRef?.localStorage ?? null;
+  if (!storage) {
+    return null;
+  }
+  try {
+    const testKey = '__storage_test__';
+    storage.setItem(testKey, '1');
+    storage.removeItem?.(testKey);
+    return storage;
+  } catch (error) {
+    logger?.warn?.('LocalStorage non disponibile, verrà utilizzato il fallback in-memory', error);
+    return null;
+  }
+}
+
+export function createStorageService(options: CreateStorageServiceOptions = {}): StorageService {
+  const { windowRef, storage: overrideStorage, logger } = options;
+  const memoryStorage = createMemoryStorage();
+  let activeStorage: StorageLike =
+    overrideStorage ?? detectLocalStorage(windowRef, logger) ?? memoryStorage;
+  let persistent = activeStorage !== memoryStorage;
+
+  function withStorage<T>(action: (driver: StorageLike) => T, fallbackValue: T): T {
+    try {
+      return action(activeStorage);
+    } catch (error) {
+      if (activeStorage !== memoryStorage) {
+        logger?.warn?.('Persistenza locale non disponibile, uso fallback in-memory', error);
+        activeStorage = memoryStorage;
+        persistent = false;
+        try {
+          return action(activeStorage);
+        } catch (fallbackError) {
+          logger?.warn?.(
+            'Operazione storage non riuscita con il fallback in-memory',
+            fallbackError,
+          );
+          return fallbackValue;
+        }
+      }
+      logger?.warn?.('Operazione storage non riuscita', error);
+      return fallbackValue;
+    }
+  }
+
+  function readRaw(key: string): string | null {
+    return withStorage<string | null>((driver) => driver.getItem(key) ?? null, null);
+  }
+
+  function writeRaw(key: string, value: string | null): void {
+    if (value === null) {
+      withStorage(
+        (driver) => {
+          driver.removeItem?.(key);
+        },
+        undefined as unknown as void,
+      );
+      return;
+    }
+    withStorage(
+      (driver) => {
+        driver.setItem(key, value);
+      },
+      undefined as unknown as void,
+    );
+  }
+
+  function loadJson<T>(key: string, defaultValue: T): T {
+    const raw = readRaw(key);
+    if (!raw) {
+      return defaultValue;
+    }
+    try {
+      return JSON.parse(raw) as T;
+    } catch (error) {
+      logger?.warn?.(`Impossibile decodificare i dati salvati per la chiave ${key}`, error);
+      return defaultValue;
+    }
+  }
+
+  function saveJson<T>(key: string, value: T): void {
+    let payload: string;
+    try {
+      payload = JSON.stringify(value);
+    } catch (error) {
+      logger?.warn?.(`Impossibile serializzare i dati per la chiave ${key}`, error);
+      return;
+    }
+    writeRaw(key, payload);
+  }
+
+  return {
+    isPersistent() {
+      return persistent;
+    },
+    loadActivityLog() {
+      const data = loadJson<unknown[]>(STORAGE_KEYS.activityLog, []);
+      return Array.isArray(data) ? data : [];
+    },
+    saveActivityLog(entries: unknown[]) {
+      saveJson(STORAGE_KEYS.activityLog, Array.isArray(entries) ? entries : []);
+    },
+    loadFilterProfiles() {
+      const data = loadJson<unknown[]>(STORAGE_KEYS.filterProfiles, []);
+      return Array.isArray(data) ? data : [];
+    },
+    saveFilterProfiles(profiles: unknown[]) {
+      saveJson(STORAGE_KEYS.filterProfiles, Array.isArray(profiles) ? profiles : []);
+    },
+    loadPreferences() {
+      const data = loadJson<StoredPreferences>(STORAGE_KEYS.preferences, null);
+      if (!data || typeof data !== 'object') {
+        return null;
+      }
+      const result: StoredPreferences = {
+        audioMuted: typeof data.audioMuted === 'boolean' ? data.audioMuted : undefined,
+        volume: typeof data.volume === 'number' ? data.volume : undefined,
+      };
+      if (result.audioMuted === undefined && result.volume === undefined) {
+        return null;
+      }
+      return result;
+    },
+    savePreferences(preferences: StoredPreferences) {
+      if (!preferences || typeof preferences !== 'object') {
+        writeRaw(STORAGE_KEYS.preferences, null);
+        return;
+      }
+      saveJson(STORAGE_KEYS.preferences, preferences);
+    },
+    loadPinnedState() {
+      const data = loadJson<unknown[]>(STORAGE_KEYS.pinned, []);
+      return Array.isArray(data) ? data : [];
+    },
+    savePinnedState(payload: unknown[]) {
+      saveJson(STORAGE_KEYS.pinned, Array.isArray(payload) ? payload : []);
+    },
+    loadLocks() {
+      const data = loadJson<StoredLocks>(STORAGE_KEYS.locks, { biomes: [], species: [] });
+      const biomes = Array.isArray(data?.biomes) ? data.biomes : [];
+      const species = Array.isArray(data?.species) ? data.species : [];
+      return { biomes, species };
+    },
+    saveLocks(payload: StoredLocks) {
+      const biomes = Array.isArray(payload?.biomes) ? payload.biomes : [];
+      const species = Array.isArray(payload?.species) ? payload.species : [];
+      saveJson(STORAGE_KEYS.locks, { biomes, species });
+    },
+    loadHistory() {
+      const data = loadJson<unknown[]>(STORAGE_KEYS.history, []);
+      return Array.isArray(data) ? data : [];
+    },
+    saveHistory(entries: unknown[]) {
+      saveJson(STORAGE_KEYS.history, Array.isArray(entries) ? entries : []);
+    },
+  };
+}

--- a/tests/docs-generator/unit/audio.test.ts
+++ b/tests/docs-generator/unit/audio.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAudioService, clampVolume } from '../../../docs/evo-tactics-pack/services/audio.ts';
+
+function createButtonMock() {
+  const listeners = new Map<string, (event: unknown) => void>();
+  return {
+    classList: { toggle: vi.fn() },
+    setAttribute: vi.fn(),
+    addEventListener: (type: string, listener: (event: unknown) => void) => {
+      listeners.set(type, listener);
+    },
+    trigger: (type: string, event: unknown) => {
+      const listener = listeners.get(type);
+      if (listener) listener(event);
+    },
+    textContent: '',
+  };
+}
+
+function createVolumeMock(initialValue = '50') {
+  const listeners = new Map<string, (event: unknown) => void>();
+  const mock = {
+    value: initialValue,
+    addEventListener: (type: string, listener: (event: unknown) => void) => {
+      listeners.set(type, listener);
+    },
+    trigger: (type: string, value: string) => {
+      const listener = listeners.get(type);
+      if (listener) {
+        listener({ target: { value } });
+      }
+    },
+  };
+  return mock;
+}
+
+describe('audio service', () => {
+  it('updates preferences and triggers persistence when controls are used', async () => {
+    const preferences = { audioMuted: false, volume: 0.4 };
+    const muteButton = createButtonMock();
+    const volumeInput = createVolumeMock('40');
+    const controls = { hidden: false, setAttribute: vi.fn() };
+    const savePreferences = vi.fn();
+    const play = vi.fn(() => Promise.resolve());
+    const pause = vi.fn();
+
+    const service = createAudioService({
+      cues: { rare: 'stub-source' },
+      preferences,
+      elements: {
+        controls,
+        mute: muteButton,
+        volume: volumeInput,
+      },
+      loadPreferences: () => ({ audioMuted: false, volume: 0.4 }),
+      savePreferences,
+      createAudioElement: () => ({ volume: 0.4, currentTime: 0, play, pause }),
+      logger: { warn: vi.fn() },
+      defaultVolume: 0.4,
+    });
+
+    service.setupControls();
+
+    expect(muteButton.classList.toggle).toHaveBeenCalledWith('is-muted', false);
+    expect(volumeInput.value).toBe('40');
+
+    muteButton.trigger('click', { preventDefault: vi.fn() });
+    expect(preferences.audioMuted).toBe(true);
+    expect(savePreferences).toHaveBeenCalledWith({ audioMuted: true, volume: 0.4 });
+
+    volumeInput.trigger('input', '80');
+    expect(preferences.volume).toBeCloseTo(0.8, 5);
+    expect(preferences.audioMuted).toBe(false);
+
+    volumeInput.trigger('change', volumeInput.value);
+    expect(savePreferences).toHaveBeenCalledWith({ audioMuted: false, volume: 0.8 });
+
+    await service.playCue('rare');
+    expect(play).toHaveBeenCalled();
+    expect(pause).not.toHaveBeenCalled();
+  });
+
+  it('hides controls when audio elements cannot be created', () => {
+    const preferences = { audioMuted: false, volume: 0.5 };
+    const controls = { hidden: false, setAttribute: vi.fn() };
+
+    const service = createAudioService({
+      cues: { rare: 'missing' },
+      preferences,
+      elements: {
+        controls,
+        mute: null,
+        volume: null,
+      },
+      loadPreferences: () => null,
+      savePreferences: () => {},
+      createAudioElement: () => null,
+      logger: { warn: vi.fn() },
+    });
+
+    service.setupControls();
+    expect(controls.hidden).toBe(true);
+    expect(controls.setAttribute).toHaveBeenCalledWith('aria-hidden', 'true');
+  });
+
+  it('clamps volume values within the supported range', () => {
+    expect(clampVolume(1.2)).toBe(1);
+    expect(clampVolume(-1)).toBe(0);
+    expect(clampVolume('0.25')).toBeCloseTo(0.25, 5);
+    expect(clampVolume(NaN)).toBe(0.5);
+  });
+});

--- a/tests/docs-generator/unit/storage.test.ts
+++ b/tests/docs-generator/unit/storage.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createStorageService,
+  STORAGE_KEYS,
+} from '../../../docs/evo-tactics-pack/services/storage.ts';
+
+type MockStorage = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+  store: Map<string, string>;
+};
+
+function createMockStorage(): MockStorage {
+  const store = new Map<string, string>();
+  return {
+    store,
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+  };
+}
+
+describe('storage service', () => {
+  it('serialises and restores filter profiles using the provided driver', () => {
+    const mockStorage = createMockStorage();
+    const service = createStorageService({ storage: mockStorage });
+
+    const payload = [
+      {
+        name: 'Profilo A',
+        filters: { flags: ['alpha'], roles: ['support'], tags: [] },
+        updatedAt: '2024-10-01T10:00:00.000Z',
+      },
+      null,
+    ];
+
+    service.saveFilterProfiles(payload);
+
+    const saved = mockStorage.store.get(STORAGE_KEYS.filterProfiles);
+    expect(saved).toBeTruthy();
+
+    const parsed = JSON.parse(saved ?? '[]');
+    expect(parsed[0]).toMatchObject(payload[0]);
+
+    const restored = service.loadFilterProfiles();
+    expect(restored).toStrictEqual(parsed);
+  });
+
+  it('falls back to in-memory storage when the driver fails', () => {
+    const failingStorage = {
+      getItem: vi.fn(() => {
+        throw new Error('unavailable');
+      }),
+      setItem: vi.fn(() => {
+        throw new Error('unavailable');
+      }),
+      removeItem: vi.fn(() => {
+        throw new Error('unavailable');
+      }),
+    };
+    const logger = { warn: vi.fn() };
+    const service = createStorageService({ storage: failingStorage, logger });
+
+    const payload = [{ id: 'evt', message: 'ok', timestamp: new Date().toISOString() }];
+    service.saveActivityLog(payload);
+
+    expect(service.isPersistent()).toBe(false);
+    expect(logger.warn).toHaveBeenCalled();
+
+    const restored = service.loadActivityLog();
+    expect(restored).toStrictEqual(payload);
+  });
+});


### PR DESCRIPTION
## Summary
- add a storage helper with an in-memory fallback and wire generator persistence through it
- extract audio cue/controls handling into a reusable service and update the generator to use it
- cover the new services with unit tests for happy paths and fallbacks

## Testing
- npm run test:docs-generator

------
https://chatgpt.com/codex/tasks/task_b_690a2e839fa0832a98078570397b4135