### PR TITLE
Enhance generator audit tooling and coverage checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,33 @@ jobs:
           path: ${{ steps.chromium_meta.outputs.archive }}
           retention-days: 5
 
+  generator-dashboard-validation:
+    runs-on: ubuntu-latest
+    needs:
+      - paths-filter
+      - playwright-bundle
+    if: needs.paths-filter.outputs.deploy == 'true'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate generator dashboard
+        run: |
+          python tests/validate_dashboard.py --metrics-output logs/qa/dashboard_ci_metrics.json --no-log
+
+      - name: Upload dashboard metrics
+        uses: actions/upload-artifact@v4
+        with:
+          name: generator-dashboard-metrics
+          path: logs/qa/dashboard_ci_metrics.json
+          if-no-files-found: error
+
   typescript-tests:
     runs-on: ubuntu-latest
     needs: paths-filter


### PR DESCRIPTION
## Summary
- extend the docs generator integration suite to cover multi-language glossary entries and stored audio preferences
- expand `scripts/generator.py` with a combined trait profile and coverage audit workflow for deploy reviews
- add an automated dashboard/generator validation step to the CI bundle pipeline and archive the metrics

## Testing
- npx vitest --config vitest.config.docs-generator.ts run tests/docs-generator/integration/generator.integration.test.ts

------
https://chatgpt.com/codex/tasks/task_e_690ba6a1857483289f0f25896fa8b1de