### PR TITLE
Align Evo Tactics generation API base across server and docs

### DIFF
--- a/docs/evo-tactics-pack/generator.html
+++ b/docs/evo-tactics-pack/generator.html
@@ -21,6 +21,10 @@
       referrerpolicy="no-referrer"
       defer
     ></script>
+    <script>
+      window.__EVO_TACTICS_API_BASE__ =
+        window.__EVO_TACTICS_API_BASE__ || 'https://api.evo-tactics.dev/';
+    </script>
     <script type="module" src="generator.bundle.js" defer></script>
   </head>
   <body>

--- a/docs/evo-tactics-pack/generator.js
+++ b/docs/evo-tactics-pack/generator.js
@@ -261,6 +261,18 @@ const state = createSessionState({
   defaultHookText: DEFAULT_HOOK_TEXT,
 });
 
+const OFFICIAL_EVO_TACTICS_API_BASE = 'https://api.evo-tactics.dev/';
+
+function normaliseApiBase(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.endsWith('/') ? trimmed : `${trimmed}/`;
+}
+
+state.api = state.api || {};
+state.api.base = normaliseApiBase(state.api.base) ?? OFFICIAL_EVO_TACTICS_API_BASE;
+
 state.nebula = state.nebula || {
   dataset: null,
   generator: null,
@@ -382,8 +394,11 @@ function renderInsightsPanel(recommendations = state.narrative?.recommendations 
   insightsPanel.render({ recommendations });
 }
 
-if (typeof window !== 'undefined' && typeof window.__EVO_TACTICS_API_BASE__ === 'string') {
-  state.api.base = window.__EVO_TACTICS_API_BASE__;
+if (typeof window !== 'undefined') {
+  const overrideBase = normaliseApiBase(window.__EVO_TACTICS_API_BASE__);
+  if (overrideBase) {
+    state.api.base = overrideBase;
+  }
 }
 
 const COMPARISON_LABELS = ['Tier medio', 'Densità hazard', 'Diversità ruoli'];
@@ -425,9 +440,12 @@ const HAZARD_LABELS = {
 };
 
 function resolveApiEndpoint(pathname) {
-  const bases = [state.api?.base, packContext?.apiBase];
-  if (typeof window !== 'undefined' && typeof window.__EVO_TACTICS_API_BASE__ === 'string') {
-    bases.push(window.__EVO_TACTICS_API_BASE__);
+  const bases = [normaliseApiBase(state.api?.base), normaliseApiBase(packContext?.apiBase)];
+  if (typeof window !== 'undefined') {
+    const overrideBase = normaliseApiBase(window.__EVO_TACTICS_API_BASE__);
+    if (overrideBase) {
+      bases.push(overrideBase);
+    }
   }
   for (const base of bases) {
     if (!base) continue;
@@ -450,8 +468,9 @@ function applyCatalogContext(data, context) {
   resolvedCatalogUrl = context?.catalogUrl ?? null;
   resolvedPackRoot = context?.resolvedBase ?? null;
   packDocsBase = context?.docsBase ?? null;
-  if (context?.apiBase) {
-    state.api.base = context.apiBase;
+  const contextApiBase = normaliseApiBase(context?.apiBase);
+  if (contextApiBase) {
+    state.api.base = contextApiBase;
   }
   state.data = data;
   populateFilters(data);

--- a/server/routes/generation.js
+++ b/server/routes/generation.js
@@ -1,9 +1,19 @@
 const express = require('express');
 
+const DEFAULT_EVO_TACTICS_API_BASE =
+  process.env.EVO_TACTICS_API_BASE || 'https://api.evo-tactics.dev/';
+const BIOME_GENERATION_ROUTE_PATH = '/api/v1/generation/biomes';
+const OFFICIAL_BIOME_GENERATION_URL = new URL(
+  BIOME_GENERATION_ROUTE_PATH,
+  DEFAULT_EVO_TACTICS_API_BASE,
+).toString();
+
 function createGenerationHandler(executor, options = {}) {
   const mapResult = typeof options.mapResult === 'function' ? options.mapResult : (value) => value;
-  const resolveStatus = typeof options.resolveStatus === 'function' ? options.resolveStatus : () => 500;
-  const defaultError = typeof options.defaultError === 'string' ? options.defaultError : 'Errore generazione';
+  const resolveStatus =
+    typeof options.resolveStatus === 'function' ? options.resolveStatus : () => 500;
+  const defaultError =
+    typeof options.defaultError === 'string' ? options.defaultError : 'Errore generazione';
 
   return async function generationRoute(req, res) {
     const payload = req.body || {};
@@ -86,4 +96,7 @@ module.exports = {
   createGenerationHandler,
   createGenerationRoutes,
   createGenerationRouter,
+  DEFAULT_EVO_TACTICS_API_BASE,
+  BIOME_GENERATION_ROUTE_PATH,
+  OFFICIAL_BIOME_GENERATION_URL,
 };


### PR DESCRIPTION
## Summary
- expose the canonical Evo Tactics biome generation endpoint and API base constants on the server
- default the generator bundle to the official api.evo-tactics.dev base and allow safe overrides from window.__EVO_TACTICS_API_BASE__
- document CDN/self-hosted configuration plus monitoring guidance for the generation worker

## Testing
- npm run test:docs-generator

------
https://chatgpt.com/codex/tasks/task_e_690ba234ad1c8328a7ee925b94cbe294