### PR TITLE
Add Evo Tactics trait operations manual

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Questi file sono scheletri collegati ai **Canvas** già creati in ChatGPT. Copia
 - `PI-Pacchetti-Forme.md` — 16 Forme, 7 PI, pacchetti A/B/C, tabelle d20/d12 (Canvas B).
 - `SistemaNPG-PF-Mutazioni.md` — NPG reattivi, PF, mutazioni T0/T1/T2, fusioni (Canvas C).
 - `Mating-Reclutamento-Nido.md` — Attrazione, Affinità/Fiducia, standard di nido, eredità (Canvas D).
+- `traits-manuale/` — guida operativa completa su schema, tassonomia e workflow trait (`docs/traits-manuale/README.md`).
 
 ## Aggiornamenti rapidi
 

--- a/docs/README_TRAITS.md
+++ b/docs/README_TRAITS.md
@@ -1,7 +1,8 @@
 # Evo Tactics — Trait Schema Pack
 
 Questo pacchetto fornisce gli **schemi JSON**, il catalogo principale dei trait e gli strumenti
-necessari per validarli.
+necessari per validarli. Per una guida narrativa e operativa consulta anche il
+[`Manuale Trait`](traits-manuale/README.md) che riassume modello dati, tassonomia e workflow.
 
 ## Struttura
 ```text

--- a/docs/traits-manuale/01-introduzione.md
+++ b/docs/traits-manuale/01-introduzione.md
@@ -1,0 +1,9 @@
+# Introduzione e fonti dati
+
+I trait rappresentano la spina dorsale del catalogo di Evo Tactics: definiscono abilità, vincoli narrativi e interazioni sistemiche ed ereditano la struttura tecnica descritta dallo schema JSON pubblicato nel repository. Il pacchetto principale abbina lo schema canonicale, il catalogo aggregato e i validatori CI dedicati così da mantenere allineate tutte le copie presenti nei pack e negli strumenti di authoring.【F:docs/README_TRAITS.md†L1-L26】
+
+Il template ufficiale esplicita campi obbligatori, vincoli di formato e sezioni opzionali che possono essere attivate in base alle esigenze di design. Questo framework garantisce coerenza editoriale (glossario, localizzazioni) e interoperabilità con le pipeline di sincronizzazione e audit.【F:docs/traits_template.md†L1-L99】
+
+Dal punto di vista operativo, la guida "How To" definisce il flusso end-to-end per gli autori: dalla preparazione del glossario alla compilazione dei file trait, passando per la validazione con gli script Python dedicati e la check-list PR finale.【F:README_HOWTO_AUTHOR_TRAIT.md†L1-L72】 La guida "Contributing" complementa il percorso fornendo la panoramica sugli strumenti, sulle dipendenze e sulle procedure di audit manuale o tramite editor UI, così da integrare rapidamente i nuovi contributi nel catalogo condiviso.【F:docs/contributing/traits.md†L1-L142】
+
+L'obiettivo del manuale è consolidare queste fonti in un'unica vista organizzata per capitoli tematici: le sezioni successive approfondiscono il modello dati, la tassonomia, le correlazioni con specie/eventi/regole ambientali e i workflow che orchestrano le attività quotidiane.

--- a/docs/traits-manuale/02-modello-dati.md
+++ b/docs/traits-manuale/02-modello-dati.md
@@ -1,0 +1,48 @@
+# Modello dati
+
+Il catalogo dei trait segue lo schema JSON canonico `config/schemas/trait.schema.json`, che definisce campi obbligatori, vincoli e sezioni opzionali modulari. La tabella seguente riassume i blocchi fondamentali richiesti da tutti i trait.
+
+## Campi obbligatori
+
+| Campo | Tipo | Vincoli chiave | Scopo |
+| --- | --- | --- | --- |
+| `id` | stringa | slug `^[a-z0-9_]+$` | Identificatore univoco e nome file della voce.【F:config/schemas/trait.schema.json†L8-L25】 |
+| `label` | stringa | riferimento `i18n:` o stringa ripulita | Nome localizzato mostrato in UI e report.【F:config/schemas/trait.schema.json†L26-L29】 |
+| `famiglia_tipologia` | stringa | formato `<Macro>/<Sotto>` | Cluster funzionale di appartenenza.【F:config/schemas/trait.schema.json†L30-L35】 |
+| `fattore_mantenimento_energetico` | stringa | `i18n:` o stringa ripulita | Costo narrativo/energetico del tratto.【F:config/schemas/trait.schema.json†L36-L39】 |
+| `tier` | stringa | `T1`–`T6` | Gradino di progressione e gating di accesso.【F:config/schemas/trait.schema.json†L40-L44】 |
+| `slot` | array[string] | lettere maiuscole uniche | Slot occupati, può essere vuoto.【F:config/schemas/trait.schema.json†L45-L52】 |
+| `sinergie` | array[string] | slug normalizzati | Lista di trait compatibili.【F:config/schemas/trait.schema.json†L56-L63】 |
+| `conflitti` | array[string] | slug normalizzati | Lista di trait incompatibili.【F:config/schemas/trait.schema.json†L64-L71】 |
+| `mutazione_indotta` | stringa | `i18n:` o stringa ripulita | Descrizione sintetica dell'adattamento.【F:config/schemas/trait.schema.json†L87-L90】 |
+| `uso_funzione` | stringa | `i18n:` o stringa ripulita | Funzione principale in gioco.【F:config/schemas/trait.schema.json†L91-L94】 |
+| `spinta_selettiva` | stringa | `i18n:` o stringa ripulita | Motivazione evolutiva/tattica.【F:config/schemas/trait.schema.json†L95-L98】 |
+
+## Moduli opzionali
+
+Lo schema consente blocchi aggiuntivi che arricchiscono le descrizioni e collegano i trait ad altri dataset. I più rilevanti sono:
+
+- **Profilo slot** (`slot_profile`), per descrivere specializzazioni core/complementari.【F:config/schemas/trait.schema.json†L53-L55】【F:config/schemas/trait.schema.json†L337-L348】
+- **Requisiti ambientali** (`requisiti_ambientali`), con condizioni di bioma, fonti e metadati di espansione.【F:config/schemas/trait.schema.json†L80-L85】【F:config/schemas/trait.schema.json†L350-L391】
+- **Tag tattici** (`usage_tags`) e **origine dati** (`data_origin`), fondamentali per filtri, audit e tracciamento delle fonti editoriali.【F:config/schemas/trait.schema.json†L113-L124】
+- **Flag di completezza** (`completion_flags`) per monitorare copertura biomi/specie e altre check editoriali.【F:config/schemas/trait.schema.json†L125-L143】
+- **Affinità specie** (`species_affinity`) e sinergie PI per integrazione con le matrici di specie e pianificazione pacchetti.【F:config/schemas/trait.schema.json†L99-L112】【F:config/schemas/trait.schema.json†L393-L400】
+- **Metriche quantitative**, costi energetici e campi di versioning che supportano strumenti analitici e tracciamento storico.【F:config/schemas/trait.schema.json†L161-L282】
+
+## Slot, tier, sinergie e conflitti
+
+Il catalogo attuale include 174 trait nel file `data/traits/index.json`. La distribuzione dei tier è concentrata sui gradini iniziali: 151 trait T1, 17 T2 e 6 T3, a indicare che il manuale deve coprire soprattutto scenari di onboarding e mid-game.【661b50†L14-L15】【ead201†L1-L13】
+
+Gli slot sono spesso multipli: molte voci occupano combinazioni `A`/`B`/`C`, mentre i tratti jolly mantengono lo slot vuoto (es. `ali_fulminee`).【533d62†L1-L12】【F:data/traits/index.json†L5-L34】 Tutti i trait elencano sinergie reciproche (solo 6 non le usano) e definiscono conflitti espliciti dove necessario; la quasi totalità possiede almeno una sinergia per supportare la costruzione di combo e pacchetti.【c14400†L1-L12】
+
+## Usage tags e spinta tattica
+
+I tag d'uso forniscono una tassonomia tattica condivisa con telemetria e UI. I più frequenti sono `support` (70 trait), `scout` e `tank` (47 ciascuno), seguiti da `sustain`, `breaker` e `controller`. Queste etichette sono richieste dalle checklist di processo e alimentano filtri automatici nelle dashboard.【4d514f†L1-L7】【F:docs/process/trait_data_reference.md†L17-L71】
+
+## Flag di completezza
+
+Tutte le voci hanno flag di completezza compilati; in particolare `has_species_link`, `has_usage_tags` e `has_data_origin` sono impostati a `true` per il 100% del catalogo, mentre `has_biome` evidenzia ancora 11 trait senza associazione ambientale specifica.【dd62fe†L19-L21】 Questo consente di isolare rapidamente le lacune durante gli audit o quando si pianificano nuove espansioni ambientali.
+
+## Esempio aggregato
+
+Il tratto `ali_fulminee` mostra una voce completa con origine dati, sinergie, requisiti ambientali e note di espansione, fungendo da riferimento per le compilazioni sensorali.【F:data/traits/index.json†L5-L35】 Utilizzare esempi reali dal catalogo aiuta a mantenere coerenza con i pattern approvati e facilita l'onboarding dei nuovi autori.

--- a/docs/traits-manuale/03-tassonomia-famiglie.md
+++ b/docs/traits-manuale/03-tassonomia-famiglie.md
@@ -1,0 +1,23 @@
+# Tassonomia e famiglie funzionali
+
+Il catalogo 2.0 censisce 57 famiglie funzionali (`famiglia_tipologia`), derivate dal campo `<Macro>/<Sotto>` definito nello schema. Le macro più rappresentate sono Tegumentario/Difensivo, Strategico/Tattico, Sensoriale/Analitico, Locomotorio/Mobilità e Digestivo/Metabolico: ciascuna supera la dozzina di trait e determina i principali cluster di bilanciamento.【4c8626†L24-L33】
+
+## Panoramica delle famiglie principali
+
+| Famiglia (Macro/Sub) | Conteggio trait | Trait di riferimento | Descrizione sintetica |
+| --- | --- | --- | --- |
+| Tegumentario/Difensivo | 17 | `armatura_pietra_planare` | Cristallizza il dermascheletro con runiche difensive, ottimizzato per scenari planari ad alta pressione.【4c8626†L24-L33】【F:data/traits/index.json†L858-L889】 |
+| Strategico/Tattico | 15 | `pathfinder` | Specializzazioni di coordinamento e controllo mappe multi-bioma (vedi tabella esempi nel template).【4c8626†L24-L33】【F:docs/traits_template.md†L159-L175】 |
+| Sensoriale/Analitico | 14 | `ali_fulminee` | Amplifica percezioni multispettrali per scouting in stratosfera tempestosa.【4c8626†L24-L33】【F:data/traits/index.json†L5-L35】 |
+| Locomotorio/Mobilità | 14 | `zampe_a_molla` | Abilita dash esplosivi per ingaggio o disimpegno rapido nelle missioni verticali.【4c8626†L24-L33】【F:docs/traits_template.md†L165-L177】 |
+| Supporto/Logistico | 13 | `antenne_eco_turbina` | Intreccia canali cooperativi per distribuire risorse e modulazioni ritmiche condivise.【4c8626†L24-L33】【F:data/traits/index.json†L246-L288】 |
+| Offensivo/Assalto | 13 | `antenne_flusso_mareale` | Aumenta burst e penetrazione durante finestre di vulnerabilità controllate.【4c8626†L24-L33】【F:docs/traits_template.md†L165-L178】 |
+| Simbiotico/Cooperativo | 13 | `antenne_reagenti` | Stabilizza reti simbiotiche ed enzimo-transfer condivisi per supporto di lungo periodo.【4c8626†L24-L33】【F:docs/traits_template.md†L165-L182】 |
+
+> **Suggerimento:** il report `reports/trait_fields_by_type.json` (rigenerabile con `python tools/py/collect_trait_fields.py`) espone per ogni famiglia l'elenco dei campi attivi, utile per verificare quando nuove proprietà vengono introdotte in un solo cluster.【F:docs/traits_template.md†L118-L157】
+
+## Famiglie rare e specializzate
+
+Alcune famiglie hanno un numero limitato di trait, spesso dedicati a pacchetti narrativi specifici (es. Sensoriale/Nervoso con 2 voci). Questi casi richiedono maggiore attenzione per mantenere sinergie e conflitti reciproci allineati quando si aggiungono nuove abilità.
+
+Utilizzare la tassonomia come guida permette di bilanciare le pipeline di design: nuove proposte dovrebbero mantenere proporzioni simili fra macro-tipologie o colmare lacune identificate nei report di coverage, documentati nella sezione finale del manuale.

--- a/docs/traits-manuale/04-collegamenti-cross-dataset.md
+++ b/docs/traits-manuale/04-collegamenti-cross-dataset.md
@@ -1,0 +1,33 @@
+# Collegamenti a specie, eventi e regole ambientali
+
+Le tabelle dei trait dialogano con matrici dedicate che mappano sinergie, requisiti e suggerimenti dinamici. Questa sezione riassume come leggere e mantenere i collegamenti principali.
+
+## Matrice specie & eventi
+
+Il file `docs/catalog/species_trait_matrix.json` collega 74 specie e 5 eventi ecologici ai trait canonici, per un totale di 219 trait unici referenziati fra blocchi core, opzionali e sinergie.【661b50†L4-L15】 Ogni voce espone biome di riferimento, morfotipo, capability richieste e lista di trait obbligatori/opzionali, come illustrato dall'evento "Banshee Risonante" qui sotto.【F:docs/catalog/species_trait_matrix.json†L1-L66】
+
+| Campo | Contenuto | Note operative |
+| --- | --- | --- |
+| `core_traits` | Trait indispensabili per specie/eventi (es. adattamento volo, metabolismo dedicato). | Devono restare sincronizzati con `data/traits/index.json` quando si rinomina o si rimuove un tratto.【F:docs/catalog/species_trait_matrix.json†L3-L33】 |
+| `optional_traits` | Trait consigliati o situazionali, spesso ripetuti per enfatizzare sinergie narrative. | Aggiornare i riferimenti incrociati nelle schede trait (`sinergie`, `species_affinity`).【F:docs/catalog/species_trait_matrix.json†L20-L33】【F:data/traits/index.json†L246-L288】 |
+| `environment_focus` | Bioma o condizione primaria dell'evento/specie. | Allineare con `requisiti_ambientali` e `biome_tags` per evitare discrepanze durante il coverage report.【F:docs/catalog/species_trait_matrix.json†L15-L17】【F:data/traits/index.json†L17-L34】 |
+| `required_capabilities` | Capability tecniche per spawn/missione. | Validare con `scripts/trait_audit.py --check` quando si introducono nuove capability o si modificano gli slot.【F:docs/catalog/species_trait_matrix.json†L28-L31】 |
+
+Le specie seguono la stessa struttura, aggiungendo ruoli ecosistemici (`role`) e riferimenti diretti ai file YAML dei pack, che fungono da fonte verità per generare baseline e coverage.【F:docs/catalog/species_trait_matrix.json†L234-L320】 Quando si aggiorna un trait, assicurarsi che eventuali riferimenti in questa matrice vengano sincronizzati (rinominando slug o ricalcolando i trait consigliati).
+
+## Regole ambientali
+
+Le regole ambientali definite in `packs/evo_tactics_pack/docs/catalog/env_traits.json` forniscono suggerimenti automatici di trait in base a biomi, hazard, morfotipi o condizioni climatiche. Il dataset contiene 33 regole e riutilizza il glossario dei trait per mantenere coerenza terminologica.【35aebf†L1-L14】【F:packs/evo_tactics_pack/docs/catalog/env_traits.json†L1-L118】
+
+| Trigger (`when`) | Suggerimenti (`suggest`) | Note |
+| --- | --- | --- |
+| `biome_class = foresta_temperata` | `peli_idrofobici`, bonus `res_cold +1`, bias `warden`/`skirmisher` | Garantire che i trait suggeriti abbiano `has_biome = true` e slot coerenti con le unità assegnate.【F:packs/evo_tactics_pack/docs/catalog/env_traits.json†L5-L20】 |
+| `koppen_in = {Cfb, Cfa}` | `pelli_fitte`, abilita `guard_stance` | Utilizzare per scenari climatici senza bioma specifico ma con codici Köppen.【F:packs/evo_tactics_pack/docs/catalog/env_traits.json†L22-L36】 |
+| `hazard_any = pendenze_instabili` | Richiede capability `jump_bonus`/`pathing_bonus` | Aggiungere i trait nel catalogo solo dopo aver verificato sinergia con le capability richieste.【F:packs/evo_tactics_pack/docs/catalog/env_traits.json†L38-L48】 |
+| `hazard_any = magnetic_patches` | Suggerisce `enzimi_chelanti`, abilita `trap_detect_ion` | Cross-check con `usage_tags` difensivi per evitare sovrapposizioni con i trait offensivi.【F:packs/evo_tactics_pack/docs/catalog/env_traits.json†L95-L118】 |
+
+Quando si estendono le regole ambientali, ricordarsi di:
+
+1. Aggiornare o aggiungere i trait nel catalogo principale (`data/traits/index.json`) mantenendo `data_origin` coerente.
+2. Rigenerare baseline e coverage (`python tools/py/build_trait_baseline.py`, `python tools/py/report_trait_coverage.py`) per verificare impatti su missioni e pacchetti.
+3. Documentare i nuovi trigger nella matrice specie/eventi se introducono sinergie dedicate.

--- a/docs/traits-manuale/05-workflow-strumenti.md
+++ b/docs/traits-manuale/05-workflow-strumenti.md
@@ -1,0 +1,33 @@
+# Workflow & strumenti
+
+Questa sezione raccoglie il flusso operativo consolidato e i comandi principali da eseguire durante la manutenzione del catalogo.
+
+## Percorso manuale consigliato
+
+1. **Allineare il glossario**: aggiornare `data/core/traits/glossary.json` con label/description approvate e validare il file con `python -m json.tool` prima di procedere.【F:README_HOWTO_AUTHOR_TRAIT.md†L15-L26】
+2. **Compilare/aggiornare il trait** seguendo lo schema e assicurandosi di popolare tutti i campi obbligatori (slot, tier, sinergie, conflitti).【F:README_HOWTO_AUTHOR_TRAIT.md†L28-L39】【F:docs/contributing/traits.md†L17-L30】
+3. **Sincronizzare i report** generando `reports/trait_fields_by_type.json` e `reports/trait_texts.json` tramite `python tools/py/collect_trait_fields.py`, quindi propagare le localizzazioni con `scripts/sync_trait_locales.py`.【F:README_HOWTO_AUTHOR_TRAIT.md†L41-L58】【F:docs/contributing/traits.md†L34-L69】
+4. **Rigenerare indice, baseline e coverage** per verificare coerenza con specie e regole ambientali (`build_trait_index.js`, `build_trait_baseline.py`, `report_trait_coverage.py`).【F:docs/contributing/traits.md†L36-L88】【F:docs/process/trait_data_reference.md†L91-L123】
+5. **Eseguire gli audit finali** (`validate_registry_naming.py`, `scripts/trait_audit.py --check`) e archiviare i log in `logs/`.【F:docs/contributing/traits.md†L89-L142】【F:docs/process/trait_data_reference.md†L124-L167】
+6. **Compilare la checklist PR** verificando flag di completezza, localizzazioni sincronizzate e impatti su coverage/baseline.【F:README_HOWTO_AUTHOR_TRAIT.md†L62-L75】
+
+## Strumenti e comandi principali
+
+| Obiettivo | Comando | Output | Fonte |
+| --- | --- | --- | --- |
+| Validazione schema trait | `python tools/py/trait_template_validator.py --summary` | Verifica campi obbligatori e restituisce riepilogo per tipologia. |【F:docs/README_TRAITS.md†L23-L32】【F:docs/traits_template.md†L26-L47】 |
+| Report campi & glossario | `python tools/py/collect_trait_fields.py --output reports/trait_fields_by_type.json --glossary-output reports/trait_texts.json` | Aggiorna report per famiglia e testi approvati. |【F:docs/contributing/traits.md†L34-L41】【F:docs/traits_template.md†L118-L157】 |
+| Sync localizzazioni | `python scripts/sync_trait_locales.py --language it --glossary data/core/traits/glossary.json` | Allinea i file `locales/<lingua>/traits.json`. |【F:docs/contributing/traits.md†L38-L69】 |
+| Ricostruzione indice | `node scripts/build_trait_index.js --output data/traits/index.csv` | Genera indice rapido con flag di completezza e metadati. |【F:docs/process/trait_data_reference.md†L10-L13】【F:docs/contributing/traits.md†L71-L88】 |
+| Baseline & coverage | `python tools/py/build_trait_baseline.py ...` + `python tools/py/report_trait_coverage.py ...` | Aggiorna `data/derived/analysis/` e fallisce in strict se mancano collegamenti. |【F:docs/contributing/traits.md†L75-L88】【F:docs/process/trait_data_reference.md†L107-L163】 |
+| Audit completo | `python3 scripts/trait_audit.py --check` | Produce/valida `logs/trait_audit.md` e pipeline di verifica finale. |【F:docs/contributing/traits.md†L40-L42】【F:docs/process/trait_data_reference.md†L13-L15】【F:docs/process/trait_data_reference.md†L145-L163】 |
+
+## Checklist rapida
+
+- [ ] Glossario, trait e report aggiornati (`reports/trait_fields_by_type.json`, `reports/trait_texts.json`).【F:README_HOWTO_AUTHOR_TRAIT.md†L62-L75】
+- [ ] `data/traits/index.json` allineato con specie/eventi/ambiente (sinergie reciproche e flag aggiornati).【F:docs/process/trait_data_reference.md†L91-L124】
+- [ ] Coverage e baseline rigenerate (`data/derived/analysis/trait_coverage_report.json`, `data/derived/analysis/trait_baseline.yaml`).【F:docs/process/trait_data_reference.md†L105-L123】【F:docs/process/trait_data_reference.md†L151-L163】
+- [ ] Log di audit salvati (`logs/trait_audit.md`) e comandi eseguiti riportati nella PR.【F:docs/contributing/traits.md†L89-L142】
+- [ ] Nuove regole ambientali o specie collegate documentate nella sezione [Collegamenti cross-dataset](04-collegamenti-cross-dataset.md).
+
+Per esplorare ulteriori analisi (gap, coverage storica, baseline PI) consultare la directory `data/derived/analysis/` e i report JSON/CSV generati dagli script ETL, mantenendo i link aggiornati nelle note PR quando vengono rigenerati.【F:docs/process/trait_data_reference.md†L10-L163】

--- a/docs/traits-manuale/README.md
+++ b/docs/traits-manuale/README.md
@@ -1,0 +1,20 @@
+# Manuale operativo dei trait
+
+Questa sezione raccoglie la guida consolidata per modellare, documentare e collegare i trait di Evo Tactics. Il manuale integra lo schema, i template e le checklist già presenti nel repository e fornisce viste dedicate su tassonomia, collegamenti cross-dataset e strumenti di lavoro.
+
+## Struttura del manuale
+
+1. [Introduzione e fonti dati](01-introduzione.md)
+2. [Modello dati](02-modello-dati.md)
+3. [Tassonomia e famiglie funzionali](03-tassonomia-famiglie.md)
+4. [Collegamenti a specie, eventi e regole ambientali](04-collegamenti-cross-dataset.md)
+5. [Workflow & strumenti](05-workflow-strumenti.md)
+
+Ogni capitolo include tabelle di riferimento, rimandi incrociati e collegamenti rapidi ai dataset o agli script che abilitano la manutenzione quotidiana.
+
+## Obiettivi
+
+- Fornire una sintesi unica delle regole editoriali e tecniche dei trait.
+- Raccogliere i dati chiave (slot, tier, sinergie, tassonomie) in tabelle consultabili.
+- Allineare i riferimenti a specie, eventi e regole ambientali per agevolare audit e playtest.
+- Consolidare le procedure operative e gli strumenti indispensabili lungo l'intero ciclo di vita del catalogo.


### PR DESCRIPTION
## Summary
- add a dedicated trait operations manual under docs/traits-manuale with sections on the data model, taxonomy, cross-dataset links, and workflows
- link the manual from the main documentation index and the trait schema readme for easier discovery

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e3b635cf4832abfb687ebe6f40f1d)