### PR TITLE
Fix tab indentation for evo tactics pack recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ structured:
 audit: sitemap links report search redirects structured
 
 evo-tactics-pack:
-node scripts/build_evo_tactics_pack_dist.mjs
+	node scripts/build_evo_tactics_pack_dist.mjs


### PR DESCRIPTION
## Summary
- add the missing leading tab to the `evo-tactics-pack` recipe so GNU Make treats it as a command

## Testing
- git commit

------
https://chatgpt.com/codex/tasks/task_b_690bbf4175e8832a9447a6796661a615