### PR TITLE
Add Evo Tactics Mongo schema docs and tooling

### DIFF
--- a/docs/evo-tactics-pack/db-schema.md
+++ b/docs/evo-tactics-pack/db-schema.md
@@ -1,0 +1,282 @@
+# Evo Tactics Pack – MongoDB Schema
+
+Questo documento descrive la struttura dati pensata per servire l'ecosistema **Evo Tactics Pack** quando viene proiettato dentro un datastore MongoDB. Le sorgenti primarie dei dati sono i cataloghi JSON generati nello repository (`packs/evo_tactics_pack/docs/catalog`). Il modello è organizzato in cinque collezioni principali: `biomes`, `species`, `traits`, `sessions` e `activity_logs`.
+
+## Panoramica delle collezioni
+
+| Collezione      | Descrizione                                                                            | Origine dati                                                                |
+| --------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `biomes`        | Manifest e metadata dei biomi disponibili nel pacchetto.                               | `catalog_data.json` (`ecosistema.biomi`, `biomi`, `ecosistema.connessioni`) |
+| `species`       | Anagrafiche delle specie, eventi climatici e unità giocabili.                          | `docs/catalog/species/*.json`                                               |
+| `traits`        | Glossario dei tratti genetici/ambientali unificato con i riferimenti di bilanciamento. | `trait_glossary.json`, `trait_reference.json`, `env_traits.json`            |
+| `sessions`      | Sessioni di gioco o simulazioni alimentate dal generatore Evo.                         | Eventi applicativi (telemetria runtime, non presenti nei cataloghi statici) |
+| `activity_logs` | Log granulari generati durante le sessioni (azioni giocatore/sistema).                 | Eventi applicativi (telemetria runtime, non presenti nei cataloghi statici) |
+
+## `biomes`
+
+### Documento tipo
+
+```jsonc
+{
+  "_id": "badlands",
+  "label": "Brulle Terre Ferrose (Badlands)",
+  "network_id": "BADLANDS",
+  "profile": {
+    "biome_profile": "canyons_risonanti",
+    "weight": 0.45,
+    "manifest": { /* riepilogo specie, gruppi funzionali, ecc. */ },
+    "foodweb": { /* nodi/anelli della rete trofica */ }
+  },
+  "source_path": "../../data/ecosystems/badlands.biome.yaml",
+  "generated_at": ISODate("2025-11-05T18:52:43.280Z"),
+  "connections": [
+    {
+      "to": "FORESTA_TEMPERATA",
+      "type": "corridor",
+      "resistance": 0.6,
+      "seasonality": "primavera/autunno",
+      "notes": "gole ombreggiate e canyon → valichi boscosi"
+    },
+    /* altre connessioni */
+  ]
+}
+```
+
+### Indici
+
+- `_id` (implicitamente indicizzato).
+- `network_id` univoco (`unique: true`) per ricercare rapidamente connessioni inter-bioma.
+- Indice multivalore `connections.to` per query sui corridoi ecologici.
+
+### Relazioni
+
+- `species.biomes` referenzia `_id` della collezione `biomes`.
+- `sessions.biome_id` (campo previsto) punta al bioma usato in una sessione.
+
+## `species`
+
+### Documento tipo
+
+I file JSON in `docs/catalog/species/*.json` vengono importati quasi 1:1.
+
+```jsonc
+{
+  "_id": "aurora-gull",
+  "display_name": "Gabbiano d’Aurora",
+  "biomes": ["cryosteppe"],
+  "role_trofico": "dispersore_ponte",
+  "functional_tags": ["impollinatore", "dispersore_semi"],
+  "flags": {
+    "apex": false,
+    "keystone": false,
+    "bridge": true,
+    "event": false,
+    "threat": false,
+    "sentient": false
+  },
+  "balance": {
+    "rarity": "R2",
+    "threat_tier": "T1",
+    "encounter_role": "ambient"
+  },
+  "playable_unit": true,
+  "morphotype": "volatore_planatore",
+  "vc": {
+    "aggro": 0.2,
+    "risk": 0.2,
+    "cohesion": 0.7,
+    "setup": 0.5,
+    "explore": 0.8,
+    "tilt": 0.2
+  },
+  "spawn_rules": {
+    "orario": ["diurno"],
+    "meteo": ["sereno_freddo"],
+    "densita": "mid"
+  },
+  "environment_affinity": {
+    "biome_class": "mezzanotte_orbitale",
+    "koppen": ["BSk", "Dfc"]
+  },
+  "derived_from_environment": {
+    "suggested_traits": ["criostasi_adattiva", "eco_interno_riflesso", "sonno_emisferico_alternato"],
+    "optional_traits": ["sacche_galleggianti_ascensoriali", "occhi_infrarosso_composti"],
+    "jobs_bias": ["skirmisher", "vanguard", "warden"],
+    "required_capabilities": [],
+    "services_links": []
+  },
+  "telemetry": {
+    "expected_pick_rate": 0.16,
+    "spawn_weight": 0.24
+  },
+  "genetic_traits": [],
+  "services_links": [],
+  "description": "i18n:species.aurora-gull.description",
+  "receipt": {
+    "source": "PTPF.v1.0",
+    "author": "designer",
+    "date": "2025-10-25",
+    "trace_hash": "to-fill"
+  },
+  "last_synced_at": ISODate("2025-11-05T18:52:43.280Z")
+}
+```
+
+### Indici
+
+- `_id` (implicitamente indicizzato).
+- `biomes` (indice multikey) per recuperare rapidamente tutte le specie di un bioma.
+- `flags.apex`, `flags.keystone`, `flags.event` per filtri veloci su ruoli speciali.
+- `playable_unit` + `balance.encounter_role` come indice composito per la selezione rapida delle unità giocabili in una determinata fascia di incontro.
+
+### Relazioni
+
+- `biomes` → `biomes._id`.
+- `derived_from_environment.suggested_traits`/`optional_traits` → `traits._id`.
+- `sessions.primary_species_id` (campo previsto) → `species._id`.
+- `activity_logs.subject_id` può puntare sia a specie (`subject_type: "species"`) sia a eventi (`flags.event = true`).
+
+## `traits`
+
+### Documento tipo
+
+Durante il seed i dati del glossario e del riferimento vengono fusi in un unico documento:
+
+```jsonc
+{
+  "_id": "antenne_plasmatiche_tempesta",
+  "labels": {
+    "it": "Antenne Plasmatiche di Tempesta",
+    "en": "Antenne Plasmatiche di Tempesta"
+  },
+  "descriptions": {
+    "it": "Convoglia fulmini atmosferici in attacchi o scudi psionici.",
+    "en": "Channels storm lightning into psionic strikes or shields."
+  },
+  "reference": {
+    "tier": "T1",
+    "slot": [],
+    "usage_tags": ["scout", "support"],
+    "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
+    "requisiti_ambientali": [
+      {
+        "capacita_richieste": [],
+        "condizioni": {"biome_class": "stratosfera_tempestosa"},
+        "fonte": "env_to_traits",
+        "meta": {"notes": "Ali Fulminee ottimizza..."}
+      }
+    ]
+  },
+  "environment_recommendations": [
+    {
+      "conditions": {"biome_class": "badlands"},
+      "effects": {"res_fire": "+1"},
+      "jobs_bias": ["vanguard", "warden"],
+      "require_capability_any": null
+    }
+  ],
+  "source": {
+    "glossary_version": "1.0",
+    "reference_version": "2.0",
+    "glossary_updated_at": ISODate("2025-10-29T14:21:01+00:00")
+  }
+}
+```
+
+### Indici
+
+- `_id` (implicitamente indicizzato).
+- `reference.tier` per filtrare velocemente i tratti per livello di potenza.
+- `reference.slot` (multikey) per ricerche per tipo di slot.
+
+### Relazioni
+
+- `species.derived_from_environment.*traits` → `traits._id`.
+- `sessions.loadout.traits` → `traits._id`.
+
+## `sessions`
+
+Collezione runtime usata per tracciare le generazioni/partite avviate con il generatore Evo.
+
+### Documento tipo
+
+```jsonc
+{
+  "_id": ObjectId,
+  "pack_id": "evo_tactics_pack",
+  "status": "active",               // active | completed | aborted
+  "player_id": "user-123",
+  "biome_id": "cryosteppe",
+  "primary_species_id": "aurora-gull",
+  "seed_version": "2025-11-05T18:52:43.280Z",
+  "started_at": ISODate("2025-11-05T19:00:00Z"),
+  "ended_at": ISODate("2025-11-05T20:15:00Z"),
+  "summary": {
+    "score": 1840,
+    "outcome": "victory",
+    "telemetry_snapshot_id": ObjectId
+  },
+  "metadata": {
+    "platform": "tabletop-sim",
+    "build": "1.14.3",
+    "tags": ["playtest", "alpha"]
+  }
+}
+```
+
+### Indici
+
+- `status` + `started_at` (composito) per estrarre timeline attive o completate.
+- `player_id` per cronologia utente.
+- `pack_id` + `biome_id` per analisi aggregate per pacchetto/bioma.
+
+### Relazioni
+
+- `biome_id` → `biomes._id`.
+- `primary_species_id` → `species._id`.
+- `summary.telemetry_snapshot_id` → collezioni di analytics (se presenti).
+- `activity_logs.session_id` → `sessions._id`.
+
+## `activity_logs`
+
+Stream append-only di eventi granulari associati alle sessioni.
+
+### Documento tipo
+
+```jsonc
+{
+  "_id": ObjectId,
+  "session_id": ObjectId,
+  "timestamp": ISODate("2025-11-05T19:03:12Z"),
+  "event_type": "trait_selected",
+  "subject_type": "species",      // species | trait | biome | system
+  "subject_id": "aurora-gull",
+  "payload": {
+    "trait_id": "antenne_plasmatiche_tempesta",
+    "source": "player"
+  },
+  "pack_id": "evo_tactics_pack",
+  "metadata": {
+    "request_id": "3c2035",
+    "platform": "tabletop-sim"
+  }
+}
+```
+
+### Indici
+
+- `session_id` + `timestamp` (composito) per riprodurre velocemente una sessione.
+- `event_type` per analisi puntuali.
+- `pack_id` + `subject_id` per ricostruire l'impatto di specie/tratti nel tempo.
+- Eventuale indice TTL su `expires_at` (se il campo viene introdotto) per prune automatico dei log.
+
+### Relazioni
+
+- `session_id` → `sessions._id`.
+- `subject_id` → `species._id` / `traits._id` / `biomes._id` a seconda di `subject_type`.
+
+## Evoluzione dello schema
+
+- Le migrazioni iniziali (`202411050001_initialize_evo_schema.py`) creano le collezioni con gli indici chiave e vengono orchestrate tramite lo script Python `scripts/db/run_migrations.py` (comandi `up`, `down`, `status`).
+- Migrazioni successive (es. `202411050002_add_pack_id_to_sessions.py`) dimostrano come introdurre nuovi campi obbligatori (`pack_id` su `sessions`) e relativi indici, mantenendo retro-compatibilità con i dati esistenti.
+- Le modifiche future (nuovi attributi ai tratti, nuove tipologie di log) devono seguire lo stesso approccio incrementale, aggiornando prima lo schema via migrazione e solo dopo gli script di seed/servizi applicativi.

--- a/migrations/evo_tactics_pack/202411050001_initialize_evo_schema.py
+++ b/migrations/evo_tactics_pack/202411050001_initialize_evo_schema.py
@@ -1,0 +1,72 @@
+"""Initial schema definition for Evo Tactics Pack collections."""
+
+from __future__ import annotations
+
+from pymongo.database import Database
+
+MIGRATION_ID = "202411050001"
+DESCRIPTION = "Initialize core collections and indexes for Evo Tactics Pack"
+
+
+def _ensure_collection(db: Database, name: str) -> None:
+    if name in db.list_collection_names():
+        return
+    db.create_collection(name)
+
+
+def upgrade(db: Database) -> None:
+    _ensure_collection(db, "biomes")
+    _ensure_collection(db, "species")
+    _ensure_collection(db, "traits")
+    _ensure_collection(db, "sessions")
+    _ensure_collection(db, "activity_logs")
+
+    db["biomes"].create_index("network_id", unique=True, sparse=True, name="network_id_unique")
+    db["biomes"].create_index("connections.to", name="connections_to_idx")
+
+    db["species"].create_index("biomes", name="biomes_idx")
+    db["species"].create_index([("flags.apex", 1)], name="flags_apex_idx")
+    db["species"].create_index([("flags.keystone", 1)], name="flags_keystone_idx")
+    db["species"].create_index([("flags.event", 1)], name="flags_event_idx")
+    db["species"].create_index([("playable_unit", 1), ("balance.encounter_role", 1)], name="playable_encounter_idx")
+
+    db["traits"].create_index("reference.tier", name="tier_idx")
+    db["traits"].create_index("reference.slot", name="slot_idx")
+
+    db["sessions"].create_index([("status", 1), ("started_at", -1)], name="status_started_idx")
+    db["sessions"].create_index([("player_id", 1), ("started_at", -1)], name="player_started_idx")
+    db["sessions"].create_index([("biome_id", 1)], name="biome_idx")
+
+    db["activity_logs"].create_index([("session_id", 1), ("timestamp", 1)], name="session_ts_idx")
+    db["activity_logs"].create_index([("event_type", 1)], name="event_type_idx")
+    db["activity_logs"].create_index([("pack_id", 1), ("subject_id", 1)], name="pack_subject_idx")
+
+
+def downgrade(db: Database) -> None:
+    index_map = {
+        "biomes": ["network_id_unique", "connections_to_idx"],
+        "species": [
+            "biomes_idx",
+            "flags_apex_idx",
+            "flags_keystone_idx",
+            "flags_event_idx",
+            "playable_encounter_idx",
+        ],
+        "traits": ["tier_idx", "slot_idx"],
+        "sessions": ["status_started_idx", "player_started_idx", "biome_idx"],
+        "activity_logs": ["session_ts_idx", "event_type_idx", "pack_subject_idx"],
+    }
+
+    for name, indexes in index_map.items():
+        collection = db[name]
+        for index in indexes:
+            try:
+                collection.drop_index(index)
+            except Exception:
+                pass
+
+    for name in ["activity_logs", "sessions", "traits", "species", "biomes"]:
+        try:
+            db.drop_collection(name)
+        except Exception:
+            pass

--- a/migrations/evo_tactics_pack/202411050002_add_pack_id_to_sessions.py
+++ b/migrations/evo_tactics_pack/202411050002_add_pack_id_to_sessions.py
@@ -1,0 +1,31 @@
+"""Add mandatory pack identifier to sessions and supporting index."""
+
+from __future__ import annotations
+
+from pymongo.database import Database
+
+MIGRATION_ID = "202411050002"
+DESCRIPTION = "Backfill sessions.pack_id and add pack/status index"
+DEFAULT_PACK_ID = "evo_tactics_pack"
+
+
+def upgrade(db: Database) -> None:
+    db["sessions"].update_many(
+        {"pack_id": {"$exists": False}},
+        {"$set": {"pack_id": DEFAULT_PACK_ID}},
+    )
+    db["sessions"].create_index(
+        [("pack_id", 1), ("status", 1)],
+        name="pack_status_idx",
+    )
+
+
+def downgrade(db: Database) -> None:
+    try:
+        db["sessions"].drop_index("pack_status_idx")
+    except Exception:
+        pass
+    db["sessions"].update_many(
+        {"pack_id": DEFAULT_PACK_ID},
+        {"$unset": {"pack_id": ""}},
+    )

--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
     "format:check": "prettier --check .",
     "style:check": "node scripts/trait_style_check.js",
     "prepare": "node scripts/husky-install.cjs",
-    "sync:evo-pack": "node scripts/update_evo_pack_catalog.js && node scripts/sync_evo_pack_assets.js"
+    "sync:evo-pack": "node scripts/update_evo_pack_catalog.js && node scripts/sync_evo_pack_assets.js",
+    "db:migrate": "python scripts/db/run_migrations.py up",
+    "db:migrate:down": "python scripts/db/run_migrations.py down",
+    "db:migrate:status": "python scripts/db/run_migrations.py status"
   },
   "dependencies": {
     "ajv": "^8.17.1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pyyaml
 numpy
+pymongo

--- a/scripts/db/run_migrations.py
+++ b/scripts/db/run_migrations.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Minimal migration runner for the Evo Tactics Pack schema.
+
+The implementation is intentionally lightweight but mirrors the workflow of
+`migrate-mongo`: migrations live inside `migrations/evo_tactics_pack`, each
+module exposes a `MIGRATION_ID`, a human readable `DESCRIPTION` and two
+functions `upgrade(db)` / `downgrade(db)`.
+
+Usage::
+
+    python scripts/db/run_migrations.py up
+    python scripts/db/run_migrations.py down
+    python scripts/db/run_migrations.py status
+
+Connection settings can be configured via CLI arguments or through the
+`MONGO_URL` and `MONGO_DB` environment variables.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Iterable, List
+
+from pymongo import MongoClient
+from pymongo.database import Database
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATIONS_DIR = REPO_ROOT / "migrations" / "evo_tactics_pack"
+CHANGELOG_COLLECTION = "evo_schema_migrations"
+
+
+@dataclass
+class Migration:
+    migration_id: str
+    description: str
+    path: Path
+    upgrade: Callable[[Database], None]
+    downgrade: Callable[[Database], None]
+
+
+def load_migration(module_path: Path) -> Migration:
+    spec = importlib.util.spec_from_file_location(module_path.stem, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot import migration module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+
+    migration_id = getattr(module, "MIGRATION_ID", module_path.stem)
+    description = getattr(module, "DESCRIPTION", "")
+    upgrade = getattr(module, "upgrade")
+    downgrade = getattr(module, "downgrade")
+
+    if not callable(upgrade) or not callable(downgrade):
+        raise RuntimeError(f"Migration {module_path} must define callable upgrade()/downgrade()")
+
+    return Migration(
+        migration_id=str(migration_id),
+        description=str(description),
+        path=module_path,
+        upgrade=upgrade,
+        downgrade=downgrade,
+    )
+
+
+def discover_migrations(directory: Path) -> List[Migration]:
+    if not directory.exists():
+        return []
+    migrations: List[Migration] = []
+    for path in sorted(directory.glob("*.py")):
+        migrations.append(load_migration(path))
+    return migrations
+
+
+def get_applied_migrations(db: Database) -> List[str]:
+    collection = db[CHANGELOG_COLLECTION]
+    cursor = collection.find({}, projection={"_id": True}).sort("_id", 1)
+    return [entry["_id"] for entry in cursor]
+
+
+def record_migration(db: Database, migration: Migration) -> None:
+    db[CHANGELOG_COLLECTION].insert_one(
+        {
+            "_id": migration.migration_id,
+            "description": migration.description,
+            "path": str(migration.path.relative_to(REPO_ROOT)),
+            "applied_at": datetime.utcnow(),
+        }
+    )
+
+
+def remove_migration_record(db: Database, migration_id: str) -> None:
+    db[CHANGELOG_COLLECTION].delete_one({"_id": migration_id})
+
+
+def action_up(db: Database, migrations: Iterable[Migration]) -> None:
+    applied = set(get_applied_migrations(db))
+    for migration in migrations:
+        if migration.migration_id in applied:
+            continue
+        print(f"Applying migration {migration.migration_id} ({migration.description})")
+        migration.upgrade(db)
+        record_migration(db, migration)
+    print("All pending migrations applied")
+
+
+def action_down(db: Database, migrations: List[Migration]) -> None:
+    applied = get_applied_migrations(db)
+    if not applied:
+        print("No migrations to rollback")
+        return
+    last_id = applied[-1]
+    migration_map = {migration.migration_id: migration for migration in migrations}
+    migration = migration_map.get(last_id)
+    if migration is None:
+        raise RuntimeError(f"Migration {last_id} not found in {MIGRATIONS_DIR}")
+    print(f"Rolling back migration {migration.migration_id} ({migration.description})")
+    migration.downgrade(db)
+    remove_migration_record(db, migration.migration_id)
+
+
+def action_status(db: Database, migrations: List[Migration]) -> None:
+    applied = set(get_applied_migrations(db))
+    for migration in migrations:
+        state = "up" if migration.migration_id in applied else "down"
+        print(f"{migration.migration_id} [{state}] - {migration.description}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Evo Tactics schema migrations")
+    parser.add_argument("command", choices=["up", "down", "status"], help="Operation to perform")
+    parser.add_argument("--mongo-url", default=os.environ.get("MONGO_URL", "mongodb://localhost:27017"))
+    parser.add_argument("--database", default=os.environ.get("MONGO_DB", "evo_tactics"))
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    migrations = discover_migrations(MIGRATIONS_DIR)
+    if not migrations:
+        print(f"No migrations found under {MIGRATIONS_DIR}")
+        return
+
+    client = MongoClient(args.mongo_url)
+    db = client[args.database]
+
+    if args.command == "up":
+        action_up(db, migrations)
+    elif args.command == "down":
+        action_down(db, migrations)
+    elif args.command == "status":
+        action_status(db, migrations)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/db/seed_evo_generator.py
+++ b/scripts/db/seed_evo_generator.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Seed data for the Evo Tactics Pack MongoDB collections.
+
+The script reads the generated JSON catalog under
+`packs/evo_tactics_pack/docs/catalog` and upserts the information inside the
+`biomes`, `species` and `traits` collections. It also hydrates metadata that is
+useful for the runtime services (e.g. environment-specific trait suggestions).
+
+Usage examples::
+
+    python scripts/db/seed_evo_generator.py \
+        --mongo-url mongodb://localhost:27017 --database evo_tactics
+
+    python scripts/db/seed_evo_generator.py --dry-run
+
+The MongoDB connection string and database name can also be provided via the
+`MONGO_URL` and `MONGO_DB` environment variables.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping
+
+from pymongo import MongoClient, ReplaceOne
+from pymongo.collection import Collection
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CATALOG_ROOT = REPO_ROOT / "packs" / "evo_tactics_pack" / "docs" / "catalog"
+
+
+def parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        # `datetime.fromisoformat` non gestisce "Z" in Python < 3.11.
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_biomes() -> List[Dict[str, Any]]:
+    catalog_path = CATALOG_ROOT / "catalog_data.json"
+    catalog = load_json(catalog_path)
+
+    generated_at = parse_datetime(catalog.get("generated_at"))
+    ecosystem = catalog.get("ecosistema", {})
+    top_level_biomes = ecosystem.get("biomi", [])
+    detailed_biomes: Mapping[str, Mapping[str, Any]] = {
+        biome.get("id"): biome for biome in catalog.get("biomi", [])
+    }
+
+    connections_by_network: MutableMapping[str, List[Mapping[str, Any]]] = defaultdict(list)
+    for connection in ecosystem.get("connessioni", []):
+        network_id = connection.get("from")
+        if not network_id:
+            continue
+        connections_by_network[network_id].append(connection)
+
+    docs: List[Dict[str, Any]] = []
+    for biome in top_level_biomes:
+        biome_id = biome.get("id")
+        detail = detailed_biomes.get(biome_id, {})
+        doc = {
+            "_id": biome_id,
+            "label": biome.get("label"),
+            "network_id": biome.get("network_id"),
+            "profile": {
+                "biome_profile": biome.get("biome_profile"),
+                "weight": biome.get("weight"),
+                "manifest": detail.get("manifest"),
+                "foodweb": detail.get("foodweb"),
+            },
+            "source_path": biome.get("path"),
+            "generated_at": generated_at,
+            "connections": connections_by_network.get(biome.get("network_id"), []),
+        }
+        docs.append(doc)
+
+    return docs
+
+
+def load_species() -> List[Dict[str, Any]]:
+    species_dir = CATALOG_ROOT / "species"
+    docs: List[Dict[str, Any]] = []
+    for path in sorted(species_dir.glob("*.json")):
+        if path.name == "index.json":
+            continue
+        payload = load_json(path)
+        payload["_id"] = payload.get("id")
+        last_synced_at = payload.get("last_synced_at")
+        parsed_synced_at = parse_datetime(last_synced_at)
+        if parsed_synced_at:
+            payload["last_synced_at"] = parsed_synced_at
+        docs.append(payload)
+    return docs
+
+
+def build_environment_lookup(env_rules: Iterable[Mapping[str, Any]]) -> Mapping[str, List[Mapping[str, Any]]]:
+    lookup: MutableMapping[str, List[Mapping[str, Any]]] = defaultdict(list)
+    for rule in env_rules:
+        suggest = rule.get("suggest", {}) or {}
+        traits = suggest.get("traits") or []
+        if not traits:
+            continue
+        entry = {
+            "conditions": rule.get("when", {}),
+            "effects": suggest.get("effects"),
+            "jobs_bias": suggest.get("jobs_bias"),
+            "services_links": suggest.get("services_links"),
+            "weight": rule.get("weight"),
+            "require_capability_all": rule.get("require_capability_all"),
+            "require_capability_any": rule.get("require_capability_any"),
+        }
+        for trait_id in traits:
+            lookup[trait_id].append(entry)
+    return lookup
+
+
+def load_traits() -> List[Dict[str, Any]]:
+    glossary = load_json(CATALOG_ROOT / "trait_glossary.json")
+    reference = load_json(CATALOG_ROOT / "trait_reference.json")
+    env_traits = load_json(CATALOG_ROOT / "env_traits.json")
+
+    glossary_traits: Mapping[str, Mapping[str, Any]] = glossary.get("traits", {})
+    reference_traits: Mapping[str, Mapping[str, Any]] = reference.get("traits", {})
+    env_lookup = build_environment_lookup(env_traits.get("rules", []))
+
+    glossary_version = glossary.get("schema_version")
+    reference_version = reference.get("schema_version")
+    glossary_updated_at = parse_datetime(glossary.get("updated_at"))
+
+    docs: List[Dict[str, Any]] = []
+    for trait_id, glossary_data in glossary_traits.items():
+        labels = {
+            "it": glossary_data.get("label_it"),
+            "en": glossary_data.get("label_en"),
+        }
+        descriptions = {
+            "it": glossary_data.get("description_it"),
+            "en": glossary_data.get("description_en"),
+        }
+        merged = {
+            "_id": trait_id,
+            "labels": labels,
+            "descriptions": descriptions,
+            "reference": reference_traits.get(trait_id, {}),
+            "environment_recommendations": env_lookup.get(trait_id, []),
+            "source": {
+                "glossary_version": glossary_version,
+                "reference_version": reference_version,
+                "glossary_updated_at": glossary_updated_at,
+            },
+        }
+        docs.append(merged)
+
+    return docs
+
+
+def bulk_upsert(collection: Collection, documents: Iterable[Mapping[str, Any]]) -> None:
+    requests = []
+    for document in documents:
+        document_id = document.get("_id")
+        if not document_id:
+            continue
+        requests.append(ReplaceOne({"_id": document_id}, document, upsert=True))
+    if not requests:
+        return
+    result = collection.bulk_write(requests, ordered=False)
+    inserted = result.upserted_count
+    modified = result.modified_count
+    print(f"[{collection.name}] upserted: {inserted}, modified: {modified}")
+
+
+def seed_database(client: MongoClient, database_name: str, dry_run: bool = False) -> None:
+    db = client[database_name]
+
+    biomes = load_biomes()
+    species = load_species()
+    traits = load_traits()
+
+    print(f"Found {len(biomes)} biomes, {len(species)} species, {len(traits)} traits")
+
+    if dry_run:
+        print("Dry run enabled: data was not written to MongoDB")
+        return
+
+    bulk_upsert(db["biomes"], biomes)
+    bulk_upsert(db["species"], species)
+    bulk_upsert(db["traits"], traits)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Seed MongoDB with Evo Tactics catalog data")
+    parser.add_argument(
+        "--mongo-url",
+        default=os.environ.get("MONGO_URL", "mongodb://localhost:27017"),
+        help="MongoDB connection string",
+    )
+    parser.add_argument(
+        "--database",
+        default=os.environ.get("MONGO_DB", "evo_tactics"),
+        help="Target database name",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Do not write anything, only print stats",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args()
+
+    client = MongoClient(args.mongo_url)
+    seed_database(client, args.database, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document the MongoDB collections, relationships, and indexes for the Evo Tactics pack
- add a Python seeding script that imports the generated catalog JSON into MongoDB
- provide a lightweight migration runner with the first two incremental migrations and npm hooks

## Testing
- `python scripts/db/seed_evo_generator.py --dry-run` *(fails: module `pymongo` not installed in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_690bb334a3dc8328ba20e443f43ca33c