### PR TITLE
Prevent off-canvas navigation from being focusable when closed

### DIFF
--- a/webapp/src/components/navigation/navigation.component.ts
+++ b/webapp/src/components/navigation/navigation.component.ts
@@ -99,6 +99,8 @@ export const registerNavigationComponent = (module: any): void => {
         ng-class="{ 'navigation--open': $ctrl.isOpen }"
         role="navigation"
         aria-label="Primary"
+        ng-attr-aria-hidden="{{ $ctrl.isOpen ? undefined : 'true' }}"
+        ng-attr-inert="{{ $ctrl.isOpen ? undefined : 'inert' }}"
       >
         <div class="navigation__header">
           <button


### PR DESCRIPTION
## Summary
- toggle accessibility attributes on the mission console navigation so it is hidden from assistive tech when closed

## Testing
- git commit (runs npm run lint --workspaces --if-present via hooks)

------
https://chatgpt.com/codex/tasks/task_e_690aa39eeddc8328b76f97007d43d6c7