### PR TITLE
feat(trait-editor): add routed trait detail and editor workflow

### DIFF
--- a/Trait Editor/src/app.module.ts
+++ b/Trait Editor/src/app.module.ts
@@ -2,6 +2,10 @@ declare const angular: any;
 
 import { registerTraitLibraryPage } from './pages/trait-library/trait-library.page';
 import { registerTraitDataService } from './services/trait-data.service';
+import { registerTraitDetailPage } from './pages/trait-detail/trait-detail.page';
+import { registerTraitEditorPage } from './pages/trait-editor/trait-editor.page';
+import { registerTraitStateService } from './services/trait-state.service';
+import { registerTraitPreviewComponent } from './components/trait-preview/trait-preview.component';
 
 export function registerAppModule(): any {
   const module = angular
@@ -14,7 +18,18 @@ export function registerAppModule(): any {
 
         $routeProvider
           .when('/', {
+            redirectTo: '/traits',
+          })
+          .when('/traits', {
             template: '<trait-library></trait-library>',
+            reloadOnUrl: false,
+          })
+          .when('/traits/:id', {
+            template: '<trait-detail></trait-detail>',
+            reloadOnUrl: false,
+          })
+          .when('/traits/:id/edit', {
+            template: '<trait-editor></trait-editor>',
             reloadOnUrl: false,
           })
           .otherwise({ redirectTo: '/' });
@@ -22,7 +37,11 @@ export function registerAppModule(): any {
     ]);
 
   registerTraitDataService(module);
+  registerTraitStateService(module);
   registerTraitLibraryPage(module);
+  registerTraitDetailPage(module);
+  registerTraitEditorPage(module);
+  registerTraitPreviewComponent(module);
 
   module.component('appRoot', {
     template: `

--- a/Trait Editor/src/components/trait-preview/trait-preview.component.ts
+++ b/Trait Editor/src/components/trait-preview/trait-preview.component.ts
@@ -1,0 +1,50 @@
+import type { Trait } from '../../types/trait';
+
+class TraitPreviewController {
+  public trait?: Trait | null;
+  public compact = false;
+
+  get hasTrait(): boolean {
+    return Boolean(this.trait);
+  }
+}
+
+export const registerTraitPreviewComponent = (module: any): void => {
+  module.component('traitPreview', {
+    bindings: {
+      trait: '<',
+      compact: '<?',
+    },
+    controller: TraitPreviewController,
+    controllerAs: '$ctrl',
+    template: `
+      <div class="trait-preview" ng-class="{ 'trait-preview--compact': $ctrl.compact }" ng-if="$ctrl.hasTrait">
+        <header class="trait-preview__header">
+          <div>
+            <h2 class="trait-preview__name">{{ $ctrl.trait.name }}</h2>
+            <p class="trait-preview__archetype">{{ $ctrl.trait.archetype }}</p>
+          </div>
+          <span class="trait-preview__tag">Anteprima</span>
+        </header>
+        <p class="trait-preview__description">{{ $ctrl.trait.description }}</p>
+        <dl class="trait-preview__details">
+          <div>
+            <dt>Stile di gioco</dt>
+            <dd>{{ $ctrl.trait.playstyle }}</dd>
+          </div>
+          <div>
+            <dt>Mosse distintive</dt>
+            <dd>
+              <ul class="trait-preview__moves">
+                <li ng-repeat="move in $ctrl.trait.signatureMoves track by $index">{{ move }}</li>
+              </ul>
+            </dd>
+          </div>
+        </dl>
+      </div>
+      <p class="trait-preview__empty" ng-if="!$ctrl.hasTrait">
+        Nessun tratto selezionato.
+      </p>
+    `,
+  });
+};

--- a/Trait Editor/src/pages/trait-detail/trait-detail.page.ts
+++ b/Trait Editor/src/pages/trait-detail/trait-detail.page.ts
@@ -1,0 +1,125 @@
+import type { Trait } from '../../types/trait';
+import { TraitDataService } from '../../services/trait-data.service';
+import { TraitStateService, type TraitUiState } from '../../services/trait-state.service';
+
+class TraitDetailController {
+  public trait: Trait | null = null;
+  public ui: TraitUiState = { isLoading: false, status: null, previewTrait: null };
+
+  static $inject = ['$routeParams', '$scope', 'TraitDataService', 'TraitStateService', '$location'];
+
+  constructor(
+    private readonly $routeParams: any,
+    private readonly $scope: any,
+    private readonly dataService: TraitDataService,
+    private readonly stateService: TraitStateService,
+    private readonly $location: any,
+  ) {}
+
+  $onInit(): void {
+    this.stateService.subscribe(this.$scope, (state) => {
+      this.ui = state;
+    });
+
+    const { id } = this.$routeParams;
+    this.loadTrait(id);
+  }
+
+  $onDestroy(): void {
+    this.stateService.setPreviewTrait(null);
+    this.stateService.setLoading(false);
+    this.stateService.setStatus(null);
+  }
+
+  goToEditor(): void {
+    if (this.trait) {
+      this.$location.path(`/traits/${this.trait.id}/edit`);
+    }
+  }
+
+  private loadTrait(id: string): void {
+    this.stateService.setStatus(null);
+    this.stateService.setLoading(true);
+
+    this.dataService
+      .getTraitById(id)
+      .then((trait) => {
+        if (!trait) {
+          this.stateService.setStatus('Il tratto richiesto non è stato trovato.', 'error');
+          this.trait = null;
+          this.stateService.setPreviewTrait(null);
+          return;
+        }
+
+        this.trait = trait;
+        this.stateService.setPreviewTrait(trait);
+        const lastError = this.dataService.getLastError();
+        if (lastError) {
+          this.stateService.setStatus('Dati caricati da backup locale a causa di un problema di rete.', 'info');
+        }
+      })
+      .catch((error: Error) => {
+        console.error('Impossibile caricare il tratto richiesto:', error);
+        this.stateService.setStatus('Non è stato possibile recuperare i dettagli del tratto selezionato.', 'error');
+        this.trait = null;
+        this.stateService.setPreviewTrait(null);
+      })
+      .finally(() => {
+        this.stateService.setLoading(false);
+      });
+  }
+
+  statusIcon(): string {
+    const status = this.ui.status;
+    if (!status) {
+      return '';
+    }
+
+    if (status.variant === 'error') {
+      return '⚠️';
+    }
+
+    if (status.variant === 'success') {
+      return '✅';
+    }
+
+    return 'ℹ️';
+  }
+}
+
+export const registerTraitDetailPage = (module: any): void => {
+  module.component('traitDetail', {
+    controller: TraitDetailController,
+    controllerAs: '$ctrl',
+    template: `
+      <section class="page">
+        <header class="page__header">
+          <div>
+            <h1 class="page__title">Dettaglio tratto</h1>
+            <p class="page__subtitle">
+              Analizza le caratteristiche complete di un tratto e decidi se modificarlo o tornare all'elenco.
+            </p>
+          </div>
+          <div class="page__actions">
+            <a class="button button--ghost" ng-href="#!/traits">Torna all'elenco</a>
+            <button class="button" type="button" ng-click="$ctrl.goToEditor()" ng-disabled="!$ctrl.trait">
+              Modifica tratto
+            </button>
+          </div>
+        </header>
+
+        <div class="status-banner" ng-if="$ctrl.ui.status" ng-class="'status-banner--' + $ctrl.ui.status.variant">
+          <span class="status-banner__icon" aria-hidden="true">{{ $ctrl.statusIcon() }}</span>
+          <p class="status-banner__text">{{ $ctrl.ui.status.message }}</p>
+        </div>
+
+        <div class="loader" ng-if="$ctrl.ui.isLoading">
+          <span class="loader__spinner" aria-hidden="true"></span>
+          <p class="loader__label">Caricamento del tratto in corso...</p>
+        </div>
+
+        <trait-preview trait="$ctrl.trait" ng-if="!$ctrl.ui.isLoading"></trait-preview>
+      </section>
+    `,
+  });
+};

--- a/Trait Editor/src/pages/trait-editor/trait-editor.page.ts
+++ b/Trait Editor/src/pages/trait-editor/trait-editor.page.ts
@@ -1,0 +1,347 @@
+import type { Trait } from '../../types/trait';
+import { TraitDataService } from '../../services/trait-data.service';
+import { TraitStateService, type TraitUiState } from '../../services/trait-state.service';
+
+interface TraitFormModel extends Trait {}
+
+class TraitEditorController {
+  public trait: Trait | null = null;
+  public formModel: TraitFormModel | null = null;
+  public ui: TraitUiState = { isLoading: false, status: null, previewTrait: null };
+
+  static $inject = ['$routeParams', '$scope', '$location', '$timeout', 'TraitDataService', 'TraitStateService'];
+
+  constructor(
+    private readonly $routeParams: any,
+    private readonly $scope: any,
+    private readonly $location: any,
+    private readonly $timeout: any,
+    private readonly dataService: TraitDataService,
+    private readonly stateService: TraitStateService,
+  ) {}
+
+  $onInit(): void {
+    this.stateService.subscribe(this.$scope, (state) => {
+      this.ui = state;
+    });
+
+    const { id } = this.$routeParams;
+    this.loadTrait(id);
+  }
+
+  $onDestroy(): void {
+    this.stateService.setPreviewTrait(null);
+    this.stateService.setLoading(false);
+    this.stateService.setStatus(null);
+  }
+
+  addSignatureMove(): void {
+    if (this.formModel) {
+      this.formModel.signatureMoves.push('');
+      this.propagatePreview();
+    }
+  }
+
+  removeSignatureMove(index: number): void {
+    if (this.formModel) {
+      this.formModel.signatureMoves.splice(index, 1);
+      this.propagatePreview();
+    }
+  }
+
+  onFormChange(): void {
+    this.propagatePreview();
+  }
+
+  canConfirm(editorForm: any): boolean {
+    return Boolean(this.formModel && this.trait && editorForm.$valid && this.isDirty());
+  }
+
+  confirm(editorForm: any): void {
+    if (!this.formModel || !this.trait || !editorForm.$valid) {
+      return;
+    }
+
+    const payload = this.cloneTrait(this.formModel);
+    this.stateService.setStatus(null);
+    this.stateService.setLoading(true);
+
+    this.dataService
+      .saveTrait(payload)
+      .then((savedTrait) => {
+        this.trait = savedTrait;
+        this.formModel = this.cloneTrait(savedTrait);
+        this.stateService.setPreviewTrait(savedTrait);
+        this.stateService.setStatus('Modifiche salvate con successo.', 'success');
+        this.$timeout(() => this.stateService.setStatus(null), 3000);
+        this.$location.path(`/traits/${savedTrait.id}`);
+      })
+      .catch((error: Error) => {
+        console.error('Errore durante il salvataggio del tratto:', error);
+        const message =
+          error?.message ?? 'Si è verificato un errore imprevisto durante il salvataggio del tratto.';
+        this.stateService.setStatus(message, 'error');
+      })
+      .finally(() => {
+        this.stateService.setLoading(false);
+      });
+  }
+
+  cancel(): void {
+    if (!this.trait) {
+      this.$location.path('/traits');
+      return;
+    }
+
+    this.formModel = this.cloneTrait(this.trait);
+    this.stateService.setPreviewTrait(this.trait);
+    this.stateService.setStatus(null);
+    this.$location.path(`/traits/${this.trait.id}`);
+  }
+
+  isDirty(): boolean {
+    if (!this.trait || !this.formModel) {
+      return false;
+    }
+
+    return JSON.stringify(this.trait) !== JSON.stringify(this.formModel);
+  }
+
+  private loadTrait(id: string): void {
+    this.stateService.setStatus(null);
+    this.stateService.setLoading(true);
+
+    this.dataService
+      .getTraitById(id)
+      .then((trait) => {
+        if (!trait) {
+          this.stateService.setStatus('Il tratto richiesto non è stato trovato.', 'error');
+          this.trait = null;
+          this.formModel = null;
+          this.stateService.setPreviewTrait(null);
+          return;
+        }
+
+        this.trait = trait;
+        this.formModel = this.cloneTrait(trait);
+        this.stateService.setPreviewTrait(trait);
+        const lastError = this.dataService.getLastError();
+        if (lastError) {
+          this.stateService.setStatus('Modifica locale: la sorgente remota non è stata raggiunta.', 'info');
+        }
+      })
+      .catch((error: Error) => {
+        console.error('Impossibile caricare il tratto per la modifica:', error);
+        this.stateService.setStatus('Non è stato possibile preparare il tratto per la modifica.', 'error');
+        this.trait = null;
+        this.formModel = null;
+      })
+      .finally(() => {
+        this.stateService.setLoading(false);
+      });
+  }
+
+  statusIcon(): string {
+    const status = this.ui.status;
+    if (!status) {
+      return '';
+    }
+
+    if (status.variant === 'error') {
+      return '⚠️';
+    }
+
+    if (status.variant === 'success') {
+      return '✅';
+    }
+
+    return 'ℹ️';
+  }
+
+  private propagatePreview(): void {
+    if (this.formModel) {
+      this.stateService.setPreviewTrait(this.formModel);
+    }
+  }
+
+  private cloneTrait(trait: Trait): Trait {
+    return { ...trait, signatureMoves: [...trait.signatureMoves] };
+  }
+}
+
+export const registerTraitEditorPage = (module: any): void => {
+  module.component('traitEditor', {
+    controller: TraitEditorController,
+    controllerAs: '$ctrl',
+    template: `
+      <section class="page">
+        <header class="page__header">
+          <div>
+            <h1 class="page__title">Editor del tratto</h1>
+            <p class="page__subtitle">
+              Aggiorna le proprietà del tratto e visualizza un'anteprima dal vivo delle modifiche prima di confermarle.
+            </p>
+          </div>
+          <div class="page__actions">
+            <a class="button button--ghost" ng-href="#!/traits/{{ $ctrl.trait?.id ?? '' }}" ng-if="$ctrl.trait">
+              Torna al dettaglio
+            </a>
+            <a class="button button--ghost" ng-href="#!/traits" ng-if="!$ctrl.trait">
+              Torna all'elenco
+            </a>
+          </div>
+        </header>
+
+        <div class="status-banner" ng-if="$ctrl.ui.status" ng-class="'status-banner--' + $ctrl.ui.status.variant">
+          <span class="status-banner__icon" aria-hidden="true">{{ $ctrl.statusIcon() }}</span>
+          <p class="status-banner__text">{{ $ctrl.ui.status.message }}</p>
+        </div>
+
+        <div class="loader" ng-if="$ctrl.ui.isLoading">
+          <span class="loader__spinner" aria-hidden="true"></span>
+          <p class="loader__label">Preparazione dell'editor in corso...</p>
+        </div>
+
+        <div class="editor-layout" ng-if="!$ctrl.ui.isLoading && $ctrl.formModel">
+          <form name="editorForm" class="trait-form" novalidate ng-submit="$ctrl.confirm(editorForm)">
+            <fieldset class="trait-form__section">
+              <legend class="trait-form__legend">Informazioni generali</legend>
+              <div class="form-field" ng-class="{ 'form-field--invalid': editorForm.name.$invalid && editorForm.name.$touched }">
+                <label for="trait-name">Nome</label>
+                <input
+                  id="trait-name"
+                  name="name"
+                  type="text"
+                  ng-model="$ctrl.formModel.name"
+                  ng-change="$ctrl.onFormChange()"
+                  required
+                  minlength="3"
+                />
+                <p class="form-field__error" ng-if="editorForm.name.$error.required && editorForm.name.$touched">
+                  Il nome è obbligatorio.
+                </p>
+                <p class="form-field__error" ng-if="editorForm.name.$error.minlength && editorForm.name.$touched">
+                  Il nome deve contenere almeno 3 caratteri.
+                </p>
+              </div>
+
+              <div
+                class="form-field"
+                ng-class="{ 'form-field--invalid': editorForm.archetype.$invalid && editorForm.archetype.$touched }"
+              >
+                <label for="trait-archetype">Archetipo</label>
+                <input
+                  id="trait-archetype"
+                  name="archetype"
+                  type="text"
+                  ng-model="$ctrl.formModel.archetype"
+                  ng-change="$ctrl.onFormChange()"
+                  required
+                />
+                <p class="form-field__error" ng-if="editorForm.archetype.$error.required && editorForm.archetype.$touched">
+                  L'archetipo è obbligatorio.
+                </p>
+              </div>
+
+              <div
+                class="form-field"
+                ng-class="{ 'form-field--invalid': editorForm.playstyle.$invalid && editorForm.playstyle.$touched }"
+              >
+                <label for="trait-playstyle">Stile di gioco</label>
+                <textarea
+                  id="trait-playstyle"
+                  name="playstyle"
+                  rows="3"
+                  ng-model="$ctrl.formModel.playstyle"
+                  ng-change="$ctrl.onFormChange()"
+                  required
+                ></textarea>
+                <p class="form-field__error" ng-if="editorForm.playstyle.$error.required && editorForm.playstyle.$touched">
+                  Lo stile di gioco è obbligatorio.
+                </p>
+              </div>
+
+              <div
+                class="form-field"
+                ng-class="{ 'form-field--invalid': editorForm.description.$invalid && editorForm.description.$touched }"
+              >
+                <label for="trait-description">Descrizione</label>
+                <textarea
+                  id="trait-description"
+                  name="description"
+                  rows="4"
+                  ng-model="$ctrl.formModel.description"
+                  ng-change="$ctrl.onFormChange()"
+                  required
+                  minlength="10"
+                ></textarea>
+                <p class="form-field__error" ng-if="editorForm.description.$error.required && editorForm.description.$touched">
+                  La descrizione è obbligatoria.
+                </p>
+                <p class="form-field__error" ng-if="editorForm.description.$error.minlength && editorForm.description.$touched">
+                  La descrizione deve contenere almeno 10 caratteri.
+                </p>
+              </div>
+            </fieldset>
+
+            <fieldset class="trait-form__section">
+              <legend class="trait-form__legend">Mosse distintive</legend>
+
+              <div class="signature-moves">
+                <div
+                  class="signature-moves__item"
+                  ng-repeat="move in $ctrl.formModel.signatureMoves track by $index"
+                  ng-class="{
+                    'signature-moves__item--invalid':
+                      editorForm['move' + $index].$invalid && editorForm['move' + $index].$touched,
+                  }"
+                >
+                  <label class="signature-moves__label" for="move-{{$index}}">Mossa {{$index + 1}}</label>
+                  <div class="signature-moves__controls">
+                    <input
+                      id="move-{{$index}}"
+                      name="move{{$index}}"
+                      type="text"
+                      ng-model="$ctrl.formModel.signatureMoves[$index]"
+                      ng-change="$ctrl.onFormChange()"
+                      required
+                      minlength="3"
+                    />
+                    <button type="button" class="button button--icon" ng-click="$ctrl.removeSignatureMove($index)">
+                      <span aria-hidden="true">✕</span>
+                      <span class="visually-hidden">Rimuovi mossa {{$index + 1}}</span>
+                    </button>
+                  </div>
+                  <p class="form-field__error" ng-if="editorForm['move' + $index].$error.required && editorForm['move' + $index].$touched">
+                    La mossa è obbligatoria.
+                  </p>
+                  <p class="form-field__error" ng-if="editorForm['move' + $index].$error.minlength && editorForm['move' + $index].$touched">
+                    La mossa deve contenere almeno 3 caratteri.
+                  </p>
+                </div>
+              </div>
+
+              <button type="button" class="button button--ghost" ng-click="$ctrl.addSignatureMove()">
+                Aggiungi mossa
+              </button>
+            </fieldset>
+
+            <div class="trait-form__actions">
+              <button type="submit" class="button" ng-disabled="!$ctrl.canConfirm(editorForm)">
+                Conferma modifiche
+              </button>
+              <button type="button" class="button button--ghost" ng-click="$ctrl.cancel()">
+                Annulla
+              </button>
+            </div>
+          </form>
+
+          <aside class="editor-layout__preview">
+            <h2 class="editor-layout__title">Anteprima live</h2>
+            <trait-preview trait="$ctrl.formModel"></trait-preview>
+          </aside>
+        </div>
+      </section>
+    `,
+  });
+};

--- a/Trait Editor/src/services/trait-data.service.ts
+++ b/Trait Editor/src/services/trait-data.service.ts
@@ -1,10 +1,11 @@
-import { getSampleTraits, resolveTraitSource } from '../data/traits.sample';
+import { TRAIT_DATA_ENDPOINT, getSampleTraits, resolveTraitSource } from '../data/traits.sample';
 import type { Trait } from '../types/trait';
 
 export class TraitDataService {
   private cache: Trait[] | null = null;
   private readonly useRemoteSource: boolean;
   private readonly endpointOverride?: string;
+  private lastError: Error | null = null;
 
   static $inject = ['$q'];
 
@@ -27,18 +28,106 @@ export class TraitDataService {
       .when(resolveTraitSource(this.useRemoteSource, this.endpointOverride))
       .then((traits) => {
         this.cache = traits;
+        this.lastError = null;
         return this.cloneTraits(traits);
       })
       .catch((error) => {
         console.error('Impossibile caricare i tratti:', error);
+        this.lastError = error instanceof Error ? error : new Error(String(error));
         const fallback = getSampleTraits();
         this.cache = fallback;
         return this.cloneTraits(fallback);
       });
   }
 
+  getTraitById(id: string): Promise<Trait | null> {
+    return this.getTraits().then((traits) => {
+      const trait = traits.find((item) => item.id === id);
+      return trait ? this.cloneTrait(trait) : null;
+    });
+  }
+
+  saveTrait(updatedTrait: Trait): Promise<Trait> {
+    const traitCopy = this.cloneTrait(updatedTrait);
+
+    const persist = async (): Promise<void> => {
+      if (!this.useRemoteSource) {
+        return;
+      }
+
+      const endpoint = this.endpointOverride ?? TRAIT_DATA_ENDPOINT;
+      const target = this.buildRemoteMutationEndpoint(endpoint, traitCopy.id);
+
+      if (!target) {
+        throw new Error('Endpoint remoto non configurato per il salvataggio dei tratti.');
+      }
+
+      if (typeof fetch !== 'function') {
+        throw new Error('Fetch API non disponibile per completare il salvataggio remoto.');
+      }
+
+      const response = await fetch(target, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(traitCopy),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Il salvataggio remoto è fallito con stato ${response.status}.`);
+      }
+    };
+
+    return this.$q
+      .when(persist())
+      .then(() => {
+        this.lastError = null;
+        if (!this.cache) {
+          this.cache = [traitCopy];
+        } else {
+          const index = this.cache.findIndex((trait) => trait.id === traitCopy.id);
+          if (index >= 0) {
+            this.cache.splice(index, 1, traitCopy);
+          } else {
+            this.cache.push(traitCopy);
+          }
+        }
+        return this.cloneTrait(traitCopy);
+      })
+      .catch((error: Error) => {
+        const err = error instanceof Error ? error : new Error(String(error));
+        this.lastError = err;
+        return this.$q.reject(err);
+      });
+  }
+
+  getLastError(): Error | null {
+    return this.lastError;
+  }
+
   private cloneTraits(traits: Trait[]): Trait[] {
     return traits.map((trait) => ({ ...trait, signatureMoves: [...trait.signatureMoves] }));
+  }
+
+  private cloneTrait(trait: Trait): Trait {
+    return { ...trait, signatureMoves: [...trait.signatureMoves] };
+  }
+
+  private buildRemoteMutationEndpoint(baseEndpoint: string, id: string): string | null {
+    if (!baseEndpoint || typeof baseEndpoint !== 'string') {
+      return null;
+    }
+
+    if (baseEndpoint.endsWith('/')) {
+      return `${baseEndpoint}${id}`;
+    }
+
+    if (baseEndpoint.endsWith('.json')) {
+      return baseEndpoint.replace(/\/[^/]*$/, `/${id}.json`);
+    }
+
+    return `${baseEndpoint}/${id}`;
   }
 }
 

--- a/Trait Editor/src/services/trait-state.service.ts
+++ b/Trait Editor/src/services/trait-state.service.ts
@@ -1,0 +1,75 @@
+import type { Trait } from '../types/trait';
+
+export interface TraitStatus {
+  message: string;
+  variant: 'info' | 'error' | 'success';
+}
+
+export interface TraitUiState {
+  isLoading: boolean;
+  status: TraitStatus | null;
+  previewTrait: Trait | null;
+}
+
+const INITIAL_STATE: TraitUiState = {
+  isLoading: false,
+  status: null,
+  previewTrait: null,
+};
+
+export class TraitStateService {
+  private state: TraitUiState = { ...INITIAL_STATE };
+
+  static $inject = ['$rootScope'];
+
+  constructor(private readonly $rootScope: any) {}
+
+  subscribe(scope: any, callback: (state: TraitUiState) => void): void {
+    callback(this.snapshot());
+    const deregister = this.$rootScope.$on('traitStateChanged', () => {
+      callback(this.snapshot());
+    });
+
+    scope.$on('$destroy', deregister);
+  }
+
+  setLoading(isLoading: boolean): void {
+    this.state.isLoading = isLoading;
+    this.broadcast();
+  }
+
+  setStatus(message: string | null, variant: TraitStatus['variant'] = 'info'): void {
+    this.state.status = message ? { message, variant } : null;
+    this.broadcast();
+  }
+
+  setPreviewTrait(trait: Trait | null): void {
+    this.state.previewTrait = trait ? this.cloneTrait(trait) : null;
+    this.broadcast();
+  }
+
+  reset(): void {
+    this.state = { ...INITIAL_STATE };
+    this.broadcast();
+  }
+
+  private broadcast(): void {
+    this.$rootScope.$broadcast('traitStateChanged');
+  }
+
+  private snapshot(): TraitUiState {
+    return {
+      isLoading: this.state.isLoading,
+      status: this.state.status ? { ...this.state.status } : null,
+      previewTrait: this.state.previewTrait ? this.cloneTrait(this.state.previewTrait) : null,
+    };
+  }
+
+  private cloneTrait(trait: Trait): Trait {
+    return { ...trait, signatureMoves: [...trait.signatureMoves] };
+  }
+}
+
+export const registerTraitStateService = (module: any): void => {
+  module.service('TraitStateService', TraitStateService);
+};

--- a/Trait Editor/src/styles/main.css
+++ b/Trait Editor/src/styles/main.css
@@ -234,3 +234,351 @@ body {
   clip: rect(0, 0, 0, 0);
   border: 0;
 }
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.65rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, rgba(122, 92, 255, 0.85), rgba(79, 140, 255, 0.85));
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.button:hover,
+.button:focus-visible {
+  box-shadow: 0 12px 24px rgba(79, 140, 255, 0.35);
+  transform: translateY(-1px);
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.button--ghost {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.button--ghost:hover,
+.button--ghost:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.button--icon {
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  border-radius: 50%;
+  font-size: 1rem;
+}
+
+.trait-card__link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.trait-card__link:hover,
+.trait-card__link:focus {
+  text-decoration: underline;
+}
+
+.trait-card__footer {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: auto;
+}
+
+.status-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 188, 71, 0.35);
+  background: rgba(255, 188, 71, 0.12);
+  color: #ffd9a3;
+}
+
+.status-banner__icon {
+  font-size: 1.25rem;
+}
+
+.status-banner__text {
+  margin: 0;
+  line-height: 1.4;
+}
+
+.status-banner--error {
+  border-color: rgba(255, 137, 137, 0.45);
+  background: rgba(255, 137, 137, 0.12);
+  color: #ffb5b5;
+}
+
+.status-banner--success {
+  border-color: rgba(122, 255, 190, 0.4);
+  background: rgba(122, 255, 190, 0.12);
+  color: #b3ffe0;
+}
+
+.status-banner--info {
+  border-color: rgba(122, 178, 255, 0.4);
+  background: rgba(122, 178, 255, 0.12);
+  color: #c6e3ff;
+}
+
+.loader {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  border: 1px dashed var(--border-dashed);
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--text-muted);
+}
+
+.loader__spinner {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 255, 255, 0.2);
+  border-top-color: var(--accent);
+  animation: spin 1s linear infinite;
+}
+
+.loader__label {
+  margin: 0;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.trait-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  background: var(--surface-alt);
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  padding: 1.75rem;
+  box-shadow: 0 18px 36px rgba(5, 12, 32, 0.25);
+}
+
+.trait-preview--compact {
+  padding: 1.25rem;
+}
+
+.trait-preview__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.trait-preview__name {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.trait-preview__archetype {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+}
+
+.trait-preview__tag {
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid var(--accent-soft);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.trait-preview__description {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.trait-preview__details {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.trait-preview__details dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: 0.25rem;
+}
+
+.trait-preview__details dd {
+  margin: 0;
+}
+
+.trait-preview__moves {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--text-muted);
+}
+
+.trait-preview__empty {
+  margin: 0;
+  padding: 1.25rem;
+  border-radius: 12px;
+  border: 1px dashed var(--border-dashed);
+  text-align: center;
+  color: var(--text-muted);
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.editor-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 360px);
+  gap: 2rem;
+}
+
+@media (max-width: 1080px) {
+  .editor-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.editor-layout__preview {
+  position: sticky;
+  top: 2rem;
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.editor-layout__title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.trait-form {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 2rem;
+  box-shadow: 0 18px 36px rgba(5, 12, 32, 0.25);
+}
+
+.trait-form__section {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.trait-form__legend {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.form-field label {
+  font-weight: 600;
+}
+
+.form-field input,
+.form-field textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: inherit;
+  font: inherit;
+  resize: vertical;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-field input:focus,
+.form-field textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.form-field--invalid input,
+.form-field--invalid textarea,
+.signature-moves__item--invalid input {
+  border-color: rgba(255, 137, 137, 0.8);
+  box-shadow: 0 0 0 3px rgba(255, 137, 137, 0.25);
+}
+
+.form-field__error {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #ff9d9d;
+}
+
+.signature-moves {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.signature-moves__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.signature-moves__controls {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.signature-moves__controls input {
+  flex: 1;
+}
+
+.signature-moves__label {
+  font-weight: 600;
+}
+
+.trait-form__actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+}
+
+@media (max-width: 720px) {
+  .trait-form__actions {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce dedicated routes for trait list, detail, and editor pages and register shared preview component
- add trait state service plus data service helpers to surface loading, error, and save flows across views
- implement dynamic editor form with client-side validation, live preview, and styling updates for status feedback

## Testing
- npm run build *(fails: Could not resolve entry module "index.html" during vite build)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690f3fc7131c832a9caba2269c629e77)