### PR TITLE
Add standalone AngularJS Trait Editor package

### DIFF
--- a/Trait Editor/README.md
+++ b/Trait Editor/README.md
@@ -1,0 +1,44 @@
+# Trait Editor
+
+Sandbox indipendente per la libreria dei tratti, pensata per revisioni rapide e pubblicazione statica.
+
+## Requisiti
+
+- Node.js 18+
+- npm 9+
+
+## Installazione
+
+```bash
+cd "Trait Editor"
+npm install
+```
+
+## Comandi disponibili
+
+- `npm run dev` avvia il dev server Vite su <http://localhost:5173> con hot module replacement.
+- `npm run build` genera la build statica nella cartella `dist/`.
+- `npm run preview` esegue una preview locale della build prodotta.
+
+## Origine dei dati
+
+Di default l'app utilizza i mock definiti in `src/data/traits.sample.ts`.
+Per collegarsi al dataset reale (`../data/traits/index.json` nel monorepo) esporta le seguenti variabili d'ambiente prima di avviare Vite:
+
+```bash
+export VITE_TRAIT_DATA_SOURCE=remote
+# opzionale: override dell'endpoint relativo
+export VITE_TRAIT_DATA_URL=../data/traits/index.json
+```
+
+Il servizio `TraitDataService` effettua automaticamente il fallback ai mock se il fetch remoto non è disponibile.
+
+## Pubblicazione
+
+1. Esegui `npm run build` per produrre la cartella `dist/`.
+2. Distribuisci il contenuto di `dist/` su un hosting statico (GitHub Pages, S3, Netlify, ecc.).
+3. Imposta `VITE_BASE_PATH` o `BASE_PATH` prima della build se il sito verrà servito da una sottocartella.
+
+## Nota sul caricamento di AngularJS
+
+L'app si affida alla CDN Google per caricare AngularJS 1.8.x (`angular`, `angular-route`, `angular-animate`, `angular-sanitize`). Verifica le policy di Content Security Policy del target di pubblicazione e aggiungi eventuali eccezioni se richiesto.

--- a/Trait Editor/package.json
+++ b/Trait Editor/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "trait-editor",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vite": "^5.4.8"
+  }
+}

--- a/Trait Editor/public/index.html
+++ b/Trait Editor/public/index.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="it">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Trait Editor</title>
+  </head>
+  <body>
+    <div id="app" ng-cloak></div>
+    <script>
+      (() => {
+        if (typeof window === 'undefined') {
+          return;
+        }
+        const win = window;
+        const { pathname, search, hash } = win.location;
+
+        const normaliseBasePath = (value) => {
+          if (!value || typeof value !== 'string') {
+            return '/';
+          }
+          const trimmed = value.trim();
+          if (!trimmed) {
+            return '/';
+          }
+          const withoutIndex = trimmed.endsWith('/index.html')
+            ? trimmed.slice(0, -'/index.html'.length)
+            : trimmed;
+          const editorIndex = withoutIndex.indexOf('/trait-editor/');
+          const baseCandidate =
+            editorIndex >= 0 ? withoutIndex.slice(0, editorIndex) : withoutIndex;
+          if (!baseCandidate) {
+            return '/';
+          }
+          return baseCandidate.endsWith('/') ? baseCandidate : `${baseCandidate}/`;
+        };
+
+        const basePath = normaliseBasePath(pathname);
+        win.__TRAIT_EDITOR_BASE__ = basePath;
+
+        if (pathname.endsWith('/index.html')) {
+          const newUrl = `${basePath}${search}${hash}`;
+          win.history.replaceState({}, '', newUrl);
+        }
+      })();
+    </script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.3/angular.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.3/angular-route.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.3/angular-animate.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.3/angular-sanitize.min.js"></script>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/Trait Editor/src/app.module.ts
+++ b/Trait Editor/src/app.module.ts
@@ -1,0 +1,44 @@
+declare const angular: any;
+
+import { registerTraitLibraryPage } from './pages/trait-library/trait-library.page';
+import { registerTraitDataService } from './services/trait-data.service';
+
+export function registerAppModule(): any {
+  const module = angular
+    .module('traitEditorApp', ['ngRoute', 'ngAnimate', 'ngSanitize'])
+    .config([
+      '$routeProvider',
+      '$locationProvider',
+      ($routeProvider: any, $locationProvider: any) => {
+        $locationProvider.hashPrefix('');
+
+        $routeProvider
+          .when('/', {
+            template: '<trait-library></trait-library>',
+            reloadOnUrl: false,
+          })
+          .otherwise({ redirectTo: '/' });
+      },
+    ]);
+
+  registerTraitDataService(module);
+  registerTraitLibraryPage(module);
+
+  module.component('appRoot', {
+    template: `
+      <div class="app-shell">
+        <header class="app-shell__header">
+          <h1 class="app-shell__title">Trait Editor</h1>
+          <p class="app-shell__subtitle">
+            Anteprima indipendente della libreria tratti con mock locali o dataset condivisi.
+          </p>
+        </header>
+        <main class="app-shell__content">
+          <div class="app-shell__viewport" ng-view></div>
+        </main>
+      </div>
+    `,
+  });
+
+  return module;
+}

--- a/Trait Editor/src/data/traits.sample.ts
+++ b/Trait Editor/src/data/traits.sample.ts
@@ -1,0 +1,77 @@
+import type { Trait } from '../types/trait';
+
+export const TRAIT_DATA_ENDPOINT = '../data/traits/index.json';
+
+const traitsSample: Trait[] = [
+  {
+    id: 'spectre-3',
+    name: 'Spectre-3',
+    description:
+      'Adaptive infiltrator specialising in precision sabotage and split-second decision cycles.',
+    archetype: 'Infiltrator Savant',
+    playstyle: 'High tempo, precision takedowns, opportunistic reroutes.',
+    signatureMoves: ['Phase-Locked Entry', 'Ghostline Relay', 'Vector Cancel'],
+  },
+  {
+    id: 'nova-lead',
+    name: 'Nova-Lead',
+    description:
+      'Command tactician orchestrating multi-squad pushes and dynamic risk balancing in contested zones.',
+    archetype: 'Command Vanguard',
+    playstyle: 'Coordinated aggression, distributed command, fallback elasticity.',
+    signatureMoves: ['Solaris Surge', 'Command Relay Burst', 'Zero Hour Anchor'],
+  },
+  {
+    id: 'helix-warden',
+    name: 'Helix Warden',
+    description:
+      'Containment specialist who anchors anomaly perimeters while orchestrating stabiliser arrays.',
+    archetype: 'Anomaly Custodian',
+    playstyle: 'Territory denial, layered defences, sustained countermeasures.',
+    signatureMoves: ['Tidewall Invocation', 'Gravitic Shear', 'Containment Pulse'],
+  },
+  {
+    id: 'echo-ridge',
+    name: 'Echo Ridge',
+    description:
+      'Recon collective that threads deep behind enemy lines to surface actionable telemetry.',
+    archetype: 'Recon Collective',
+    playstyle: 'Stealth scouting, asynchronous reporting, tactical adaptation.',
+    signatureMoves: ['Silent Parallax', 'Data Loom', 'Ridgeback Cascade'],
+  },
+];
+
+export const getSampleTraits = (): Trait[] =>
+  traitsSample.map((trait) => ({ ...trait, signatureMoves: [...trait.signatureMoves] }));
+
+export const fetchTraitsFromMonorepo = async (
+  endpoint: string = TRAIT_DATA_ENDPOINT,
+): Promise<Trait[]> => {
+  if (typeof fetch !== 'function') {
+    throw new Error('Fetch API non disponibile nell\'ambiente corrente.');
+  }
+
+  const response = await fetch(endpoint, { cache: 'no-cache' });
+  if (!response.ok) {
+    throw new Error(`Impossibile recuperare i tratti da ${endpoint}: ${response.status}`);
+  }
+
+  const data = (await response.json()) as Trait[];
+  return data.map((trait) => ({ ...trait, signatureMoves: [...trait.signatureMoves] }));
+};
+
+export const resolveTraitSource = async (
+  useRemoteSource: boolean,
+  endpoint?: string,
+): Promise<Trait[]> => {
+  if (!useRemoteSource) {
+    return getSampleTraits();
+  }
+
+  try {
+    return await fetchTraitsFromMonorepo(endpoint ?? TRAIT_DATA_ENDPOINT);
+  } catch (error) {
+    console.warn('Falling back to sample traits after remote fetch failure:', error);
+    return getSampleTraits();
+  }
+};

--- a/Trait Editor/src/main.ts
+++ b/Trait Editor/src/main.ts
@@ -1,0 +1,25 @@
+import { registerAppModule } from './app.module';
+import './styles/main.css';
+
+declare const document: Document;
+declare const angular: any;
+
+if (typeof angular === 'undefined') {
+  throw new Error('AngularJS non è stato caricato. Verifica gli script nel file index.html.');
+}
+
+const appModule = registerAppModule();
+
+angular.element(document).ready(() => {
+  const rootElement = document.getElementById('app');
+  if (!rootElement) {
+    throw new Error('Unable to find application mount element with id "app".');
+  }
+
+  if (!rootElement.hasChildNodes()) {
+    const appRoot = document.createElement('app-root');
+    rootElement.append(appRoot);
+  }
+
+  angular.bootstrap(rootElement, [appModule.name], { strictDi: true });
+});

--- a/Trait Editor/src/pages/trait-library/trait-library.page.ts
+++ b/Trait Editor/src/pages/trait-library/trait-library.page.ts
@@ -1,0 +1,111 @@
+import type { Trait } from '../../types/trait';
+import { TraitDataService } from '../../services/trait-data.service';
+
+class TraitLibraryController {
+  public traits: Trait[] = [];
+  public filter = '';
+  public selectedArchetype = 'all';
+  public isLoading = false;
+
+  static $inject = ['TraitDataService'];
+
+  constructor(private readonly dataService: TraitDataService) {}
+
+  $onInit(): void {
+    this.isLoading = true;
+    this.dataService
+      .getTraits()
+      .then((traits) => {
+        this.traits = traits;
+      })
+      .finally(() => {
+        this.isLoading = false;
+      });
+  }
+
+  archetypes(): string[] {
+    const set = new Set<string>(this.traits.map((trait) => trait.archetype));
+    return ['all', ...Array.from(set).sort((a, b) => a.localeCompare(b))];
+  }
+
+  filteredTraits(): Trait[] {
+    const term = this.filter.trim().toLowerCase();
+    return this.traits.filter((trait) => {
+      const matchesArchetype =
+        this.selectedArchetype === 'all' || trait.archetype === this.selectedArchetype;
+      const matchesTerm =
+        !term ||
+        trait.name.toLowerCase().includes(term) ||
+        trait.description.toLowerCase().includes(term) ||
+        trait.playstyle.toLowerCase().includes(term);
+      return matchesArchetype && matchesTerm;
+    });
+  }
+}
+
+export const registerTraitLibraryPage = (module: any): void => {
+  module.component('traitLibrary', {
+    controller: TraitLibraryController,
+    controllerAs: '$ctrl',
+    template: `
+      <section class="page">
+        <header class="page__header">
+          <div>
+            <h1 class="page__title">Libreria dei tratti</h1>
+            <p class="page__subtitle">
+              Conosci gli operatori, abbina i loro punti di forza e personalizza la composizione della squadra.
+            </p>
+          </div>
+          <div class="page__actions traits-controls">
+            <label class="search-field">
+              <span class="visually-hidden">Filtra tratti</span>
+              <input
+                type="search"
+                placeholder="Cerca per nome o stile di gioco"
+                ng-model="$ctrl.filter"
+                class="search-field__input"
+                ng-disabled="$ctrl.isLoading"
+              />
+            </label>
+            <label class="select-field">
+              <span class="visually-hidden">Filtra per archetipo</span>
+              <select ng-model="$ctrl.selectedArchetype" class="select-field__input" ng-disabled="$ctrl.isLoading">
+                <option ng-repeat="archetype in $ctrl.archetypes()" ng-value="archetype">
+                  {{ archetype === 'all' ? 'Tutti gli archetipi' : archetype }}
+                </option>
+              </select>
+            </label>
+          </div>
+        </header>
+
+        <section class="traits-grid" ng-if="!$ctrl.isLoading">
+          <article class="trait-card" ng-repeat="trait in $ctrl.filteredTraits()">
+            <header class="trait-card__header">
+              <h2 class="trait-card__name">{{ trait.name }}</h2>
+              <span class="trait-card__archetype">{{ trait.archetype }}</span>
+            </header>
+            <p class="trait-card__description">{{ trait.description }}</p>
+            <dl class="trait-card__details">
+              <div>
+                <dt>Stile di gioco</dt>
+                <dd>{{ trait.playstyle }}</dd>
+              </div>
+              <div>
+                <dt>Mosse distintive</dt>
+                <dd>
+                  <ul class="trait-card__moves">
+                    <li ng-repeat="move in trait.signatureMoves">{{ move }}</li>
+                  </ul>
+                </dd>
+              </div>
+            </dl>
+          </article>
+          <p class="traits-empty" ng-if="!$ctrl.filteredTraits().length">
+            Nessun tratto corrisponde ai filtri selezionati.
+          </p>
+        </section>
+        <p class="traits-empty" ng-if="$ctrl.isLoading">Caricamento dei tratti in corso...</p>
+      </section>
+    `,
+  });
+};

--- a/Trait Editor/src/services/trait-data.service.ts
+++ b/Trait Editor/src/services/trait-data.service.ts
@@ -1,0 +1,47 @@
+import { getSampleTraits, resolveTraitSource } from '../data/traits.sample';
+import type { Trait } from '../types/trait';
+
+export class TraitDataService {
+  private cache: Trait[] | null = null;
+  private readonly useRemoteSource: boolean;
+  private readonly endpointOverride?: string;
+
+  static $inject = ['$q'];
+
+  constructor(private readonly $q: any) {
+    const source = (import.meta.env.VITE_TRAIT_DATA_SOURCE ?? '').toLowerCase();
+    this.useRemoteSource = source === 'remote';
+
+    const endpoint = import.meta.env.VITE_TRAIT_DATA_URL;
+    if (typeof endpoint === 'string' && endpoint.trim().length > 0) {
+      this.endpointOverride = endpoint.trim();
+    }
+  }
+
+  getTraits(): Promise<Trait[]> {
+    if (this.cache) {
+      return this.$q.resolve(this.cloneTraits(this.cache));
+    }
+
+    return this.$q
+      .when(resolveTraitSource(this.useRemoteSource, this.endpointOverride))
+      .then((traits) => {
+        this.cache = traits;
+        return this.cloneTraits(traits);
+      })
+      .catch((error) => {
+        console.error('Impossibile caricare i tratti:', error);
+        const fallback = getSampleTraits();
+        this.cache = fallback;
+        return this.cloneTraits(fallback);
+      });
+  }
+
+  private cloneTraits(traits: Trait[]): Trait[] {
+    return traits.map((trait) => ({ ...trait, signatureMoves: [...trait.signatureMoves] }));
+  }
+}
+
+export const registerTraitDataService = (module: any): void => {
+  module.service('TraitDataService', TraitDataService);
+};

--- a/Trait Editor/src/styles/main.css
+++ b/Trait Editor/src/styles/main.css
@@ -1,0 +1,236 @@
+:root {
+  color-scheme: dark light;
+  --surface: rgba(15, 20, 35, 0.88);
+  --surface-alt: rgba(21, 28, 48, 0.92);
+  --border: rgba(255, 255, 255, 0.1);
+  --border-dashed: rgba(255, 255, 255, 0.2);
+  --accent: #7a5cff;
+  --accent-soft: rgba(122, 92, 255, 0.12);
+  --text: #f6f7ff;
+  --text-muted: rgba(235, 238, 255, 0.75);
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 18% 22%, rgba(122, 92, 255, 0.22), transparent 40%),
+    radial-gradient(circle at 82% 12%, rgba(79, 140, 255, 0.18), transparent 45%),
+    linear-gradient(160deg, #060811 0%, #070a18 40%, #0d1326 100%);
+  color: var(--text);
+}
+
+#app {
+  min-height: 100vh;
+}
+
+[ng-cloak] {
+  display: none !important;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-shell__header {
+  padding: 2.5rem 3rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+  background: rgba(10, 14, 28, 0.85);
+  backdrop-filter: blur(12px);
+}
+
+.app-shell__title {
+  margin: 0;
+  font-size: 2.25rem;
+  letter-spacing: -0.01em;
+}
+
+.app-shell__subtitle {
+  margin: 0.75rem 0 0;
+  color: var(--text-muted);
+  max-width: 65ch;
+  line-height: 1.5;
+}
+
+.app-shell__content {
+  flex: 1;
+  padding: 2.5rem 3rem 3rem;
+  display: flex;
+  justify-content: center;
+}
+
+.app-shell__viewport {
+  width: 100%;
+  max-width: 1280px;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.page__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  align-items: flex-start;
+}
+
+@media (max-width: 960px) {
+  .app-shell__header {
+    padding: 2rem 1.5rem 1.25rem;
+  }
+
+  .app-shell__content {
+    padding: 2rem 1.5rem 2.5rem;
+  }
+
+  .page__header {
+    flex-direction: column;
+  }
+}
+
+.page__title {
+  font-size: 2rem;
+  margin: 0 0 0.25rem;
+}
+
+.page__subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  max-width: 60ch;
+}
+
+.page__actions {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.traits-controls {
+  align-items: stretch;
+}
+
+.traits-controls .search-field,
+.traits-controls .select-field {
+  flex: 1;
+  min-width: 200px;
+}
+
+.search-field__input,
+.select-field__input {
+  width: 100%;
+  padding: 0.7rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: inherit;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-field__input:focus,
+.select-field__input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.traits-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.trait-card {
+  background: var(--surface-alt);
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 18px 36px rgba(5, 12, 32, 0.25);
+}
+
+.trait-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.trait-card__name {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.trait-card__archetype {
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--accent-soft);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.trait-card__description {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.trait-card__details {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.trait-card__details dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: 0.25rem;
+}
+
+.trait-card__details dd {
+  margin: 0;
+}
+
+.trait-card__moves {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--text-muted);
+}
+
+.traits-empty {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: 1.25rem;
+  border-radius: 12px;
+  border: 1px dashed var(--border-dashed);
+  text-align: center;
+  color: var(--text-muted);
+  background: rgba(0, 0, 0, 0.15);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/Trait Editor/src/types/trait.ts
+++ b/Trait Editor/src/types/trait.ts
@@ -1,0 +1,8 @@
+export interface Trait {
+  id: string;
+  name: string;
+  description: string;
+  archetype: string;
+  playstyle: string;
+  signatureMoves: string[];
+}

--- a/Trait Editor/tsconfig.json
+++ b/Trait Editor/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": true,
+    "checkJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/__tests__/**", "src/**/__mocks__/**"]
+}

--- a/Trait Editor/vite.config.ts
+++ b/Trait Editor/vite.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, loadEnv } from 'vite';
+
+export default defineConfig(({ command, mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const baseFromEnv = env.VITE_BASE_PATH ?? env.BASE_PATH;
+  const normalizedBase = baseFromEnv
+    ? baseFromEnv.endsWith('/')
+      ? baseFromEnv
+      : `${baseFromEnv}/`
+    : undefined;
+
+  return {
+    base: command === 'serve' ? '/' : normalizedBase ?? './',
+    server: {
+      fs: {
+        allow: ['..'],
+      },
+    },
+    build: {
+      outDir: 'dist',
+      emptyOutDir: true,
+      manifest: true,
+      rollupOptions: {
+        output: {
+          entryFileNames: 'assets/[name]-[hash].js',
+          chunkFileNames: 'assets/[name]-[hash].js',
+          assetFileNames: 'assets/[name]-[hash][extname]',
+        },
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- scaffold a standalone Vite package under `Trait Editor/` for working on the trait library in isolation
- port the trait library page, data service, types, sample data and styling from the main webapp with remote data helpers
- document installation, build, data source configuration and publication steps for the new package

## Testing
- npm install *(fails: 403 Forbidden when downloading esbuild from the npm registry)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e434269e4832a98c42451cf4efc96)