### PR TITLE
Fix catalog loader API base override priority

### DIFF
--- a/services/data-source.js
+++ b/services/data-source.js
@@ -381,8 +381,8 @@ export function createCatalogDataSource(options = {}) {
     [
       readQueryOverride(windowRef),
       readMetaOverride(documentRef),
-      normaliseBase(baseUrl),
       readWindowOverride(windowRef),
+      normaliseBase(baseUrl),
       normaliseBase(defaultBase),
     ].filter(Boolean);
 


### PR DESCRIPTION
## Summary
- prioritize the window-level Evo Tactics API base override ahead of persisted defaults when selecting the catalog base URL

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_690cfb7b5e8c832aab94b4ae38552fb7