### PR TITLE
Refactor docs generator anchor navigation

### DIFF
--- a/docs/evo-tactics-pack/generator.js
+++ b/docs/evo-tactics-pack/generator.js
@@ -5,6 +5,7 @@ import {
   PACK_PATH,
 } from './pack-data.js';
 import { resolveGeneratorElements, resolveAnchorUi } from './ui/elements.ts';
+import { createAnchorNavigator } from './views/anchor.js';
 import { createSessionState } from './state/session.ts';
 import { randomId } from './utils/ids.ts';
 import { buildGenerationConstraints, createTagEntry } from './utils/normalizers.ts';
@@ -37,17 +38,7 @@ import * as exportView from './views/export.js';
 
 const elements = resolveGeneratorElements(document);
 const anchorUi = resolveAnchorUi(document);
-
-const anchorState = {
-  descriptors: [],
-  descriptorsById: new Map(),
-  sectionsById: new Map(),
-  minimaps: new Map(),
-  observer: null,
-  scrollHandler: null,
-  activeId: null,
-  lastToggle: null,
-};
+const anchorNavigator = createAnchorNavigator();
 
 const PACK_ROOT_CANDIDATES = getPackRootCandidates();
 const EXPORT_BASE_FOLDER = `${PACK_PATH}out/generator/`;
@@ -1681,9 +1672,8 @@ function attachInsightHandlers() {
       event.preventDefault();
       const panelId = button.dataset.panelId;
       if (!panelId) return;
-      if (anchorState.descriptorsById.has(panelId)) {
-        setActiveSection(panelId, { updateHash: true });
-        scrollToPanel(panelId);
+      if (anchorNavigator.setActiveSection(panelId, { updateHash: true })) {
+        anchorNavigator.scrollToPanel(panelId);
       }
       const label = button.dataset.panelLabel ?? getPanelLabel(panelId) ?? panelId;
       setStatus(`Navigazione rapida: ${label}.`, 'info', {
@@ -3121,380 +3111,6 @@ function slugify(value) {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 60);
-}
-
-function getPanelIdFromHash() {
-  if (typeof window === 'undefined') return null;
-  const hash = window.location.hash ?? '';
-  if (!hash) return null;
-  const id = hash.replace(/^#/, '');
-  if (!id) return null;
-  const target = document.getElementById(id);
-  if (!target) return null;
-  return target.dataset?.panel ?? null;
-}
-
-function scrollToPanel(panelId, { smooth = true } = {}) {
-  if (!panelId) return;
-  const entry = anchorState.sectionsById.get(panelId);
-  const panel = entry?.element;
-  if (!panel) return;
-  if (!panel.hasAttribute('tabindex')) {
-    panel.setAttribute('tabindex', '-1');
-  }
-  const behavior = smooth ? 'smooth' : 'auto';
-  panel.scrollIntoView({ behavior, block: 'start' });
-  window.requestAnimationFrame(() => {
-    try {
-      panel.focus({ preventScroll: true });
-    } catch (error) {
-      panel.focus();
-    }
-  });
-}
-
-function updateBreadcrumbs(sectionId) {
-  const descriptor = anchorState.descriptorsById.get(sectionId);
-  const label = descriptor?.label ?? '';
-  anchorUi.breadcrumbTargets.forEach((target) => {
-    if (target) {
-      target.textContent = label;
-      target.dataset.activeAnchor = sectionId ?? '';
-    }
-  });
-}
-
-function updateMinimapState() {
-  anchorState.minimaps.forEach((map) => {
-    map.forEach(({ item, progress }, id) => {
-      const descriptor = anchorState.descriptorsById.get(id);
-      if (!descriptor) return;
-      const ratio = Math.max(0, Math.min(1, descriptor.progress ?? 0));
-      progress.style.setProperty('--progress', `${Math.round(ratio * 100)}%`);
-      if (anchorState.activeId === id) {
-        item.classList.add('is-active');
-      } else {
-        item.classList.remove('is-active');
-      }
-    });
-  });
-}
-
-function setActiveSection(sectionId, { updateHash = false, silent = false } = {}) {
-  if (!sectionId || !anchorState.descriptorsById.has(sectionId)) {
-    return;
-  }
-
-  const previous = anchorState.activeId;
-  anchorState.activeId = sectionId;
-
-  if (previous !== sectionId || !silent) {
-    anchorState.descriptors.forEach((descriptor) => {
-      if (descriptor.id === sectionId) {
-        descriptor.anchor.classList.add('is-active');
-        descriptor.anchor.setAttribute('aria-current', 'location');
-      } else {
-        descriptor.anchor.classList.remove('is-active');
-        descriptor.anchor.removeAttribute('aria-current');
-      }
-    });
-    updateBreadcrumbs(sectionId);
-    updateMinimapState();
-  }
-
-  if (updateHash) {
-    const panel = anchorState.sectionsById.get(sectionId)?.element;
-    if (panel?.id && typeof window !== 'undefined' && window.history?.replaceState) {
-      window.history.replaceState(null, '', `#${panel.id}`);
-    }
-  }
-}
-
-function computeActiveSection() {
-  if (!anchorState.descriptors.length) return null;
-  const visible = anchorState.descriptors.filter((descriptor) => descriptor.isIntersecting);
-  if (visible.length) {
-    visible.sort((a, b) => (a.top ?? 0) - (b.top ?? 0));
-    return visible[0].id;
-  }
-
-  let candidate = null;
-  let minTop = Infinity;
-  anchorState.descriptors.forEach((descriptor) => {
-    const section = anchorState.sectionsById.get(descriptor.id);
-    const element = section?.element;
-    if (!element) return;
-    const rect = element.getBoundingClientRect();
-    if (rect.top >= 0 && rect.top < minTop) {
-      minTop = rect.top;
-      candidate = descriptor.id;
-    }
-  });
-
-  if (candidate) return candidate;
-  return anchorState.descriptors[anchorState.descriptors.length - 1]?.id ?? null;
-}
-
-function handleAnchorObserver(entries) {
-  entries.forEach((entry) => {
-    const id = entry.target.dataset.panel;
-    if (!id) return;
-    const descriptor = anchorState.descriptorsById.get(id);
-    if (!descriptor) return;
-    descriptor.progress = entry.intersectionRatio ?? 0;
-    descriptor.isIntersecting = entry.isIntersecting;
-    descriptor.top = entry.boundingClientRect?.top ?? 0;
-    descriptor.bottom = entry.boundingClientRect?.bottom ?? 0;
-  });
-
-  const nextActive = computeActiveSection();
-  if (nextActive) {
-    setActiveSection(nextActive, { silent: true });
-  }
-  updateMinimapState();
-}
-
-function cleanupScrollFallback() {
-  if (!anchorState.scrollHandler || typeof window === 'undefined') {
-    return;
-  }
-  window.removeEventListener('scroll', anchorState.scrollHandler);
-  window.removeEventListener('resize', anchorState.scrollHandler);
-  anchorState.scrollHandler = null;
-}
-
-function createAnchorObserver() {
-  if (anchorState.observer) {
-    anchorState.observer.disconnect();
-  }
-  cleanupScrollFallback();
-  if (!anchorUi.panels.length) return;
-
-  if (typeof IntersectionObserver === 'undefined') {
-    if (typeof window === 'undefined') {
-      return;
-    }
-    anchorState.scrollHandler = () => {
-      const viewportHeight = window.innerHeight || document.documentElement?.clientHeight || 1;
-
-      anchorState.descriptors.forEach((descriptor) => {
-        const section = anchorState.sectionsById.get(descriptor.id);
-        const element = section?.element;
-        if (!element) return;
-
-        const rect = element.getBoundingClientRect();
-        const height = rect.height || element.offsetHeight || 1;
-        const visible = Math.max(0, Math.min(rect.bottom, viewportHeight) - Math.max(rect.top, 0));
-        const ratio = Math.max(0, Math.min(1, visible / height));
-
-        descriptor.progress = Number.isFinite(ratio) ? ratio : 0;
-        descriptor.isIntersecting = rect.top < viewportHeight && rect.bottom > 0;
-        descriptor.top = rect.top;
-        descriptor.bottom = rect.bottom;
-      });
-
-      const nextActive = computeActiveSection();
-      if (nextActive) {
-        setActiveSection(nextActive, { silent: true });
-      }
-      updateMinimapState();
-    };
-
-    window.addEventListener('scroll', anchorState.scrollHandler, { passive: true });
-    window.addEventListener('resize', anchorState.scrollHandler);
-    anchorState.scrollHandler();
-    return;
-  }
-
-  const thresholds = [];
-  for (let value = 0; value <= 1; value += 0.25) {
-    thresholds.push(Number(value.toFixed(2)));
-  }
-
-  anchorState.observer = new IntersectionObserver(handleAnchorObserver, {
-    rootMargin: '-40% 0px -40% 0px',
-    threshold: thresholds,
-  });
-
-  anchorState.sectionsById.forEach(({ element }) => {
-    if (element) {
-      anchorState.observer.observe(element);
-    }
-  });
-}
-
-function setupMinimaps() {
-  anchorState.minimaps = new Map();
-
-  anchorUi.minimapContainers.forEach((container) => {
-    if (!container) return;
-    const isOverlay = container.dataset.minimapMode === 'overlay';
-    const existingTitle = container.querySelector('.codex-minimap__title');
-    const label =
-      container.dataset.minimapLabel || existingTitle?.textContent?.trim() || 'Minimappa';
-
-    container.innerHTML = '';
-
-    if (!isOverlay) {
-      const title = document.createElement('p');
-      title.className = 'codex-minimap__title';
-      title.textContent = label;
-      container.appendChild(title);
-    }
-
-    const list = document.createElement('ol');
-    list.className = isOverlay ? 'codex-overlay__list' : 'codex-minimap__list';
-    const registry = new Map();
-
-    anchorState.descriptors.forEach((descriptor) => {
-      const item = document.createElement('li');
-      item.className = isOverlay ? 'codex-overlay__item' : 'codex-minimap__item';
-      item.dataset.minimapItem = descriptor.id;
-
-      const trigger = document.createElement('button');
-      trigger.type = 'button';
-      trigger.className = isOverlay ? 'codex-overlay__link' : 'codex-minimap__link';
-      trigger.textContent = descriptor.label;
-      trigger.addEventListener('click', () => {
-        setActiveSection(descriptor.id, { updateHash: true });
-        scrollToPanel(descriptor.id);
-        if (isOverlay) {
-          closeCodex();
-        }
-      });
-
-      const progress = document.createElement('span');
-      progress.className = isOverlay ? 'codex-overlay__progress' : 'codex-minimap__progress';
-      progress.style.setProperty('--progress', '0%');
-
-      item.append(trigger, progress);
-      list.appendChild(item);
-      registry.set(descriptor.id, { item, progress });
-    });
-
-    container.appendChild(list);
-    anchorState.minimaps.set(container, registry);
-  });
-
-  updateMinimapState();
-}
-
-function closeCodex() {
-  if (!anchorUi.overlay || anchorUi.overlay.hidden) {
-    return;
-  }
-  anchorUi.overlay.hidden = true;
-  anchorUi.overlay.setAttribute('aria-hidden', 'true');
-  document.body.classList.remove('codex-open');
-  if (anchorState.lastToggle && typeof anchorState.lastToggle.focus === 'function') {
-    anchorState.lastToggle.focus();
-  }
-  anchorState.lastToggle = null;
-}
-
-function setupAnchorNavigation() {
-  if (!anchorUi.anchors.length || !anchorUi.panels.length) {
-    return;
-  }
-
-  anchorState.sectionsById = new Map();
-  anchorUi.panels.forEach((panel) => {
-    const panelId = panel.dataset.panel;
-    if (!panelId) return;
-    anchorState.sectionsById.set(panelId, { element: panel });
-    if (!panel.hasAttribute('tabindex')) {
-      panel.setAttribute('tabindex', '-1');
-    }
-  });
-
-  anchorState.descriptors = anchorUi.anchors
-    .map((anchor) => {
-      const id = anchor.dataset.anchorTarget;
-      if (!id || !anchorState.sectionsById.has(id)) return null;
-      const label = anchor.textContent?.trim() || id;
-      return { id, label, anchor, progress: 0, isIntersecting: false, top: 0, bottom: 0 };
-    })
-    .filter(Boolean);
-
-  anchorState.descriptorsById = new Map(
-    anchorState.descriptors.map((descriptor) => [descriptor.id, descriptor]),
-  );
-
-  if (!anchorState.descriptors.length) {
-    return;
-  }
-
-  anchorState.descriptors.forEach((descriptor) => {
-    descriptor.anchor.addEventListener('click', (event) => {
-      event.preventDefault();
-      setActiveSection(descriptor.id, { updateHash: true });
-      scrollToPanel(descriptor.id);
-      closeCodex();
-    });
-  });
-
-  setupMinimaps();
-  createAnchorObserver();
-
-  const initialId = getPanelIdFromHash();
-  if (initialId && anchorState.descriptorsById.has(initialId)) {
-    setActiveSection(initialId, { silent: true });
-  } else {
-    setActiveSection(anchorState.descriptors[0].id, { silent: true });
-  }
-
-  window.addEventListener('hashchange', () => {
-    const fromHash = getPanelIdFromHash();
-    if (fromHash && anchorState.descriptorsById.has(fromHash)) {
-      setActiveSection(fromHash, { silent: true });
-    }
-  });
-}
-
-function openCodex() {
-  if (!anchorUi.overlay) return;
-  if (!anchorState.minimaps.size) {
-    setupMinimaps();
-  }
-  anchorUi.overlay.hidden = false;
-  anchorUi.overlay.setAttribute('aria-hidden', 'false');
-  document.body.classList.add('codex-open');
-  updateMinimapState();
-  const closeButton = anchorUi.overlay.querySelector('[data-codex-close]');
-  if (closeButton) {
-    closeButton.focus({ preventScroll: true });
-  }
-}
-
-function setupCodexControls() {
-  if (!anchorUi.overlay) return;
-
-  anchorUi.codexToggles.forEach((button) => {
-    if (!button) return;
-    button.addEventListener('click', () => {
-      anchorState.lastToggle = button;
-      openCodex();
-    });
-  });
-
-  anchorUi.codexClosers.forEach((button) => {
-    if (!button) return;
-    button.addEventListener('click', () => {
-      closeCodex();
-    });
-  });
-
-  anchorUi.overlay.addEventListener('click', (event) => {
-    if (event.target === anchorUi.overlay) {
-      closeCodex();
-    }
-  });
-
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape' && document.body.classList.contains('codex-open')) {
-      closeCodex();
-    }
-  });
 }
 
 function uniqueById(items) {
@@ -7873,8 +7489,7 @@ biomesPanel.setup();
 seedsPanel.setup();
 composerPanel.setup();
 insightsPanel.setup();
-setupAnchorNavigation();
-setupCodexControls();
+anchorNavigator.init(anchorUi);
 renderTraitsPanel();
 renderParametersPanel();
 renderHistoryPanel();
@@ -7915,6 +7530,15 @@ if (typeof window !== 'undefined') {
     },
     setApiBase(base) {
       state.api.base = base ?? null;
+    },
+    initAnchorNavigation(ui) {
+      return anchorNavigator.init(ui ?? anchorUi);
+    },
+    setActiveSection(sectionId, options) {
+      return anchorNavigator.setActiveSection(sectionId, options);
+    },
+    scrollToPanel(sectionId, options) {
+      return anchorNavigator.scrollToPanel(sectionId, options);
     },
     requestBiomeSynthesis,
     manualLoadCatalog,

--- a/docs/evo-tactics-pack/views/anchor.js
+++ b/docs/evo-tactics-pack/views/anchor.js
@@ -1,0 +1,563 @@
+const DEFAULT_LABEL = '';
+
+function filterElements(list) {
+  return Array.isArray(list) ? list.filter((node) => node instanceof HTMLElement) : [];
+}
+
+function toArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  return [value];
+}
+
+export function createAnchorNavigator(environment = {}) {
+  const doc = environment.document ?? (typeof document !== 'undefined' ? document : null);
+  const win = environment.window ?? (typeof window !== 'undefined' ? window : null);
+
+  const state = {
+    doc,
+    win,
+    ui: {
+      anchors: [],
+      panels: [],
+      breadcrumbTargets: [],
+      minimapContainers: [],
+      overlay: null,
+      codexToggles: [],
+      codexClosers: [],
+    },
+    descriptors: [],
+    descriptorsById: new Map(),
+    sectionsById: new Map(),
+    minimaps: new Map(),
+    observer: null,
+    scrollHandler: null,
+    activeId: null,
+    lastToggle: null,
+    anchorHandlers: new Map(),
+    toggleHandlers: new Map(),
+    closerHandlers: new Map(),
+    overlayClickHandler: null,
+    keydownHandler: null,
+    hashHandler: null,
+  };
+
+  function setUi(ui) {
+    state.ui.anchors = filterElements(toArray(ui?.anchors));
+    state.ui.panels = filterElements(toArray(ui?.panels));
+    state.ui.breadcrumbTargets = filterElements(toArray(ui?.breadcrumbTargets));
+    state.ui.minimapContainers = filterElements(toArray(ui?.minimapContainers));
+    state.ui.overlay = ui?.overlay instanceof HTMLElement ? ui.overlay : null;
+    state.ui.codexToggles = filterElements(toArray(ui?.codexToggles));
+    state.ui.codexClosers = filterElements(toArray(ui?.codexClosers));
+  }
+
+  function getPanelIdFromHash() {
+    if (!state.win) return null;
+    const hash = state.win.location?.hash ?? '';
+    if (!hash) return null;
+    const id = hash.replace(/^#/, '');
+    if (!id) return null;
+    const element = state.doc?.getElementById(id);
+    if (!element) return null;
+    return element.dataset?.panel ?? null;
+  }
+
+  function updateBreadcrumbs(sectionId) {
+    const descriptor = state.descriptorsById.get(sectionId);
+    const label = descriptor?.label ?? DEFAULT_LABEL;
+    state.ui.breadcrumbTargets.forEach((target) => {
+      target.textContent = label;
+      target.dataset.activeAnchor = sectionId ?? '';
+    });
+  }
+
+  function updateMinimapState() {
+    state.minimaps.forEach((registry) => {
+      registry.forEach(({ item, progress }, id) => {
+        const descriptor = state.descriptorsById.get(id);
+        if (!descriptor) return;
+        const ratio = Math.max(0, Math.min(1, descriptor.progress ?? 0));
+        progress.style.setProperty('--progress', `${Math.round(ratio * 100)}%`);
+        if (state.activeId === id) {
+          item.classList.add('is-active');
+        } else {
+          item.classList.remove('is-active');
+        }
+      });
+    });
+  }
+
+  function setActiveSection(sectionId, { updateHash = false, silent = false } = {}) {
+    if (!sectionId || !state.descriptorsById.has(sectionId)) {
+      return false;
+    }
+
+    const previous = state.activeId;
+    state.activeId = sectionId;
+
+    if (previous !== sectionId || !silent) {
+      state.descriptors.forEach((descriptor) => {
+        if (descriptor.id === sectionId) {
+          descriptor.anchor.classList.add('is-active');
+          descriptor.anchor.setAttribute('aria-current', 'location');
+        } else {
+          descriptor.anchor.classList.remove('is-active');
+          descriptor.anchor.removeAttribute('aria-current');
+        }
+      });
+      updateBreadcrumbs(sectionId);
+      updateMinimapState();
+    }
+
+    if (updateHash) {
+      const panel = state.sectionsById.get(sectionId)?.element;
+      if (panel?.id && state.win?.history?.replaceState) {
+        state.win.history.replaceState(null, '', `#${panel.id}`);
+      }
+    }
+
+    return true;
+  }
+
+  function focusPanel(panel) {
+    if (!panel || typeof panel.focus !== 'function') {
+      return;
+    }
+    try {
+      panel.focus({ preventScroll: true });
+    } catch (error) {
+      panel.focus();
+    }
+  }
+
+  function scrollToPanel(panelId, { smooth = true } = {}) {
+    if (!panelId) return false;
+    const entry = state.sectionsById.get(panelId);
+    const panel = entry?.element;
+    if (!panel) return false;
+    if (!panel.hasAttribute('tabindex')) {
+      panel.setAttribute('tabindex', '-1');
+    }
+    if (typeof panel.scrollIntoView === 'function') {
+      const behavior = smooth ? 'smooth' : 'auto';
+      panel.scrollIntoView({ behavior, block: 'start' });
+    }
+    if (typeof state.win?.requestAnimationFrame === 'function') {
+      state.win.requestAnimationFrame(() => focusPanel(panel));
+    } else {
+      focusPanel(panel);
+    }
+    return true;
+  }
+
+  function computeActiveSection() {
+    if (!state.descriptors.length) return null;
+    const visible = state.descriptors.filter((descriptor) => descriptor.isIntersecting);
+    if (visible.length) {
+      visible.sort((a, b) => (a.top ?? 0) - (b.top ?? 0));
+      return visible[0].id;
+    }
+
+    let candidate = null;
+    let minTop = Infinity;
+    state.descriptors.forEach((descriptor) => {
+      const section = state.sectionsById.get(descriptor.id);
+      const element = section?.element;
+      if (!element) return;
+      const rect = element.getBoundingClientRect();
+      if (rect.top >= 0 && rect.top < minTop) {
+        minTop = rect.top;
+        candidate = descriptor.id;
+      }
+    });
+
+    if (candidate) return candidate;
+    return state.descriptors[state.descriptors.length - 1]?.id ?? null;
+  }
+
+  function handleAnchorObserver(entries) {
+    entries.forEach((entry) => {
+      const id = entry.target?.dataset?.panel;
+      if (!id) return;
+      const descriptor = state.descriptorsById.get(id);
+      if (!descriptor) return;
+      descriptor.progress = entry.intersectionRatio ?? 0;
+      descriptor.isIntersecting = !!entry.isIntersecting;
+      descriptor.top = entry.boundingClientRect?.top ?? 0;
+      descriptor.bottom = entry.boundingClientRect?.bottom ?? 0;
+    });
+
+    const nextActive = computeActiveSection();
+    if (nextActive) {
+      setActiveSection(nextActive, { silent: true });
+    }
+    updateMinimapState();
+  }
+
+  function cleanupScrollFallback() {
+    if (!state.scrollHandler || !state.win) {
+      return;
+    }
+    state.win.removeEventListener('scroll', state.scrollHandler);
+    state.win.removeEventListener('resize', state.scrollHandler);
+    state.scrollHandler = null;
+  }
+
+  function createScrollFallback() {
+    if (!state.win) return;
+    state.scrollHandler = () => {
+      const viewportHeight = state.win.innerHeight || state.doc?.documentElement?.clientHeight || 1;
+
+      state.descriptors.forEach((descriptor) => {
+        const section = state.sectionsById.get(descriptor.id);
+        const element = section?.element;
+        if (!element) return;
+
+        const rect = element.getBoundingClientRect();
+        const height = rect.height || element.offsetHeight || 1;
+        const visible = Math.max(0, Math.min(rect.bottom, viewportHeight) - Math.max(rect.top, 0));
+        const ratio = Math.max(0, Math.min(1, visible / height));
+
+        descriptor.progress = Number.isFinite(ratio) ? ratio : 0;
+        descriptor.isIntersecting = rect.top < viewportHeight && rect.bottom > 0;
+        descriptor.top = rect.top;
+        descriptor.bottom = rect.bottom;
+      });
+
+      const nextActive = computeActiveSection();
+      if (nextActive) {
+        setActiveSection(nextActive, { silent: true });
+      }
+      updateMinimapState();
+    };
+
+    state.win.addEventListener('scroll', state.scrollHandler, { passive: true });
+    state.win.addEventListener('resize', state.scrollHandler);
+    state.scrollHandler();
+  }
+
+  function createAnchorObserver() {
+    if (state.observer) {
+      state.observer.disconnect();
+      state.observer = null;
+    }
+    cleanupScrollFallback();
+    if (!state.sectionsById.size) return;
+
+    const IntersectionObserverCtor =
+      (state.win && state.win.IntersectionObserver) || globalThis.IntersectionObserver;
+
+    if (typeof IntersectionObserverCtor === 'undefined') {
+      createScrollFallback();
+      return;
+    }
+
+    const thresholds = [];
+    for (let value = 0; value <= 1; value += 0.25) {
+      thresholds.push(Number(value.toFixed(2)));
+    }
+
+    state.observer = new IntersectionObserverCtor(handleAnchorObserver, {
+      rootMargin: '-40% 0px -40% 0px',
+      threshold: thresholds,
+    });
+
+    state.sectionsById.forEach(({ element }) => {
+      if (element) {
+        state.observer.observe(element);
+      }
+    });
+  }
+
+  function setupMinimaps() {
+    state.minimaps.clear();
+    if (!state.doc) return;
+
+    state.ui.minimapContainers.forEach((container) => {
+      const isOverlay = container.dataset.minimapMode === 'overlay';
+      const existingTitle = container.querySelector('.codex-minimap__title');
+      const label =
+        container.dataset.minimapLabel || existingTitle?.textContent?.trim() || 'Minimappa';
+
+      container.innerHTML = '';
+
+      if (!isOverlay) {
+        const title = state.doc.createElement('p');
+        title.className = 'codex-minimap__title';
+        title.textContent = label;
+        container.appendChild(title);
+      }
+
+      const list = state.doc.createElement('ol');
+      list.className = isOverlay ? 'codex-overlay__list' : 'codex-minimap__list';
+      const registry = new Map();
+
+      state.descriptors.forEach((descriptor) => {
+        const item = state.doc.createElement('li');
+        item.className = isOverlay ? 'codex-overlay__item' : 'codex-minimap__item';
+        item.dataset.minimapItem = descriptor.id;
+
+        const trigger = state.doc.createElement('button');
+        trigger.type = 'button';
+        trigger.className = isOverlay ? 'codex-overlay__link' : 'codex-minimap__link';
+        trigger.textContent = descriptor.label;
+        const handler = () => {
+          if (setActiveSection(descriptor.id, { updateHash: true })) {
+            scrollToPanel(descriptor.id);
+          }
+          if (isOverlay) {
+            closeOverlay();
+          }
+        };
+        trigger.addEventListener('click', handler);
+
+        const progress = state.doc.createElement('span');
+        progress.className = isOverlay ? 'codex-overlay__progress' : 'codex-minimap__progress';
+        progress.style.setProperty('--progress', '0%');
+
+        item.append(trigger, progress);
+        list.appendChild(item);
+        registry.set(descriptor.id, { item, progress });
+      });
+
+      container.appendChild(list);
+      state.minimaps.set(container, registry);
+    });
+
+    updateMinimapState();
+  }
+
+  function closeOverlay({ skipFocus = false } = {}) {
+    const overlay = state.ui.overlay;
+    if (!overlay || overlay.hidden) {
+      state.lastToggle = skipFocus ? state.lastToggle : null;
+      return;
+    }
+    overlay.hidden = true;
+    overlay.setAttribute('aria-hidden', 'true');
+    state.doc?.body?.classList.remove('codex-open');
+    if (!skipFocus && state.lastToggle && typeof state.lastToggle.focus === 'function') {
+      state.lastToggle.focus();
+    }
+    state.lastToggle = null;
+  }
+
+  function openOverlay() {
+    const overlay = state.ui.overlay;
+    if (!overlay) return;
+    if (!state.minimaps.size) {
+      setupMinimaps();
+    }
+    overlay.hidden = false;
+    overlay.setAttribute('aria-hidden', 'false');
+    state.doc?.body?.classList.add('codex-open');
+    updateMinimapState();
+    const closeButton = overlay.querySelector('[data-codex-close]');
+    if (closeButton instanceof HTMLElement) {
+      closeButton.focus({ preventScroll: true });
+    }
+  }
+
+  function setupOverlayControls() {
+    const overlay = state.ui.overlay;
+    if (!overlay) return;
+
+    closeOverlay({ skipFocus: true });
+
+    state.ui.codexToggles.forEach((button) => {
+      const handler = () => {
+        state.lastToggle = button;
+        openOverlay();
+      };
+      button.addEventListener('click', handler);
+      state.toggleHandlers.set(button, handler);
+    });
+
+    state.ui.codexClosers.forEach((button) => {
+      const handler = () => {
+        closeOverlay();
+      };
+      button.addEventListener('click', handler);
+      state.closerHandlers.set(button, handler);
+    });
+
+    state.overlayClickHandler = (event) => {
+      if (event.target === overlay) {
+        closeOverlay();
+      }
+    };
+    overlay.addEventListener('click', state.overlayClickHandler);
+
+    if (state.doc) {
+      state.keydownHandler = (event) => {
+        if (event.key === 'Escape' && state.doc.body?.classList.contains('codex-open')) {
+          closeOverlay();
+        }
+      };
+      state.doc.addEventListener('keydown', state.keydownHandler);
+    }
+  }
+
+  function attachAnchorHandlers() {
+    state.anchorHandlers.forEach((handler, anchor) => {
+      anchor.removeEventListener('click', handler);
+    });
+    state.anchorHandlers.clear();
+
+    state.descriptors.forEach((descriptor) => {
+      const handler = (event) => {
+        event.preventDefault();
+        if (setActiveSection(descriptor.id, { updateHash: true })) {
+          scrollToPanel(descriptor.id);
+        }
+        closeOverlay();
+      };
+      descriptor.anchor.addEventListener('click', handler);
+      state.anchorHandlers.set(descriptor.anchor, handler);
+    });
+  }
+
+  function attachHashHandler() {
+    if (!state.win) return;
+    if (state.hashHandler) {
+      state.win.removeEventListener('hashchange', state.hashHandler);
+    }
+    state.hashHandler = () => {
+      const fromHash = getPanelIdFromHash();
+      if (fromHash) {
+        setActiveSection(fromHash, { silent: true });
+      }
+    };
+    state.win.addEventListener('hashchange', state.hashHandler);
+  }
+
+  function detachOverlayControls() {
+    state.ui.codexToggles.forEach((button) => {
+      const handler = state.toggleHandlers.get(button);
+      if (handler) {
+        button.removeEventListener('click', handler);
+      }
+    });
+    state.toggleHandlers.clear();
+
+    state.ui.codexClosers.forEach((button) => {
+      const handler = state.closerHandlers.get(button);
+      if (handler) {
+        button.removeEventListener('click', handler);
+      }
+    });
+    state.closerHandlers.clear();
+
+    if (state.overlayClickHandler && state.ui.overlay) {
+      state.ui.overlay.removeEventListener('click', state.overlayClickHandler);
+      state.overlayClickHandler = null;
+    }
+
+    if (state.keydownHandler && state.doc) {
+      state.doc.removeEventListener('keydown', state.keydownHandler);
+      state.keydownHandler = null;
+    }
+  }
+
+  function detachHashHandler() {
+    if (state.hashHandler && state.win) {
+      state.win.removeEventListener('hashchange', state.hashHandler);
+      state.hashHandler = null;
+    }
+  }
+
+  function destroy() {
+    cleanupScrollFallback();
+    if (state.observer) {
+      state.observer.disconnect();
+      state.observer = null;
+    }
+    detachHashHandler();
+    detachOverlayControls();
+    state.anchorHandlers.forEach((handler, anchor) => {
+      anchor.removeEventListener('click', handler);
+    });
+    state.anchorHandlers.clear();
+    closeOverlay({ skipFocus: true });
+    state.descriptors = [];
+    state.descriptorsById.clear();
+    state.sectionsById.clear();
+    state.minimaps.clear();
+    state.activeId = null;
+    state.lastToggle = null;
+    setUi({});
+  }
+
+  function init(ui) {
+    destroy();
+    setUi(ui);
+
+    if (!state.ui.anchors.length || !state.ui.panels.length) {
+      return { activeId: null };
+    }
+
+    state.sectionsById = new Map();
+    state.ui.panels.forEach((panel) => {
+      const panelId = panel.dataset.panel;
+      if (!panelId) return;
+      state.sectionsById.set(panelId, { element: panel });
+      if (!panel.hasAttribute('tabindex')) {
+        panel.setAttribute('tabindex', '-1');
+      }
+    });
+
+    state.descriptors = state.ui.anchors
+      .map((anchor) => {
+        const id = anchor.dataset.anchorTarget;
+        if (!id || !state.sectionsById.has(id)) return null;
+        const label = anchor.textContent?.trim() || id;
+        return {
+          id,
+          label,
+          anchor,
+          progress: 0,
+          isIntersecting: false,
+          top: 0,
+          bottom: 0,
+        };
+      })
+      .filter(Boolean);
+
+    state.descriptorsById = new Map(
+      state.descriptors.map((descriptor) => [descriptor.id, descriptor]),
+    );
+
+    if (!state.descriptors.length) {
+      return { activeId: null };
+    }
+
+    attachAnchorHandlers();
+    setupMinimaps();
+    createAnchorObserver();
+    setupOverlayControls();
+    attachHashHandler();
+
+    const initialId = getPanelIdFromHash();
+    if (initialId && state.descriptorsById.has(initialId)) {
+      setActiveSection(initialId, { silent: true });
+    } else {
+      setActiveSection(state.descriptors[0].id, { silent: true });
+    }
+
+    return { activeId: state.activeId };
+  }
+
+  return {
+    init,
+    setActiveSection,
+    scrollToPanel,
+    destroy,
+    openOverlay,
+    closeOverlay,
+    hasSection: (sectionId) => state.descriptorsById.has(sectionId),
+    getActiveSection: () => state.activeId,
+  };
+}
+
+export default createAnchorNavigator;

--- a/tests/docs-generator/integration/anchor-view.integration.test.ts
+++ b/tests/docs-generator/integration/anchor-view.integration.test.ts
@@ -1,0 +1,141 @@
+/// <reference types="vitest" />
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createAnchorNavigator } from '../../../docs/evo-tactics-pack/views/anchor.js';
+
+describe('docs generator — anchor navigation integration', () => {
+  let anchorNavigator: ReturnType<typeof createAnchorNavigator>;
+  let anchorUi: ReturnType<typeof createAnchorFixtures>;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    anchorNavigator = createAnchorNavigator();
+    anchorUi = createAnchorFixtures();
+    anchorNavigator.init(anchorUi);
+  });
+
+  afterEach(() => {
+    anchorNavigator.destroy();
+    document.body.innerHTML = '';
+  });
+
+  it('synchronises active section with breadcrumb targets and overlay minimap', () => {
+    const [primaryBreadcrumb, overlayBreadcrumb] = anchorUi.breadcrumbTargets;
+
+    expect(anchorNavigator.getActiveSection()).toBe('section-alpha');
+    expect(primaryBreadcrumb.textContent).toBe('Section Alpha');
+    expect(overlayBreadcrumb.textContent).toBe('Section Alpha');
+
+    const overlayMap = anchorUi.minimapContainers[1];
+    const initialOverlayItem = overlayMap.querySelector('[data-minimap-item="section-alpha"]');
+    expect(initialOverlayItem).toBeTruthy();
+    expect(initialOverlayItem?.classList.contains('is-active')).toBe(true);
+
+    anchorNavigator.setActiveSection('section-beta');
+
+    expect(anchorNavigator.getActiveSection()).toBe('section-beta');
+    expect(primaryBreadcrumb.textContent).toBe('Section Beta');
+    expect(overlayBreadcrumb.textContent).toBe('Section Beta');
+
+    const overlayActive = overlayMap.querySelector('[data-minimap-item="section-beta"]');
+    const overlayInactive = overlayMap.querySelector('[data-minimap-item="section-alpha"]');
+    expect(overlayActive?.classList.contains('is-active')).toBe(true);
+    expect(overlayInactive?.classList.contains('is-active')).toBe(false);
+  });
+
+  it('toggles the overlay via codex controls', () => {
+    const [toggleButton] = anchorUi.codexToggles;
+    const [closeButton] = anchorUi.codexClosers;
+
+    expect(anchorUi.overlay.hidden).toBe(true);
+    expect(document.body.classList.contains('codex-open')).toBe(false);
+
+    toggleButton.click();
+
+    expect(anchorUi.overlay.hidden).toBe(false);
+    expect(anchorUi.overlay.getAttribute('aria-hidden')).toBe('false');
+    expect(document.body.classList.contains('codex-open')).toBe(true);
+
+    closeButton.click();
+
+    expect(anchorUi.overlay.hidden).toBe(true);
+    expect(anchorUi.overlay.getAttribute('aria-hidden')).toBe('true');
+    expect(document.body.classList.contains('codex-open')).toBe(false);
+  });
+});
+
+function createAnchorFixtures() {
+  const sections = [
+    { id: 'section-alpha', label: 'Section Alpha' },
+    { id: 'section-beta', label: 'Section Beta' },
+  ];
+
+  const anchors: HTMLAnchorElement[] = [];
+  const panels: HTMLElement[] = [];
+
+  sections.forEach((section) => {
+    const anchor = document.createElement('a');
+    anchor.dataset.anchorTarget = section.id;
+    anchor.href = `#${section.id}`;
+    anchor.textContent = section.label;
+    document.body.appendChild(anchor);
+    anchors.push(anchor);
+
+    const panel = document.createElement('section');
+    panel.dataset.panel = section.id;
+    panel.id = section.id;
+    panel.textContent = section.label;
+    document.body.appendChild(panel);
+    panels.push(panel);
+  });
+
+  const primaryBreadcrumb = document.createElement('p');
+  primaryBreadcrumb.dataset.anchorBreadcrumb = 'true';
+  document.body.appendChild(primaryBreadcrumb);
+
+  const minimap = document.createElement('div');
+  minimap.dataset.anchorMinimap = 'true';
+  document.body.appendChild(minimap);
+
+  const overlay = document.createElement('div');
+  overlay.dataset.codexOverlay = 'true';
+  overlay.hidden = true;
+  overlay.setAttribute('aria-hidden', 'true');
+
+  const overlayBreadcrumb = document.createElement('p');
+  overlayBreadcrumb.dataset.anchorBreadcrumb = 'true';
+  overlayBreadcrumb.dataset.breadcrumbMode = 'overlay';
+  overlay.appendChild(overlayBreadcrumb);
+
+  const overlayMinimap = document.createElement('div');
+  overlayMinimap.dataset.anchorMinimap = 'true';
+  overlayMinimap.dataset.minimapMode = 'overlay';
+  overlay.appendChild(overlayMinimap);
+
+  const closeButton = document.createElement('button');
+  closeButton.type = 'button';
+  closeButton.dataset.codexClose = 'true';
+  overlay.appendChild(closeButton);
+
+  document.body.appendChild(overlay);
+
+  const toggleButton = document.createElement('button');
+  toggleButton.type = 'button';
+  toggleButton.dataset.codexToggle = 'true';
+  document.body.appendChild(toggleButton);
+
+  const breadcrumbTargets = [primaryBreadcrumb, overlayBreadcrumb];
+  const minimapContainers = [minimap, overlayMinimap];
+  const codexToggles = [toggleButton];
+  const codexClosers = [closeButton];
+
+  return {
+    anchors,
+    panels,
+    breadcrumbTargets,
+    minimapContainers,
+    overlay,
+    codexToggles,
+    codexClosers,
+  } as const;
+}

--- a/tests/docs-generator/integration/generator.integration.test.ts
+++ b/tests/docs-generator/integration/generator.integration.test.ts
@@ -441,17 +441,16 @@ function createAnchorUi() {
   minimap.dataset.anchorMinimap = 'parameters';
   document.body.appendChild(minimap);
 
-  const overlay = document.createElement('div');
-  overlay.dataset.codexOverlay = 'true';
-  document.body.appendChild(overlay);
-
   const toggle = document.createElement('button');
   toggle.dataset.codexToggle = 'true';
   document.body.appendChild(toggle);
 
   const closer = document.createElement('button');
   closer.dataset.codexClose = 'true';
-  document.body.appendChild(closer);
+  const overlay = document.createElement('div');
+  overlay.dataset.codexOverlay = 'true';
+  overlay.appendChild(closer);
+  document.body.appendChild(overlay);
 
   return {
     root,


### PR DESCRIPTION
## Summary
- extract the generator anchor/minimap/overlay logic into a dedicated `views/anchor.js` module that exposes `init`, `setActiveSection`, and `destroy`
- update the generator bootstrap to use the new navigator API and expose helper methods for tests and consumers
- add jsdom-based integration coverage for anchor navigation and adjust existing generator integration fixtures

## Testing
- npm run test:docs-generator

------
https://chatgpt.com/codex/tasks/task_b_690a33258908832aa58b8d52ecc5dfef