### PR TITLE
feat: enable remote trait data configuration

### DIFF
--- a/Trait Editor/.env.local
+++ b/Trait Editor/.env.local
@@ -1,0 +1,2 @@
+VITE_TRAIT_DATA_SOURCE=remote
+VITE_TRAIT_DATA_URL=../data/traits/index.json

--- a/Trait Editor/README.md
+++ b/Trait Editor/README.md
@@ -26,15 +26,26 @@ npm install
 ## Origine dei dati
 
 Di default l'app utilizza i mock definiti in `src/data/traits.sample.ts`.
-Per collegarsi al dataset reale (`../data/traits/index.json` nel monorepo) esporta le seguenti variabili d'ambiente prima di avviare Vite:
+Per collegarsi al dataset reale (`../data/traits/index.json` nel monorepo) puoi:
 
-```bash
-export VITE_TRAIT_DATA_SOURCE=remote
-# opzionale: override dell'endpoint relativo
-export VITE_TRAIT_DATA_URL=../data/traits/index.json
-```
+1. Esportare le variabili d'ambiente prima di avviare Vite:
 
-Il servizio `TraitDataService` effettua automaticamente il fallback ai mock se il fetch remoto non è disponibile.
+   ```bash
+   export VITE_TRAIT_DATA_SOURCE=remote
+   # opzionale: override dell'endpoint relativo
+   export VITE_TRAIT_DATA_URL=../data/traits/index.json
+   ```
+
+2. Oppure creare un file `.env.local` nella cartella `Trait Editor/` con il seguente contenuto (comodo per lo sviluppo locale):
+
+   ```bash
+   VITE_TRAIT_DATA_SOURCE=remote
+   VITE_TRAIT_DATA_URL=../data/traits/index.json
+   ```
+
+Durante lo sviluppo Vite carica automaticamente `.env.local`. In produzione puoi applicare le stesse variabili sul runtime di hosting.
+
+Il servizio `TraitDataService` effettua automaticamente il fallback ai mock se il fetch remoto non è disponibile, registrando l'errore in console.
 
 ## Pubblicazione
 


### PR DESCRIPTION
## Summary
- add a local environment file that forces the trait editor to use the monorepo dataset
- expand the trait editor README with instructions for switching between mock and real data sources

## Testing
- npm run dev -- --host 127.0.0.1 --port 4173 --clearScreen false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e826528f4832aa6918949d9f86b92)