### PR TITLE
Make mission console navigation persistent outside slider

### DIFF
--- a/webapp/src/app.module.ts
+++ b/webapp/src/app.module.ts
@@ -96,28 +96,32 @@ export function registerAppModule(): any {
     controller: AppRootController,
     template: `
       <div class="app-shell" ng-class="{ 'app-shell--menu-open': $ctrl.isMenuVisible }">
-        <button
-          class="app-shell__menu-toggle"
-          type="button"
-          ng-click="$ctrl.toggleMenu()"
-          aria-controls="mission-console-navigation"
-          aria-expanded="{{ $ctrl.isMenuVisible ? 'true' : 'false' }}"
-        >
-          <span class="visually-hidden">Apri il menù Evo-Tactics Console</span>
-          <span aria-hidden="true">☰</span>
-        </button>
-        <mission-console-navigation
-          current="$ctrl.currentRoute"
-          is-open="$ctrl.isMenuVisible"
-          on-toggle="$ctrl.toggleMenu()"
-        ></mission-console-navigation>
-        <div
-          class="app-shell__overlay"
-          ng-class="{ 'app-shell__overlay--visible': $ctrl.isMenuVisible }"
-          ng-click="$ctrl.toggleMenu()"
-          aria-hidden="true"
-        ></div>
-        <main class="app-shell__content" ng-view></main>
+        <div class="app-shell__sidebar">
+          <mission-console-navigation
+            current="$ctrl.currentRoute"
+            is-open="$ctrl.isMenuVisible"
+            on-toggle="$ctrl.toggleMenu()"
+          ></mission-console-navigation>
+        </div>
+        <div class="app-shell__main">
+          <button
+            class="app-shell__menu-toggle"
+            type="button"
+            ng-click="$ctrl.toggleMenu()"
+            aria-controls="mission-console-navigation"
+            aria-expanded="{{ $ctrl.isMenuVisible ? 'true' : 'false' }}"
+          >
+            <span class="visually-hidden">Apri il menù Evo-Tactics Console</span>
+            <span aria-hidden="true">☰</span>
+          </button>
+          <div
+            class="app-shell__overlay"
+            ng-class="{ 'app-shell__overlay--visible': $ctrl.isMenuVisible }"
+            ng-click="$ctrl.toggleMenu()"
+            aria-hidden="true"
+          ></div>
+          <main class="app-shell__content" ng-view></main>
+        </div>
       </div>
     `,
   });

--- a/webapp/src/styles/main.css
+++ b/webapp/src/styles/main.css
@@ -42,6 +42,18 @@ body {
   position: relative;
   min-height: 100vh;
   overflow-x: hidden;
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
+.app-shell__sidebar {
+  position: relative;
+  z-index: 50;
+}
+
+.app-shell__main {
+  position: relative;
+  min-height: 100vh;
 }
 
 .app-shell--menu-open {
@@ -140,9 +152,46 @@ body {
   transform: translateX(0);
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 1024px) {
+  .app-shell {
+    grid-template-columns: minmax(280px, 340px) 1fr;
+  }
+
+  .app-shell__sidebar {
+    align-self: stretch;
+  }
+
+  .app-shell__menu-toggle {
+    display: none;
+  }
+
+  .app-shell__overlay {
+    display: none;
+  }
+
   .navigation {
-    width: 360px;
+    position: sticky;
+    top: 0;
+    left: unset;
+    bottom: unset;
+    width: 100%;
+    max-width: none;
+    transform: none;
+    box-shadow: none;
+    height: 100vh;
+  }
+
+  .navigation--open {
+    transform: none;
+  }
+}
+
+@media (min-width: 1200px) {
+  .app-shell {
+    grid-template-columns: 360px 1fr;
+  }
+
+  .navigation {
     padding-inline: 2.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- restructure the app shell so the mission console navigation renders in its own sidebar instead of inside the sliding content panel
- update responsive styles to keep the drawer behavior on mobile while keeping the sidebar visible on larger viewports

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_690aa57016a48328a1ea3bd06ffdd24c