### PR TITLE
Document TraitDataService remote fallback workflow

### DIFF
--- a/Trait Editor/README.md
+++ b/Trait Editor/README.md
@@ -50,7 +50,8 @@ Per collegarsi al dataset reale (`../data/traits/index.json` nel monorepo) puoi:
 
 Durante lo sviluppo Vite carica automaticamente `.env.local`. In produzione puoi applicare le stesse variabili sul runtime di hosting.
 
-Il servizio `TraitDataService` effettua automaticamente il fallback ai mock se il fetch remoto non è disponibile, registrando l'errore in console.
+Il servizio `TraitDataService` effettua automaticamente il fallback ai mock se il fetch remoto non è disponibile, registrando l'errore in console con `console.error('Impossibile caricare i tratti:', error)` e delegando a `resolveTraitSource` la gestione dell'avviso `console.warn('Falling back to sample traits after remote fetch failure:', error)`.
+Per verificare localmente entrambe le condizioni puoi eseguire `node scripts/simulate-trait-source.mjs`, che mocka `fetch` prima con un payload remoto e poi con un `503`, mostrando la ricaduta sui mock (`fallback traits length: 4`).
 
 ## Pubblicazione
 

--- a/Trait Editor/docs/standalone-trait-editor.md
+++ b/Trait Editor/docs/standalone-trait-editor.md
@@ -41,7 +41,8 @@ Il pacchetto **Trait Editor/** mette a disposizione un editor standalone per la 
   export VITE_TRAIT_DATA_URL=../data/traits/index.json
   ```
   In alternativa puoi creare un file `.env.local` con gli stessi valori (caricato automaticamente da Vite) oppure puntare a una copia locale con `VITE_TRAIT_DATA_URL=/percorso/custom/index.json`.
-- In assenza di una sorgente remota valida l'applicazione esegue il fallback automatico ai mock definiti in `src/data/traits.sample.ts`, loggando l'evento in console.
+- In assenza di una sorgente remota valida l'applicazione esegue il fallback automatico ai mock definiti in `src/data/traits.sample.ts`, loggando l'evento in console (`console.error('Impossibile caricare i tratti:', error)` dal servizio AngularJS e `console.warn('Falling back to sample traits after remote fetch failure:', error)` dalla funzione di fetch).
+- Puoi riprodurre facilmente entrambi i casi senza avviare l'interfaccia grazie allo script `node scripts/simulate-trait-source.mjs`, che alterna una risposta mock remota ad un `503` simulato.
 - Riprendi le checklist operative descritte in [Workflow & strumenti](workflow-strumenti.md) per assicurare la coerenza tra aggiornamenti manuali, script di validazione e pubblicazione.
 
 ## Risorse collegate

--- a/Trait Editor/scripts/simulate-trait-source.mjs
+++ b/Trait Editor/scripts/simulate-trait-source.mjs
@@ -1,0 +1,86 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+import ts from 'typescript';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(here, '..');
+
+async function importFromTs(relativePath) {
+  const absolutePath = path.resolve(projectRoot, relativePath);
+  const source = await readFile(absolutePath, 'utf8');
+
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.ES2022,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      esModuleInterop: true,
+    },
+    fileName: relativePath,
+  });
+
+  const moduleUrl = pathToFileURL(absolutePath).toString();
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(transpiled.outputText, 'utf8').toString('base64')}`;
+
+  return import(dataUrl + `#${moduleUrl}`);
+}
+
+const { resolveTraitSource, getSampleTraits } = await importFromTs('src/data/traits.sample.ts');
+
+function mockFetchSuccess(payload) {
+  return async (endpoint) => {
+    console.log('[mock] Fetching from', endpoint);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => payload,
+    };
+  };
+}
+
+function mockFetchFailure(message, status = 503) {
+  return async (endpoint) => {
+    console.log('[mock] Fetching from', endpoint, '-> forcing failure');
+    return {
+      ok: false,
+      status,
+      json: async () => {
+        throw new Error(message);
+      },
+    };
+  };
+}
+
+async function runSimulation() {
+  const remoteEndpoint = 'https://example.test/api/traits';
+
+  const remotePayload = [
+    {
+      id: 'sim-alpha',
+      name: 'Sim Alpha',
+      description: 'Unità mock restituita dalla simulazione di successo.',
+      archetype: 'Diagnostic Runner',
+      playstyle: 'Analitico, prova-integrazione, osservazione.',
+      signatureMoves: ['Trace Route', 'Heartbeat Ping', 'Diff Analyzer'],
+    },
+  ];
+
+  globalThis.fetch = mockFetchSuccess(remotePayload);
+  const remoteResult = await resolveTraitSource(true, remoteEndpoint);
+  console.log('[success] Remote traits:', remoteResult);
+
+  const sampleCache = getSampleTraits();
+
+  globalThis.fetch = mockFetchFailure('Service unavailable');
+  const fallbackResult = await resolveTraitSource(true, remoteEndpoint);
+  console.log('[failure] Fallback traits length:', fallbackResult.length);
+  console.log('[failure] Sample matches fallback:',
+    fallbackResult.length === sampleCache.length &&
+      fallbackResult.every((trait, index) => trait.id === sampleCache[index].id));
+}
+
+runSimulation().catch((error) => {
+  console.error('[simulation error]', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a script that mocks remote success and failure to demonstrate TraitDataService fallback behaviour
- expand README and docs with guidance on endpoint configuration, console messaging, and the new simulation workflow

## Testing
- node "Trait Editor/scripts/simulate-trait-source.mjs"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e9f526b6c832aa72c31ee641f137f)