### PR TITLE
Add patch-package dependency to Trait Editor

### DIFF
--- a/Trait Editor/README.md
+++ b/Trait Editor/README.md
@@ -14,6 +14,9 @@ cd "Trait Editor"
 npm install
 ```
 
+> **Suggerimento:** se devi eseguire l'installazione in ambienti bloccati (es. CI) puoi utilizzare `npm install --ignore-scripts`.
+> Il progetto non applica patch automatiche post-install, quindi l'opzione non comporta effetti collaterali.
+
 ## Comandi disponibili
 
 - `npm run dev` avvia il dev server Vite su <http://localhost:5173> con hot module replacement.

--- a/Trait Editor/package.json
+++ b/Trait Editor/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
+    "patch-package": "^6.5.1",
     "typescript": "^5.9.3",
     "vite": "^5.4.8"
   }


### PR DESCRIPTION
## Summary
- add patch-package to the Trait Editor devDependencies
- document how to use npm install with --ignore-scripts when patches are not required

## Testing
- npm install *(fails: npm ERR! code E403 403 Forbidden - GET https://registry.npmjs.org/patch-package)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e80dcfb9c832ab3bad9be586e890e)