### PR TITLE
Refactor generator workspace layout

### DIFF
--- a/docs/evo-tactics-pack/generator.html
+++ b/docs/evo-tactics-pack/generator.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="it">
   <head>
     <meta charset="utf-8" />
@@ -39,8 +39,8 @@
         <p class="section__kicker">Ecosystem Pack</p>
         <h1>Generatore di ecosistemi</h1>
         <p>
-          Scegli il numero di biomi, applica filtri su flag, ruoli e tag funzionali, quindi
-          genera un set coerente di specie con seed d'incontro calcolati automaticamente.
+          Scegli il numero di biomi, applica filtri su flag, ruoli e tag funzionali, quindi genera
+          un set coerente di specie con seed d'incontro calcolati automaticamente.
         </p>
       </div>
       <nav class="chip-list" aria-label="Navigazione secondaria">
@@ -56,21 +56,13 @@
         <div class="anchor-nav">
           <div class="anchor-nav__header">
             <p class="anchor-nav__title">Sommario</p>
-            <button
-              type="button"
-              class="button button--ghost anchor-nav__toggle"
-              data-codex-toggle
-            >
+            <button type="button" class="button button--ghost anchor-nav__toggle" data-codex-toggle>
               ⌘ Codex mode
             </button>
           </div>
           <ol class="anchor-nav__list" data-anchor-list>
             <li class="anchor-nav__item">
-              <a
-                class="anchor-nav__link"
-                href="#generator-guide"
-                data-anchor-target="guide"
-              >
+              <a class="anchor-nav__link" href="#generator-guide" data-anchor-target="guide">
                 Mini guida
               </a>
             </li>
@@ -84,47 +76,27 @@
               </a>
             </li>
             <li class="anchor-nav__item">
-              <a
-                class="anchor-nav__link"
-                href="#generator-traits"
-                data-anchor-target="traits"
-              >
+              <a class="anchor-nav__link" href="#generator-traits" data-anchor-target="traits">
                 Pacchetti ambientali
               </a>
             </li>
             <li class="anchor-nav__item">
-              <a
-                class="anchor-nav__link"
-                href="#generator-biomes"
-                data-anchor-target="biomes"
-              >
+              <a class="anchor-nav__link" href="#generator-biomes" data-anchor-target="biomes">
                 Biomi selezionati
               </a>
             </li>
             <li class="anchor-nav__item">
-              <a
-                class="anchor-nav__link"
-                href="#generator-seeds"
-                data-anchor-target="seeds"
-              >
+              <a class="anchor-nav__link" href="#generator-seeds" data-anchor-target="seeds">
                 Encounter seed
               </a>
             </li>
             <li class="anchor-nav__item">
-              <a
-                class="anchor-nav__link"
-                href="#generator-composer"
-                data-anchor-target="composer"
-              >
+              <a class="anchor-nav__link" href="#generator-composer" data-anchor-target="composer">
                 Composizione avanzata
               </a>
             </li>
             <li class="anchor-nav__item">
-              <a
-                class="anchor-nav__link"
-                href="#generator-insights"
-                data-anchor-target="insights"
-              >
+              <a class="anchor-nav__link" href="#generator-insights" data-anchor-target="insights">
                 Insight contestuali
               </a>
             </li>
@@ -132,582 +104,679 @@
         </div>
       </nav>
 
-      <div class="layout__content">
-        <section class="section" id="generator-flows" aria-labelledby="generator-flows-title">
-          <div class="section__header">
-            <h2 id="generator-flows-title">Mappa flussi utente</h2>
-            <p>
-              Stato in tempo reale dei tre percorsi chiave del generatore: onboarding, riepilogo e
-              cronologia.
-            </p>
-          </div>
-          <ol class="generator-flow-map" id="generator-flow-map-list" aria-live="polite"></ol>
-        </section>
-
-        <section
-          class="section"
-          id="generator-guide"
-          aria-labelledby="generator-guide-title"
-          data-anchor-target="guide"
-        >
-          <div class="section__header">
-            <h2 id="generator-guide-title">Mini guida rapida</h2>
-            <p>
-              Quattro passaggi per ottenere rapidamente ecosistemi giocabili e sfruttare le funzioni
-              avanzate del generatore.
-            </p>
-          </div>
-          <article class="card card--highlight generator-guide">
-            <ol class="generator-guide__steps">
-              <li>
-                <h3>Imposta i parametri di base</h3>
-                <p>
-                  Scegli il numero di biomi e applica filtri su flag, ruoli e tag funzionali. I
-                  profili ti permettono di salvare combinazioni ricorrenti per i re-roll successivi.
-                </p>
-              </li>
-              <li>
-                <h3>Genera l'ecosistema</h3>
-                <p>
-                  Usa <strong>Genera ecosistema</strong> per creare una rete sintetica coerente. I
-                  pulsanti di re-roll ti consentono di rigenerare biomi, specie o seed mantenendo i
-                  vincoli scelti.
-                </p>
-              </li>
-              <li>
-                <h3>Affina con pinnature e cronologia</h3>
-                <p>
-                  Pinna le specie chiave, confronta fino a tre candidati e registra snapshot dalla
-                  cronologia per documentare le estrazioni migliori.
-                </p>
-              </li>
-              <li>
-                <h3>Esporta e condividi</h3>
-                <p>
-                  Sfrutta i preset del pannello Export per scaricare manifest JSON/YAML, bundle ZIP e
-                  dossier PDF/HTML già pronti per il tavolo di gioco.
-                </p>
-              </li>
-            </ol>
-            <p class="generator-guide__tip">
-              Suggerimento: attiva il <strong>Codex mode</strong> dal sommario laterale per avere
-              minimappe contestuali e collegamenti rapidi a ogni sezione.
-            </p>
-          </article>
-        </section>
-
-        <section
-          class="section"
-          id="generator-parameters"
-          data-panel="parameters"
-          data-flow-node="onboarding"
-        >
-          <article class="card card--highlight">
-            <form class="form" id="generator-form">
-              <h2 class="form__title">Parametri</h2>
-              <div class="generator-form__section">
-                <h3 class="generator-form__legend">Vincoli principali</h3>
-                <div class="generator-form__grid">
-                  <label class="form__field">
-                    <span>Numero di biomi</span>
-                    <input id="nBiomi" type="number" min="1" max="6" value="2" />
-                  </label>
-                </div>
-              </div>
-              <div class="generator-form__section">
-                <h3 class="generator-form__legend">Filtra ecosistema</h3>
-                <div class="generator-form__grid generator-form__grid--filters">
-                  <label class="form__field">
-                    <span>Flags richiesti</span>
-                    <div
-                      id="flags"
-                      class="chip-multiselect"
-                      data-multiselect
-                      data-empty-label="Nessun flag disponibile"
-                      role="group"
-                      aria-label="Seleziona uno o più flag ecosistemici"
-                    ></div>
-                  </label>
-                  <label class="form__field">
-                    <span>Ruoli trofici</span>
-                    <div
-                      id="roles"
-                      class="chip-multiselect"
-                      data-multiselect
-                      data-empty-label="Nessun ruolo disponibile"
-                      role="group"
-                      aria-label="Seleziona uno o più ruoli trofici"
-                    ></div>
-                  </label>
-                  <label class="form__field">
-                    <span>Tag funzionali</span>
-                    <div
-                      id="tags"
-                      class="chip-multiselect"
-                      data-multiselect
-                      data-empty-label="Nessun tag funzionale disponibile"
-                      role="group"
-                      aria-label="Seleziona uno o più tag funzionali"
-                    ></div>
-                  </label>
-                </div>
-                <p class="form__hint" id="generator-filters-hint">
-                  Nessun filtro attivo. Tocca le capsule per attivare vincoli specifici.
-                </p>
+      <div class="layout__content generator-layout">
+        <div class="generator-layout__grid generator-layout__grid--overview">
+          <section class="section" id="generator-flows" aria-labelledby="generator-flows-title">
+            <div class="section__header">
+              <h2 id="generator-flows-title">Mappa flussi utente</h2>
+              <p>
+                Stato in tempo reale dei tre percorsi chiave del generatore: onboarding, riepilogo e
+                cronologia.
+              </p>
             </div>
-              <section
-                class="generator-profiles surface-panel surface-panel--overlay"
-                id="generator-profiles"
-                aria-labelledby="generator-profiles-title"
+            <ol class="generator-flow-map" id="generator-flow-map-list" aria-live="polite"></ol>
+          </section>
+
+          <section
+            class="section"
+            id="generator-guide"
+            aria-labelledby="generator-guide-title"
+            data-anchor-target="guide"
+          >
+            <div class="section__header">
+              <h2 id="generator-guide-title">Mini guida rapida</h2>
+              <p>
+                Quattro passaggi per ottenere rapidamente ecosistemi giocabili e sfruttare le
+                funzioni avanzate del generatore.
+              </p>
+            </div>
+            <article class="card card--highlight generator-guide">
+              <ol class="generator-guide__steps">
+                <li>
+                  <h3>Imposta i parametri di base</h3>
+                  <p>
+                    Scegli il numero di biomi e applica filtri su flag, ruoli e tag funzionali. I
+                    profili ti permettono di salvare combinazioni ricorrenti per i re-roll
+                    successivi.
+                  </p>
+                </li>
+                <li>
+                  <h3>Genera l'ecosistema</h3>
+                  <p>
+                    Usa <strong>Genera ecosistema</strong> per creare una rete sintetica coerente. I
+                    pulsanti di re-roll ti consentono di rigenerare biomi, specie o seed mantenendo
+                    i vincoli scelti.
+                  </p>
+                </li>
+                <li>
+                  <h3>Affina con pinnature e cronologia</h3>
+                  <p>
+                    Pinna le specie chiave, confronta fino a tre candidati e registra snapshot dalla
+                    cronologia per documentare le estrazioni migliori.
+                  </p>
+                </li>
+                <li>
+                  <h3>Esporta e condividi</h3>
+                  <p>
+                    Sfrutta i preset del pannello Export per scaricare manifest JSON/YAML, bundle
+                    ZIP e dossier PDF/HTML già pronti per il tavolo di gioco.
+                  </p>
+                </li>
+              </ol>
+              <p class="generator-guide__tip">
+                Suggerimento: attiva il <strong>Codex mode</strong> dal sommario laterale per avere
+                minimappe contestuali e collegamenti rapidi a ogni sezione.
+              </p>
+            </article>
+          </section>
+        </div>
+
+        <div class="generator-layout__grid generator-layout__grid--workspace">
+          <div class="generator-layout__grid generator-layout__grid--controls">
+            <section
+              class="section"
+              id="generator-parameters"
+              data-panel="parameters"
+              data-flow-node="onboarding"
+            >
+              <article
+                class="card card--highlight generator-panel"
+                aria-labelledby="generator-parameters-title"
               >
-                <div class="generator-profiles__header">
-                  <h3 class="generator-form__legend" id="generator-profiles-title">
-                    Profili filtro
-                  </h3>
-                  <button
-                    type="button"
-                    class="button button--ghost generator-profiles__reset"
-                    data-action="profile-clear-all"
-                  >
-                    Svuota profili
-                  </button>
-                </div>
-                <p class="generator-profiles__hint">
-                  Salva combinazioni di filtri per richiamarle rapidamente durante i re-roll.
-                </p>
-                <p class="generator-profiles__empty" id="generator-profile-empty">
-                  Nessun profilo salvato. Usa "Salva" su uno slot per crearne uno nuovo.
-                </p>
-                <ul
-                  class="generator-profiles__slots"
-                  id="generator-profile-slots"
-                  aria-live="polite"
-                ></ul>
-              </section>
-              <div class="form__actions generator-form__actions">
-                <button type="button" class="button" data-action="roll-ecos">
-                  🎲 Genera ecosistema
-                </button>
-                <button type="button" class="button button--secondary" data-action="reroll-biomi">
-                  ↻ Re-roll biomi
-                </button>
-                <button type="button" class="button button--secondary" data-action="reroll-species">
-                  ↻ Re-roll specie
-                </button>
-                <button type="button" class="button button--ghost" data-action="reroll-seeds">
-                  ↻ Re-roll encounter seed
-                </button>
-                <button type="button" class="button button--ghost" data-action="export-json">
-                  ⬇︎ JSON
-                </button>
-                <button type="button" class="button button--ghost" data-action="export-yaml">
-                  ⬇︎ YAML
-                </button>
-              </div>
-              <p class="form__hint generator-form__result-hint">
-                Dopo la generazione i risultati vengono mostrati nel riepilogo sottostante e
-                nelle sezioni "Biomi selezionati" e "Encounter seed".
-              </p>
-            </form>
-            <section
-              class="generator-export-panel surface-panel surface-panel--overlay"
-              id="generator-export"
-              aria-labelledby="generator-export-title"
-            >
-              <div class="generator-export-panel__header">
-                <h3 class="generator-export-panel__title" id="generator-export-title">
-                  Manifest export
-                </h3>
-                <label class="form__field generator-export-panel__preset">
-                  <span>Preset</span>
-                  <select id="generator-export-preset" aria-describedby="generator-export-preset-status"></select>
-                </label>
-              </div>
-              <p
-                class="form__hint generator-export__preset-hint"
-                id="generator-export-preset-status"
-                role="status"
-                aria-live="polite"
-                hidden
-              ></p>
-              <p class="generator-export__meta" id="generator-export-meta">
-                Genera un ecosistema per preparare il manifest dei file.
-              </p>
-              <p class="generator-export__empty" id="generator-export-empty">
-                Nessun contenuto disponibile. Genera un ecosistema per sbloccare i preset.
-              </p>
-              <ul
-                class="generator-export__list"
-                id="generator-export-list"
-                aria-live="polite"
-              ></ul>
-              <div class="generator-export__actions" id="generator-export-actions">
-                <button type="button" class="button button--ghost" data-action="download-preset-zip">
-                  ⬇︎ Bundle ZIP
-                </button>
-                <button type="button" class="button button--ghost" data-action="download-dossier-html">
-                  ⬇︎ Dossier HTML
-                </button>
-                <button type="button" class="button button--ghost" data-action="download-dossier-pdf">
-                  ⬇︎ Dossier PDF
-                </button>
-              </div>
-              <div class="generator-export__preview" id="generator-export-preview" hidden>
-                <details id="generator-preview-json-details">
-                  <summary>Anteprima JSON</summary>
-                  <pre id="generator-preview-json"></pre>
-                </details>
-                <details id="generator-preview-yaml-details">
-                  <summary>Anteprima YAML</summary>
-                  <pre id="generator-preview-yaml"></pre>
-                </details>
-                <section class="generator-dossier" aria-labelledby="generator-dossier-title">
-                  <header class="generator-dossier__header">
-                    <h4 class="generator-dossier__title" id="generator-dossier-title">
-                      Anteprima dossier
-                    </h4>
-                    <p class="generator-dossier__hint" id="generator-dossier-empty">
-                      Genera un ecosistema per abilitare il dossier.
+                <form class="form" id="generator-form">
+                  <h2 class="form__title" id="generator-parameters-title">Parametri</h2>
+                  <div class="generator-form__section">
+                    <h3 class="generator-form__legend">Vincoli principali</h3>
+                    <div class="generator-form__grid">
+                      <label class="form__field">
+                        <span>Numero di biomi</span>
+                        <input id="nBiomi" type="number" min="1" max="6" value="2" />
+                      </label>
+                    </div>
+                  </div>
+                  <div class="generator-form__section">
+                    <h3 class="generator-form__legend">Filtra ecosistema</h3>
+                    <div class="generator-form__grid generator-form__grid--filters">
+                      <label class="form__field">
+                        <span>Flags richiesti</span>
+                        <div
+                          id="flags"
+                          class="chip-multiselect"
+                          data-multiselect
+                          data-empty-label="Nessun flag disponibile"
+                          role="group"
+                          aria-label="Seleziona uno o più flag ecosistemici"
+                        ></div>
+                      </label>
+                      <label class="form__field">
+                        <span>Ruoli trofici</span>
+                        <div
+                          id="roles"
+                          class="chip-multiselect"
+                          data-multiselect
+                          data-empty-label="Nessun ruolo disponibile"
+                          role="group"
+                          aria-label="Seleziona uno o più ruoli trofici"
+                        ></div>
+                      </label>
+                      <label class="form__field">
+                        <span>Tag funzionali</span>
+                        <div
+                          id="tags"
+                          class="chip-multiselect"
+                          data-multiselect
+                          data-empty-label="Nessun tag funzionale disponibile"
+                          role="group"
+                          aria-label="Seleziona uno o più tag funzionali"
+                        ></div>
+                      </label>
+                    </div>
+                    <p class="form__hint" id="generator-filters-hint">
+                      Nessun filtro attivo. Tocca le capsule per attivare vincoli specifici.
                     </p>
-                  </header>
-                  <div class="generator-dossier__preview" id="generator-dossier-preview"></div>
-                </section>
-              </div>
-              <p class="generator-export__empty" id="generator-preview-empty">
-                Genera un ecosistema per visualizzare le anteprime.
-              </p>
-            </section>
-            <section
-              class="generator-composer surface-panel surface-panel--overlay"
-              id="generator-composer"
-              aria-labelledby="generator-composer-title"
-              data-panel="composer"
-            >
-              <header class="generator-composer__header">
-                <div>
-                  <h3 class="generator-composer__title" id="generator-composer-title">
-                    Composizione avanzata
-                  </h3>
-                  <p class="generator-composer__description">
-                    Configura preset combinati e applica vincoli di sinergia basati sulle
-                    estrazioni correnti.
-                  </p>
-                </div>
-                <div class="generator-composer__constraints">
-                  <label class="generator-composer__slider" for="generator-composer-synergy">
-                    <span>Sinergia minima</span>
-                    <input
-                      type="range"
-                      id="generator-composer-synergy"
-                      min="0"
-                      max="100"
-                      step="5"
-                      value="45"
-                    />
-                  </label>
-                  <output
-                    id="generator-composer-synergy-value"
-                    class="generator-composer__slider-output"
-                    for="generator-composer-synergy"
-                  >
-                    45%
-                  </output>
-                </div>
-              </header>
-              <div class="generator-composer__grid">
-                <article class="generator-composer__module" aria-labelledby="composer-presets-title">
-                  <header class="generator-composer__module-header">
-                    <h4 class="generator-composer__module-title" id="composer-presets-title">
-                      Preset combinati suggeriti
-                    </h4>
-                    <p class="generator-composer__module-hint">
-                      Basati su ruoli predominanti e punteggi di sinergia aggregati.
-                    </p>
-                  </header>
-                  <p class="generator-composer__empty" id="generator-composer-presets-empty">
-                    Genera un ecosistema per ottenere preset suggeriti.
-                  </p>
-                  <ul
-                    class="generator-composer__list"
-                    id="generator-composer-presets"
-                    aria-live="polite"
-                  ></ul>
-                </article>
-                <article class="generator-composer__module" aria-labelledby="composer-roles-title">
-                  <header class="generator-composer__module-header">
-                    <h4 class="generator-composer__module-title" id="composer-roles-title">
-                      Vincoli ruoli &amp; sinergie
-                    </h4>
-                    <p class="generator-composer__module-hint">
-                      Seleziona ruoli prioritari per guidare i prossimi re-roll.
-                    </p>
-                  </header>
-                  <div
-                    class="generator-composer__roles"
-                    id="generator-composer-role-toggles"
-                    role="group"
-                    aria-label="Ruoli prioritari"
-                  ></div>
+                  </div>
                   <section
-                    class="generator-composer__suggestions"
-                    aria-labelledby="composer-suggestions-title"
+                    class="generator-profiles surface-panel surface-panel--overlay"
+                    id="generator-profiles"
+                    aria-labelledby="generator-profiles-title"
                   >
-                    <h5 class="generator-composer__suggestions-title" id="composer-suggestions-title">
-                      Suggerimenti contestuali
-                    </h5>
-                    <p class="generator-composer__empty" id="generator-composer-suggestions-empty">
-                      Non appena generi un ecosistema compariranno raccomandazioni dinamiche.
+                    <div class="generator-profiles__header">
+                      <h3 class="generator-form__legend" id="generator-profiles-title">
+                        Profili filtro
+                      </h3>
+                      <button
+                        type="button"
+                        class="button button--ghost generator-profiles__reset"
+                        data-action="profile-clear-all"
+                      >
+                        Svuota profili
+                      </button>
+                    </div>
+                    <p class="generator-profiles__hint">
+                      Salva combinazioni di filtri per richiamarle rapidamente durante i re-roll.
+                    </p>
+                    <p class="generator-profiles__empty" id="generator-profile-empty">
+                      Nessun profilo salvato. Usa "Salva" su uno slot per crearne uno nuovo.
                     </p>
                     <ul
-                      class="generator-composer__suggestion-list"
-                      id="generator-composer-suggestions"
+                      class="generator-profiles__slots"
+                      id="generator-profile-slots"
                       aria-live="polite"
                     ></ul>
                   </section>
-                </article>
-                <article class="generator-composer__module" aria-labelledby="composer-radar-title">
-                  <header class="generator-composer__module-header">
-                    <h4 class="generator-composer__module-title" id="composer-radar-title">
-                      Radar sinergie ruoli
-                    </h4>
-                    <p class="generator-composer__module-hint">
-                      Visualizza la sinergia media per flag chiave dell'ecosistema.
-                    </p>
-                  </header>
-                  <div class="generator-composer__radar" id="generator-composer-radar-container">
-                    <canvas id="generator-synergy-radar" aria-label="Radar sinergie"></canvas>
-                  </div>
-                </article>
-                <article class="generator-composer__module" aria-labelledby="composer-heatmap-title">
-                  <header class="generator-composer__module-header">
-                    <h4 class="generator-composer__module-title" id="composer-heatmap-title">
-                      Heatmap ruoli per bioma
-                    </h4>
-                    <p class="generator-composer__module-hint">
-                      Intensità calcolata sui punteggi di sinergia medi per flag.
-                    </p>
-                  </header>
-                  <div
-                    class="generator-composer__heatmap"
-                    id="generator-role-heatmap"
-                    role="table"
-                    aria-label="Matrice sinergie ruoli"
-                  ></div>
-                </article>
-              </div>
-            </section>
-          <section
-            class="generator-summary"
-            id="generator-summary"
-            aria-labelledby="generator-summary-title"
-            data-flow-node="summary"
-          >
-            <h3 class="generator-summary__title" id="generator-summary-title">Riepilogo rapido</h3>
-            <dl class="generator-summary__metrics">
-              <div class="generator-summary__metric">
-                <dt class="generator-summary__label">Biomi</dt>
-                <dd class="generator-summary__value" data-summary="biomes">0</dd>
-              </div>
-              <div class="generator-summary__metric">
-                <dt class="generator-summary__label">Specie</dt>
-                <dd class="generator-summary__value" data-summary="species">0</dd>
-              </div>
-              <div class="generator-summary__metric">
-                <dt class="generator-summary__label">Seed</dt>
-                <dd class="generator-summary__value" data-summary="seeds">0</dd>
-              </div>
-            </dl>
-            <p class="generator-summary__status" id="generator-status" aria-live="polite">
-              Carica il catalogo per iniziare.
-            </p>
-            <p class="generator-summary__note" id="generator-last-action">Ultimo aggiornamento: —</p>
-            <section
-              class="generator-narrative"
-              id="generator-narrative"
-              aria-labelledby="generator-narrative-title"
-              data-has-narrative="false"
-            >
-              <div class="generator-narrative__header">
-                <h4 class="generator-summary__subtitle" id="generator-narrative-title">
-                  Narrativa dinamica
-                </h4>
-                <div class="generator-audio-controls" id="generator-audio-controls">
-                  <button
-                    type="button"
-                    class="button button--ghost generator-audio-controls__mute"
-                    id="generator-audio-mute"
-                    aria-pressed="false"
-                  >
-                    🔈 Audio attivo
-                  </button>
-                  <label class="generator-audio-controls__volume" for="generator-audio-volume">
-                    <span class="visually-hidden">Volume effetti sonori</span>
-                    <input
-                      type="range"
-                      id="generator-audio-volume"
-                      min="0"
-                      max="100"
-                      value="75"
-                    />
-                  </label>
-                </div>
-              </div>
-              <article class="narrative-panel" id="generator-briefing-panel">
-                <h5 class="narrative-panel__title">Mission briefing</h5>
-                <p class="narrative-panel__body" data-narrative="briefing">
-                  Genera un ecosistema per ottenere il briefing operativo.
-                </p>
-              </article>
-              <article class="narrative-panel" id="generator-hook-panel">
-                <h5 class="narrative-panel__title">Hook narrativo</h5>
-                <p class="narrative-panel__body" data-narrative="hook">
-                  Gli hook narrativi compariranno dopo la prima generazione.
-                </p>
-              </article>
-              <article class="narrative-panel" id="generator-insight-panel">
-                <h5 class="narrative-panel__title">Suggerimenti rapidi</h5>
-                <p class="narrative-panel__body" id="generator-insight-empty">
-                  Genera un ecosistema per sbloccare consigli contestuali.
-                </p>
-                <ul class="generator-insight__list" id="generator-insight-list" hidden></ul>
-              </article>
-            </section>
-            <div class="generator-summary__pins surface-panel surface-panel--tight">
-              <h4 class="generator-summary__subtitle">Specie pinnate</h4>
-              <p class="generator-summary__empty" id="generator-pinned-empty">
-                Nessuna specie pinnata. Usa il pulsante
-                <span class="icon icon--inline" aria-hidden="true">📌</span>pin sulle card per aggiungerle.
-              </p>
-              <ul class="generator-pins" id="generator-pinned-list" aria-live="polite"></ul>
-            </div>
-            <section
-              class="generator-history surface-panel surface-panel--overlay"
-              id="generator-history"
-              aria-labelledby="generator-history-title"
-              data-flow-node="history"
-            >
-              <div class="generator-history__header">
-                <h4 class="generator-summary__subtitle" id="generator-history-title">
-                  Cronologia snapshot
-                </h4>
-                <button
-                  type="button"
-                  class="button button--ghost generator-history__clear"
-                  data-action="history-clear"
-                >
-                  Svuota cronologia
-                </button>
-              </div>
-              <p class="generator-summary__empty" id="generator-history-empty">
-                Nessuna cronologia salvata. Genera o ricalcola un ecosistema per creare snapshot.
-              </p>
-              <ol class="generator-history__list" id="generator-history-list" aria-live="polite"></ol>
-            </section>
-            <section
-              class="generator-activity surface-panel surface-panel--overlay"
-              id="generator-activity"
-              aria-labelledby="generator-activity-title"
-            >
-              <div class="generator-activity__header">
-                <h4 class="generator-summary__subtitle" id="generator-activity-title">
-                  Timeline attività
-                </h4>
-                <div class="generator-activity__controls">
-                  <label class="form__field generator-activity__search">
-                    <span class="visually-hidden">Cerca nella timeline</span>
-                    <input
-                      type="search"
-                      id="activity-search"
-                      placeholder="Cerca eventi nella timeline"
-                      autocomplete="off"
-                    />
-                  </label>
-                  <fieldset class="generator-activity__tones">
-                    <legend class="visually-hidden">Filtra per stato</legend>
-                    <label class="chip">
-                      <input type="checkbox" value="success" data-activity-tone checked />
-                      <span>Successo</span>
-                    </label>
-                    <label class="chip">
-                      <input type="checkbox" value="info" data-activity-tone checked />
-                      <span>Info</span>
-                    </label>
-                    <label class="chip">
-                      <input type="checkbox" value="warn" data-activity-tone checked />
-                      <span>Avvisi</span>
-                    </label>
-                    <label class="chip">
-                      <input type="checkbox" value="error" data-activity-tone checked />
-                      <span>Errori</span>
-                    </label>
-                  </fieldset>
-                  <label class="form__field generator-activity__tags">
-                    <span>Tag</span>
-                    <select id="activity-tags" multiple size="4"></select>
-                  </label>
-                  <label class="generator-activity__pinned">
-                    <input type="checkbox" id="activity-pinned-only" />
-                    <span>Solo eventi pinnati</span>
-                  </label>
-                  <div class="generator-activity__export">
-                    <button
-                      type="button"
-                      class="button button--ghost"
-                      data-action="export-log-json"
-                    >
-                      ⬇︎ Log JSON
+                  <div class="form__actions generator-form__actions">
+                    <button type="button" class="button" data-action="roll-ecos">
+                      🎲 Genera ecosistema
                     </button>
                     <button
                       type="button"
-                      class="button button--ghost"
-                      data-action="export-log-csv"
+                      class="button button--secondary"
+                      data-action="reroll-biomi"
                     >
-                      ⬇︎ Log CSV
+                      ↻ Re-roll biomi
+                    </button>
+                    <button
+                      type="button"
+                      class="button button--secondary"
+                      data-action="reroll-species"
+                    >
+                      ↻ Re-roll specie
+                    </button>
+                    <button type="button" class="button button--ghost" data-action="reroll-seeds">
+                      ↻ Re-roll encounter seed
+                    </button>
+                    <button type="button" class="button button--ghost" data-action="export-json">
+                      ⬇︎ JSON
+                    </button>
+                    <button type="button" class="button button--ghost" data-action="export-yaml">
+                      ⬇︎ YAML
                     </button>
                   </div>
+                  <p class="form__hint generator-form__result-hint">
+                    Dopo la generazione i risultati vengono mostrati nel riepilogo e nelle sezioni
+                    "Biomi selezionati" e "Encounter seed".
+                  </p>
+                </form>
+              </article>
+            </section>
+
+            <section class="section" aria-labelledby="generator-export-title">
+              <article
+                class="generator-export-panel surface-panel surface-panel--overlay generator-panel"
+                id="generator-export"
+              >
+                <div class="generator-export-panel__header">
+                  <h3 class="generator-export-panel__title" id="generator-export-title">
+                    Manifest export
+                  </h3>
+                  <label class="form__field generator-export-panel__preset">
+                    <span>Preset</span>
+                    <select
+                      id="generator-export-preset"
+                      aria-describedby="generator-export-preset-status"
+                    ></select>
+                  </label>
+                </div>
+                <p
+                  class="form__hint generator-export__preset-hint"
+                  id="generator-export-preset-status"
+                  role="status"
+                  aria-live="polite"
+                  hidden
+                ></p>
+                <p class="generator-export__meta" id="generator-export-meta">
+                  Genera un ecosistema per preparare il manifest dei file.
+                </p>
+                <p class="generator-export__empty" id="generator-export-empty">
+                  Nessun contenuto disponibile. Genera un ecosistema per sbloccare i preset.
+                </p>
+                <ul
+                  class="generator-export__list"
+                  id="generator-export-list"
+                  aria-live="polite"
+                ></ul>
+                <div class="generator-export__actions" id="generator-export-actions">
                   <button
                     type="button"
-                    class="button button--ghost generator-activity__reset"
-                    data-action="reset-activity-filters"
+                    class="button button--ghost"
+                    data-action="download-preset-zip"
                   >
-                    Azzera filtri
+                    ⬇︎ Bundle ZIP
+                  </button>
+                  <button
+                    type="button"
+                    class="button button--ghost"
+                    data-action="download-dossier-html"
+                  >
+                    ⬇︎ Dossier HTML
+                  </button>
+                  <button
+                    type="button"
+                    class="button button--ghost"
+                    data-action="download-dossier-pdf"
+                  >
+                    ⬇︎ Dossier PDF
                   </button>
                 </div>
-              </div>
-              <p class="generator-summary__empty" id="generator-log-empty">
-                Nessuna attività registrata.
-              </p>
-              <ol class="generator-timeline" id="generator-log" aria-live="polite"></ol>
+                <div class="generator-export__preview" id="generator-export-preview" hidden>
+                  <details id="generator-preview-json-details">
+                    <summary>Anteprima JSON</summary>
+                    <pre id="generator-preview-json"></pre>
+                  </details>
+                  <details id="generator-preview-yaml-details">
+                    <summary>Anteprima YAML</summary>
+                    <pre id="generator-preview-yaml"></pre>
+                  </details>
+                  <section class="generator-dossier" aria-labelledby="generator-dossier-title">
+                    <header class="generator-dossier__header">
+                      <h4 class="generator-dossier__title" id="generator-dossier-title">
+                        Anteprima dossier
+                      </h4>
+                      <p class="generator-dossier__hint" id="generator-dossier-empty">
+                        Genera un ecosistema per abilitare il dossier.
+                      </p>
+                    </header>
+                    <div class="generator-dossier__preview" id="generator-dossier-preview"></div>
+                  </section>
+                </div>
+                <p class="generator-export__empty" id="generator-preview-empty">
+                  Genera un ecosistema per visualizzare le anteprime.
+                </p>
+              </article>
             </section>
+
             <section
-              class="generator-compare surface-panel surface-panel--overlay"
-              id="generator-compare-panel"
-              aria-labelledby="generator-compare-title"
+              class="section"
+              aria-labelledby="generator-composer-title"
+              data-panel="composer"
             >
-              <div class="generator-compare__header">
-                <h4 class="generator-compare__title" id="generator-compare-title">
-                  Confronto specie
-                </h4>
-                <p class="generator-compare__hint">
-                  Seleziona fino a tre specie con il pulsante <span aria-hidden="true">📊</span>
-                  <span class="visually-hidden">Confronta</span> sulle card per visualizzare il grafico radar.
-                </p>
-              </div>
-              <p class="generator-compare__empty" id="generator-compare-empty">
-                Nessuna specie in confronto. Usa il pulsante 📊 sulle card per aggiungerle.
-              </p>
-              <ul class="generator-compare__list" id="generator-compare-list" aria-live="polite"></ul>
-              <div class="generator-compare__chart" id="generator-compare-chart" hidden>
-                <canvas id="generator-compare-canvas" aria-describedby="generator-compare-title"></canvas>
-                <p class="generator-compare__fallback" id="generator-compare-fallback" hidden>
-                  Impossibile caricare il grafico radar. Controlla la connessione o la console per
-                  ulteriori dettagli.
-                </p>
-              </div>
+              <article
+                class="generator-composer surface-panel surface-panel--overlay generator-panel"
+                id="generator-composer"
+                aria-labelledby="generator-composer-title"
+              >
+                <header class="generator-composer__header">
+                  <div>
+                    <h3 class="generator-composer__title" id="generator-composer-title">
+                      Composizione avanzata
+                    </h3>
+                    <p class="generator-composer__description">
+                      Configura preset combinati e applica vincoli di sinergia basati sulle
+                      estrazioni correnti.
+                    </p>
+                  </div>
+                  <div class="generator-composer__constraints">
+                    <label class="generator-composer__slider" for="generator-composer-synergy">
+                      <span>Sinergia minima</span>
+                      <input
+                        type="range"
+                        id="generator-composer-synergy"
+                        min="0"
+                        max="100"
+                        step="5"
+                        value="45"
+                      />
+                    </label>
+                    <output
+                      id="generator-composer-synergy-value"
+                      class="generator-composer__slider-output"
+                      for="generator-composer-synergy"
+                    >
+                      45%
+                    </output>
+                  </div>
+                </header>
+                <div class="generator-composer__grid">
+                  <article
+                    class="generator-composer__module"
+                    aria-labelledby="composer-presets-title"
+                  >
+                    <header class="generator-composer__module-header">
+                      <h4 class="generator-composer__module-title" id="composer-presets-title">
+                        Preset combinati suggeriti
+                      </h4>
+                      <p class="generator-composer__module-hint">
+                        Basati su ruoli predominanti e punteggi di sinergia aggregati.
+                      </p>
+                    </header>
+                    <p class="generator-composer__empty" id="generator-composer-presets-empty">
+                      Genera un ecosistema per ottenere preset suggeriti.
+                    </p>
+                    <ul
+                      class="generator-composer__list"
+                      id="generator-composer-presets"
+                      aria-live="polite"
+                    ></ul>
+                  </article>
+                  <article
+                    class="generator-composer__module"
+                    aria-labelledby="composer-roles-title"
+                  >
+                    <header class="generator-composer__module-header">
+                      <h4 class="generator-composer__module-title" id="composer-roles-title">
+                        Vincoli ruoli &amp; sinergie
+                      </h4>
+                      <p class="generator-composer__module-hint">
+                        Seleziona ruoli prioritari per guidare i prossimi re-roll.
+                      </p>
+                    </header>
+                    <div
+                      class="generator-composer__roles"
+                      id="generator-composer-role-toggles"
+                      role="group"
+                      aria-label="Ruoli prioritari"
+                    ></div>
+                    <section
+                      class="generator-composer__suggestions"
+                      aria-labelledby="composer-suggestions-title"
+                    >
+                      <h5
+                        class="generator-composer__suggestions-title"
+                        id="composer-suggestions-title"
+                      >
+                        Suggerimenti contestuali
+                      </h5>
+                      <p
+                        class="generator-composer__empty"
+                        id="generator-composer-suggestions-empty"
+                      >
+                        Non appena generi un ecosistema compariranno raccomandazioni dinamiche.
+                      </p>
+                      <ul
+                        class="generator-composer__suggestion-list"
+                        id="generator-composer-suggestions"
+                        aria-live="polite"
+                      ></ul>
+                    </section>
+                  </article>
+                  <article
+                    class="generator-composer__module"
+                    aria-labelledby="composer-radar-title"
+                  >
+                    <header class="generator-composer__module-header">
+                      <h4 class="generator-composer__module-title" id="composer-radar-title">
+                        Radar sinergie
+                      </h4>
+                      <p class="generator-composer__module-hint">
+                        Visualizza gli spread dei punteggi combinati per ruoli chiave.
+                      </p>
+                    </header>
+                    <div class="generator-composer__chart" id="generator-synergy-radar"></div>
+                  </article>
+                  <article
+                    class="generator-composer__module"
+                    aria-labelledby="composer-heatmap-title"
+                  >
+                    <header class="generator-composer__module-header">
+                      <h4 class="generator-composer__module-title" id="composer-heatmap-title">
+                        Heatmap ruoli per bioma
+                      </h4>
+                      <p class="generator-composer__module-hint">
+                        Intensità calcolata sui punteggi di sinergia medi per flag.
+                      </p>
+                    </header>
+                    <div
+                      class="generator-composer__heatmap"
+                      id="generator-role-heatmap"
+                      role="table"
+                      aria-label="Matrice sinergie ruoli"
+                    ></div>
+                  </article>
+                </div>
+              </article>
             </section>
-          </section>
-        </article>
-        </section>
+          </div>
+
+          <div class="generator-layout__grid generator-layout__grid--outcomes">
+            <section class="section" aria-labelledby="generator-summary-title">
+              <article
+                class="generator-summary surface-panel surface-panel--overlay generator-panel"
+                id="generator-summary"
+                aria-labelledby="generator-summary-title"
+                data-flow-node="summary"
+              >
+                <header class="generator-summary__header">
+                  <h3 class="generator-summary__title" id="generator-summary-title">
+                    Riepilogo rapido
+                  </h3>
+                  <dl class="generator-summary__metrics">
+                    <div class="generator-summary__metric">
+                      <dt class="generator-summary__label">Biomi</dt>
+                      <dd class="generator-summary__value" data-summary="biomes">0</dd>
+                    </div>
+                    <div class="generator-summary__metric">
+                      <dt class="generator-summary__label">Specie</dt>
+                      <dd class="generator-summary__value" data-summary="species">0</dd>
+                    </div>
+                    <div class="generator-summary__metric">
+                      <dt class="generator-summary__label">Seed</dt>
+                      <dd class="generator-summary__value" data-summary="seeds">0</dd>
+                    </div>
+                  </dl>
+                </header>
+                <p class="generator-summary__status" id="generator-status" aria-live="polite">
+                  Carica il catalogo per iniziare.
+                </p>
+                <p class="generator-summary__note" id="generator-last-action">
+                  Ultimo aggiornamento: —
+                </p>
+                <div class="generator-summary__grid">
+                  <section
+                    class="generator-narrative"
+                    id="generator-narrative"
+                    aria-labelledby="generator-narrative-title"
+                    data-has-narrative="false"
+                  >
+                    <div class="generator-narrative__header">
+                      <h4 class="generator-summary__subtitle" id="generator-narrative-title">
+                        Narrativa dinamica
+                      </h4>
+                      <div class="generator-audio-controls" id="generator-audio-controls">
+                        <button
+                          type="button"
+                          class="button button--ghost generator-audio-controls__mute"
+                          id="generator-audio-mute"
+                          aria-pressed="false"
+                        >
+                          🔈 Audio attivo
+                        </button>
+                        <label
+                          class="generator-audio-controls__volume"
+                          for="generator-audio-volume"
+                        >
+                          <span class="visually-hidden">Volume effetti sonori</span>
+                          <input
+                            type="range"
+                            id="generator-audio-volume"
+                            min="0"
+                            max="100"
+                            value="75"
+                          />
+                        </label>
+                      </div>
+                    </div>
+                    <article class="narrative-panel" id="generator-briefing-panel">
+                      <h5 class="narrative-panel__title">Mission briefing</h5>
+                      <p class="narrative-panel__body" data-narrative="briefing">
+                        Genera un ecosistema per ottenere il briefing operativo.
+                      </p>
+                    </article>
+                    <article class="narrative-panel" id="generator-hook-panel">
+                      <h5 class="narrative-panel__title">Hook narrativo</h5>
+                      <p class="narrative-panel__body" data-narrative="hook">
+                        Gli hook narrativi compariranno dopo la prima generazione.
+                      </p>
+                    </article>
+                    <article class="narrative-panel" id="generator-insight-panel">
+                      <h5 class="narrative-panel__title">Suggerimenti rapidi</h5>
+                      <p class="narrative-panel__body" id="generator-insight-empty">
+                        Genera un ecosistema per sbloccare consigli contestuali.
+                      </p>
+                      <ul class="generator-insight__list" id="generator-insight-list" hidden></ul>
+                    </article>
+                  </section>
+                  <div class="generator-summary__pins surface-panel surface-panel--tight">
+                    <h4 class="generator-summary__subtitle">Specie pinnate</h4>
+                    <p class="generator-summary__empty" id="generator-pinned-empty">
+                      Nessuna specie pinnata. Usa il pulsante
+                      <span class="icon icon--inline" aria-hidden="true">📌</span>pin sulle card per
+                      aggiungerle.
+                    </p>
+                    <ul class="generator-pins" id="generator-pinned-list" aria-live="polite"></ul>
+                  </div>
+                </div>
+              </article>
+            </section>
+
+            <section class="section" aria-labelledby="generator-history-title">
+              <article
+                class="generator-history surface-panel surface-panel--overlay generator-panel"
+                id="generator-history"
+                aria-labelledby="generator-history-title"
+                data-flow-node="history"
+                data-has-entries="false"
+              >
+                <div class="generator-history__header">
+                  <h4 class="generator-summary__subtitle" id="generator-history-title">
+                    Cronologia snapshot
+                  </h4>
+                  <button
+                    type="button"
+                    class="button button--ghost generator-history__clear"
+                    data-action="history-clear"
+                  >
+                    Svuota cronologia
+                  </button>
+                </div>
+                <p class="generator-summary__empty" id="generator-history-empty">
+                  Nessuna cronologia salvata. Genera o ricalcola un ecosistema per creare snapshot.
+                </p>
+                <ol
+                  class="generator-history__list"
+                  id="generator-history-list"
+                  aria-live="polite"
+                ></ol>
+              </article>
+            </section>
+
+            <section class="section" aria-labelledby="generator-activity-title">
+              <article
+                class="generator-activity surface-panel surface-panel--overlay generator-panel"
+                id="generator-activity"
+                aria-labelledby="generator-activity-title"
+              >
+                <div class="generator-activity__header">
+                  <h4 class="generator-summary__subtitle" id="generator-activity-title">
+                    Timeline attività
+                  </h4>
+                  <div class="generator-activity__controls">
+                    <label class="form__field generator-activity__search">
+                      <span class="visually-hidden">Cerca nella timeline</span>
+                      <input
+                        type="search"
+                        id="activity-search"
+                        placeholder="Cerca eventi nella timeline"
+                        autocomplete="off"
+                      />
+                    </label>
+                    <fieldset class="generator-activity__tones">
+                      <legend class="visually-hidden">Filtra per stato</legend>
+                      <label class="chip">
+                        <input type="checkbox" value="success" data-activity-tone checked />
+                        <span>Successo</span>
+                      </label>
+                      <label class="chip">
+                        <input type="checkbox" value="info" data-activity-tone checked />
+                        <span>Info</span>
+                      </label>
+                      <label class="chip">
+                        <input type="checkbox" value="warn" data-activity-tone checked />
+                        <span>Avvisi</span>
+                      </label>
+                      <label class="chip">
+                        <input type="checkbox" value="error" data-activity-tone checked />
+                        <span>Errori</span>
+                      </label>
+                    </fieldset>
+                    <label class="form__field generator-activity__tags">
+                      <span>Tag</span>
+                      <select id="activity-tags" multiple size="4"></select>
+                    </label>
+                    <label class="generator-activity__pinned">
+                      <input type="checkbox" id="activity-pinned-only" />
+                      <span>Solo eventi pinnati</span>
+                    </label>
+                    <div class="generator-activity__export">
+                      <button
+                        type="button"
+                        class="button button--ghost"
+                        data-action="export-log-json"
+                      >
+                        ⬇︎ Log JSON
+                      </button>
+                      <button
+                        type="button"
+                        class="button button--ghost"
+                        data-action="export-log-csv"
+                      >
+                        ⬇︎ Log CSV
+                      </button>
+                    </div>
+                    <button
+                      type="button"
+                      class="button button--ghost generator-activity__reset"
+                      data-action="reset-activity-filters"
+                    >
+                      Azzera filtri
+                    </button>
+                  </div>
+                </div>
+                <p class="generator-summary__empty" id="generator-log-empty">
+                  Nessuna attività registrata.
+                </p>
+                <ol class="generator-timeline" id="generator-log" aria-live="polite"></ol>
+              </article>
+            </section>
+
+            <section class="section" aria-labelledby="generator-compare-title">
+              <article
+                class="generator-compare surface-panel surface-panel--overlay generator-panel"
+                id="generator-compare-panel"
+                aria-labelledby="generator-compare-title"
+                data-state="empty"
+              >
+                <div class="generator-compare__header">
+                  <h4 class="generator-compare__title" id="generator-compare-title">
+                    Confronto specie
+                  </h4>
+                  <p class="generator-compare__hint">
+                    Seleziona fino a tre specie con il pulsante <span aria-hidden="true">📊</span>
+                    <span class="visually-hidden">Confronta</span> sulle card per visualizzare il
+                    grafico radar.
+                  </p>
+                </div>
+                <p class="generator-compare__empty" id="generator-compare-empty">
+                  Nessuna specie in confronto. Usa il pulsante 📊 sulle card per aggiungerle.
+                </p>
+                <ul
+                  class="generator-compare__list"
+                  id="generator-compare-list"
+                  aria-live="polite"
+                ></ul>
+                <div class="generator-compare__chart" id="generator-compare-chart" hidden>
+                  <canvas
+                    id="generator-compare-canvas"
+                    aria-describedby="generator-compare-title"
+                  ></canvas>
+                  <p class="generator-compare__fallback" id="generator-compare-fallback" hidden>
+                    Impossibile caricare il grafico radar. Controlla la connessione o la console per
+                    ulteriori dettagli.
+                  </p>
+                </div>
+              </article>
+            </section>
+          </div>
+        </div>
 
         <section class="section" id="generator-traits" data-panel="traits">
           <div class="section__header">
@@ -773,9 +842,7 @@
       >
         <div class="codex-breadcrumb">
           <p class="codex-breadcrumb__label">Sezione attuale</p>
-          <p class="codex-breadcrumb__trail" data-anchor-breadcrumb aria-live="polite">
-            Parametri
-          </p>
+          <p class="codex-breadcrumb__trail" data-anchor-breadcrumb aria-live="polite">Parametri</p>
         </div>
         <div class="codex-minimap" data-anchor-minimap>
           <p class="codex-minimap__title">Minimappa</p>
@@ -815,16 +882,14 @@
           >
             Parametri
           </p>
-          <button
-            type="button"
-            class="button button--ghost codex-overlay__close"
-            data-codex-close
-          >
+          <button type="button" class="button button--ghost codex-overlay__close" data-codex-close>
             Chiudi Codex
           </button>
         </header>
         <div class="codex-overlay__body">
-          <p class="codex-overlay__subtitle">Naviga tra le sezioni e ottieni una panoramica rapida.</p>
+          <p class="codex-overlay__subtitle">
+            Naviga tra le sezioni e ottieni una panoramica rapida.
+          </p>
           <nav
             class="codex-overlay__map"
             aria-label="Minimappa Codex"

--- a/docs/site.css
+++ b/docs/site.css
@@ -639,6 +639,49 @@ a:focus-visible {
   margin-bottom: 0;
 }
 
+.generator-layout {
+  display: grid;
+  gap: 64px;
+}
+
+.generator-layout__grid {
+  display: grid;
+  gap: 32px;
+}
+
+.generator-layout__grid--overview {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: stretch;
+}
+
+.generator-layout__grid--workspace {
+  gap: 48px;
+}
+
+.generator-layout__grid--controls,
+.generator-layout__grid--outcomes {
+  display: grid;
+  gap: 32px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: start;
+}
+
+.generator-panel {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.generator-panel > * {
+  flex-shrink: 0;
+}
+
+.generator-summary__grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
 .layout__rail {
   position: sticky;
   top: 32px;
@@ -2264,7 +2307,7 @@ body.codex-open {
   font-size: var(--font-size-xs);
 }
 
-.generator-summary[data-has-history='false'] .generator-history {
+.generator-history[data-has-entries='false'] {
   opacity: 0.72;
 }
 
@@ -2875,11 +2918,11 @@ body.codex-open {
   color: rgba(244, 114, 182, 0.8);
 }
 
-.generator-summary[data-has-comparison='false'] #generator-compare-panel {
+.generator-compare[data-state='empty'] {
   opacity: 0.75;
 }
 
-.generator-summary[data-has-comparison='false'] .generator-compare__chart {
+.generator-compare[data-state='empty'] .generator-compare__chart {
   display: none;
 }
 
@@ -3712,6 +3755,24 @@ a[aria-disabled='true'] {
 
   .hero__content {
     max-width: none;
+  }
+
+  .generator-layout {
+    gap: 40px;
+  }
+
+  .generator-layout__grid--overview {
+    grid-template-columns: 1fr;
+  }
+
+  .generator-layout__grid--controls,
+  .generator-layout__grid--outcomes {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+
+  .generator-summary__grid {
+    grid-template-columns: 1fr;
   }
 
   .layout--generator {


### PR DESCRIPTION
## Summary
- reorganize the Evo Tactics generator page into overview, workspace, and outcomes grids so controls, exports, and analysis panels sit side by side
- update generator styles to support the new multi-column layout, flex panels, and state-aware history/compare treatments with responsive fallbacks

## Testing
- npm run test:docs-generator

------
https://chatgpt.com/codex/tasks/task_b_690a3b21559c832a808c45c11e0055c0