### PR TITLE
Add local documentation bundle for Trait Editor

### DIFF
--- a/Trait Editor/README.md
+++ b/Trait Editor/README.md
@@ -2,6 +2,11 @@
 
 Sandbox indipendente per la libreria dei tratti, pensata per revisioni rapide e pubblicazione statica.
 
+## Documentazione
+
+- Consulta la cartella [`docs/`](docs/README.md) per l'indice locale dei capitoli duplicati dal manuale (`docs/traits-manuale/**/*`) e dal vademecum `README_HOWTO_AUTHOR_TRAIT.md`.
+- Ogni file indica il percorso sorgente nel monorepo: quando aggiorni il materiale, ricordati di sincronizzare entrambe le copie (locale e originale) e di riportare la data dell'ultima revisione.
+
 ## Requisiti
 
 - Node.js 18+

--- a/Trait Editor/docs/README.md
+++ b/Trait Editor/docs/README.md
@@ -1,0 +1,35 @@
+# Trait Editor – Documentazione locale
+
+> Questa cartella raccoglie una copia curata della documentazione trait mantenuta nel monorepo principale. Ogni file indica l'origine esatta per facilitarne la sincronizzazione.
+
+## Riferimenti monorepo
+
+I capitoli di riferimento restano pubblicati nel repository principale. Questo elenco riepiloga i file essenziali da monitorare:
+
+- `docs/traits-manuale/README.md` – indice del manuale operativo dei trait e struttura dei capitoli.
+- `docs/traits-manuale/01-introduzione.md` – contesto narrativo/dati e fonti di verità.
+- `docs/traits-manuale/02-modello-dati.md` – specifica dei campi dello schema JSON.
+- `docs/traits-manuale/03-tassonomia-famiglie.md` – classificazione funzionale e macro-famiglie.
+- `docs/traits-manuale/04-collegamenti-cross-dataset.md` – mapping con specie, eventi, regole ambientali.
+- `docs/traits-manuale/05-workflow-strumenti.md` – workflow operativo con checklist e comandi.
+- `docs/traits-manuale/06-standalone-trait-editor.md` – guida dedicata al pacchetto standalone (fonte di questa cartella).
+- `README_HOWTO_AUTHOR_TRAIT.md` – vademecum rapido per la redazione/aggiornamento dei trait.
+- `docs/contributing/traits.md` – linee guida contributive estese (richiamate dalle checklist).
+- `ops/handbook/mongodb.md` – note operative che includono i controlli sui dataset `traits` durante le validazioni dati.
+
+Aggiorna questa sezione se emergono nuovi capitoli o workflow che impattano la manutenzione dei trait.
+
+## Indice dei capitoli locali
+
+1. [Manuale operativo (estratto)](manuale-operativo.md)
+2. [Workflow & strumenti](workflow-strumenti.md)
+3. [STANDALONE Trait Editor](standalone-trait-editor.md)
+4. [Guida rapida all'editor standalone](quickstart-standalone.md)
+5. [How-To authoring trait](howto-author-trait.md)
+
+## Sincronizzazione
+
+- Ogni file riporta all'inizio il percorso sorgente nel monorepo.
+- Per applicare aggiornamenti, confronta il file locale con l'originale (`git diff docs/... Trait\ Editor/docs/...`).
+- Dopo aver sincronizzato i contenuti, aggiorna la data di revisione nel front matter iniziale (se presente) o nel paragrafo introduttivo.
+- Ricordati di aggiornare anche il capitolo principale del manuale (`docs/traits-manuale/06-standalone-trait-editor.md`) e il `Trait Editor/README.md` con il numero di versione o la data dell'ultima sincronizzazione.

--- a/Trait Editor/docs/howto-author-trait.md
+++ b/Trait Editor/docs/howto-author-trait.md
@@ -1,0 +1,61 @@
+# Come scrivere o aggiornare un trait
+
+> Copia adattata di `README_HOWTO_AUTHOR_TRAIT.md`.
+> Percorsi aggiornati per l'utilizzo insieme al pacchetto standalone.
+
+Questa guida operativa raccoglie il vademecum aggiornato per ideare, modellare e consegnare un trait nel catalogo del gioco. È pensata come riferimento rapido per autori e reviewer e integra la documentazione tecnica presente in `docs/` del monorepo.
+
+## 1. Prima di iniziare
+1. Identifica il ruolo narrativo e tattico del trait (slot, tier, macro-tipologia).
+2. Recupera i riferimenti dal [template dati](../../docs/traits_template.md) e dai report correnti (`../reports/trait_fields_by_type.json`, `../reports/trait_texts.json`).
+3. Allinea label e descrizioni con il team di design/localization prima di procedere agli update dei file.
+
+## 2. Aggiornare il glossario
+1. Apri `../data/core/traits/glossary.json` e aggiungi (o aggiorna) la voce del trait con almeno:
+   - `label_it` / `label_en`
+   - `description_it` / `description_en`
+2. Mantieni il testo conciso (≤ 160 caratteri) e coerente con il tono del gioco.
+3. Esegui un lint veloce per validare la sintassi JSON:
+   ```bash
+   python -m json.tool data/core/traits/glossary.json > /tmp/trait_glossary.json
+   mv /tmp/trait_glossary.json data/core/traits/glossary.json
+   ```
+   > Esegui i comandi dalla radice del monorepo.
+
+## 3. Compilare il file trait
+1. Duplica lo scheletro minimo dal template e salva in `../data/traits/<tipologia>/<id>.json`.
+2. Popola i campi obbligatori (`id`, `label`, `famiglia_tipologia`, `tier`, `mutazione_indotta`, `uso_funzione`, `spinta_selettiva`, `sinergie`, `conflitti`).
+3. Inserisci i testi come stringhe reali **solo** se stai creando il trait da zero; al termine eseguirai lo script di sincronizzazione che li convertirà in riferimenti `i18n:traits.<id>.<campo>`.
+4. Valida il file con lo schema:
+   ```bash
+   python tools/py/trait_template_validator.py data/traits/<tipologia>/<id>.json
+   ```
+   > Il comando va eseguito dalla radice del monorepo.
+
+## 4. Sincronizzare localizzazioni e report
+1. Genera il riepilogo dei campi e delle stringhe approvate:
+   ```bash
+   python tools/py/collect_trait_fields.py \
+     --output reports/trait_fields_by_type.json \
+     --glossary data/core/traits/glossary.json \
+     --glossary-output reports/trait_texts.json
+   ```
+2. Propaga label e descrizioni approvate nelle localizzazioni (italiano di default, sostituisci `--language` se necessario):
+   ```bash
+   python scripts/sync_trait_locales.py \
+     --traits-dir data/traits \
+     --locales-dir locales \
+     --language it \
+     --glossary data/core/traits/glossary.json
+   ```
+3. Riesegui i generatori di indice/coverage se richiesto dalla checklist del team (`build_trait_index.js`, `report_trait_coverage.py`).
+
+## 5. Checklist PR
+- [ ] Glossario aggiornato con label/description nelle lingue supportate.
+- [ ] File trait valido secondo lo schema e con riferimenti `i18n:`.
+- [ ] `reports/trait_fields_by_type.json` e `reports/trait_texts.json` rigenerati (allega gli output o includi il comando nel log PR).
+- [ ] `scripts/sync_trait_locales.py` eseguito (eventualmente in `--dry-run`) e diff `locales/<lingua>/traits.json` revisionato.
+- [ ] Copertura e baseline aggiornate se il trait influisce su queste metriche.
+- [ ] Changelog/rollout plan aggiornati con note operative se il trait introduce processi o naming nuovi.
+
+Seguendo questi passaggi il team di revisione potrà validare rapidamente i contenuti, mantenendo allineati glossario, localizzazioni e checklist operative. Consulta [Workflow & strumenti](workflow-strumenti.md) per la checklist estesa.

--- a/Trait Editor/docs/manuale-operativo.md
+++ b/Trait Editor/docs/manuale-operativo.md
@@ -1,0 +1,23 @@
+# Manuale operativo dei trait (estratto)
+
+> Copia adattata di `docs/traits-manuale/README.md`.
+> Ultimo allineamento: consultare il commit corrente del monorepo.
+
+Il manuale originale struttura la documentazione trait in sei capitoli principali. Questa versione locale ne conserva la mappa e i rimandi chiave, così da contestualizzare rapidamente il materiale necessario quando si lavora sul pacchetto standalone.
+
+## Capitoli
+
+1. **Introduzione e fonti dati** (`docs/traits-manuale/01-introduzione.md`)
+   - Raccoglie lo scenario editoriale e tecnico del catalogo trait, includendo schema, template e contributi.
+2. **Modello dati** (`docs/traits-manuale/02-modello-dati.md`)
+   - Descrive i campi obbligatori/opzionali del JSON e le convalide applicate dagli script di repository.
+3. **Tassonomia e famiglie** (`docs/traits-manuale/03-tassonomia-famiglie.md`)
+   - Offre panoramiche su slot, tier e correlazioni funzionali utili durante la progettazione.
+4. **Collegamenti cross-dataset** (`docs/traits-manuale/04-collegamenti-cross-dataset.md`)
+   - Elenca i riferimenti incrociati con specie, eventi e regole ambientali, supportando gli audit.
+5. **Workflow & strumenti** (`Trait Editor/docs/workflow-strumenti.md`)
+   - Sezione duplicata localmente, contiene checklist, comandi e script da eseguire.
+6. **STANDALONE Trait Editor** (`Trait Editor/docs/standalone-trait-editor.md`)
+   - Capitolo duplicato e contestualizzato per descrivere l'uso del pacchetto indipendente.
+
+Per i capitoli non duplicati (1–4), fare riferimento ai file originali nel monorepo. Questo estratto funge da bussola per la navigazione rapida quando si opera fuori dal repository principale.

--- a/Trait Editor/docs/quickstart-standalone.md
+++ b/Trait Editor/docs/quickstart-standalone.md
@@ -1,0 +1,35 @@
+# Guida rapida all'editor standalone
+
+> Documento originale per il pacchetto standalone.
+
+Questa guida sintetizza i passaggi minimi per avviare l'editor e verificare una modifica ai trait quando si lavora fuori dal monorepo.
+
+## 1. Preparazione
+- Clona o scarica il pacchetto `Trait Editor/` insieme alla cartella `data/traits/` del monorepo.
+- Copia eventuali file di configurazione (`.env.local`) che puntano al dataset condiviso.
+- Verifica la presenza di Node.js 18+ con `node --version`.
+
+## 2. Configura l'accesso ai dati
+1. Se lavori con il dataset ufficiale, posiziona `data/traits/index.json` a un livello superiore rispetto al pacchetto.
+2. Crea un file `.env.local` nella radice di `Trait Editor/` con il seguente contenuto:
+   ```bash
+   VITE_TRAIT_DATA_SOURCE=remote
+   VITE_TRAIT_DATA_URL=../data/traits/index.json
+   ```
+3. Per testare dati sperimentali, duplica il file e modifica `VITE_TRAIT_DATA_URL` verso la copia desiderata.
+
+## 3. Avvio e verifica
+1. Installa le dipendenze con `npm install`.
+2. Avvia il server di sviluppo: `npm run dev`.
+3. Apri <http://localhost:5173> e seleziona il trait da verificare.
+4. Controlla che form, anteprima e localizzazioni riflettano gli ultimi aggiornamenti.
+5. Se necessario, esegui `npm run build` per generare la versione statica e validare la pipeline di deploy.
+
+## 4. Checklist rapida
+- [ ] Mock disattivati o aggiornati (`src/data/traits.sample.ts`) se usi dati reali.
+- [ ] Variabili `VITE_*` definite (`printenv | grep VITE_`).
+- [ ] Log del browser puliti: nessun errore di fetch o validazione.
+- [ ] Screenshots aggiornati allegati alla PR (se richiesti).
+- [ ] Documentazione locale sincronizzata (aggiorna i riferimenti in `Trait Editor/docs/`).
+
+Per dubbi o approfondimenti consulta [Workflow & strumenti](workflow-strumenti.md) e la guida completa [STANDALONE Trait Editor](standalone-trait-editor.md).

--- a/Trait Editor/docs/standalone-trait-editor.md
+++ b/Trait Editor/docs/standalone-trait-editor.md
@@ -1,0 +1,50 @@
+# STANDALONE Trait Editor
+
+> Copia adattata di `docs/traits-manuale/06-standalone-trait-editor.md`.
+> Aggiornata per la distribuzione insieme al pacchetto.
+
+## Panoramica
+Il pacchetto **Trait Editor/** mette a disposizione un editor standalone per la manutenzione del catalogo trait senza dover avviare l'intera webapp di gioco. L'obiettivo è velocizzare le iterazioni sul dataset, sfruttando un'interfaccia dedicata ma coerente con i modelli descritti nello [schema e dataset dei trait](../../docs/README_TRAITS.md). Questo capitolo estende il workflow operativo presentato in [Workflow & strumenti](workflow-strumenti.md) con indicazioni specifiche per l'esecuzione e la sincronizzazione del pacchetto.
+
+## Prerequisiti
+- Node.js >= 18 (allineato con il repository principale).
+- Gestore pacchetti `npm` (installato con Node.js).
+- Ambiente di sviluppo compatibile con [Vite](https://vitejs.dev/), utilizzato come bundler del pacchetto.
+
+## Setup rapido
+1. Posizionati nella directory del pacchetto:
+   ```bash
+   cd Trait\ Editor/
+   ```
+2. Installa le dipendenze:
+   ```bash
+   npm install
+   ```
+3. Avvia l'ambiente di sviluppo con hot reload:
+   ```bash
+   npm run dev
+   ```
+4. (Opzionale) Effettua una preview della build prodotta:
+   ```bash
+   npm run preview
+   ```
+5. Crea la build di produzione quando necessario:
+   ```bash
+   npm run build
+   ```
+
+## Configurazione del datasource
+- L'editor legge i dati dei trait a partire dal servizio `TraitDataService` e dalle variabili `VITE_*` documentate nel [README del pacchetto](../README.md).
+- Per sincronizzare il catalogo con i dati ufficiali del monorepo, imposta le variabili d'ambiente prima di eseguire `npm run dev`/`npm run preview`:
+  ```bash
+  export VITE_TRAIT_DATA_SOURCE=remote
+  export VITE_TRAIT_DATA_URL=../data/traits/index.json
+  ```
+  In alternativa puoi creare un file `.env.local` con gli stessi valori (caricato automaticamente da Vite) oppure puntare a una copia locale con `VITE_TRAIT_DATA_URL=/percorso/custom/index.json`.
+- In assenza di una sorgente remota valida l'applicazione esegue il fallback automatico ai mock definiti in `src/data/traits.sample.ts`, loggando l'evento in console.
+- Riprendi le checklist operative descritte in [Workflow & strumenti](workflow-strumenti.md) per assicurare la coerenza tra aggiornamenti manuali, script di validazione e pubblicazione.
+
+## Risorse collegate
+- [Schema e dataset dei trait](../../docs/README_TRAITS.md)
+- [Workflow & strumenti](workflow-strumenti.md)
+- [How-To authoring trait](howto-author-trait.md)

--- a/Trait Editor/docs/workflow-strumenti.md
+++ b/Trait Editor/docs/workflow-strumenti.md
@@ -1,0 +1,55 @@
+# Workflow & strumenti
+
+> Copia adattata di `docs/traits-manuale/05-workflow-strumenti.md`.
+> Revisionata per l'utilizzo dentro il pacchetto standalone.
+
+Questa sezione raccoglie il flusso operativo consolidato e i comandi principali da eseguire durante la manutenzione del catalogo. I riferimenti puntano ai file del monorepo quando richiesto e alla documentazione locale quando disponibile.
+
+## Percorso manuale consigliato
+
+1. **Allineare il glossario**
+   - Aggiorna `../data/core/traits/glossary.json` con label/description approvate.
+   - Valida il JSON con `python -m json.tool` prima di procedere.
+   - Riferimento: `README_HOWTO_AUTHOR_TRAIT.md` nel monorepo.
+2. **Compilare/aggiornare il trait**
+   - Segui lo schema e popola slot, tier, sinergie, conflitti.
+   - Consulta `docs/traits_template.md` e le linee guida in `docs/contributing/traits.md`.
+3. **Verificare l'anteprima nel Trait Editor standalone**
+   - Avvia `npm run dev` da `Trait Editor/`.
+   - Imposta `VITE_TRAIT_DATA_SOURCE=remote` e `VITE_TRAIT_DATA_URL=../data/traits/index.json`.
+   - Approfondimento: [STANDALONE Trait Editor](standalone-trait-editor.md).
+4. **Sincronizzare i report**
+   - Esegui `python tools/py/collect_trait_fields.py` per aggiornare `reports/trait_fields_by_type.json` e `reports/trait_texts.json`.
+   - Propaga le localizzazioni con `python scripts/sync_trait_locales.py`.
+5. **Rigenerare indice, baseline e coverage**
+   - `node scripts/build_trait_index.js --output data/traits/index.csv`.
+   - `python tools/py/build_trait_baseline.py` e `python tools/py/report_trait_coverage.py` per aggiornare `data/derived/analysis/`.
+6. **Eseguire gli audit finali**
+   - `python3 scripts/trait_audit.py --check`.
+   - Archivia i log in `logs/` come parte della PR.
+7. **Compilare la checklist PR**
+   - Rivedi flag di completezza, localizzazioni, impatti su coverage/baseline.
+   - Segui le checklist riportate in `README_HOWTO_AUTHOR_TRAIT.md` e `docs/contributing/traits.md`.
+
+## Strumenti e comandi principali
+
+| Obiettivo | Comando | Output |
+| --- | --- | --- |
+| Validazione schema trait | `python tools/py/trait_template_validator.py --summary` | Verifica campi obbligatori e restituisce riepiloghi per tipologia. |
+| Report campi & glossario | `python tools/py/collect_trait_fields.py --output reports/trait_fields_by_type.json --glossary-output reports/trait_texts.json` | Aggiorna report per famiglia e testi approvati. |
+| Sync localizzazioni | `python scripts/sync_trait_locales.py --language it --glossary data/core/traits/glossary.json` | Allinea `locales/<lingua>/traits.json`. |
+| Ricostruzione indice | `node scripts/build_trait_index.js --output data/traits/index.csv` | Genera indice con flag di completezza e metadati. |
+| Baseline & coverage | `python tools/py/build_trait_baseline.py ...` + `python tools/py/report_trait_coverage.py ...` | Aggiorna `data/derived/analysis/` e fallisce in strict se mancano collegamenti. |
+| Audit completo | `python3 scripts/trait_audit.py --check` | Produce/valida `logs/trait_audit.md` e pipeline di verifica finale. |
+| Anteprima editor standalone | `npm run dev` (da `Trait Editor/`, con `VITE_TRAIT_DATA_SOURCE`, `VITE_TRAIT_DATA_URL`) | Interfaccia AngularJS con sync remoto e fallback mock automatico. |
+
+## Checklist rapida
+
+- [ ] Glossario e report (`reports/trait_fields_by_type.json`, `reports/trait_texts.json`) aggiornati.
+- [ ] `data/traits/index.json` allineato con specie/eventi/ambiente.
+- [ ] Coverage e baseline rigenerate (`data/derived/analysis/trait_coverage_report.json`, `data/derived/analysis/trait_baseline.yaml`).
+- [ ] Log di audit salvati (`logs/trait_audit.md`).
+- [ ] Trait Editor standalone configurato sul dataset ufficiale (`VITE_TRAIT_DATA_SOURCE=remote`, `VITE_TRAIT_DATA_URL=../data/traits/index.json`).
+- [ ] Collegamenti cross-dataset aggiornati quando necessario (`docs/traits-manuale/04-collegamenti-cross-dataset.md`).
+
+Per esplorare ulteriori analisi (gap, coverage storica, baseline PI) consulta la directory `data/derived/analysis/` e i report JSON/CSV generati dagli script ETL. Mantieni i link aggiornati nelle note PR quando vengono rigenerati.

--- a/docs/traits-manuale/06-standalone-trait-editor.md
+++ b/docs/traits-manuale/06-standalone-trait-editor.md
@@ -3,6 +3,11 @@
 ## Panoramica
 Il pacchetto **Trait Editor/** mette a disposizione un editor standalone per la manutenzione del catalogo trait senza dover avviare l'intera webapp di gioco. L'obiettivo è velocizzare le iterazioni sul dataset, sfruttando un'interfaccia dedicata ma coerente con i modelli descritti nello [schema e dataset dei trait](../README_TRAITS.md). Il capitolo estende il workflow operativo presentato in [Workflow & strumenti](05-workflow-strumenti.md) con indicazioni specifiche per l'esecuzione e la sincronizzazione del pacchetto.
 
+## Documentazione locale
+- Una copia curata dei capitoli essenziali è distribuita insieme al pacchetto nella cartella [`Trait Editor/docs/`](../../Trait%20Editor/docs/README.md).
+- Ogni file locale riporta il percorso d'origine (es. `docs/traits-manuale/05-workflow-strumenti.md`, `README_HOWTO_AUTHOR_TRAIT.md`) per facilitare i confronti.
+- Per mantenere sincronizzati i contenuti, confronta periodicamente i file con le rispettive controparti nel monorepo e aggiorna note o date di revisione in entrambi i percorsi.
+
 ## Prerequisiti
 - Node.js >= 18 (versione allineata con quella usata dal repository).
 - Gestore pacchetti `npm` (installato insieme a Node.js).


### PR DESCRIPTION
## Summary
- add a local documentation tree under `Trait Editor/docs/` with an index back to the monorepo sources
- adapt the workflow/how-to chapters and provide a quickstart guide tailored to the standalone package
- update the main manual and package README to highlight the local docs and explain how to keep them in sync

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e862a1db4832aa14833952637dc38)