### PR TITLE
feat(webapp): integrate real trait index with fallback service

### DIFF
--- a/webapp/public/data/traits/details/ali_fulminee.json
+++ b/webapp/public/data/traits/details/ali_fulminee.json
@@ -1,0 +1,61 @@
+{
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  },
+  "conflitti": [],
+  "data_origin": "coverage_q4_2025",
+  "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+  "famiglia_tipologia": "Sensoriale/Analitico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
+  "id": "ali_fulminee",
+  "label": "Ali Fulminee",
+  "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "stratosfera_tempestosa"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "coverage_q4_2025",
+        "notes": "Ali Fulminee ottimizza le operazioni sensoriale nelle condizioni di stratosfera tempestosa.",
+        "tier": "T1"
+      }
+    }
+  ],
+  "sinergie": [
+    "focus_frazionato",
+    "sinapsi_coraline_polifoniche"
+  ],
+  "sinergie_pi": {
+    "co_occorrenze": [],
+    "combo_totale": 2,
+    "forme": [],
+    "tabelle_random": []
+  },
+  "slot": [],
+  "slot_profile": {
+    "complementare": "analitico",
+    "core": "sensoriale"
+  },
+  "species_affinity": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+  "tier": "T1",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
+  "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+}

--- a/webapp/public/data/traits/details/ali_ioniche.json
+++ b/webapp/public/data/traits/details/ali_ioniche.json
@@ -1,0 +1,60 @@
+{
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  },
+  "conflitti": [],
+  "data_origin": "coverage_q4_2025",
+  "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+  "famiglia_tipologia": "Locomotorio/Mobilità",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
+  "id": "ali_ioniche",
+  "label": "Ali Ioniche",
+  "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "canopia_ionica"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "coverage_q4_2025",
+        "notes": "Ali Ioniche ottimizza le operazioni locomotorio nelle condizioni di canopia ionica.",
+        "tier": "T1"
+      }
+    }
+  ],
+  "sinergie": [
+    "coda_frusta_cinetica",
+    "zampe_a_molla"
+  ],
+  "sinergie_pi": {
+    "co_occorrenze": [],
+    "combo_totale": 2,
+    "forme": [],
+    "tabelle_random": []
+  },
+  "slot": [],
+  "slot_profile": {
+    "complementare": "mobilita",
+    "core": "locomotorio"
+  },
+  "species_affinity": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "canopia-ionica-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+  "tier": "T1",
+  "usage_tags": [
+    "scout"
+  ],
+  "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+}

--- a/webapp/public/data/traits/details/pathfinder.json
+++ b/webapp/public/data/traits/details/pathfinder.json
@@ -1,0 +1,57 @@
+{
+  "biome_tags": [
+    "foresta_acida",
+    "foresta_miceliale"
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  },
+  "conflitti": [],
+  "data_origin": "controllo_psionico",
+  "debolezza": "Valore ridotto in scenari a corridoio o con tilt già stabilizzato.",
+  "famiglia_tipologia": "Esplorazione/Tattico",
+  "fattore_mantenimento_energetico": "Basso (Sincronizzazione con HUD di esplorazione)",
+  "id": "pathfinder",
+  "label": "Pathfinder",
+  "mutazione_indotta": "Suite sensoriale orientata a scouting e lettura minacce.",
+  "requisiti_ambientali": [],
+  "sinergie": [],
+  "sinergie_pi": {
+    "co_occorrenze": [
+      "PE",
+      "cap_pt",
+      "starter_bioma"
+    ],
+    "combo_totale": 1,
+    "forme": [
+      "ENFP"
+    ],
+    "tabelle_random": []
+  },
+  "slot": [
+    "A"
+  ],
+  "slot_profile": {
+    "complementare": "ricognizione",
+    "core": "strategia"
+  },
+  "species_affinity": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "sentinella-radice",
+      "weight": 1
+    }
+  ],
+  "spinta_selettiva": "Missioni con indice explore alto e opzioni opzionali da capitalizzare.",
+  "tier": "T1",
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
+  "uso_funzione": "Ottimizza esplorazione e controllo mappe multi-bioma."
+}

--- a/webapp/public/data/traits/index.mock.json
+++ b/webapp/public/data/traits/index.mock.json
@@ -1,0 +1,184 @@
+{
+  "schema_version": "2.0",
+  "trait_glossary": "data/core/traits/glossary.json",
+  "traits": {
+    "ali_fulminee": {
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ali_fulminee",
+      "label": "Ali Fulminee",
+      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ali Fulminee ottimizza le operazioni sensoriale nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
+      "tier": "T1",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+    },
+    "ali_ioniche": {
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "coverage_q4_2025",
+      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ali_ioniche",
+      "label": "Ali Ioniche",
+      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ali Ioniche ottimizza le operazioni locomotorio nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "canopia-ionica-trait-keeper",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "tier": "T1",
+      "usage_tags": [
+        "scout"
+      ],
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+    },
+    "pathfinder": {
+      "biome_tags": [
+        "foresta_acida",
+        "foresta_miceliale"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      },
+      "conflitti": [],
+      "data_origin": "controllo_psionico",
+      "debolezza": "Valore ridotto in scenari a corridoio o con tilt già stabilizzato.",
+      "famiglia_tipologia": "Esplorazione/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Sincronizzazione con HUD di esplorazione)",
+      "id": "pathfinder",
+      "label": "Pathfinder",
+      "mutazione_indotta": "Suite sensoriale orientata a scouting e lettura minacce.",
+      "requisiti_ambientali": [],
+      "sinergie": [],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "PE",
+          "cap_pt",
+          "starter_bioma"
+        ],
+        "combo_totale": 1,
+        "forme": [
+          "ENFP"
+        ],
+        "tabelle_random": []
+      },
+      "slot": [
+        "A"
+      ],
+      "slot_profile": {
+        "complementare": "ricognizione",
+        "core": "strategia"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sentinella-radice",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "Missioni con indice explore alto e opzioni opzionali da capitalizzare.",
+      "tier": "T1",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "uso_funzione": "Ottimizza esplorazione e controllo mappe multi-bioma."
+    }
+  }
+}

--- a/webapp/src/app.module.ts
+++ b/webapp/src/app.module.ts
@@ -9,6 +9,7 @@ import { registerMissionControlPage } from './pages/mission-control/mission-cont
 import { registerMissionConsolePage } from './pages/mission-console/mission-console.page';
 import { registerEcosystemPackPage } from './pages/ecosystem-pack/ecosystem-pack.page';
 import { registerDataStoreService } from './services/data-store.service';
+import { registerTraitService } from './app/services/trait.service';
 
 class AppRootController {
   public isMenuVisible = false;
@@ -91,6 +92,7 @@ export function registerAppModule(): any {
   registerMissionControlPage(module);
   registerMissionConsolePage(module);
   registerEcosystemPackPage(module);
+  registerTraitService(module);
 
   module.component('appRoot', {
     controller: AppRootController,

--- a/webapp/src/app/models/traits.ts
+++ b/webapp/src/app/models/traits.ts
@@ -1,0 +1,134 @@
+import { z } from 'zod';
+
+export const traitCompletionFlagsSchema = z.object({
+  has_biome: z.boolean(),
+  has_data_origin: z.boolean(),
+  has_species_link: z.boolean(),
+  has_usage_tags: z.boolean(),
+});
+
+export const traitRequirementMetaSchema = z
+  .object({
+    expansion: z.string().optional(),
+    notes: z.string().optional(),
+    tier: z.string().optional(),
+  })
+  .catchall(z.unknown())
+  .optional();
+
+export const traitRequirementConditionsSchema = z
+  .object({
+    biome_class: z.string().optional(),
+  })
+  .catchall(z.unknown());
+
+export const traitRequirementSchema = z.object({
+  capacita_richieste: z.array(z.string()),
+  condizioni: traitRequirementConditionsSchema,
+  fonte: z.string(),
+  meta: traitRequirementMetaSchema,
+});
+
+export const traitSlotProfileSchema = z.object({
+  core: z.string(),
+  complementare: z.string(),
+});
+
+export const traitSynergyPiSchema = z.object({
+  co_occorrenze: z.array(z.string()),
+  combo_totale: z.number(),
+  forme: z.array(z.string()),
+  tabelle_random: z.array(z.string()),
+});
+
+export const traitSpeciesAffinitySchema = z.object({
+  roles: z.array(z.string()),
+  species_id: z.string(),
+  weight: z.number(),
+});
+
+export const traitIndexEntrySchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  tier: z.string(),
+  famiglia_tipologia: z.string(),
+  slot_profile: traitSlotProfileSchema,
+  slot: z.array(z.string()),
+  usage_tags: z.array(z.string()),
+  completion_flags: traitCompletionFlagsSchema,
+  data_origin: z.string(),
+  debolezza: z.string(),
+  mutazione_indotta: z.string(),
+  requisiti_ambientali: z.array(traitRequirementSchema),
+  sinergie: z.array(z.string()),
+  sinergie_pi: traitSynergyPiSchema,
+  species_affinity: z.array(traitSpeciesAffinitySchema),
+  spinta_selettiva: z.string(),
+  uso_funzione: z.string(),
+  fattore_mantenimento_energetico: z.string(),
+  conflitti: z.array(z.string()),
+  biome_tags: z.array(z.string()).optional(),
+});
+
+export const traitIndexSchema = z.object({
+  schema_version: z.string(),
+  trait_glossary: z.string(),
+  traits: z.record(traitIndexEntrySchema),
+});
+
+export type TraitIndexDocument = z.infer<typeof traitIndexSchema>;
+export type TraitIndexEntry = z.infer<typeof traitIndexEntrySchema>;
+export type TraitRequirement = z.infer<typeof traitRequirementSchema>;
+export type TraitRequirementMeta = z.infer<typeof traitRequirementMetaSchema>;
+export type TraitRequirementConditions = z.infer<typeof traitRequirementConditionsSchema>;
+export type TraitSlotProfile = z.infer<typeof traitSlotProfileSchema>;
+export type TraitSynergyPi = z.infer<typeof traitSynergyPiSchema>;
+export type TraitCompletionFlags = z.infer<typeof traitCompletionFlagsSchema>;
+export type TraitSpeciesAffinity = z.infer<typeof traitSpeciesAffinitySchema>;
+
+export type TraitEnvironment = 'dev' | 'mock' | 'prod';
+export type TraitDataSource = 'remote' | 'fallback' | 'mock';
+
+export interface TraitListItem {
+  id: string;
+  label: string;
+  tier: string;
+  family: string;
+  coreRole: string;
+  complementaryRole: string;
+  usageTags: string[];
+  summary: string;
+  searchText: string;
+}
+
+export interface TraitDetail extends TraitListItem {
+  weakness: string;
+  mutation: string;
+  selectivePressure: string;
+  function: string;
+  synergies: string[];
+  conflicts: string[];
+  energyMaintenance: string;
+  dataOrigin: string;
+  requirements: TraitRequirement[];
+  speciesAffinity: TraitSpeciesAffinity[];
+  completionFlags: TraitCompletionFlags;
+  synergyInsights: TraitSynergyPi;
+  biomeTags?: string[];
+}
+
+export interface TraitListResponse {
+  traits: TraitListItem[];
+  schemaVersion: string;
+  glossaryPath: string;
+  environment: TraitEnvironment;
+  source: TraitDataSource;
+  usedMock: boolean;
+}
+
+export interface TraitDetailResponse {
+  trait: TraitDetail;
+  environment: TraitEnvironment;
+  source: TraitDataSource;
+  usedMock: boolean;
+}

--- a/webapp/src/app/services/trait.service.ts
+++ b/webapp/src/app/services/trait.service.ts
@@ -1,0 +1,394 @@
+import {
+  TraitDetail,
+  TraitDetailResponse,
+  TraitEnvironment,
+  TraitIndexDocument,
+  TraitIndexEntry,
+  TraitListItem,
+  TraitListResponse,
+  TraitDataSource,
+  traitIndexEntrySchema,
+  traitIndexSchema,
+} from '../models/traits';
+
+interface TraitServiceConfig {
+  environment: TraitEnvironment;
+  remoteIndexUrl: string | null;
+  remoteDetailUrlTemplate: string | null;
+  mockIndexUrl: string;
+  mockDetailUrlTemplate: string;
+}
+
+const HTTP_URL_PATTERN = /^https?:\/\//i;
+
+function isAbsoluteUrl(value: string): boolean {
+  return HTTP_URL_PATTERN.test(value);
+}
+
+function ensureTrailingSlash(value: string): string {
+  if (!value || value === '/') {
+    return value || '/';
+  }
+  return value.endsWith('/') ? value : `${value}/`;
+}
+
+function stripLeadingSlash(value: string): string {
+  return value.startsWith('/') ? value.slice(1) : value;
+}
+
+function resolveTraitEnvironment(rawEnv?: string, mode?: string): TraitEnvironment {
+  const candidate = (rawEnv ?? mode ?? '').toLowerCase();
+  if (candidate.startsWith('prod')) {
+    return 'prod';
+  }
+  if (candidate === 'mock') {
+    return 'mock';
+  }
+  if (candidate === 'test') {
+    return 'mock';
+  }
+  return 'dev';
+}
+
+function resolveWithApiBase(candidate: string | undefined, apiBase: string | undefined): string | null {
+  if (!candidate || candidate.trim() === '') {
+    return null;
+  }
+  const value = candidate.trim();
+  if (isAbsoluteUrl(value)) {
+    return value;
+  }
+  if (value.startsWith('/')) {
+    if (apiBase && apiBase.trim() !== '') {
+      const base = apiBase.endsWith('/') ? apiBase.slice(0, -1) : apiBase;
+      return `${base}${value}`;
+    }
+    return value;
+  }
+  if (apiBase && apiBase.trim() !== '') {
+    const base = apiBase.endsWith('/') ? apiBase.slice(0, -1) : apiBase;
+    return `${base}/${value}`;
+  }
+  return value;
+}
+
+function resolveAssetPath(candidate: string, baseUrl: string | undefined): string {
+  if (isAbsoluteUrl(candidate)) {
+    return candidate;
+  }
+  const normalisedBase = ensureTrailingSlash(baseUrl ?? '/');
+  const normalisedCandidate = stripLeadingSlash(candidate);
+  return `${normalisedBase}${normalisedCandidate}`;
+}
+
+const traitServiceConfig: TraitServiceConfig = (() => {
+  const env = import.meta.env as Record<string, string | undefined>;
+  const environment = resolveTraitEnvironment(env.VITE_TRAITS_ENV, env.MODE);
+  const apiBase = env.VITE_API_BASE;
+  const baseUrl = env.BASE_URL;
+
+  const remoteIndexUrl = resolveWithApiBase(env.VITE_TRAITS_INDEX_URL, apiBase);
+  const remoteDetailUrlTemplate = resolveWithApiBase(env.VITE_TRAITS_DETAIL_URL, apiBase);
+
+  const mockIndexCandidate = env.VITE_TRAITS_MOCK_INDEX ?? 'data/traits/index.mock.json';
+  const mockDetailCandidate = env.VITE_TRAITS_MOCK_DETAIL ?? 'data/traits/details/:id.json';
+
+  return {
+    environment,
+    remoteIndexUrl,
+    remoteDetailUrlTemplate,
+    mockIndexUrl: resolveAssetPath(mockIndexCandidate, baseUrl),
+    mockDetailUrlTemplate: resolveAssetPath(mockDetailCandidate, baseUrl),
+  };
+})();
+
+export class TraitServiceError extends Error {
+  public readonly status?: number;
+  public readonly source?: TraitDataSource;
+
+  constructor(message: string, options: { status?: number; source?: TraitDataSource } = {}) {
+    super(message);
+    this.name = 'TraitServiceError';
+    this.status = options.status;
+    this.source = options.source;
+  }
+}
+
+interface FetchSuccess<T> {
+  ok: true;
+  data: T;
+  source: TraitDataSource;
+}
+
+interface FetchFailure {
+  ok: false;
+  error: TraitServiceError;
+}
+
+export class TraitService {
+  static $inject: string[] = [];
+
+  private readonly config: TraitServiceConfig;
+  private indexCache: TraitIndexDocument | null = null;
+
+  constructor() {
+    this.config = traitServiceConfig;
+  }
+
+  async listTraits(): Promise<TraitListResponse> {
+    const environment = this.config.environment;
+    const preferMock = environment === 'mock';
+    let lastError: TraitServiceError | null = null;
+
+    if (!preferMock && this.config.remoteIndexUrl) {
+      const remote = await this.loadIndex(this.config.remoteIndexUrl, 'remote');
+      if (remote.ok) {
+        return this.buildListResponse(remote.data, environment, 'remote', false);
+      }
+      lastError = remote.error;
+    }
+
+    const fallbackSource: TraitDataSource = preferMock ? 'mock' : 'fallback';
+    const fallback = await this.loadIndex(this.config.mockIndexUrl, fallbackSource);
+    if (fallback.ok) {
+      return this.buildListResponse(
+        fallback.data,
+        environment,
+        fallbackSource,
+        fallbackSource !== 'remote',
+      );
+    }
+
+    throw lastError ?? fallback.error;
+  }
+
+  async getTraitById(traitId: string): Promise<TraitDetailResponse> {
+    if (!traitId || traitId.trim() === '') {
+      throw new TraitServiceError('ID tratto non valido');
+    }
+
+    const environment = this.config.environment;
+    const preferMock = environment === 'mock';
+    let lastError: TraitServiceError | null = null;
+
+    if (!preferMock && this.config.remoteDetailUrlTemplate) {
+      const remote = await this.loadDetail(this.config.remoteDetailUrlTemplate, traitId, 'remote');
+      if (remote.ok) {
+        return this.buildDetailResponse(remote.data, environment, 'remote', false);
+      }
+      lastError = remote.error;
+    }
+
+    const cached = this.getCachedTrait(traitId);
+    if (cached) {
+      return this.buildDetailResponse(
+        cached,
+        environment,
+        preferMock ? 'mock' : 'fallback',
+        preferMock || !this.config.remoteDetailUrlTemplate,
+      );
+    }
+
+    const fallbackSource: TraitDataSource = preferMock ? 'mock' : 'fallback';
+    const fallback = await this.loadDetail(this.config.mockDetailUrlTemplate, traitId, fallbackSource);
+    if (fallback.ok) {
+      return this.buildDetailResponse(
+        fallback.data,
+        environment,
+        fallbackSource,
+        fallbackSource !== 'remote',
+      );
+    }
+
+    throw lastError ?? fallback.error;
+  }
+
+  private getCachedTrait(traitId: string): TraitIndexEntry | null {
+    if (!this.indexCache) {
+      return null;
+    }
+    return this.indexCache.traits[traitId] ?? null;
+  }
+
+  private async loadIndex(
+    url: string,
+    source: TraitDataSource,
+  ): Promise<FetchSuccess<TraitIndexDocument> | FetchFailure> {
+    try {
+      const payload = await this.fetchJson(url, source);
+      const parsed = traitIndexSchema.safeParse(payload.data);
+      if (!parsed.success) {
+        throw new TraitServiceError('Indice tratti non valido', { source });
+      }
+      this.indexCache = parsed.data;
+      return { ok: true, data: parsed.data, source };
+    } catch (error) {
+      if (error instanceof TraitServiceError) {
+        return { ok: false, error };
+      }
+      return {
+        ok: false,
+        error: new TraitServiceError('Errore sconosciuto durante il caricamento indice', { source }),
+      };
+    }
+  }
+
+  private async loadDetail(
+    template: string,
+    traitId: string,
+    source: TraitDataSource,
+  ): Promise<FetchSuccess<TraitIndexEntry> | FetchFailure> {
+    const url = this.buildDetailUrl(template, traitId);
+    try {
+      const payload = await this.fetchJson(url, source);
+      const parsed = traitIndexEntrySchema.safeParse(payload.data);
+      if (!parsed.success) {
+        throw new TraitServiceError('Dettaglio tratto non valido', { source });
+      }
+      return { ok: true, data: parsed.data, source };
+    } catch (error) {
+      if (error instanceof TraitServiceError) {
+        return { ok: false, error };
+      }
+      return {
+        ok: false,
+        error: new TraitServiceError('Errore sconosciuto durante il caricamento tratto', { source }),
+      };
+    }
+  }
+
+  private buildDetailUrl(template: string, traitId: string): string {
+    const token = encodeURIComponent(traitId);
+    return template.replace(':id', token);
+  }
+
+  private async fetchJson(
+    url: string,
+    source: TraitDataSource,
+  ): Promise<{ data: unknown; status: number }> {
+    try {
+      const response = await fetch(url, {
+        headers: {
+          Accept: 'application/json',
+        },
+      });
+      if (!response.ok) {
+        const message = `Richiesta ${source} fallita (${response.status})`;
+        throw new TraitServiceError(message, { status: response.status, source });
+      }
+      const data = await response.json();
+      return { data, status: response.status };
+    } catch (error) {
+      if (error instanceof TraitServiceError) {
+        throw error;
+      }
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Errore di rete durante il caricamento dei dati dei tratti';
+      throw new TraitServiceError(message, { source });
+    }
+  }
+
+  private buildListResponse(
+    document: TraitIndexDocument,
+    environment: TraitEnvironment,
+    source: TraitDataSource,
+    usedMock: boolean,
+  ): TraitListResponse {
+    const traits = Object.values(document.traits)
+      .map((entry) => this.toListItem(entry))
+      .sort((a, b) => a.label.localeCompare(b.label, 'it'));
+
+    return {
+      traits,
+      schemaVersion: document.schema_version,
+      glossaryPath: document.trait_glossary,
+      environment,
+      source,
+      usedMock,
+    };
+  }
+
+  private buildDetailResponse(
+    entry: TraitIndexEntry,
+    environment: TraitEnvironment,
+    source: TraitDataSource,
+    usedMock: boolean,
+  ): TraitDetailResponse {
+    const trait = this.toDetail(entry);
+    return {
+      trait,
+      environment,
+      source,
+      usedMock,
+    };
+  }
+
+  private toListItem(entry: TraitIndexEntry): TraitListItem {
+    const usageTags = Array.isArray(entry.usage_tags) ? [...entry.usage_tags] : [];
+    const searchable = [
+      entry.label,
+      entry.famiglia_tipologia,
+      entry.uso_funzione,
+      entry.spinta_selettiva,
+      entry.mutazione_indotta,
+      entry.debolezza,
+      ...usageTags,
+      ...(Array.isArray(entry.sinergie) ? entry.sinergie : []),
+      ...(Array.isArray(entry.conflitti) ? entry.conflitti : []),
+    ]
+      .join(' ')
+      .toLowerCase();
+
+    return {
+      id: entry.id,
+      label: entry.label,
+      tier: entry.tier,
+      family: entry.famiglia_tipologia,
+      coreRole: entry.slot_profile?.core ?? 'sconosciuto',
+      complementaryRole: entry.slot_profile?.complementare ?? 'sconosciuto',
+      usageTags,
+      summary: entry.uso_funzione,
+      searchText: searchable,
+    };
+  }
+
+  private toDetail(entry: TraitIndexEntry): TraitDetail {
+    const listItem = this.toListItem(entry);
+    return {
+      ...listItem,
+      weakness: entry.debolezza,
+      mutation: entry.mutazione_indotta,
+      selectivePressure: entry.spinta_selettiva,
+      function: entry.uso_funzione,
+      synergies: Array.isArray(entry.sinergie) ? [...entry.sinergie] : [],
+      conflicts: Array.isArray(entry.conflitti) ? [...entry.conflitti] : [],
+      energyMaintenance: entry.fattore_mantenimento_energetico,
+      dataOrigin: entry.data_origin,
+      requirements: entry.requisiti_ambientali.map((req) => ({
+        capacita_richieste: [...req.capacita_richieste],
+        condizioni: { ...req.condizioni },
+        fonte: req.fonte,
+        meta: req.meta ? { ...req.meta } : undefined,
+      })),
+      speciesAffinity: entry.species_affinity.map((aff) => ({
+        roles: [...aff.roles],
+        species_id: aff.species_id,
+        weight: aff.weight,
+      })),
+      completionFlags: { ...entry.completion_flags },
+      synergyInsights: {
+        co_occorrenze: [...entry.sinergie_pi.co_occorrenze],
+        combo_totale: entry.sinergie_pi.combo_totale,
+        forme: [...entry.sinergie_pi.forme],
+        tabelle_random: [...entry.sinergie_pi.tabelle_random],
+      },
+      biomeTags: entry.biome_tags ? [...entry.biome_tags] : undefined,
+    };
+  }
+}
+
+export const registerTraitService = (module: any): void => {
+  module.service('TraitService', TraitService);
+};

--- a/webapp/src/pages/traits/traits.page.ts
+++ b/webapp/src/pages/traits/traits.page.ts
@@ -1,36 +1,128 @@
-import type { Trait } from '../../types';
-import { DataStoreService } from '../../services/data-store.service';
+import type {
+  TraitDetail,
+  TraitEnvironment,
+  TraitListItem,
+  TraitDataSource,
+} from '../../app/models/traits';
+import { TraitService, TraitServiceError } from '../../app/services/trait.service';
 
 class TraitsController {
-  public traits: Trait[] = [];
+  public traits: TraitListItem[] = [];
   public filter = '';
-  public selectedArchetype = 'all';
+  public selectedCoreRole = 'all';
+  public isListLoading = false;
+  public listError: string | null = null;
+  public listEnvironment: TraitEnvironment = 'dev';
+  public listSource: TraitDataSource = 'mock';
+  public usingMockData = false;
+  public selectedTrait: TraitDetail | null = null;
+  public selectedTraitId: string | null = null;
+  public isDetailLoading = false;
+  public detailError: string | null = null;
+  public detailStatus?: number;
+  public detailSource: TraitDataSource | null = null;
+  public detailUsingMock = false;
 
-  static $inject = ['DataStoreService'];
+  static $inject = ['$scope', 'TraitService'];
 
-  constructor(private readonly dataStore: DataStoreService) {}
+  constructor(private readonly $scope: any, private readonly traitService: TraitService) {}
 
   $onInit(): void {
-    this.traits = this.dataStore.getTraits();
+    void this.loadTraits();
   }
 
-  archetypes(): string[] {
-    const set = new Set<string>(this.traits.map((trait) => trait.archetype));
-    return ['all', ...Array.from(set)];
+  roles(): string[] {
+    const set = new Set<string>(this.traits.map((trait) => trait.coreRole));
+    const roles = Array.from(set).sort((a, b) => a.localeCompare(b, 'it'));
+    return ['all', ...roles];
   }
 
-  filteredTraits(): Trait[] {
+  filteredTraits(): TraitListItem[] {
     const term = this.filter.trim().toLowerCase();
     return this.traits.filter((trait) => {
-      const matchesArchetype =
-        this.selectedArchetype === 'all' || trait.archetype === this.selectedArchetype;
-      const matchesTerm =
-        !term ||
-        trait.name.toLowerCase().includes(term) ||
-        trait.description.toLowerCase().includes(term) ||
-        trait.playstyle.toLowerCase().includes(term);
-      return matchesArchetype && matchesTerm;
+      const matchesRole =
+        this.selectedCoreRole === 'all' || trait.coreRole === this.selectedCoreRole;
+      const matchesTerm = !term || trait.searchText.includes(term);
+      return matchesRole && matchesTerm;
     });
+  }
+
+  reload(): void {
+    void this.loadTraits();
+  }
+
+  async openTrait(traitId: string): Promise<void> {
+    if (!traitId) {
+      return;
+    }
+
+    this.selectedTraitId = traitId;
+    this.isDetailLoading = true;
+    this.detailError = null;
+    this.detailStatus = undefined;
+    this.detailSource = null;
+    this.detailUsingMock = false;
+
+    try {
+      const response = await this.traitService.getTraitById(traitId);
+      this.selectedTrait = response.trait;
+      this.detailSource = response.source;
+      this.detailUsingMock = response.usedMock;
+    } catch (error) {
+      this.selectedTrait = null;
+      if (error instanceof TraitServiceError) {
+        this.detailStatus = error.status;
+        if (error.status === 404) {
+          this.detailError = 'Tratto non trovato (404).';
+        } else if (error.status === 500) {
+          this.detailError = 'Errore interno del server (500).';
+        } else {
+          this.detailError = error.message || 'Impossibile caricare il dettaglio del tratto.';
+        }
+      } else {
+        this.detailError = 'Errore imprevisto durante il caricamento del tratto.';
+      }
+    } finally {
+      this.isDetailLoading = false;
+      this.$scope.$applyAsync();
+    }
+  }
+
+  closeTrait(): void {
+    this.selectedTrait = null;
+    this.selectedTraitId = null;
+    this.detailError = null;
+    this.detailStatus = undefined;
+    this.detailSource = null;
+    this.detailUsingMock = false;
+  }
+
+  private async loadTraits(): Promise<void> {
+    this.isListLoading = true;
+    this.listError = null;
+    try {
+      const response = await this.traitService.listTraits();
+      this.traits = response.traits;
+      this.listEnvironment = response.environment;
+      this.listSource = response.source;
+      this.usingMockData = response.usedMock;
+    } catch (error) {
+      this.traits = [];
+      if (error instanceof TraitServiceError) {
+        if (error.status === 404) {
+          this.listError = 'Indice dei tratti non trovato (404).';
+        } else if (error.status === 500) {
+          this.listError = 'Errore interno del server durante il caricamento dei tratti (500).';
+        } else {
+          this.listError = error.message || 'Impossibile recuperare i tratti.';
+        }
+      } else {
+        this.listError = 'Errore imprevisto durante il caricamento dei tratti.';
+      }
+    } finally {
+      this.isListLoading = false;
+      this.$scope.$applyAsync();
+    }
   }
 }
 
@@ -58,37 +150,173 @@ export const registerTraitsPage = (module: any): void => {
               />
             </label>
             <label class="select-field">
-              <span class="visually-hidden">Filtra per archetipo</span>
-              <select ng-model="$ctrl.selectedArchetype" class="select-field__input">
-                <option ng-repeat="archetype in $ctrl.archetypes()" ng-value="archetype">
-                  {{ archetype === 'all' ? 'Tutti gli archetipi' : archetype }}
+              <span class="visually-hidden">Filtra per ruolo core</span>
+              <select ng-model="$ctrl.selectedCoreRole" class="select-field__input">
+                <option ng-repeat="role in $ctrl.roles()" ng-value="role">
+                  {{ role === 'all' ? 'Tutti i ruoli' : role }}
                 </option>
               </select>
             </label>
           </div>
         </header>
 
-        <section class="traits-grid">
-          <article class="trait-card" ng-repeat="trait in $ctrl.filteredTraits()">
-            <header class="trait-card__header">
-              <h2 class="trait-card__name">{{ trait.name }}</h2>
-              <span class="trait-card__archetype">{{ trait.archetype }}</span>
-            </header>
-            <p class="trait-card__description">{{ trait.description }}</p>
-            <dl class="trait-card__details">
+        <section class="traits-status" ng-if="$ctrl.listError">
+          <p class="traits-status__message traits-status__message--error">
+            {{ $ctrl.listError }}
+          </p>
+          <button type="button" class="button button--secondary" ng-click="$ctrl.reload()">
+            Riprova
+          </button>
+        </section>
+
+        <section class="traits-status" ng-if="$ctrl.isListLoading && !$ctrl.listError">
+          <p class="traits-status__message">Caricamento dei tratti in corso...</p>
+        </section>
+
+        <section
+          class="traits-status traits-status--warning"
+          ng-if="!$ctrl.listError && $ctrl.usingMockData"
+        >
+          <p class="traits-status__message">
+            Stai visualizzando dati mock per la libreria tratti (ambiente: {{ $ctrl.listEnvironment }}).
+          </p>
+        </section>
+
+        <section
+          class="traits-status traits-status--info"
+          ng-if="!$ctrl.listError && !$ctrl.usingMockData"
+        >
+          <p class="traits-status__message">
+            Fonte dati: {{ $ctrl.listSource }} · Ambiente: {{ $ctrl.listEnvironment }}
+          </p>
+        </section>
+
+        <section class="trait-detail" ng-if="$ctrl.selectedTrait || $ctrl.isDetailLoading || $ctrl.detailError">
+          <header class="trait-detail__header">
+            <h2 class="trait-detail__title">Dettagli tratto</h2>
+            <button type="button" class="button button--ghost" ng-click="$ctrl.closeTrait()">
+              Chiudi
+            </button>
+          </header>
+          <div class="trait-detail__body" ng-if="$ctrl.isDetailLoading">
+            <p>Caricamento del tratto in corso...</p>
+          </div>
+          <div class="trait-detail__body" ng-if="$ctrl.detailError && !$ctrl.isDetailLoading">
+            <p class="trait-detail__error">{{ $ctrl.detailError }}</p>
+          </div>
+          <div class="trait-detail__body" ng-if="$ctrl.selectedTrait && !$ctrl.isDetailLoading">
+            <h3 class="trait-detail__name">{{ $ctrl.selectedTrait.label }}</h3>
+            <p class="trait-detail__summary">{{ $ctrl.selectedTrait.function }}</p>
+            <dl class="trait-detail__meta">
               <div>
-                <dt>Stile di gioco</dt>
-                <dd>{{ trait.playstyle }}</dd>
+                <dt>Tier</dt>
+                <dd>{{ $ctrl.selectedTrait.tier }}</dd>
               </div>
               <div>
-                <dt>Mosse distintive</dt>
-                <dd>
-                  <ul class="trait-card__moves">
-                    <li ng-repeat="move in trait.signatureMoves">{{ move }}</li>
-                  </ul>
-                </dd>
+                <dt>Famiglia</dt>
+                <dd>{{ $ctrl.selectedTrait.family }}</dd>
+              </div>
+              <div>
+                <dt>Ruolo core</dt>
+                <dd>{{ $ctrl.selectedTrait.coreRole }}</dd>
+              </div>
+              <div>
+                <dt>Ruolo complementare</dt>
+                <dd>{{ $ctrl.selectedTrait.complementaryRole }}</dd>
+              </div>
+              <div>
+                <dt>Origine dati</dt>
+                <dd>{{ $ctrl.selectedTrait.dataOrigin }}</dd>
+              </div>
+              <div>
+                <dt>Energia</dt>
+                <dd>{{ $ctrl.selectedTrait.energyMaintenance }}</dd>
               </div>
             </dl>
+            <section class="trait-detail__section">
+              <h4>Uso tattico</h4>
+              <p>{{ $ctrl.selectedTrait.function }}</p>
+            </section>
+            <section class="trait-detail__section">
+              <h4>Spinta selettiva</h4>
+              <p>{{ $ctrl.selectedTrait.selectivePressure }}</p>
+            </section>
+            <section class="trait-detail__section">
+              <h4>Mutazione indotta</h4>
+              <p>{{ $ctrl.selectedTrait.mutation }}</p>
+            </section>
+            <section class="trait-detail__section">
+              <h4>Punti deboli</h4>
+              <p>{{ $ctrl.selectedTrait.weakness }}</p>
+            </section>
+            <section class="trait-detail__section" ng-if="$ctrl.selectedTrait.usageTags.length">
+              <h4>Tag operativi</h4>
+              <ul class="trait-detail__tags">
+                <li ng-repeat="tag in $ctrl.selectedTrait.usageTags track by tag">{{ tag }}</li>
+              </ul>
+            </section>
+            <section class="trait-detail__section" ng-if="$ctrl.selectedTrait.synergies.length">
+              <h4>Sinergie</h4>
+              <ul class="trait-detail__list">
+                <li ng-repeat="item in $ctrl.selectedTrait.synergies track by item">{{ item }}</li>
+              </ul>
+            </section>
+            <section class="trait-detail__section" ng-if="$ctrl.selectedTrait.conflicts.length">
+              <h4>Conflitti</h4>
+              <ul class="trait-detail__list">
+                <li ng-repeat="item in $ctrl.selectedTrait.conflicts track by item">{{ item }}</li>
+              </ul>
+            </section>
+            <section class="trait-detail__section" ng-if="$ctrl.selectedTrait.biomeTags && $ctrl.selectedTrait.biomeTags.length">
+              <h4>Biome</h4>
+              <ul class="trait-detail__tags">
+                <li ng-repeat="tag in $ctrl.selectedTrait.biomeTags track by tag">{{ tag }}</li>
+              </ul>
+            </section>
+            <section class="trait-detail__section" ng-if="$ctrl.selectedTrait.requirements.length">
+              <h4>Requisiti ambientali</h4>
+              <ul class="trait-detail__requirements">
+                <li ng-repeat="req in $ctrl.selectedTrait.requirements track by $index">
+                  <strong>{{ req.condizioni.biome_class || 'Condizione' }}:</strong>
+                  <span>{{ req.meta?.notes || 'Richiede condizioni specifiche.' }}</span>
+                </li>
+              </ul>
+            </section>
+            <footer class="trait-detail__footer" ng-if="$ctrl.detailSource">
+              <p>
+                Fonte dettaglio: {{ $ctrl.detailSource }}
+                <span ng-if="$ctrl.detailUsingMock">(mock)</span>
+              </p>
+            </footer>
+          </div>
+        </section>
+
+        <section class="traits-grid" ng-if="!$ctrl.listError && !$ctrl.isListLoading">
+          <article class="trait-card" ng-repeat="trait in $ctrl.filteredTraits() track by trait.id">
+            <header class="trait-card__header">
+              <div class="trait-card__titles">
+                <h2 class="trait-card__name">{{ trait.label }}</h2>
+                <p class="trait-card__meta">
+                  <span class="trait-card__tier">Tier {{ trait.tier }}</span>
+                  <span class="trait-card__family">{{ trait.family }}</span>
+                </p>
+              </div>
+              <div class="trait-card__roles">
+                <span class="trait-card__role trait-card__role--core">{{ trait.coreRole }}</span>
+                <span class="trait-card__role trait-card__role--complementary">
+                  {{ trait.complementaryRole }}
+                </span>
+              </div>
+            </header>
+            <p class="trait-card__description">{{ trait.summary }}</p>
+            <ul class="trait-card__tags" ng-if="trait.usageTags.length">
+              <li ng-repeat="tag in trait.usageTags track by tag">{{ tag }}</li>
+            </ul>
+            <footer class="trait-card__footer">
+              <button type="button" class="button button--secondary" ng-click="$ctrl.openTrait(trait.id)">
+                Dettagli
+              </button>
+            </footer>
           </article>
           <p class="traits-empty" ng-if="!$ctrl.filteredTraits().length">
             Nessun tratto corrisponde ai filtri selezionati.

--- a/webapp/src/styles/main.css
+++ b/webapp/src/styles/main.css
@@ -716,16 +716,56 @@ body {
 .trait-card__header {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: flex-start;
   gap: 1rem;
 }
 
-.trait-card__archetype {
+.trait-card__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.trait-card__meta {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.trait-card__tier {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.trait-card__family {
+  font-style: italic;
+}
+
+.trait-card__roles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  align-items: flex-end;
+}
+
+.trait-card__role {
   padding: 0.25rem 0.75rem;
   border-radius: 999px;
-  border: 1px solid rgba(79, 140, 255, 0.4);
   font-size: 0.75rem;
   letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid rgba(79, 140, 255, 0.35);
+}
+
+.trait-card__role--core {
+  background: rgba(79, 140, 255, 0.12);
+}
+
+.trait-card__role--complementary {
+  background: rgba(79, 140, 255, 0.06);
 }
 
 .trait-card__description {
@@ -733,28 +773,29 @@ body {
   color: var(--color-text-secondary);
 }
 
-.trait-card__details {
+.trait-card__tags {
   margin: 0;
-  display: grid;
-  gap: 0.75rem;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
-.trait-card__details dt {
+.trait-card__tags li {
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   font-size: 0.75rem;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--color-text-secondary);
-  margin-bottom: 0.25rem;
 }
 
-.trait-card__details dd {
-  margin: 0;
-}
-
-.trait-card__moves {
-  margin: 0;
-  padding-left: 1.25rem;
-  color: var(--color-text-secondary);
+.trait-card__footer {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .traits-empty {
@@ -764,6 +805,156 @@ body {
   border-radius: 12px;
   border: 1px dashed var(--color-border);
   text-align: center;
+  color: var(--color-text-secondary);
+}
+
+.traits-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  margin-bottom: 1rem;
+}
+
+.traits-status--warning {
+  border-color: rgba(255, 200, 0, 0.4);
+  background: rgba(255, 200, 0, 0.08);
+}
+
+.traits-status--info {
+  border-color: rgba(79, 140, 255, 0.4);
+  background: rgba(79, 140, 255, 0.08);
+}
+
+.traits-status__message {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.traits-status__message--error {
+  color: var(--color-error-text);
+  font-weight: 600;
+}
+
+.trait-detail {
+  margin-bottom: 2rem;
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  background: var(--color-surface-alt);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+}
+
+.trait-detail__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.trait-detail__title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.trait-detail__body {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.trait-detail__name {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.trait-detail__summary {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.trait-detail__meta {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.trait-detail__meta dt {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.trait-detail__meta dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.trait-detail__section h4 {
+  margin: 0 0 0.25rem 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.trait-detail__section p {
+  margin: 0;
+}
+
+.trait-detail__tags,
+.trait-detail__list,
+.trait-detail__requirements {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--color-text-secondary);
+}
+
+.trait-detail__tags {
+  list-style: none;
+  padding-left: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.trait-detail__tags li {
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.trait-detail__requirements {
+  list-style: none;
+  padding-left: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.trait-detail__requirements strong {
+  margin-right: 0.5rem;
+}
+
+.trait-detail__error {
+  margin: 0;
+  color: var(--color-error-text);
+  font-weight: 600;
+}
+
+.trait-detail__footer {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
   color: var(--color-text-secondary);
 }
 


### PR DESCRIPTION
## Summary
- define strongly-typed DTOs for the traits index schema and expose a TraitService with environment-aware endpoints and mock fallbacks
- refresh the traits page to fetch data asynchronously, show environment/source banners, and surface detailed trait information with error states
- add mock trait payloads and supporting styles for the new layout and status messaging

## Testing
- npm test -- --run *(fails: GraphQL + REST integration expectations return 0 instead of 3)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690f42957550832a8aaeb3f97e1b5ff6)