### PR TITLE
Document standalone trait editor workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ node dist/roll_pack.js ENTP invoker --seed demo
      ```
   3. Controlla i log in `reports/incoming/` e `logs/traits_tracking.md`.
 - **Copertura trait/specie**: report aggiornati e quicklook disponibili in `docs/catalog/species_trait_matrix.json` e `docs/catalog/species_trait_quicklook.csv`.
+- **Trait Editor standalone** (`Trait Editor/`): esegui `npm run dev` (con `VITE_TRAIT_DATA_SOURCE=remote`, `VITE_TRAIT_DATA_URL=../data/traits/index.json`) per validare rapidamente i trait aggiornati senza avviare la webapp principale. Il README del pacchetto descrive fallback mock, preview (`npm run preview`) e opzioni di deploy statico.
 
 ## Storico aggiornamenti & archivio
 

--- a/docs/traits-manuale/05-workflow-strumenti.md
+++ b/docs/traits-manuale/05-workflow-strumenti.md
@@ -6,10 +6,11 @@ Questa sezione raccoglie il flusso operativo consolidato e i comandi principali 
 
 1. **Allineare il glossario**: aggiornare `data/core/traits/glossary.json` con label/description approvate e validare il file con `python -m json.tool` prima di procedere.【F:README_HOWTO_AUTHOR_TRAIT.md†L15-L26】
 2. **Compilare/aggiornare il trait** seguendo lo schema e assicurandosi di popolare tutti i campi obbligatori (slot, tier, sinergie, conflitti).【F:README_HOWTO_AUTHOR_TRAIT.md†L28-L39】【F:docs/contributing/traits.md†L17-L30】
-3. **Sincronizzare i report** generando `reports/trait_fields_by_type.json` e `reports/trait_texts.json` tramite `python tools/py/collect_trait_fields.py`, quindi propagare le localizzazioni con `scripts/sync_trait_locales.py`.【F:README_HOWTO_AUTHOR_TRAIT.md†L41-L58】【F:docs/contributing/traits.md†L34-L69】
-4. **Rigenerare indice, baseline e coverage** per verificare coerenza con specie e regole ambientali (`build_trait_index.js`, `build_trait_baseline.py`, `report_trait_coverage.py`).【F:docs/contributing/traits.md†L36-L88】【F:docs/process/trait_data_reference.md†L91-L123】
-5. **Eseguire gli audit finali** (`validate_registry_naming.py`, `scripts/trait_audit.py --check`) e archiviare i log in `logs/`.【F:docs/contributing/traits.md†L89-L142】【F:docs/process/trait_data_reference.md†L124-L167】
-6. **Compilare la checklist PR** verificando flag di completezza, localizzazioni sincronizzate e impatti su coverage/baseline.【F:README_HOWTO_AUTHOR_TRAIT.md†L62-L75】
+3. **Verificare l'anteprima nel Trait Editor standalone**: avviare `npm run dev` da `Trait Editor/`, collegare il datasource con `VITE_TRAIT_DATA_SOURCE=remote` e `VITE_TRAIT_DATA_URL=../data/traits/index.json`, quindi confermare che form e anteprime riflettano le modifiche appena introdotte.【F:Trait Editor/README.md†L12-L45】【F:docs/traits-manuale/06-standalone-trait-editor.md†L14-L41】
+4. **Sincronizzare i report** generando `reports/trait_fields_by_type.json` e `reports/trait_texts.json` tramite `python tools/py/collect_trait_fields.py`, quindi propagare le localizzazioni con `scripts/sync_trait_locales.py`.【F:README_HOWTO_AUTHOR_TRAIT.md†L41-L58】【F:docs/contributing/traits.md†L34-L69】
+5. **Rigenerare indice, baseline e coverage** per verificare coerenza con specie e regole ambientali (`build_trait_index.js`, `build_trait_baseline.py`, `report_trait_coverage.py`).【F:docs/contributing/traits.md†L36-L88】【F:docs/process/trait_data_reference.md†L91-L123】
+6. **Eseguire gli audit finali** (`validate_registry_naming.py`, `scripts/trait_audit.py --check`) e archiviare i log in `logs/`.【F:docs/contributing/traits.md†L89-L142】【F:docs/process/trait_data_reference.md†L124-L167】
+7. **Compilare la checklist PR** verificando flag di completezza, localizzazioni sincronizzate e impatti su coverage/baseline.【F:README_HOWTO_AUTHOR_TRAIT.md†L62-L75】
 
 ## Strumenti e comandi principali
 
@@ -21,6 +22,7 @@ Questa sezione raccoglie il flusso operativo consolidato e i comandi principali 
 | Ricostruzione indice | `node scripts/build_trait_index.js --output data/traits/index.csv` | Genera indice rapido con flag di completezza e metadati. |【F:docs/process/trait_data_reference.md†L10-L13】【F:docs/contributing/traits.md†L71-L88】 |
 | Baseline & coverage | `python tools/py/build_trait_baseline.py ...` + `python tools/py/report_trait_coverage.py ...` | Aggiorna `data/derived/analysis/` e fallisce in strict se mancano collegamenti. |【F:docs/contributing/traits.md†L75-L88】【F:docs/process/trait_data_reference.md†L107-L163】 |
 | Audit completo | `python3 scripts/trait_audit.py --check` | Produce/valida `logs/trait_audit.md` e pipeline di verifica finale. |【F:docs/contributing/traits.md†L40-L42】【F:docs/process/trait_data_reference.md†L13-L15】【F:docs/process/trait_data_reference.md†L145-L163】 |
+| Anteprima editor standalone | `npm run dev` (da `Trait Editor/`, con variabili `VITE_TRAIT_DATA_SOURCE`, `VITE_TRAIT_DATA_URL`) | Interfaccia AngularJS con sync remoto e fallback mock automatico. |【F:Trait Editor/README.md†L12-L45】【F:docs/traits-manuale/06-standalone-trait-editor.md†L14-L41】 |
 
 ## Checklist rapida
 
@@ -28,6 +30,7 @@ Questa sezione raccoglie il flusso operativo consolidato e i comandi principali 
 - [ ] `data/traits/index.json` allineato con specie/eventi/ambiente (sinergie reciproche e flag aggiornati).【F:docs/process/trait_data_reference.md†L91-L124】
 - [ ] Coverage e baseline rigenerate (`data/derived/analysis/trait_coverage_report.json`, `data/derived/analysis/trait_baseline.yaml`).【F:docs/process/trait_data_reference.md†L105-L123】【F:docs/process/trait_data_reference.md†L151-L163】
 - [ ] Log di audit salvati (`logs/trait_audit.md`) e comandi eseguiti riportati nella PR.【F:docs/contributing/traits.md†L89-L142】
+- [ ] Trait Editor standalone configurato sul dataset ufficiale (`VITE_TRAIT_DATA_SOURCE=remote`, `VITE_TRAIT_DATA_URL=../data/traits/index.json`) con anteprime verificate.【F:docs/traits-manuale/06-standalone-trait-editor.md†L26-L41】
 - [ ] Nuove regole ambientali o specie collegate documentate nella sezione [Collegamenti cross-dataset](04-collegamenti-cross-dataset.md).
 
 Per esplorare ulteriori analisi (gap, coverage storica, baseline PI) consultare la directory `data/derived/analysis/` e i report JSON/CSV generati dagli script ETL, mantenendo i link aggiornati nelle note PR quando vengono rigenerati.【F:docs/process/trait_data_reference.md†L10-L163】

--- a/docs/traits-manuale/06-standalone-trait-editor.md
+++ b/docs/traits-manuale/06-standalone-trait-editor.md
@@ -1,7 +1,7 @@
 # STANDALONE Trait Editor
 
 ## Panoramica
-Il pacchetto **Trait Editor/** mette a disposizione un editor standalone per la manutenzione del catalogo trait senza dover avviare l'intera webapp di gioco. L'obiettivo è velocizzare le iterazioni sul dataset, sfruttando un'interfaccia dedicata ma coerente con i modelli descritti nello [schema e dataset dei trait](../README_TRAITS.md). Il capitolo estende il workflow operativo presentato in [Workflow & strumenti](05-workflow-strumenti.md) con indicazioni specifiche per l'esecuzione locale del pacchetto.
+Il pacchetto **Trait Editor/** mette a disposizione un editor standalone per la manutenzione del catalogo trait senza dover avviare l'intera webapp di gioco. L'obiettivo è velocizzare le iterazioni sul dataset, sfruttando un'interfaccia dedicata ma coerente con i modelli descritti nello [schema e dataset dei trait](../README_TRAITS.md). Il capitolo estende il workflow operativo presentato in [Workflow & strumenti](05-workflow-strumenti.md) con indicazioni specifiche per l'esecuzione e la sincronizzazione del pacchetto.
 
 ## Prerequisiti
 - Node.js >= 18 (versione allineata con quella usata dal repository).
@@ -21,14 +21,24 @@ Il pacchetto **Trait Editor/** mette a disposizione un editor standalone per la 
    ```bash
    npm run dev
    ```
-4. Creare la build di produzione quando necessario:
+4. (Opzionale) Effettuare una preview della build prodotta:
+   ```bash
+   npm run preview
+   ```
+5. Creare la build di produzione quando necessario:
    ```bash
    npm run build
    ```
 
 ## Configurazione del datasource
-- L'editor legge i dati dei trait a partire dal file `Trait Editor/README.md`, che documenta struttura e opzioni del pacchetto. Verificare che la configurazione del percorso di lettura punti al dataset corretto prima di avviare l'applicazione.
-- Per sincronizzare il catalogo con i dati ufficiali, collegare la sorgente a `data/traits/index.json`. In alternativa è possibile utilizzare mock locali per test e prototipi rapidi (es. `Trait Editor/mock-data/*.json`).
+- L'editor legge i dati dei trait a partire dal servizio `TraitDataService` e dalle variabili `VITE_*` documentate in `Trait Editor/README.md`. Verificare il file prima di avviare l'applicazione.
+- Per sincronizzare il catalogo con i dati ufficiali, impostare le variabili d'ambiente prima di eseguire `npm run dev`/`npm run preview`:
+  ```bash
+  export VITE_TRAIT_DATA_SOURCE=remote
+  export VITE_TRAIT_DATA_URL=../data/traits/index.json
+  ```
+  In alternativa è possibile creare un file `.env.local` con gli stessi valori (caricato automaticamente da Vite) oppure puntare a una copia locale con `VITE_TRAIT_DATA_URL=/percorso/custom/index.json`.
+- In assenza di una sorgente remota valida l'applicazione esegue il fallback automatico ai mock definiti in `src/data/traits.sample.ts`, loggando l'evento in console.
 - Riprendere le checklist operative descritte in [Workflow & strumenti](05-workflow-strumenti.md) per assicurare la coerenza tra aggiornamenti manuali, script di validazione e pubblicazione.
 
 ## Risorse collegate


### PR DESCRIPTION
## Summary
- align the standalone Trait Editor manual with the npm scripts and Vite datasource configuration
- extend the workflow checklist with the preview step and tooling entry for the standalone editor
- reference the standalone Trait Editor from the top-level dataset documentation

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e83cfc60c832ab45c54ad18763aaa)