### PR TITLE
Convert Evo-Tactics navigation to sliding menu

### DIFF
--- a/webapp/src/app.module.ts
+++ b/webapp/src/app.module.ts
@@ -75,10 +75,27 @@ export function registerAppModule(): any {
     controller: AppRootController,
     template: `
       <div class="app-shell" ng-class="{ 'app-shell--menu-open': $ctrl.isMenuVisible }">
+        <button
+          class="app-shell__menu-toggle"
+          type="button"
+          ng-click="$ctrl.toggleMenu()"
+          aria-controls="mission-console-navigation"
+          aria-expanded="{{ $ctrl.isMenuVisible ? 'true' : 'false' }}"
+        >
+          <span class="visually-hidden">Apri il menù Evo-Tactics Console</span>
+          <span aria-hidden="true">☰</span>
+        </button>
         <mission-console-navigation
           current="$ctrl.currentRoute"
+          is-open="$ctrl.isMenuVisible"
           on-toggle="$ctrl.toggleMenu()"
         ></mission-console-navigation>
+        <div
+          class="app-shell__overlay"
+          ng-class="{ 'app-shell__overlay--visible': $ctrl.isMenuVisible }"
+          ng-click="$ctrl.toggleMenu()"
+          aria-hidden="true"
+        ></div>
         <main class="app-shell__content" ng-view></main>
       </div>
     `,

--- a/webapp/src/components/navigation/navigation.component.ts
+++ b/webapp/src/components/navigation/navigation.component.ts
@@ -7,6 +7,7 @@ interface NavigationLink {
 
 class NavigationController {
   public current?: string;
+  public isOpen?: boolean;
   public onToggle?: () => void;
   public links: NavigationLink[] = [
     {
@@ -60,16 +61,29 @@ export const registerNavigationComponent = (module: any): void => {
   module.component('missionConsoleNavigation', {
     bindings: {
       current: '<',
+      isOpen: '<',
       onToggle: '&',
     },
     controller: NavigationController,
     controllerAs: '$ctrl',
     template: `
-      <nav class="navigation" role="navigation" aria-label="Primary">
+      <nav
+        id="mission-console-navigation"
+        class="navigation"
+        ng-class="{ 'navigation--open': $ctrl.isOpen }"
+        role="navigation"
+        aria-label="Primary"
+      >
         <div class="navigation__header">
-          <button class="navigation__menu-button" type="button" ng-click="$ctrl.toggleMenu()">
+          <button
+            class="navigation__menu-button"
+            type="button"
+            ng-click="$ctrl.toggleMenu()"
+            aria-expanded="{{ $ctrl.isOpen ? 'true' : 'false' }}"
+            aria-controls="mission-console-navigation"
+          >
             <span class="visually-hidden">Toggle menu</span>
-            &#9776;
+            <span aria-hidden="true">{{ $ctrl.isOpen ? '✕' : '☰' }}</span>
           </button>
           <div class="navigation__brand">
             <span class="navigation__title">Evo-Tactics Console</span>

--- a/webapp/src/styles/main.css
+++ b/webapp/src/styles/main.css
@@ -39,56 +39,111 @@ body {
 }
 
 .app-shell {
-  display: grid;
-  grid-template-columns: 320px 1fr;
+  position: relative;
   min-height: 100vh;
+  overflow-x: hidden;
 }
 
 .app-shell--menu-open {
-  grid-template-columns: 320px 1fr;
+  overflow: hidden;
 }
 
-@media (max-width: 960px) {
-  .app-shell {
-    grid-template-columns: 1fr;
-  }
+.app-shell__menu-toggle {
+  position: fixed;
+  top: 1.75rem;
+  left: 1.75rem;
+  z-index: 40;
+  width: 48px;
+  height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 14px;
+  border: 1px solid var(--color-border);
+  background: rgba(12, 18, 32, 0.92);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  box-shadow: 0 18px 36px rgba(6, 9, 18, 0.38);
+  transition:
+    transform 160ms ease,
+    opacity 160ms ease;
+}
 
-  .app-shell--menu-open {
-    grid-template-columns: 1fr;
-  }
+.app-shell__menu-toggle:hover,
+.app-shell__menu-toggle:focus {
+  outline: none;
+  transform: translateY(-2px);
+}
+
+.app-shell--menu-open .app-shell__menu-toggle {
+  opacity: 0;
+  pointer-events: none;
+  transform: scale(0.9);
+}
+
+.app-shell__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 6, 12, 0.6);
+  backdrop-filter: blur(4px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 200ms ease;
+  z-index: 30;
+}
+
+.app-shell__overlay--visible {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .app-shell__content {
+  position: relative;
   padding: 2rem 3rem;
   background: linear-gradient(180deg, rgba(19, 26, 43, 0.85) 0%, rgba(12, 18, 32, 0.85) 100%);
   backdrop-filter: blur(12px);
+  min-height: 100vh;
+  transition: transform 220ms ease;
 }
 
 @media (max-width: 960px) {
+  .app-shell__menu-toggle {
+    top: 1.25rem;
+    left: 1.25rem;
+  }
+
   .app-shell__content {
     padding: 1.5rem;
   }
 }
 
 .navigation {
-  position: sticky;
+  position: fixed;
   top: 0;
-  align-self: start;
+  left: 0;
+  bottom: 0;
+  width: min(320px, 88vw);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  padding: 2rem 1.5rem;
-  background: rgba(12, 18, 32, 0.92);
-  border-right: 1px solid var(--color-border);
-  box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.04);
+  padding: 2rem 1.75rem 2.5rem;
+  background: rgba(12, 18, 32, 0.94);
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 30px 60px rgba(6, 9, 18, 0.55);
+  transform: translateX(-100%);
+  transition: transform 220ms cubic-bezier(0.32, 0.72, 0, 1);
+  z-index: 50;
+  overflow-y: auto;
 }
 
-@media (max-width: 960px) {
+.navigation--open {
+  transform: translateX(0);
+}
+
+@media (min-width: 1200px) {
   .navigation {
-    position: relative;
-    border-right: none;
-    border-bottom: 1px solid var(--color-border);
-    box-shadow: none;
+    width: 360px;
+    padding-inline: 2.25rem;
   }
 }
 
@@ -99,22 +154,26 @@ body {
 }
 
 .navigation__menu-button {
-  display: none;
-  width: 40px;
-  height: 40px;
-  border-radius: 8px;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
   border: 1px solid var(--color-border);
-  background: var(--color-surface-alt);
+  background: rgba(10, 14, 24, 0.9);
   color: var(--color-text-primary);
   cursor: pointer;
+  transition:
+    background 160ms ease,
+    transform 160ms ease;
 }
 
-@media (max-width: 960px) {
-  .navigation__menu-button {
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-  }
+.navigation__menu-button:hover,
+.navigation__menu-button:focus {
+  outline: none;
+  background: rgba(79, 140, 255, 0.2);
+  transform: translateY(-1px);
 }
 
 .navigation__brand {


### PR DESCRIPTION
## Summary
- convert the Evo-Tactics Console navigation into a sliding drawer with overlay and external toggle
- wire navigation component to accept open state and update accessibility attributes
- refresh styling to support the off-canvas behaviour and new controls

## Testing
- npm --prefix webapp run lint

------
https://chatgpt.com/codex/tasks/task_e_690a99f27fa08328bd5f5c34570db6c8