### PR TITLE
Add top navigation entries and supporting pages

### DIFF
--- a/webapp/src/app.module.ts
+++ b/webapp/src/app.module.ts
@@ -4,6 +4,10 @@ import { registerDashboardPage } from './pages/dashboard/dashboard.page';
 import { registerAtlasPage } from './pages/atlas/atlas.page';
 import { registerTraitsPage } from './pages/traits/traits.page';
 import { registerNebulaPage } from './pages/nebula/nebula.page';
+import { registerGeneratorPage } from './pages/generator/generator.page';
+import { registerMissionControlPage } from './pages/mission-control/mission-control.page';
+import { registerMissionConsolePage } from './pages/mission-console/mission-console.page';
+import { registerEcosystemPackPage } from './pages/ecosystem-pack/ecosystem-pack.page';
 import { registerDataStoreService } from './services/data-store.service';
 
 class AppRootController {
@@ -51,6 +55,10 @@ export function registerAppModule(): any {
             template: '<mission-dashboard></mission-dashboard>',
             reloadOnUrl: false,
           })
+          .when('/mission-console', {
+            template: '<mission-console-page></mission-console-page>',
+            reloadOnUrl: false,
+          })
           .when('/atlas', {
             template: '<atlas-explorer></atlas-explorer>',
           })
@@ -59,6 +67,15 @@ export function registerAppModule(): any {
           })
           .when('/nebula', {
             template: '<nebula-console></nebula-console>',
+          })
+          .when('/generator', {
+            template: '<mission-generator></mission-generator>',
+          })
+          .when('/mission-control', {
+            template: '<mission-control></mission-control>',
+          })
+          .when('/ecosystem-pack', {
+            template: '<ecosystem-pack></ecosystem-pack>',
           })
           .otherwise({ redirectTo: '/' });
       },
@@ -70,6 +87,10 @@ export function registerAppModule(): any {
   registerAtlasPage(module);
   registerTraitsPage(module);
   registerNebulaPage(module);
+  registerGeneratorPage(module);
+  registerMissionControlPage(module);
+  registerMissionConsolePage(module);
+  registerEcosystemPackPage(module);
 
   module.component('appRoot', {
     controller: AppRootController,

--- a/webapp/src/components/navigation/navigation.component.ts
+++ b/webapp/src/components/navigation/navigation.component.ts
@@ -9,6 +9,32 @@ class NavigationController {
   public current?: string;
   public isOpen?: boolean;
   public onToggle?: () => void;
+  public topLinks: NavigationLink[] = [
+    {
+      label: 'Generatore',
+      route: '/generator',
+      description: 'Crea scenari procedurali e parametri operativi.',
+      icon: '⚙️',
+    },
+    {
+      label: 'Mission Control',
+      route: '/mission-control',
+      description: 'Coordinamento strategico e autorizzazioni istantanee.',
+      icon: '🛰️',
+    },
+    {
+      label: 'Mission Console',
+      route: '/mission-console',
+      description: 'Quadro sinottico delle operazioni in tempo reale.',
+      icon: '🖥️',
+    },
+    {
+      label: 'Ecosystem Pack',
+      route: '/ecosystem-pack',
+      description: 'Risorse, moduli e pacchetti di estensione.',
+      icon: '🧩',
+    },
+  ];
   public links: NavigationLink[] = [
     {
       label: 'Dashboard',
@@ -90,6 +116,25 @@ export const registerNavigationComponent = (module: any): void => {
             <span class="navigation__subtitle">Mission Control</span>
           </div>
         </div>
+        <ul class="navigation__topbar" role="menubar">
+          <li
+            class="navigation__topbar-item"
+            ng-repeat="topLink in $ctrl.topLinks"
+            ng-class="{ 'navigation__topbar-item--active': $ctrl.isActive(topLink.route) }"
+          >
+            <button
+              class="navigation__topbar-link"
+              ng-class="{ 'navigation__topbar-link--active': $ctrl.isActive(topLink.route) }"
+              type="button"
+              ng-click="$ctrl.handleLinkClick(topLink.route)"
+              aria-label="{{ topLink.label }}"
+              role="menuitem"
+            >
+              <span class="navigation__topbar-icon" aria-hidden="true">{{ topLink.icon }}</span>
+              <span class="navigation__topbar-text">{{ topLink.label }}</span>
+            </button>
+          </li>
+        </ul>
         <ul class="navigation__list">
           <li
             class="navigation__item"

--- a/webapp/src/pages/ecosystem-pack/ecosystem-pack.page.ts
+++ b/webapp/src/pages/ecosystem-pack/ecosystem-pack.page.ts
@@ -1,0 +1,46 @@
+class EcosystemPackPageController {
+  public packages = [
+    {
+      name: 'Pack Strategico',
+      summary: 'Bundle di moduli per operazioni multi-teatro.',
+    },
+    {
+      name: 'Pack Biomi',
+      summary: 'Nuove mappe ambientali e variabili climatiche.',
+    },
+    {
+      name: 'Pack Supporto AI',
+      summary: 'Assistenti predittivi e routine automatizzate.',
+    },
+  ];
+}
+
+export const registerEcosystemPackPage = (module: any): void => {
+  module.component('ecosystemPack', {
+    controller: EcosystemPackPageController,
+    controllerAs: '$ctrl',
+    template: `
+      <section class="page">
+        <header class="page__header">
+          <div>
+            <h1 class="page__title">Ecosystem Pack</h1>
+            <p class="page__subtitle">
+              Espandi il sistema con pacchetti modulari certificati dal comando centrale.
+            </p>
+          </div>
+        </header>
+        <article class="panel panel--missions">
+          <h2 class="panel__title">Pacchetti disponibili</h2>
+          <ul class="mission-list">
+            <li class="mission-card" ng-repeat="pack in $ctrl.packages">
+              <div class="mission-card__header">
+                <span class="mission-card__codename">{{ pack.name }}</span>
+              </div>
+              <p class="mission-card__summary">{{ pack.summary }}</p>
+            </li>
+          </ul>
+        </article>
+      </section>
+    `,
+  });
+};

--- a/webapp/src/pages/generator/generator.page.ts
+++ b/webapp/src/pages/generator/generator.page.ts
@@ -1,0 +1,35 @@
+class GeneratorPageController {
+  public tools = ['Builder sequenziale', 'Profiler missione', 'Calcolo risorse'];
+}
+
+export const registerGeneratorPage = (module: any): void => {
+  module.component('missionGenerator', {
+    controller: GeneratorPageController,
+    controllerAs: '$ctrl',
+    template: `
+      <section class="page">
+        <header class="page__header">
+          <div>
+            <h1 class="page__title">Generatore Operativo</h1>
+            <p class="page__subtitle">
+              Configura missioni con parametri dinamici e salva preset condivisibili con il comando.
+            </p>
+          </div>
+        </header>
+        <article class="panel">
+          <h2 class="panel__title">Toolkit rapido</h2>
+          <ul class="mission-list">
+            <li class="mission-card" ng-repeat="tool in $ctrl.tools">
+              <div class="mission-card__header">
+                <span class="mission-card__codename">{{ tool }}</span>
+              </div>
+              <p class="mission-card__summary">
+                Avvia sequenze guidate per configurare risorse, vincoli e risultati attesi.
+              </p>
+            </li>
+          </ul>
+        </article>
+      </section>
+    `,
+  });
+};

--- a/webapp/src/pages/mission-console/mission-console.page.ts
+++ b/webapp/src/pages/mission-console/mission-console.page.ts
@@ -1,0 +1,7 @@
+export const registerMissionConsolePage = (module: any): void => {
+  module.component('missionConsolePage', {
+    template: `
+      <mission-dashboard></mission-dashboard>
+    `,
+  });
+};

--- a/webapp/src/pages/mission-control/mission-control.page.ts
+++ b/webapp/src/pages/mission-control/mission-control.page.ts
@@ -1,0 +1,48 @@
+class MissionControlPageController {
+  public signals = [
+    {
+      title: 'Allineamento squadre',
+      description: 'Aggiorna i team con nuove priorità operative e turni.',
+    },
+    {
+      title: 'Allocazione vettori',
+      description: 'Gestisci asset aerei, orbitali e terrestri in tempo reale.',
+    },
+    {
+      title: 'Protocollo emergenze',
+      description: "Esegui procedure accelerate quando l'anomalia supera la soglia.",
+    },
+  ];
+}
+
+export const registerMissionControlPage = (module: any): void => {
+  module.component('missionControl', {
+    controller: MissionControlPageController,
+    controllerAs: '$ctrl',
+    template: `
+      <section class="page">
+        <header class="page__header">
+          <div>
+            <h1 class="page__title">Mission Control</h1>
+            <p class="page__subtitle">
+              Coordina squadre e asset mantenendo la situazione tattica sempre sotto osservazione.
+            </p>
+          </div>
+        </header>
+        <section class="dashboard-grid">
+          <article class="panel panel--missions">
+            <h2 class="panel__title">Azioni prioritarie</h2>
+            <ul class="mission-list">
+              <li class="mission-card" ng-repeat="signal in $ctrl.signals">
+                <div class="mission-card__header">
+                  <span class="mission-card__codename">{{ signal.title }}</span>
+                </div>
+                <p class="mission-card__summary">{{ signal.description }}</p>
+              </li>
+            </ul>
+          </article>
+        </section>
+      </section>
+    `,
+  });
+};

--- a/webapp/src/styles/main.css
+++ b/webapp/src/styles/main.css
@@ -181,6 +181,60 @@ body {
   flex-direction: column;
 }
 
+.navigation__topbar {
+  display: flex;
+  gap: 0.5rem;
+  margin: 1rem 0;
+  padding: 0;
+  list-style: none;
+  overflow-x: auto;
+}
+
+.navigation__topbar-item {
+  flex: 1 1 auto;
+}
+
+.navigation__topbar-item--active .navigation__topbar-link {
+  border-color: rgba(79, 140, 255, 0.8);
+  background-color: rgba(79, 140, 255, 0.2);
+}
+
+.navigation__topbar-link {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  font-weight: 600;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.navigation__topbar-link:hover,
+.navigation__topbar-link:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.navigation__topbar-link--active {
+  border-color: rgba(79, 140, 255, 0.8);
+  background-color: rgba(79, 140, 255, 0.2);
+}
+
+.navigation__topbar-icon {
+  font-size: 1.1rem;
+}
+
+.navigation__topbar-text {
+  white-space: nowrap;
+}
+
 .navigation__title {
   font-size: 1.1rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- add a horizontal top navigation menu exposing Generatore, Mission Control, Mission Console, and Ecosystem Pack shortcuts
- create placeholder pages and routes for the new sections while wiring them into the AngularJS router
- style the new menu for active states and integrate it with the existing navigation component

## Testing
- npm --prefix webapp run build

------
https://chatgpt.com/codex/tasks/task_e_690aa205b6fc832898650e68758667bd