### PR TITLE
feat: automate mongodb migrations and seeding

### DIFF
--- a/.github/workflows/deploy-test-interface.yml
+++ b/.github/workflows/deploy-test-interface.yml
@@ -13,7 +13,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: 'pages'
   cancel-in-progress: false
 
 jobs:
@@ -26,8 +26,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          cache: "npm"
+          node-version: '20'
+          cache: 'npm'
           cache-dependency-path: tools/ts/package-lock.json
 
       - name: Install TypeScript tool dependencies
@@ -78,12 +78,20 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: '3.11'
 
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
           python -m pip install -r tools/py/requirements.txt
+
+      - name: Apply MongoDB migrations and seed
+        if: github.event_name != 'pull_request' && secrets.MONGODB_PROD_URI != ''
+        env:
+          MONGODB_PROD_URI: ${{ secrets.MONGODB_PROD_URI }}
+          MONGODB_PROD_DB: ${{ secrets.MONGODB_PROD_DB }}
+        run: ops/mongodb/apply.sh prod
 
       - name: Validate HUD smart alert logs (TAP overlay)
         run: |
@@ -118,7 +126,7 @@ jobs:
       - name: Run deploy validation checks
         env:
           DEPLOY_DATA_DIR: ${{ github.workspace }}/data
-          CI: "true"
+          CI: 'true'
           DEPLOY_SKIP_SMOKE_TEST: ${{ github.event_name == 'pull_request' && '1' || '0' }}
           PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/playwright-browsers
           DEPLOY_CHROMIUM_BUNDLE_ARCHIVE: ${{ steps.chromium_meta.outputs.archive }}

--- a/config/mongodb.dev.json
+++ b/config/mongodb.dev.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "./schemas/mongodb-config.schema.json",
+  "description": "Configurazione MongoDB per ambienti di sviluppo locale e pipeline CI.",
+  "mongoUrl": {
+    "env": "MONGODB_DEV_URI",
+    "default": "mongodb://localhost:27017"
+  },
+  "database": {
+    "env": "MONGODB_DEV_DB",
+    "default": "evo_tactics_dev"
+  },
+  "options": {
+    "appName": "game-dev",
+    "retryWrites": true
+  },
+  "seed": {
+    "dryRun": false
+  }
+}

--- a/config/mongodb.prod.json
+++ b/config/mongodb.prod.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "./schemas/mongodb-config.schema.json",
+  "description": "Configurazione MongoDB per ambienti di produzione e pre-produzione.",
+  "mongoUrl": {
+    "env": "MONGODB_PROD_URI"
+  },
+  "database": {
+    "env": "MONGODB_PROD_DB",
+    "default": "evo_tactics"
+  },
+  "options": {
+    "appName": "game-prod",
+    "retryWrites": true,
+    "readPreference": "primaryPreferred"
+  },
+  "seed": {
+    "dryRun": false
+  }
+}

--- a/config/schemas/mongodb-config.schema.json
+++ b/config/schemas/mongodb-config.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MongoDB deployment configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "value": {
+      "anyOf": [{ "type": "string" }, { "$ref": "#/definitions/envRef" }]
+    },
+    "envRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["env"],
+      "properties": {
+        "env": {
+          "type": "string",
+          "description": "Nome della variabile d'ambiente da leggere"
+        },
+        "default": {
+          "description": "Valore di fallback utilizzato quando la variabile non è impostata"
+        }
+      }
+    }
+  },
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "mongoUrl": {
+      "$ref": "#/definitions/value"
+    },
+    "uri": {
+      "$ref": "#/definitions/value"
+    },
+    "database": {
+      "$ref": "#/definitions/value"
+    },
+    "dbName": {
+      "$ref": "#/definitions/value"
+    },
+    "options": {
+      "type": "object",
+      "default": {},
+      "description": "Opzioni da passare al driver MongoClient",
+      "additionalProperties": {
+        "description": "Parametri aggiuntivi per MongoClient"
+      }
+    },
+    "seed": {
+      "type": "object",
+      "default": {},
+      "description": "Impostazioni dedicate allo script di seeding",
+      "additionalProperties": true,
+      "properties": {
+        "dryRun": {
+          "type": "boolean",
+          "description": "Forza l'esecuzione in modalità dry-run"
+        }
+      }
+    }
+  },
+  "anyOf": [{ "required": ["mongoUrl"] }, { "required": ["uri"] }],
+  "allOf": [
+    {
+      "anyOf": [{ "required": ["database"] }, { "required": ["dbName"] }]
+    }
+  ]
+}

--- a/ops/handbook/mongodb.md
+++ b/ops/handbook/mongodb.md
@@ -1,0 +1,67 @@
+# MongoDB operations handbook
+
+## Configurazioni e ambienti
+
+- I file di configurazione standard risiedono in `config/mongodb.dev.json` e `config/mongodb.prod.json` e seguono lo schema `config/schemas/mongodb-config.schema.json`.
+- I parametri sensibili (URI, credenziali, database) vengono risolti tramite variabili d'ambiente (`MONGODB_DEV_URI`, `MONGODB_PROD_URI`, ecc.) gestite dal secret manager/Actions secrets.
+- Per ambienti aggiuntivi è possibile creare un nuovo file JSON nello stesso formato e utilizzarlo sia con gli script locali sia nelle pipeline CI.
+
+## Migrazioni e seed automatizzati
+
+- Lo script `ops/mongodb/apply.sh` esegue in sequenza:
+  1. `scripts/db/run_migrations.py up --config <config>`
+  2. `scripts/db/run_migrations.py status --config <config>`
+  3. `scripts/db/seed_evo_generator.py --config <config>` (salta con `--skip-seed`).
+- Utilizzo rapido:
+
+```bash
+# Ambiente di sviluppo
+ops/mongodb/apply.sh dev
+
+# Ambiente di produzione (richiede variabili d'ambiente configurate)
+MONGODB_PROD_URI="mongodb+srv://..." \
+  MONGODB_PROD_DB="evo_tactics" \
+  ops/mongodb/apply.sh prod
+```
+
+- Il workflow GitHub Actions `.github/workflows/deploy-test-interface.yml` invoca automaticamente `ops/mongodb/apply.sh prod` durante i deploy (esclusi i `pull_request`) utilizzando i secrets `MONGODB_PROD_URI` e `MONGODB_PROD_DB`.
+
+## Backup e retention
+
+- **Frequenza**: dump completi giornalieri, con conservazione di 7 giorni in storage S3 compatibile e snapshot settimanali conservati per 6 settimane. I dump vengono eseguiti fuori orario produttivo (02:00 UTC).
+- **Comando di riferimento** (backup completo compressi in formato archivio):
+
+```bash
+mongodump \
+  --uri="$MONGODB_PROD_URI" \
+  --db "$MONGODB_PROD_DB" \
+  --archive="/backups/evo_tactics_$(date +%Y%m%d).gz" \
+  --gzip \
+  --quiet
+```
+
+- **Ripristino puntuale** (ripristino completo su istanza temporanea o ambiente di staging):
+
+```bash
+mongorestore \
+  --uri="$MONGODB_STAGING_URI" \
+  --archive="/backups/evo_tactics_20241105.gz" \
+  --gzip \
+  --nsInclude "$MONGODB_PROD_DB.*" \
+  --drop \
+  --quiet
+```
+
+- **Retention**: i dump giornalieri più vecchi di 7 giorni e gli snapshot settimanali più vecchi di 45 giorni vengono eliminati automaticamente tramite lifecycle rules dello storage.
+
+## Policy di accesso
+
+- Gli URI di produzione sono gestiti dal secret manager: soltanto il team SRE e i referenti dati hanno accesso in lettura/scrittura; gli sviluppatori usano credenziali a privilegio minimo per ambienti di sviluppo/staging.
+- Gli script CI utilizzano service account dedicati con permessi limitati al database target (`MONGODB_PROD_DB`).
+- Ogni accesso manuale in produzione deve essere tracciato aprendo un ticket Ops e registrando il comando eseguito (inclusi `mongodump`/`mongorestore`).
+
+## Procedure di ripristino
+
+1. Ripristinare un dump recente su un ambiente di staging utilizzando `mongorestore` e verificare i log di applicazione/migrazioni.
+2. Validare i dati critici (collezioni `biomes`, `species`, `traits`) confrontando i conteggi con i report generati da `scripts/db/seed_evo_generator.py --dry-run`.
+3. Pianificare la finestra di manutenzione e applicare il ripristino sul cluster primario, monitorando la replica e il consumo di risorse.

--- a/ops/mongodb/apply.sh
+++ b/ops/mongodb/apply.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+CONFIG_DIR="$ROOT_DIR/config"
+MIGRATION_SCRIPT="$ROOT_DIR/scripts/db/run_migrations.py"
+SEED_SCRIPT="$ROOT_DIR/scripts/db/seed_evo_generator.py"
+
+usage() {
+  cat <<'USAGE'
+Uso: ops/mongodb/apply.sh <ambiente|percorso-config> [--skip-seed]
+
+Esegue le migrazioni MongoDB e il seed dei dati dell'Evo Tactics Pack
+utilizzando i file di configurazione definiti in config/.
+
+Argomenti:
+  ambiente             Alias "dev"/"development" oppure "prod"/"production"
+                       per usare i file predefiniti.
+  percorso-config      Percorso esplicito a un file JSON di configurazione.
+
+Opzioni:
+  --skip-seed          Esegue solo le migrazioni, senza importare i dati di seed.
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+TARGET="$1"
+shift
+RUN_SEED=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-seed)
+      RUN_SEED=0
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Opzione sconosciuta: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+CONFIG_PATH=""
+case "$TARGET" in
+  dev|development)
+    CONFIG_PATH="$CONFIG_DIR/mongodb.dev.json"
+    ;;
+  prod|production)
+    CONFIG_PATH="$CONFIG_DIR/mongodb.prod.json"
+    ;;
+  *)
+    if [[ -f "$TARGET" ]]; then
+      CONFIG_PATH="$TARGET"
+    elif [[ -f "$CONFIG_DIR/$TARGET" ]]; then
+      CONFIG_PATH="$CONFIG_DIR/$TARGET"
+    else
+      echo "File di configurazione MongoDB non trovato: $TARGET" >&2
+      exit 1
+    fi
+    ;;
+esac
+
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  echo "File di configurazione MongoDB non trovato: $CONFIG_PATH" >&2
+  exit 1
+fi
+
+echo "[mongo] Applico migrazioni utilizzando $CONFIG_PATH"
+python3 "$MIGRATION_SCRIPT" up --config "$CONFIG_PATH"
+
+echo "[mongo] Stato migrazioni dopo l'upgrade"
+python3 "$MIGRATION_SCRIPT" status --config "$CONFIG_PATH"
+
+if [[ $RUN_SEED -eq 1 ]]; then
+  echo "[mongo] Applico seed dei dati"
+  python3 "$SEED_SCRIPT" --config "$CONFIG_PATH"
+else
+  echo "[mongo] Seed disabilitato (--skip-seed)"
+fi

--- a/scripts/db/config_loader.py
+++ b/scripts/db/config_loader.py
@@ -1,0 +1,90 @@
+"""Utilities to read MongoDB deployment configuration files."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+_ENV_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+@dataclass(frozen=True)
+class MongoConfig:
+    """Normalized MongoDB configuration."""
+
+    mongo_url: str
+    database: str
+    options: Dict[str, Any]
+    extras: Dict[str, Any]
+
+
+def _expand_placeholders(value: str) -> str:
+    """Replace ${VAR} placeholders with environment variables when available."""
+
+    def _replace(match: re.Match[str]) -> str:  # type: ignore[name-defined]
+        env_name = match.group(1)
+        return os.environ.get(env_name, match.group(0))
+
+    return _ENV_PATTERN.sub(_replace, value)
+
+
+def _resolve_entry(value: Any) -> Any:
+    if isinstance(value, str):
+        return _expand_placeholders(value)
+    if isinstance(value, Mapping):
+        if "env" in value:
+            env_name = value["env"]
+            if not isinstance(env_name, str) or not env_name:
+                raise ValueError("Chiave 'env' non valida nella configurazione MongoDB")
+            default_value = value.get("default")
+            resolved = os.environ.get(env_name, default_value)
+            if resolved is None:
+                raise ValueError(
+                    f"Variabile d'ambiente '{env_name}' richiesta ma non impostata per la configurazione MongoDB"
+                )
+            if isinstance(resolved, str):
+                return _expand_placeholders(resolved)
+            return resolved
+        return {key: _resolve_entry(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_resolve_entry(item) for item in value]
+    return value
+
+
+def load_mongo_config(config_path: str | Path) -> MongoConfig:
+    """Load and normalize a MongoDB configuration file."""
+
+    path = Path(config_path)
+    if not path.is_file():
+        raise FileNotFoundError(f"Configurazione MongoDB non trovata: {path}")
+
+    with path.open("r", encoding="utf-8") as handle:
+        raw_payload: Dict[str, Any] = json.load(handle)
+
+    resolved = _resolve_entry(raw_payload)
+
+    mongo_url = resolved.get("mongoUrl") or resolved.get("uri")
+    database = resolved.get("database") or resolved.get("dbName")
+    options = resolved.get("options") or {}
+
+    if not isinstance(mongo_url, str) or not mongo_url.strip():
+        raise ValueError(f"Parametro 'mongoUrl' non valido nel file di configurazione {path}")
+    if not isinstance(database, str) or not database.strip():
+        raise ValueError(f"Parametro 'database' non valido nel file di configurazione {path}")
+    if not isinstance(options, Mapping):
+        raise ValueError(f"Parametro 'options' deve essere un oggetto nel file di configurazione {path}")
+
+    extras = {
+        key: value
+        for key, value in resolved.items()
+        if key not in {"mongoUrl", "uri", "database", "dbName", "options"}
+    }
+
+    return MongoConfig(mongo_url=mongo_url, database=database, options=dict(options), extras=extras)
+
+
+__all__ = ["MongoConfig", "load_mongo_config"]


### PR DESCRIPTION
## Summary
- add MongoDB environment configuration files and loader utility shared by migration/seed scripts
- extend deployment workflow and ops script to run migrations plus seed automatically using the new configs
- document backup, retention, and access policies for MongoDB operations

## Testing
- python -m compileall scripts/db

------
https://chatgpt.com/codex/tasks/task_e_690bca9f43408328819ea788b7799bc8