### PR TITLE
fix: replace webapp lint step with format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,8 +186,8 @@ jobs:
       - name: Install workspace dependencies
         run: npm ci
 
-      - name: Run workspace lint checks
-        run: npm run lint
+      - name: Run workspace format checks
+        run: npm run format:check
 
       - name: Run webapp unit tests
         run: npm run test --workspace webapp


### PR DESCRIPTION
## Summary
- update the webapp-quality workflow job to run the Prettier format check instead of the removed lint script

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_690cfb8340c0832aab0a245596b79c5c