### PR TITLE
docs: document modular generator handover

### DIFF
--- a/docs/evo-tactics-pack/deploy.md
+++ b/docs/evo-tactics-pack/deploy.md
@@ -17,6 +17,25 @@ Il preset `demo-bundle` presente in `generator.js` produce tre file:
 Il comando "Scarica preset" genera uno zip con questi asset nella cartella
 `packs/evo_tactics_pack/out/generator/`.
 
+### Nuova struttura modulare
+
+Il refactor del generatore introduce moduli specializzati che semplificano
+personalizzazioni, test e contributi:
+
+- **`views/*`** contiene i controller UI per ciascun pannello del generatore
+  (`parameters`, `traits`, `biomes`, `seeds`, `composer`, `insights`, `activity`,
+  `export`). Ogni modulo esporta funzioni `init`, `render` e helper per gli
+  eventi specifici della vista.
+- **`services/*`** espone servizi riutilizzabili lato browser come lo storage
+  persistente (`storage.ts`) e il layer audio (`audio.ts`) responsabile delle cue
+  dinamiche.
+- **`tests/docs-generator/*`** racchiude gli scenari di unit e integration test
+  dedicati al generatore, con suite distinte per servizi e viste.
+
+Le dipendenze principali vengono orchestrate da `docs/evo-tactics-pack/generator.js`,
+che carica i servizi condivisi, inizializza le viste e collega gli entry point
+di esportazione (`generateDossier*` e `generatePresetFileContents`).
+
 ## Override runtime del catalogo
 
 Entrambi i moduli `docs/evo-tactics-pack/pack-data.js` (frontend) e
@@ -33,14 +52,14 @@ Entrambi i moduli `docs/evo-tactics-pack/pack-data.js` (frontend) e
 Lo script `packs/pack-data.js` legge le seguenti variabili quando eseguito via
 Node o in pipeline CI:
 
-| Variabile             | Descrizione                                                   |
-| --------------------- | ------------------------------------------------------------- |
-| `EVO_PACK_ROOT`       | Percorso locale o URL prioritario per il pack.                |
-| `EVO_PACK_BASE`       | Alias di `EVO_PACK_ROOT` utile per ambienti legacy.           |
-| `EVO_PACK_OVERRIDE`   | Ulteriore override esplicito.                                |
-| `EVO_PACK_REMOTE`     | Lista (separata da spazi o virgole) di sorgenti remote (URL). |
-| `EVO_PACK_SOURCES`    | Lista aggiuntiva di sorgenti remote.                          |
-| `EVO_REPO_ROOT`       | Radice del repository da cui risolvere i percorsi locali.    |
+| Variabile           | Descrizione                                                   |
+| ------------------- | ------------------------------------------------------------- |
+| `EVO_PACK_ROOT`     | Percorso locale o URL prioritario per il pack.                |
+| `EVO_PACK_BASE`     | Alias di `EVO_PACK_ROOT` utile per ambienti legacy.           |
+| `EVO_PACK_OVERRIDE` | Ulteriore override esplicito.                                 |
+| `EVO_PACK_REMOTE`   | Lista (separata da spazi o virgole) di sorgenti remote (URL). |
+| `EVO_PACK_SOURCES`  | Lista aggiuntiva di sorgenti remote.                          |
+| `EVO_REPO_ROOT`     | Radice del repository da cui risolvere i percorsi locali.     |
 
 Esempio di invocazione per testare un mirror remoto:
 
@@ -59,8 +78,10 @@ sorgenti locali.
    Pages mantenendo la struttura `/packs/evo_tactics_pack/`.
 3. Aggiornare il sito statico impostando `pack-root` sull'URL pubblico (query
    string, meta tag o variabile `EVO_PACK_REMOTE`).
-4. Eseguire `tests/validate_dashboard.py` per assicurarsi che il preset demo e
-   le sorgenti remote siano configurate correttamente.
+4. Eseguire `npm run test:docs-generator` per validare servizi e viste del
+   generatore (`tests/docs-generator/*`). In aggiunta, mantenere `tests/validate_dashboard.py`
+   per assicurarsi che il preset demo e le sorgenti remote siano configurate
+   correttamente.
 5. Validare manualmente il caricamento su staging verificando che il generatore
    mostri le metriche demo e consenta il download dello zip completo.
 
@@ -72,4 +93,3 @@ sorgenti locali.
   comandi dalla root del repository.
 - **Press kit non generato** — assicurarsi di avere almeno un ecosistema
   generato prima del download del preset.
-

--- a/docs/evo-tactics-pack/handover-summary.md
+++ b/docs/evo-tactics-pack/handover-summary.md
@@ -1,0 +1,66 @@
+# Handover refactor generatore Evo Tactics Pack
+
+## Obiettivo
+
+Questa nota funge da handover asincrono per il team. Riassume la nuova struttura
+modulare, i punti di integrazione aggiornati e l'esito del primo ciclo QA del
+generatore documentazione.
+
+## Mappa dipendenze
+
+```
+generator.js
+ ├─ state/session.ts (sessione e persistence)
+ ├─ services/
+ │   ├─ storage.ts (preferenze utente, cache manifest)
+ │   └─ audio.ts (cue rare/standard, controlli mute/volume)
+ ├─ ui/elements.ts (query elementi DOM, anchor navigation)
+ ├─ views/
+ │   ├─ parameters.js
+ │   ├─ traits.js
+ │   ├─ biomes.js
+ │   ├─ seeds.js
+ │   ├─ composer.js
+ │   ├─ insights.js
+ │   ├─ activity.js
+ │   └─ export.js
+ └─ services/export/dossier.ts (preset zip, press kit, dossier)
+```
+
+`services/api/generatorClient.ts` rimane il layer di fetching verso cataloghi e
+glossari remoti; i nuovi test in `tests/docs-generator/unit/generatorClient.test.ts`
+ne validano gli errori e il fallback locale.
+
+## Entry point aggiornati
+
+- `generator.js` inizializza `createStorageService` e `createAudioService`, poi
+  registra ogni vista tramite i resolver esportati in `ui/elements.ts` e
+  `views/*`.
+- Gli entry point di esportazione (`generateDossier*`, `buildPressKitMarkdown`,
+  `generatePresetFileContents`) sono reindirizzati verso `services/export/dossier.ts`,
+  mentre l'orchestrazione dei dati passa da `pack-data.js` e dalle API del
+  catalogo (`fetchTrait*`, `fetchHazardRegistry`, `fetchSpecies`).
+- Il navigatore di anchor (`createAnchorNavigator`) gestisce la sincronizzazione
+  fra pannelli UI e indicatori di stato (`USER_FLOWS`, `FLOW_STATUS_LABELS`).
+
+## QA ciclo 1
+
+- **Test automatici** — `npm run test:docs-generator` (Vitest) verde su 9 file e
+  33 test totali. Copre viste chiave, servizi audio/storage e generator client.
+- **Log principali** — le suite di integrazione confermano l'interazione dei
+  pannelli `activity`, `export`, `anchor` con il DOM virtuale; i test unitari
+  verificano gestione errori API e serializzazione dossier.
+
+## Azioni team
+
+1. **Diffusione** — condividere questo riepilogo e l'[annuncio interno](./internal-announcement.md)
+   nel canale `#evo-tactics` e nel documento di runbook.
+2. **Sessione Q&A** — dedicare 20 minuti nel prossimo stand-up per domande sui
+   moduli `views/*` e sulle convenzioni dei servizi.
+3. **Checkpoint finale** — fissare un controllo a T+5 giorni dalla pubblicazione
+   (calendar reminder) per raccogliere segnalazioni di regressione. In assenza di
+   issue entro tale finestra dichiarare concluso il refactor e aggiornare il
+   changelog interno.
+
+Per ulteriori dubbi, referenti: @tech-lead (architettura), @qa-owner (suite
+Vitest), @docs-owner (deploy catalogo).

--- a/docs/evo-tactics-pack/internal-announcement.md
+++ b/docs/evo-tactics-pack/internal-announcement.md
@@ -1,0 +1,41 @@
+# Annuncio interno — refactor generatore Evo Tactics Pack
+
+## Sintesi
+
+Il generatore dell'Evo Tactics Pack è stato modulato per separare viste,
+servizi e suite di test dedicate. Il nuovo assetto semplifica l'onboarding dei
+contributor, migliora la copertura QA e rende più prevedibili i deploy del
+bundle demo descritti nella [guida di deploy](./deploy.md).
+
+## Novità principali
+
+- **Controller UI per vista** — ogni pannello del generatore vive in
+  [`views/`](./views) con state management e listener dedicati.
+- **Servizi riutilizzabili** — lo storage persistente e le cue audio sono stati
+  estratti in [`services/storage.ts`](./services/storage.ts) e
+  [`services/audio.ts`](./services/audio.ts) per permettere mocking mirato.
+- **Test focalizzati** — la suite [`tests/docs-generator`](../../tests/docs-generator)
+  include casi unitari e di integrazione su viste, servizi e orchestrazione
+  generale, eseguibili con `npm run test:docs-generator`.
+
+## Cosa devono sapere i contributor
+
+1. **Entry point aggiornati** — `generator.js` importa i servizi modulari e
+   registra le viste attraverso `resolveGeneratorElements`. Consultare la sezione
+   "Nuova struttura modulare" nella [deploy guide](./deploy.md) per la mappa
+   completa.
+2. **Convenzioni per nuove viste** — riutilizzare gli helper offerti dai moduli
+   esistenti (`init`, `render`, `attachHandlers`) e documentare ogni pannello in
+   `views/README.md` (in preparazione).
+3. **Testing obbligatorio** — ogni modifica ai moduli deve mantenere verdi i test
+   `npm run test:docs-generator` e includere nuovi casi nella cartella unit o
+   integration pertinente.
+4. **Deploy demo** — verificare che i preset esportati dal comando "Scarica preset"
+   rispettino la struttura `packs/evo_tactics_pack/out/generator/`.
+
+## Prossimi passi
+
+- Seguire il riepilogo di handover per la mappa dipendenze e le responsabilità
+  operative.
+- Registrare eventuali regressioni nel canale `#evo-tactics` entro il checkpoint
+  finale (vedi sotto) per garantire che il refactor possa considerarsi concluso.


### PR DESCRIPTION
## Summary
- document the new modular generator structure and testing flow in the Evo Tactics deploy guide
- add an internal announcement outlining contribution guidelines for the refactored modules
- provide an asynchronous handover note with dependency map, entry points, QA outcomes, and checkpoint plan

## Testing
- npm run test:docs-generator

------
https://chatgpt.com/codex/tasks/task_b_690a5fdcca5c832ab0b728f89b439ad8