### PR TITLE
feat: add Mongo-backed catalog service for biome generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ajv": "^8.17.1",
     "cors": "^2.8.5",
     "express": "^4.19.2",
+    "mongodb": "^6.9.0",
     "js-yaml": "^4.1.0",
     "nedb-promises": "^6.2.3",
     "prom-client": "^15.1.3"
@@ -57,6 +58,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-vue": "^9.29.1",
     "husky": "^9.1.6",
+    "mongodb-memory-server": "^10.1.4",
     "prettier": "^3.3.3",
     "supertest": "^6.3.4",
     "tsx": "^4.19.0",

--- a/server/db/mongo.js
+++ b/server/db/mongo.js
@@ -1,0 +1,138 @@
+let MongoClient = null;
+
+function requireMongoClient() {
+  if (MongoClient) {
+    return MongoClient;
+  }
+  try {
+    // eslint-disable-next-line global-require
+    ({ MongoClient } = require('mongodb'));
+    return MongoClient;
+  } catch (error) {
+    throw new Error(
+      'Impossibile caricare il driver MongoDB: installare la dipendenza "mongodb" per abilitare il datastore',
+    );
+  }
+}
+
+let sharedClient = null;
+let connectPromise = null;
+let sharedConfig = null;
+
+function resolveMongoConfig(overrides = {}) {
+  const envUri =
+    overrides.uri ||
+    overrides.mongoUrl ||
+    overrides.url ||
+    (sharedConfig ? sharedConfig.uri : null) ||
+    process.env.MONGO_URL ||
+    process.env.MONGODB_URI ||
+    process.env.MONGO_URI ||
+    null;
+  const envDbName =
+    overrides.dbName ||
+    overrides.database ||
+    overrides.mongoDb ||
+    (sharedConfig ? sharedConfig.dbName : null) ||
+    process.env.MONGO_DB_NAME ||
+    process.env.MONGO_DB ||
+    null;
+  const options = {
+    ...(sharedConfig && sharedConfig.options ? sharedConfig.options : {}),
+    ...(overrides.options || {}),
+  };
+  const poolSizeEnv = Number.parseInt(process.env.MONGO_MAX_POOL_SIZE || '', 10);
+  if (!Number.isNaN(poolSizeEnv) && poolSizeEnv > 0 && options.maxPoolSize === undefined) {
+    options.maxPoolSize = poolSizeEnv;
+  }
+  const uri = envUri || null;
+  const dbName = envDbName || null;
+  return {
+    uri,
+    dbName,
+    options,
+    enabled: Boolean(uri && dbName),
+  };
+}
+
+async function connectMongo(overrides = {}) {
+  if (overrides.client) {
+    return overrides.client;
+  }
+  const config = resolveMongoConfig(overrides);
+  if (!config.enabled) {
+    throw new Error('Connessione MongoDB non configurata: impostare MONGO_URL e MONGO_DB_NAME');
+  }
+  if (sharedClient && !overrides.forceNew) {
+    return sharedClient;
+  }
+  if (!connectPromise) {
+    const mongoOptions = {
+      maxPoolSize: 10,
+      ...config.options,
+    };
+    const Driver = requireMongoClient();
+    connectPromise = Driver.connect(config.uri, mongoOptions)
+      .then((client) => {
+        sharedClient = client;
+        sharedConfig = { ...config };
+        return client;
+      })
+      .finally(() => {
+        connectPromise = null;
+      });
+  }
+  return connectPromise;
+}
+
+async function getMongoDatabase(overrides = {}) {
+  if (overrides.db) {
+    return overrides.db;
+  }
+  const client = await connectMongo(overrides);
+  const config = resolveMongoConfig(overrides);
+  if (!config.dbName) {
+    throw new Error('Nome database MongoDB non configurato');
+  }
+  return client.db(config.dbName);
+}
+
+async function closeMongo() {
+  if (connectPromise) {
+    try {
+      await connectPromise;
+    } catch (error) {
+      // ignore connection errors during close
+    }
+    connectPromise = null;
+  }
+  if (sharedClient) {
+    await sharedClient.close();
+    sharedClient = null;
+    sharedConfig = null;
+  }
+}
+
+async function checkMongoHealth(overrides = {}) {
+  try {
+    const db = await getMongoDatabase(overrides);
+    await db.command({ ping: 1 });
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+function getMongoConfig() {
+  const config = resolveMongoConfig();
+  return { uri: config.uri, dbName: config.dbName, enabled: config.enabled };
+}
+
+module.exports = {
+  connectMongo,
+  getMongoDatabase,
+  closeMongo,
+  checkMongoHealth,
+  getMongoConfig,
+  resolveMongoConfig,
+};

--- a/server/db/mongo.ts
+++ b/server/db/mongo.ts
@@ -1,0 +1,37 @@
+export interface MongoConnectionOptions {
+  uri?: string;
+  mongoUrl?: string;
+  url?: string;
+  dbName?: string;
+  database?: string;
+  mongoDb?: string;
+  options?: Record<string, unknown>;
+  client?: unknown;
+  db?: unknown;
+  forceNew?: boolean;
+}
+
+interface MongoConfig {
+  uri: string | null;
+  dbName: string | null;
+  options: Record<string, unknown>;
+  enabled: boolean;
+}
+
+const implementation = require('./mongo.js') as {
+  connectMongo: (overrides?: MongoConnectionOptions) => Promise<any>;
+  getMongoDatabase: (overrides?: MongoConnectionOptions) => Promise<any>;
+  closeMongo: () => Promise<void>;
+  checkMongoHealth: (
+    overrides?: MongoConnectionOptions,
+  ) => Promise<{ ok: boolean; error?: unknown }>;
+  getMongoConfig: () => { uri: string | null; dbName: string | null; enabled: boolean };
+  resolveMongoConfig: (overrides?: MongoConnectionOptions) => MongoConfig;
+};
+
+export const connectMongo = implementation.connectMongo;
+export const getMongoDatabase = implementation.getMongoDatabase;
+export const closeMongo = implementation.closeMongo;
+export const checkMongoHealth = implementation.checkMongoHealth;
+export const getMongoConfig = implementation.getMongoConfig;
+export const resolveMongoConfig = implementation.resolveMongoConfig;

--- a/server/routes/api/generation/biomes.js
+++ b/server/routes/api/generation/biomes.js
@@ -1,0 +1,34 @@
+function createBiomeGenerationRoute({
+  biomeSynthesizer,
+  catalogService,
+  createGenerationHandler,
+} = {}) {
+  if (!createGenerationHandler || typeof createGenerationHandler !== 'function') {
+    throw new Error('createGenerationHandler richiesto per la rotta biomi');
+  }
+  if (!biomeSynthesizer || typeof biomeSynthesizer.generate !== 'function') {
+    throw new Error('biomeSynthesizer con metodo generate richiesto');
+  }
+
+  return createGenerationHandler(
+    async (payload = {}) => {
+      if (catalogService && typeof catalogService.ensureReady === 'function') {
+        await catalogService.ensureReady();
+      }
+      const result = await biomeSynthesizer.generate({
+        count: payload.count,
+        constraints: payload.constraints || {},
+        seed: payload.seed,
+      });
+      return result;
+    },
+    {
+      mapResult: (result) => ({ biomes: result.biomes, meta: result.constraints }),
+      defaultError: 'Errore generazione biomi',
+    },
+  );
+}
+
+module.exports = {
+  createBiomeGenerationRoute,
+};

--- a/server/routes/api/generation/biomes.ts
+++ b/server/routes/api/generation/biomes.ts
@@ -1,0 +1,25 @@
+import type { RequestHandler } from 'express';
+import type { CatalogService } from '../../../services/catalog';
+import type { createGenerationHandler as CreateHandler } from '../../generation';
+
+type GenerationHandlerFactory = typeof CreateHandler;
+
+type BiomeSynthesizer = {
+  generate: (options: {
+    count?: number;
+    constraints?: Record<string, unknown>;
+    seed?: unknown;
+  }) => Promise<any>;
+};
+
+interface RouteOptions {
+  biomeSynthesizer: BiomeSynthesizer;
+  catalogService?: CatalogService;
+  createGenerationHandler: GenerationHandlerFactory;
+}
+
+const implementation = require('./biomes.js') as {
+  createBiomeGenerationRoute: (options: RouteOptions) => RequestHandler;
+};
+
+export const createBiomeGenerationRoute = implementation.createBiomeGenerationRoute;

--- a/server/services/catalog.js
+++ b/server/services/catalog.js
@@ -1,0 +1,250 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const { getMongoDatabase, checkMongoHealth } = require('../db/mongo');
+const { buildCatalogMap } = require('../../services/generation/speciesBuilder');
+
+function normaliseList(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.map((item) => (typeof item === 'string' ? item.trim() : '')).filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    return value.trim() ? [value.trim()] : [];
+  }
+  return [];
+}
+
+async function readJsonFile(filePath, fallback = {}) {
+  try {
+    const buffer = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(buffer);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return fallback;
+    }
+    throw error;
+  }
+}
+
+function mapGlossaryFromTraits(docs) {
+  const traits = {};
+  docs.forEach((doc) => {
+    const id = doc && (doc._id || doc.id || doc.trait_id);
+    if (!id) return;
+    const labels = doc.labels || {};
+    const descriptions = doc.descriptions || {};
+    traits[id] = {
+      label_it: labels.it || labels.IT || labels['it-IT'] || labels.en || id,
+      label_en: labels.en || labels.EN || labels['en-US'] || labels.it || id,
+      description_it:
+        descriptions.it || descriptions.IT || descriptions['it-IT'] || descriptions.en || null,
+      description_en:
+        descriptions.en || descriptions.EN || descriptions['en-US'] || descriptions.it || null,
+    };
+  });
+  return { traits };
+}
+
+function mapCatalogFromTraits(docs) {
+  const traits = {};
+  docs.forEach((doc) => {
+    if (!doc) return;
+    const id = doc._id || doc.id || doc.trait_id;
+    if (!id) return;
+    const reference = doc.reference || {};
+    traits[id] = {
+      label: reference.label || (doc.labels && (doc.labels.it || doc.labels.en)) || id,
+      tier: reference.tier ?? null,
+      families: reference.families ?? [],
+      energy_profile: reference.energy_profile || null,
+      usage: reference.usage || null,
+      selective_drive: reference.selective_drive || null,
+      mutation: reference.mutation || null,
+      synergies: reference.synergies ?? [],
+      conflicts: reference.conflicts ?? [],
+      environments: reference.environments ?? [],
+      weakness: reference.weakness || null,
+      usage_tags: doc.usage_tags ?? reference.usage_tags ?? [],
+      species_affinity: doc.species_affinity ?? reference.species_affinity ?? [],
+      completion_flags: doc.completion_flags ?? reference.completion_flags ?? {},
+    };
+  });
+  return buildCatalogMap({ traits });
+}
+
+function mapBiomePool(doc) {
+  if (!doc) return null;
+  const traits = doc.traits || {};
+  const templates = Array.isArray(doc.role_templates) ? doc.role_templates : [];
+  return {
+    id: doc._id || doc.id,
+    label: doc.label || null,
+    summary: doc.summary || null,
+    climate_tags: normaliseList(doc.climate_tags),
+    size: doc.size || null,
+    hazard: doc.hazard || null,
+    ecology: doc.ecology || null,
+    traits: {
+      core: normaliseList(traits.core),
+      support: normaliseList(traits.support),
+    },
+    role_templates: templates.map((entry) => ({
+      role: entry.role,
+      label: entry.label || null,
+      summary: entry.summary || null,
+      functional_tags: normaliseList(entry.functional_tags),
+      preferred_traits: normaliseList(entry.preferred_traits),
+      tier: entry.tier ?? null,
+    })),
+    metadata: doc.metadata || undefined,
+  };
+}
+
+async function loadBiomePoolsFromMongo(db) {
+  const cursor = db.collection('biome_pools').find({});
+  const docs = await cursor.toArray();
+  const pools = docs.map(mapBiomePool).filter(Boolean);
+  return { pools };
+}
+
+async function loadTraitGlossaryFromMongo(db) {
+  const cursor = db.collection('traits').find({}, { projection: { labels: 1, descriptions: 1 } });
+  const docs = await cursor.toArray();
+  return mapGlossaryFromTraits(docs);
+}
+
+async function loadTraitCatalogFromMongo(db) {
+  const cursor = db.collection('traits').find(
+    {},
+    {
+      projection: {
+        labels: 1,
+        reference: 1,
+        usage_tags: 1,
+        species_affinity: 1,
+        completion_flags: 1,
+      },
+    },
+  );
+  const docs = await cursor.toArray();
+  return mapCatalogFromTraits(docs);
+}
+
+function createCatalogService(options = {}) {
+  const dataRoot = options.dataRoot || path.resolve(__dirname, '..', '..', 'data');
+  const traitGlossaryPath =
+    options.traitGlossaryPath || path.join(dataRoot, 'core', 'traits', 'glossary.json');
+  const biomePoolsPath =
+    options.biomePoolsPath || path.join(dataRoot, 'core', 'traits', 'biome_pools.json');
+  const traitCatalogPath =
+    options.traitCatalogPath ||
+    path.resolve(__dirname, '..', '..', 'docs', 'catalog', 'catalog_data.json');
+  const logger = options.logger || console;
+  const useMongo = options.useMongo !== false;
+  const mongoOptions = options.mongo || {};
+
+  let cache = null;
+  let cacheSource = null;
+
+  async function loadFromMongo() {
+    const db = await getMongoDatabase(mongoOptions);
+    const [glossary, pools, catalog] = await Promise.all([
+      loadTraitGlossaryFromMongo(db),
+      loadBiomePoolsFromMongo(db),
+      loadTraitCatalogFromMongo(db),
+    ]);
+    return { traitGlossary: glossary, biomePools: pools, traitCatalog: catalog, source: 'mongo' };
+  }
+
+  async function loadFromDisk() {
+    const [glossary, pools, catalogPayload] = await Promise.all([
+      readJsonFile(traitGlossaryPath, { traits: {} }),
+      readJsonFile(biomePoolsPath, { pools: [] }),
+      readJsonFile(traitCatalogPath, { traits: {} }),
+    ]);
+    const traitCatalog = buildCatalogMap(catalogPayload);
+    return { traitGlossary: glossary, biomePools: pools, traitCatalog, source: 'local' };
+  }
+
+  async function ensureData() {
+    if (cache) {
+      return cache;
+    }
+    if (useMongo) {
+      try {
+        cache = await loadFromMongo();
+        cacheSource = cache.source;
+        return cache;
+      } catch (error) {
+        logger.warn('[catalog] caricamento da MongoDB fallito, uso fallback locale', {
+          error: error && error.message ? error.message : error,
+        });
+      }
+    }
+    cache = await loadFromDisk();
+    cacheSource = cache.source;
+    return cache;
+  }
+
+  async function loadTraitGlossary() {
+    const data = await ensureData();
+    return data.traitGlossary;
+  }
+
+  async function loadBiomePools() {
+    const data = await ensureData();
+    return data.biomePools;
+  }
+
+  async function loadTraitCatalog() {
+    const data = await ensureData();
+    return data.traitCatalog;
+  }
+
+  async function reload() {
+    cache = null;
+    cacheSource = null;
+    return ensureData();
+  }
+
+  async function ensureReady() {
+    const data = await ensureData();
+    return {
+      source: cacheSource,
+      traitCount: data.traitCatalog instanceof Map ? data.traitCatalog.size : 0,
+      poolCount: Array.isArray(data.biomePools?.pools) ? data.biomePools.pools.length : 0,
+    };
+  }
+
+  async function healthCheck() {
+    if (!useMongo) {
+      return { ok: true, source: 'local' };
+    }
+    const result = await checkMongoHealth(mongoOptions);
+    if (!result.ok) {
+      return { ok: false, source: 'mongo', error: result.error };
+    }
+    return { ok: true, source: 'mongo' };
+  }
+
+  function getSource() {
+    return cacheSource;
+  }
+
+  return {
+    loadTraitGlossary,
+    loadBiomePools,
+    loadTraitCatalog,
+    reload,
+    ensureReady,
+    healthCheck,
+    getSource,
+  };
+}
+
+module.exports = {
+  createCatalogService,
+  mapGlossaryFromTraits,
+  mapCatalogFromTraits,
+  mapBiomePool,
+};

--- a/server/services/catalog.ts
+++ b/server/services/catalog.ts
@@ -1,0 +1,31 @@
+export interface CatalogServiceOptions {
+  dataRoot?: string;
+  traitGlossaryPath?: string;
+  biomePoolsPath?: string;
+  traitCatalogPath?: string;
+  logger?: Pick<Console, 'warn'>;
+  useMongo?: boolean;
+  mongo?: Record<string, unknown>;
+}
+
+export interface CatalogService {
+  loadTraitGlossary: () => Promise<Record<string, unknown>>;
+  loadBiomePools: () => Promise<{ pools: unknown[] }>;
+  loadTraitCatalog: () => Promise<unknown>;
+  reload: () => Promise<Record<string, unknown>>;
+  ensureReady: () => Promise<{ source: string | null; traitCount: number; poolCount: number }>;
+  healthCheck: () => Promise<{ ok: boolean; source: string; error?: unknown }>;
+  getSource: () => string | null;
+}
+
+const implementation = require('./catalog.js') as {
+  createCatalogService: (options?: CatalogServiceOptions) => CatalogService;
+  mapGlossaryFromTraits: (docs: Array<Record<string, any>>) => Record<string, any>;
+  mapCatalogFromTraits: (docs: Array<Record<string, any>>) => unknown;
+  mapBiomePool: (doc: Record<string, any>) => Record<string, any> | null;
+};
+
+export const createCatalogService = implementation.createCatalogService;
+export const mapGlossaryFromTraits = implementation.mapGlossaryFromTraits;
+export const mapCatalogFromTraits = implementation.mapCatalogFromTraits;
+export const mapBiomePool = implementation.mapBiomePool;

--- a/services/generation/biomeSynthesizer.js
+++ b/services/generation/biomeSynthesizer.js
@@ -84,7 +84,13 @@ function normaliseTraitGlossary(glossary) {
     const descriptionIt = entry?.description_it || null;
     const descriptionEn = entry?.description_en || null;
     const description = descriptionIt || descriptionEn || null;
-    map.set(id, { id, label, description, description_it: descriptionIt, description_en: descriptionEn });
+    map.set(id, {
+      id,
+      label,
+      description,
+      description_it: descriptionIt,
+      description_en: descriptionEn,
+    });
   });
   return map;
 }
@@ -138,7 +144,9 @@ function computeScore(pool, constraints, traitGlossary) {
   if (constraints.climate && matchesClimate(pool, constraints.climate)) {
     score += 4;
   }
-  const requiredRoles = ensureArray(constraints.requiredRoles).filter((role) => ROLE_FLAG_SET.has(role));
+  const requiredRoles = ensureArray(constraints.requiredRoles).filter((role) =>
+    ROLE_FLAG_SET.has(role),
+  );
   if (requiredRoles.length) {
     const roles = new Set((pool?.role_templates ?? []).map((template) => template.role));
     requiredRoles.forEach((role) => {
@@ -151,12 +159,9 @@ function computeScore(pool, constraints, traitGlossary) {
     .map((tag) => String(tag).toLowerCase())
     .filter(Boolean);
   if (preferredTags.length) {
-    const traitIds = [
-      ...(pool?.traits?.core ?? []),
-      ...(pool?.traits?.support ?? []),
-    ];
+    const traitIds = [...(pool?.traits?.core ?? []), ...(pool?.traits?.support ?? [])];
     const labels = traitIds.map((traitId) =>
-      (traitGlossary.get(traitId)?.label || traitId).toLowerCase()
+      (traitGlossary.get(traitId)?.label || traitId).toLowerCase(),
     );
     preferredTags.forEach((tag) => {
       if (labels.some((label) => label.includes(tag) || tag.includes(label))) {
@@ -169,7 +174,9 @@ function computeScore(pool, constraints, traitGlossary) {
 
 function pickCandidatePools(pools, constraints, traitGlossary) {
   const minSize = Number.isFinite(constraints.minSize) ? constraints.minSize : 0;
-  const requiredRoles = ensureArray(constraints.requiredRoles).filter((role) => ROLE_FLAG_SET.has(role));
+  const requiredRoles = ensureArray(constraints.requiredRoles).filter((role) =>
+    ROLE_FLAG_SET.has(role),
+  );
   const filtered = (pools ?? []).filter((pool) => {
     if (!pool) return false;
     const maxSize = pool?.size?.max ?? pool?.size?.min ?? 0;
@@ -184,13 +191,15 @@ function pickCandidatePools(pools, constraints, traitGlossary) {
     }
     if (
       requiredRoles.length &&
-      requiredRoles.some((role) => !(pool?.role_templates ?? []).some((template) => template.role === role))
+      requiredRoles.some(
+        (role) => !(pool?.role_templates ?? []).some((template) => template.role === role),
+      )
     ) {
       return false;
     }
     return true;
   });
-  const candidates = (filtered.length ? filtered : pools ?? []).map((pool) => ({
+  const candidates = (filtered.length ? filtered : (pools ?? [])).map((pool) => ({
     pool,
     score: computeScore(pool, constraints, traitGlossary),
   }));
@@ -227,11 +236,13 @@ function selectTraits(pool, rng) {
 
 function cloneAffinity(entries) {
   if (!Array.isArray(entries)) return [];
-  return entries.map((entry) => ({
-    species_id: entry?.species_id || entry?.speciesId || null,
-    roles: Array.isArray(entry?.roles) ? entry.roles.filter(Boolean) : [],
-    weight: Number.isFinite(entry?.weight) ? entry.weight : Number.parseFloat(entry?.weight) || 0,
-  })).filter((entry) => entry.species_id);
+  return entries
+    .map((entry) => ({
+      species_id: entry?.species_id || entry?.speciesId || null,
+      roles: Array.isArray(entry?.roles) ? entry.roles.filter(Boolean) : [],
+      weight: Number.isFinite(entry?.weight) ? entry.weight : Number.parseFloat(entry?.weight) || 0,
+    }))
+    .filter((entry) => entry.species_id);
 }
 
 function buildTraitMetadataFromCatalog(traitIds, traitCatalog) {
@@ -248,9 +259,10 @@ function buildTraitMetadataFromCatalog(traitIds, traitCatalog) {
     const id = entry.id || traitId;
     const traitUsage = Array.isArray(entry.usage_tags) ? entry.usage_tags.filter(Boolean) : [];
     traitUsage.forEach((tag) => usageTags.add(tag));
-    const flags = entry.completion_flags && typeof entry.completion_flags === 'object'
-      ? entry.completion_flags
-      : {};
+    const flags =
+      entry.completion_flags && typeof entry.completion_flags === 'object'
+        ? entry.completion_flags
+        : {};
     Object.entries(flags).forEach(([key, value]) => {
       if (typeof value === 'boolean') {
         completionFlags[key] = completionFlags[key] || value;
@@ -273,11 +285,13 @@ function buildTraitMetadataFromCatalog(traitIds, traitCatalog) {
       species_affinity: affinityEntries,
     };
   });
-  const speciesAffinity = Array.from(affinityMap.values()).map((entry) => ({
-    species_id: entry.species_id,
-    roles: Array.from(entry.roles).sort(),
-    weight: Math.round(entry.weight * 1000) / 1000,
-  })).sort((a, b) => (b.weight - a.weight) || a.species_id.localeCompare(b.species_id));
+  const speciesAffinity = Array.from(affinityMap.values())
+    .map((entry) => ({
+      species_id: entry.species_id,
+      roles: Array.from(entry.roles).sort(),
+      weight: Math.round(entry.weight * 1000) / 1000,
+    }))
+    .sort((a, b) => b.weight - a.weight || a.species_id.localeCompare(b.species_id));
   return {
     usage_tags: Array.from(usageTags).sort(),
     species_affinity: speciesAffinity,
@@ -289,9 +303,8 @@ function buildTraitMetadataFromCatalog(traitIds, traitCatalog) {
 function mapTraitDetails(traits, traitGlossary, traitCatalog) {
   return traits.map((traitId) => {
     const glossaryEntry = traitGlossary.get(traitId) || {};
-    const catalogEntry = traitCatalog && typeof traitCatalog.get === 'function'
-      ? traitCatalog.get(traitId)
-      : null;
+    const catalogEntry =
+      traitCatalog && typeof traitCatalog.get === 'function' ? traitCatalog.get(traitId) : null;
     return {
       id: traitId,
       label: glossaryEntry.label || titleCase(traitId),
@@ -300,7 +313,9 @@ function mapTraitDetails(traits, traitGlossary, traitCatalog) {
       description_en: glossaryEntry.description_en || null,
       usage_tags: Array.isArray(catalogEntry?.usage_tags) ? [...catalogEntry.usage_tags] : [],
       completion_flags: catalogEntry?.completion_flags ? { ...catalogEntry.completion_flags } : {},
-      species_affinity: catalogEntry?.species_affinity ? cloneAffinity(catalogEntry.species_affinity) : [],
+      species_affinity: catalogEntry?.species_affinity
+        ? cloneAffinity(catalogEntry.species_affinity)
+        : [],
     };
   });
 }
@@ -336,7 +351,9 @@ async function buildSpecies(
   runtimeValidator,
 ) {
   const templates = Array.isArray(pool?.role_templates) ? pool.role_templates : [];
-  const preferredRoles = ensureArray(constraints.requiredRoles).filter((role) => ROLE_FLAG_SET.has(role));
+  const preferredRoles = ensureArray(constraints.requiredRoles).filter((role) =>
+    ROLE_FLAG_SET.has(role),
+  );
   const shuffled = shuffle(templates, rng);
   const species = [];
   const takenRoles = new Set();
@@ -373,7 +390,12 @@ async function buildSpecies(
       description: template.summary || null,
       morphology: null,
       behavior: null,
-      statistics: { threat_tier: `T${tier}`, rarity: null, energy_profile: null, synergy_score: null },
+      statistics: {
+        threat_tier: `T${tier}`,
+        rarity: null,
+        energy_profile: null,
+        synergy_score: null,
+      },
       traits: { core: preferredTraits, derived: [], conflicts: [], metadata: fallbackMetadata },
     };
 
@@ -425,7 +447,11 @@ async function buildSpecies(
 
   let validation = null;
   let correctedSpecies = species;
-  if (runtimeValidator && typeof runtimeValidator.validateSpeciesBatch === 'function' && species.length) {
+  if (
+    runtimeValidator &&
+    typeof runtimeValidator.validateSpeciesBatch === 'function' &&
+    species.length
+  ) {
     try {
       const result = await runtimeValidator.validateSpeciesBatch(species, { biomeId });
       validation = {
@@ -471,7 +497,15 @@ function summariseRolePresence(species) {
   return Array.from(presence);
 }
 
-async function buildBiomeFromPool(pool, context, traitGlossary, traitCatalog, rng, speciesBuilder, runtimeValidator) {
+async function buildBiomeFromPool(
+  pool,
+  context,
+  traitGlossary,
+  traitCatalog,
+  rng,
+  speciesBuilder,
+  runtimeValidator,
+) {
   const traits = selectTraits(pool, rng);
   const traitDetails = mapTraitDetails(traits, traitGlossary, traitCatalog);
   const id = randomId(slugify(pool.id) || 'bioma', rng);
@@ -480,7 +514,8 @@ async function buildBiomeFromPool(pool, context, traitGlossary, traitCatalog, rn
   const requestedMin = Number.isFinite(context?.minSize) ? context.minSize : poolMin;
   const effectiveMin = Math.min(poolMax, Math.max(poolMin, requestedMin));
   const range = Math.max(poolMax - effectiveMin, 0);
-  const zoneCount = effectiveMin + (range > 0 ? Math.floor((rng() || Math.random()) * (range + 1)) : 0);
+  const zoneCount =
+    effectiveMin + (range > 0 ? Math.floor((rng() || Math.random()) * (range + 1)) : 0);
   const speciesResult = await buildSpecies(
     pool,
     id,
@@ -535,12 +570,12 @@ async function buildBiomeFromPool(pool, context, traitGlossary, traitCatalog, rn
 
   const validationReport = {};
   if (
-    speciesResult.validation
-    && (
-      speciesResult.validation.error
-      || (Array.isArray(speciesResult.validation.messages) && speciesResult.validation.messages.length)
-      || (Array.isArray(speciesResult.validation.discarded) && speciesResult.validation.discarded.length)
-    )
+    speciesResult.validation &&
+    (speciesResult.validation.error ||
+      (Array.isArray(speciesResult.validation.messages) &&
+        speciesResult.validation.messages.length) ||
+      (Array.isArray(speciesResult.validation.discarded) &&
+        speciesResult.validation.discarded.length))
   ) {
     validationReport.species = speciesResult.validation;
   }
@@ -550,7 +585,11 @@ async function buildBiomeFromPool(pool, context, traitGlossary, traitCatalog, rn
       const biomeValidation = await runtimeValidator.validateBiome(biome, {
         defaultHazard: pool?.hazard?.id || null,
       });
-      if (biomeValidation && biomeValidation.corrected && typeof biomeValidation.corrected === 'object') {
+      if (
+        biomeValidation &&
+        biomeValidation.corrected &&
+        typeof biomeValidation.corrected === 'object'
+      ) {
         biome = { ...biome, ...biomeValidation.corrected };
       }
       if (biomeValidation && Array.isArray(biomeValidation.messages)) {
@@ -579,16 +618,30 @@ function resolveDataPath(dataRoot, segments = []) {
 
 function createBiomeSynthesizer(options = {}) {
   const dataRoot = options.dataRoot || path.resolve(__dirname, '..', '..', 'data');
-  const traitGlossaryPath = options.traitGlossaryPath
-    || resolveDataPath(dataRoot, ['traits', 'glossary.json']);
-  const traitPoolPath = options.traitPoolPath
-    || resolveDataPath(dataRoot, ['traits', 'biome_pools.json']);
+  const traitGlossaryPath =
+    options.traitGlossaryPath || resolveDataPath(dataRoot, ['traits', 'glossary.json']);
+  const traitPoolPath =
+    options.traitPoolPath || resolveDataPath(dataRoot, ['traits', 'biome_pools.json']);
+  const catalogService = options.catalogService || null;
   const speciesBuilderInstance = createSpeciesBuilder(
-    options.speciesBuilder || {
-      catalogPath: path.resolve(__dirname, '..', '..', 'docs', 'catalog', 'catalog_data.json'),
-    }
+    options.speciesBuilder ||
+      (catalogService
+        ? {
+            catalogLoader: () => catalogService.loadTraitCatalog(),
+          }
+        : {
+            catalogPath: path.resolve(
+              __dirname,
+              '..',
+              '..',
+              'docs',
+              'catalog',
+              'catalog_data.json',
+            ),
+          }),
   );
-  const runtimeValidator = options.runtimeValidator || createRuntimeValidator(options.runtimeValidatorOptions || {});
+  const runtimeValidator =
+    options.runtimeValidator || createRuntimeValidator(options.runtimeValidatorOptions || {});
 
   let loaded = null;
   let loadingPromise = null;
@@ -596,6 +649,23 @@ function createBiomeSynthesizer(options = {}) {
   async function load() {
     if (loaded) return loaded;
     if (loadingPromise) return loadingPromise;
+    if (catalogService) {
+      loadingPromise = Promise.all([
+        catalogService.loadTraitGlossary(),
+        catalogService.loadBiomePools(),
+        speciesBuilderInstance.ensureCatalog(),
+      ])
+        .then(([glossary, pools, catalog]) => {
+          const traitGlossary = normaliseTraitGlossary(glossary);
+          const poolList = Array.isArray(pools?.pools) ? pools.pools : [];
+          loaded = { traitGlossary, poolList, traitCatalog: catalog };
+          return loaded;
+        })
+        .finally(() => {
+          loadingPromise = null;
+        });
+      return loadingPromise;
+    }
     loadingPromise = Promise.all([
       loadJson(traitGlossaryPath),
       loadJson(traitPoolPath),
@@ -661,7 +731,9 @@ function createBiomeSynthesizer(options = {}) {
         applied: {
           hazard: constraints.hazard || null,
           climate: constraints.climate || null,
-          requiredRoles: ensureArray(constraints.requiredRoles).filter((role) => ROLE_FLAG_SET.has(role)),
+          requiredRoles: ensureArray(constraints.requiredRoles).filter((role) =>
+            ROLE_FLAG_SET.has(role),
+          ),
           preferredTags: ensureArray(constraints.preferredTags),
           minSize: Number.isFinite(constraints.minSize) ? constraints.minSize : null,
         },
@@ -672,6 +744,9 @@ function createBiomeSynthesizer(options = {}) {
 
   async function reload() {
     loaded = null;
+    if (catalogService && typeof catalogService.reload === 'function') {
+      await catalogService.reload();
+    }
     return load();
   }
 

--- a/tests/api/biome-generation-mongo.test.js
+++ b/tests/api/biome-generation-mongo.test.js
@@ -1,0 +1,176 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const { MongoClient } = require('mongodb');
+const request = require('supertest');
+
+const { createApp } = require('../../server/app');
+const { closeMongo } = require('../../server/db/mongo');
+
+function createTraitDocument(id, label, extras = {}) {
+  return {
+    _id: id,
+    labels: { it: label, en: label },
+    descriptions: { it: `${label} description`, en: `${label} description` },
+    reference: {
+      label,
+      tier: 3,
+      families: ['supporto'],
+      energy_profile: 'medio',
+      usage: 'supporto',
+      selective_drive: null,
+      mutation: null,
+      synergies: [],
+      conflicts: [],
+      environments: ['arid'],
+      weakness: null,
+      usage_tags: ['supporto'],
+      species_affinity: [
+        {
+          species_id: `synthetic-${id}`,
+          roles: ['apex'],
+          weight: 1,
+        },
+      ],
+      completion_flags: { has_usage_tags: true },
+      ...extras.reference,
+    },
+    usage_tags: extras.usage_tags,
+    species_affinity: extras.species_affinity,
+    completion_flags: extras.completion_flags,
+  };
+}
+
+async function seedMongo(db) {
+  const traits = [
+    createTraitDocument('ghiaccio_piezoelettrico', 'Ghiaccio Piezoelettrico'),
+    createTraitDocument('criostasi_adattiva', 'Criostasi Adattiva', {
+      reference: { usage_tags: ['criogenico'], environments: ['frozen'] },
+    }),
+    createTraitDocument('gusci_criovetro', 'Gusci Criovetro', {
+      reference: { usage_tags: ['difensivo'], environments: ['frozen'] },
+    }),
+    createTraitDocument('antenne_wideband', 'Antenne Wideband', {
+      reference: { usage_tags: ['supporto'], environments: ['arid'] },
+    }),
+  ];
+  await db.collection('traits').insertMany(traits);
+
+  await db.collection('biome_pools').insertOne({
+    _id: 'mongo_test_pool',
+    label: 'Bioma Mongo Test',
+    summary: 'Pool creato per verificare la generazione via MongoDB',
+    climate_tags: ['arid', 'storm'],
+    size: { min: 3, max: 5 },
+    hazard: {
+      severity: 'high',
+      description: 'Tempeste ferrose mirate dalle creste magnetiche.',
+    },
+    ecology: {
+      biome_type: 'badlands',
+      primary_resources: ['ferro_memoria'],
+    },
+    traits: {
+      core: ['ghiaccio_piezoelettrico', 'criostasi_adattiva', 'gusci_criovetro'],
+      support: ['antenne_wideband'],
+    },
+    role_templates: [
+      {
+        role: 'apex',
+        label: 'Predatore Magnetico',
+        summary: 'Concentra scariche elettromagnetiche sulle prede.',
+        functional_tags: ['offensivo'],
+        preferred_traits: ['ghiaccio_piezoelettrico', 'criostasi_adattiva'],
+        tier: 4,
+      },
+      {
+        role: 'keystone',
+        label: 'Stabilizzatore di Creste',
+        summary: 'Gestisce ponti conduttivi durante le tempeste.',
+        functional_tags: ['supporto'],
+        preferred_traits: ['antenne_wideband'],
+        tier: 3,
+      },
+      {
+        role: 'threat',
+        label: 'Sciame Ferruginoso',
+        summary: 'Causa corrosione accelerata sulle infrastrutture.',
+        functional_tags: ['sabotaggio'],
+        preferred_traits: ['gusci_criovetro'],
+        tier: 3,
+      },
+    ],
+  });
+}
+
+function restoreEnv(key, value) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+test('POST /api/v1/generation/biomes utilizza i dati MongoDB quando disponibili', async (t) => {
+  const mongoServer = await MongoMemoryServer.create();
+  const mongoUri = mongoServer.getUri();
+  const databaseName = 'evo_generator_test';
+  const client = new MongoClient(mongoUri);
+  await client.connect();
+  const db = client.db(databaseName);
+  await seedMongo(db);
+
+  const previousMongoUrl = process.env.MONGO_URL;
+  const previousMongoDb = process.env.MONGO_DB_NAME;
+  process.env.MONGO_URL = mongoUri;
+  process.env.MONGO_DB_NAME = databaseName;
+
+  t.after(async () => {
+    restoreEnv('MONGO_URL', previousMongoUrl);
+    restoreEnv('MONGO_DB_NAME', previousMongoDb);
+    await closeMongo();
+    await client.close();
+    await mongoServer.stop();
+  });
+
+  const { app } = createApp({
+    dataRoot: path.resolve(__dirname, '..', '..', 'data'),
+  });
+
+  const response = await request(app)
+    .post('/api/v1/generation/biomes')
+    .send({
+      count: 1,
+      constraints: {
+        requiredRoles: ['apex', 'keystone', 'threat'],
+        hazard: 'high',
+      },
+      seed: 42,
+    })
+    .expect(200);
+
+  const { biomes, meta } = response.body;
+  assert.ok(Array.isArray(biomes), 'la risposta deve contenere un array di biomi');
+  assert.equal(biomes.length, 1, 'deve essere generato un singolo bioma');
+  const biome = biomes[0];
+  assert.equal(
+    biome?.hazard?.description,
+    'Tempeste ferrose mirate dalle creste magnetiche.',
+    'la descrizione hazard deve provenire dal dataset MongoDB',
+  );
+  assert.equal(meta?.poolCount, 1, 'il conteggio pool deve riflettere i documenti MongoDB');
+
+  const traitIds = Array.isArray(biome?.traits?.ids) ? biome.traits.ids : [];
+  assert.ok(
+    traitIds.includes('ghiaccio_piezoelettrico'),
+    'i tratti devono includere le entry seedate',
+  );
+  assert.ok(traitIds.includes('criostasi_adattiva'));
+  assert.ok(Array.isArray(biome?.species), 'le specie generate devono essere presenti');
+  assert.ok(biome.species.length >= 3, 'le specie devono coprire i ruoli principali');
+  biome.species.forEach((species) => {
+    assert.equal(species.synthetic, true);
+    assert.ok(species.display_name);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared MongoDB connection helper and catalog service wired into the biome generation routes
- allow the biome synthesizer and species builder to consume Mongo-backed trait catalogs with local fallback
- cover the Mongo data path with an integration test that seeds an in-memory MongoDB instance

## Testing
- node --test tests/api/biome-generation-mongo.test.js *(fails: missing mongodb dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_690bb755b1a083289e5e52f21e2f4214