### PR TITLE
Add JWT-based RBAC with audit logging for trait API

### DIFF
--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,0 +1,243 @@
+const { verifyJwt } = require('../utils/jwt');
+const { createAuditLogger } = require('../services/auditLogger');
+
+function normaliseRole(value) {
+  if (!value && value !== 0) {
+    return null;
+  }
+  return String(value).trim().toLowerCase() || null;
+}
+
+function normaliseAudience(value) {
+  if (!value) {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    return value.filter(Boolean);
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function extractBearerToken(req) {
+  const header = req.get && req.get('Authorization');
+  if (header && typeof header === 'string') {
+    const match = header.match(/^Bearer\s+(.+)$/i);
+    if (match) {
+      return match[1].trim();
+    }
+  }
+  return null;
+}
+
+function extractRolesFromClaims(claims, options = {}) {
+  const rolesClaim = options.rolesClaim || process.env.AUTH_ROLES_CLAIM || 'roles';
+  const raw = claims ? claims[rolesClaim] : null;
+  let roles = [];
+  if (Array.isArray(raw)) {
+    roles = raw;
+  } else if (typeof raw === 'string' && raw.trim()) {
+    roles = raw.split(',');
+  } else if (raw && typeof raw === 'object') {
+    roles = Object.keys(raw).filter((key) => raw[key]);
+  } else if (claims && typeof claims.role === 'string') {
+    roles = [claims.role];
+  }
+  const mapped = roles
+    .map((value) => normaliseRole(value))
+    .filter((value) => Boolean(value));
+  const unique = Array.from(new Set(mapped));
+  if (!unique.length && options.fallbackRoles) {
+    return options.fallbackRoles;
+  }
+  return unique;
+}
+
+function resolveUserId(claims, options = {}) {
+  if (!claims || typeof claims !== 'object') {
+    return null;
+  }
+  const preferredClaim = options.userIdClaim || process.env.AUTH_USERID_CLAIM || null;
+  if (preferredClaim && claims[preferredClaim]) {
+    return String(claims[preferredClaim]);
+  }
+  const candidates = ['sub', 'email', 'user', 'username', 'uid'];
+  for (const key of candidates) {
+    if (claims[key]) {
+      return String(claims[key]);
+    }
+  }
+  return null;
+}
+
+function attachAuthContext(req, context = {}) {
+  if (!req.auth || typeof req.auth !== 'object') {
+    req.auth = {};
+  }
+  req.auth = {
+    ...req.auth,
+    ...context,
+    roles: Array.isArray(context.roles) ? context.roles : req.auth.roles || [],
+  };
+}
+
+function createRoleChecker(requiredRoles, options = {}) {
+  const allowAdmin = options.allowAdmin !== false;
+  const required = Array.from(new Set((requiredRoles || []).map((role) => normaliseRole(role)).filter(Boolean)));
+  return (req, res, next) => {
+    if (!required.length) {
+      next();
+      return;
+    }
+    const roles = Array.isArray(req?.auth?.roles)
+      ? req.auth.roles.map((role) => normaliseRole(role)).filter(Boolean)
+      : [];
+    if (!roles.length) {
+      res.status(403).json({ error: 'Permessi insufficienti' });
+      return;
+    }
+    const allowed = roles.some((role) => required.includes(role) || (allowAdmin && role === 'admin'));
+    if (!allowed) {
+      res.status(403).json({ error: 'Permessi insufficienti' });
+      return;
+    }
+    next();
+  };
+}
+
+function createAuditTrail(logger) {
+  if (!logger || typeof logger.record !== 'function') {
+    return async () => {};
+  }
+  return async (req, action, metadata = {}) => {
+    try {
+      await logger.record(req, action, metadata || {});
+    } catch (error) {
+      console.warn('[audit] registrazione fallita', error);
+    }
+  };
+}
+
+function createNoopMiddleware() {
+  return (req, res, next) => {
+    attachAuthContext(req, { provider: 'none', roles: req?.auth?.roles || [] });
+    next();
+  };
+}
+
+function createLegacyTokenMiddleware(token, options = {}) {
+  const headerName = options.headerName || 'X-Trait-Editor-Token';
+  const bearerEnabled = options.allowBearer !== false;
+  const legacyRoles = options.roles || ['admin'];
+  const legacyUserId = options.userId || 'legacy-token-user';
+  return (req, res, next) => {
+    const headerToken = req.get && req.get(headerName);
+    if (headerToken && String(headerToken).trim() === token) {
+      attachAuthContext(req, { provider: 'legacy-token', roles: legacyRoles, userId: legacyUserId });
+      next();
+      return;
+    }
+    if (bearerEnabled) {
+      const bearerToken = extractBearerToken(req);
+      if (bearerToken && bearerToken === token) {
+        attachAuthContext(req, { provider: 'legacy-token', roles: legacyRoles, userId: legacyUserId });
+        next();
+        return;
+      }
+    }
+    res.status(401).json({ error: 'Token mancante o non valido' });
+  };
+}
+
+function createJwtMiddleware(config = {}) {
+  const secret = config.secret || process.env.AUTH_SECRET || null;
+  if (!secret) {
+    throw new Error('AUTH_SECRET non configurato per l\'autenticazione JWT');
+  }
+  const audience = normaliseAudience(config.audience || process.env.AUTH_AUDIENCE || null);
+  const issuer = config.issuer || process.env.AUTH_ISSUER || null;
+  const clockTolerance = config.clockTolerance || process.env.AUTH_CLOCK_TOLERANCE || 0;
+  const maxAge = config.maxAge || process.env.AUTH_TOKEN_MAX_AGE || process.env.AUTH_MAX_AGE || null;
+  const fallbackRoles = config.fallbackRoles || normaliseAudience(process.env.AUTH_DEFAULT_ROLES) || [];
+
+  return (req, res, next) => {
+    const token = extractBearerToken(req);
+    if (!token) {
+      res.status(401).json({ error: 'Token mancante o non valido' });
+      return;
+    }
+    try {
+      const claims = verifyJwt(token, secret, {
+        audience: audience && audience.length ? audience : null,
+        issuer,
+        clockTolerance,
+        maxAge,
+      });
+      const roles = extractRolesFromClaims(claims, { rolesClaim: config.rolesClaim, fallbackRoles });
+      attachAuthContext(req, {
+        provider: 'jwt',
+        userId: resolveUserId(claims, { userIdClaim: config.userIdClaim }),
+        roles,
+        claims,
+      });
+      next();
+    } catch (error) {
+      res.status(401).json({ error: 'Token mancante o non valido' });
+    }
+  };
+}
+
+function createAuthHandlers(options = {}) {
+  const disabled = options.disabled === true;
+  const auditLogger = options.auditLogger || createAuditLogger(options.audit || {});
+  const auditTrail = createAuditTrail(auditLogger);
+  if (disabled) {
+    return {
+      authenticate: createNoopMiddleware(),
+      requireRoles: () => createNoopMiddleware(),
+      auditTrail,
+    };
+  }
+  const legacyToken =
+    options.legacyToken !== undefined
+      ? options.legacyToken
+      : options.token !== undefined
+        ? options.token
+        : process.env.TRAIT_EDITOR_TOKEN || process.env.TRAITS_API_TOKEN || null;
+  const secret = options.secret || process.env.AUTH_SECRET || null;
+
+  if (secret) {
+    const authenticate = createJwtMiddleware(options);
+    return {
+      authenticate,
+      requireRoles: (roles, config) => createRoleChecker(roles, config),
+      auditTrail,
+    };
+  }
+
+  if (legacyToken) {
+    const authenticate = createLegacyTokenMiddleware(legacyToken, options.legacy || {});
+    return {
+      authenticate,
+      requireRoles: () => createNoopMiddleware(),
+      auditTrail,
+    };
+  }
+
+  console.warn('[auth] nessun provider configurato: gli endpoint non sono protetti');
+  return {
+    authenticate: createNoopMiddleware(),
+    requireRoles: () => createNoopMiddleware(),
+    auditTrail,
+  };
+}
+
+module.exports = {
+  createAuthHandlers,
+  extractBearerToken,
+};

--- a/server/services/auditLogger.js
+++ b/server/services/auditLogger.js
@@ -1,0 +1,60 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+function resolveLogPath(options = {}) {
+  if (options.filePath) {
+    return options.filePath;
+  }
+  if (process.env.AUDIT_LOG_PATH) {
+    return process.env.AUDIT_LOG_PATH;
+  }
+  return path.resolve(__dirname, '..', 'logs', 'audit.log');
+}
+
+function createAuditLogger(options = {}) {
+  const targetPath = resolveLogPath(options);
+  const disabled = options.disabled || false;
+
+  async function append(entry) {
+    if (disabled || !targetPath) {
+      return;
+    }
+    const line = `${JSON.stringify(entry)}\n`;
+    try {
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+      await fs.appendFile(targetPath, line, 'utf8');
+    } catch (error) {
+      console.warn('[audit] impossibile registrare evento', error);
+    }
+  }
+
+  function buildEntry(req, action, metadata = {}) {
+    const now = new Date().toISOString();
+    const auth = req?.auth || {};
+    const user = auth.userId || auth.user || auth.email || null;
+    const roles = Array.isArray(auth.roles) ? auth.roles : [];
+    const ip = req?.ip || req?.connection?.remoteAddress || null;
+    const requestId = req?.headers?.['x-request-id'] || req?.id || null;
+    return {
+      timestamp: now,
+      action,
+      user,
+      roles,
+      ip,
+      requestId,
+      metadata,
+    };
+  }
+
+  async function record(req, action, metadata = {}) {
+    await append(buildEntry(req, action, metadata));
+  }
+
+  return {
+    record,
+  };
+}
+
+module.exports = {
+  createAuditLogger,
+};

--- a/server/utils/jwt.js
+++ b/server/utils/jwt.js
@@ -1,0 +1,177 @@
+const crypto = require('node:crypto');
+
+function base64UrlEncode(buffer) {
+  return buffer
+    .toString('base64')
+    .replace(/=+$/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function base64UrlDecode(input) {
+  const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+  const padLength = (4 - (normalized.length % 4)) % 4;
+  const padded = normalized + '='.repeat(padLength);
+  return Buffer.from(padded, 'base64');
+}
+
+function parseTimespan(value) {
+  if (value == null) {
+    return null;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const numeric = Number(trimmed);
+  if (Number.isFinite(numeric)) {
+    return numeric;
+  }
+  const match = trimmed.match(/^(\d+)([smhdw])$/i);
+  if (!match) {
+    return null;
+  }
+  const amount = Number(match[1]);
+  if (!Number.isFinite(amount)) {
+    return null;
+  }
+  const unit = match[2].toLowerCase();
+  const multipliers = {
+    s: 1,
+    m: 60,
+    h: 60 * 60,
+    d: 24 * 60 * 60,
+    w: 7 * 24 * 60 * 60,
+  };
+  return amount * multipliers[unit];
+}
+
+function createSigningInput(header, payload) {
+  const encodedHeader = base64UrlEncode(Buffer.from(JSON.stringify(header)));
+  const encodedPayload = base64UrlEncode(Buffer.from(JSON.stringify(payload)));
+  return `${encodedHeader}.${encodedPayload}`;
+}
+
+function signJwt(payload, secret, options = {}) {
+  if (!secret) {
+    throw new Error('Secret richiesto per firmare il token');
+  }
+  const header = {
+    alg: 'HS256',
+    typ: 'JWT',
+    ...(options.header || {}),
+  };
+  if (header.alg !== 'HS256') {
+    throw new Error(`Algoritmo non supportato: ${header.alg}`);
+  }
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const timespan = parseTimespan(options.expiresIn);
+  const notBefore = parseTimespan(options.notBefore);
+  const payloadData = { ...payload };
+  if (timespan) {
+    payloadData.exp = issuedAt + timespan;
+  }
+  if (notBefore) {
+    payloadData.nbf = issuedAt + notBefore;
+  }
+  payloadData.iat = payloadData.iat || issuedAt;
+  const signingInput = createSigningInput(header, payloadData);
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(signingInput)
+    .digest();
+  const encodedSignature = base64UrlEncode(signature);
+  return `${signingInput}.${encodedSignature}`;
+}
+
+function isAudienceAllowed(expected, audienceClaim) {
+  if (!expected) {
+    return true;
+  }
+  const audiences = Array.isArray(expected) ? expected : [expected];
+  if (Array.isArray(audienceClaim)) {
+    return audienceClaim.some((aud) => audiences.includes(aud));
+  }
+  return audiences.includes(audienceClaim);
+}
+
+function verifyJwt(token, secret, options = {}) {
+  if (!token || typeof token !== 'string') {
+    throw Object.assign(new Error('Token JWT richiesto'), { code: 'EJWTEMPTY' });
+  }
+  if (!secret) {
+    throw Object.assign(new Error('Secret mancante per verificare il token'), {
+      code: 'EJWTSECRET',
+    });
+  }
+  const segments = token.split('.');
+  if (segments.length !== 3) {
+    throw Object.assign(new Error('Token JWT non valido'), { code: 'EJWTMALFORMED' });
+  }
+  const [encodedHeader, encodedPayload, encodedSignature] = segments;
+  let header;
+  let payload;
+  try {
+    header = JSON.parse(base64UrlDecode(encodedHeader).toString('utf8'));
+    payload = JSON.parse(base64UrlDecode(encodedPayload).toString('utf8'));
+  } catch (error) {
+    throw Object.assign(new Error('Token JWT non decodificabile'), { code: 'EJWTPARSE' });
+  }
+  if (!header || header.alg !== 'HS256') {
+    throw Object.assign(new Error('Algoritmo JWT non supportato'), { code: 'EJWTALG' });
+  }
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const expectedSignature = crypto
+    .createHmac('sha256', secret)
+    .update(signingInput)
+    .digest();
+  const providedSignature = base64UrlDecode(encodedSignature);
+  if (providedSignature.length !== expectedSignature.length) {
+    throw Object.assign(new Error('Firma JWT non valida'), { code: 'EJWTSIGNATURE' });
+  }
+  if (!crypto.timingSafeEqual(providedSignature, expectedSignature)) {
+    throw Object.assign(new Error('Firma JWT non valida'), { code: 'EJWTSIGNATURE' });
+  }
+  const now = Math.floor(Date.now() / 1000);
+  const tolerance = parseTimespan(options.clockTolerance || 0) || 0;
+  if (payload.exp != null) {
+    const exp = Number(payload.exp);
+    if (Number.isFinite(exp) && now > exp + tolerance) {
+      throw Object.assign(new Error('Token JWT scaduto'), { code: 'EJWTEXPIRED' });
+    }
+  } else if (options.maxAge) {
+    const maxAge = parseTimespan(options.maxAge);
+    if (maxAge) {
+      const issuedAt = Number(payload.iat) || 0;
+      if (issuedAt && now > issuedAt + maxAge + tolerance) {
+        throw Object.assign(new Error('Token JWT oltre la durata massima'), {
+          code: 'EJWTMAXAGE',
+        });
+      }
+    }
+  }
+  if (payload.nbf != null) {
+    const nbf = Number(payload.nbf);
+    if (Number.isFinite(nbf) && now + tolerance < nbf) {
+      throw Object.assign(new Error('Token JWT non ancora valido'), { code: 'EJWTNOTBEFORE' });
+    }
+  }
+  if (options.issuer && payload.iss && payload.iss !== options.issuer) {
+    throw Object.assign(new Error('Issuer JWT non valido'), { code: 'EJWTISSUER' });
+  }
+  if (options.audience && payload.aud && !isAudienceAllowed(options.audience, payload.aud)) {
+    throw Object.assign(new Error('Audience JWT non valida'), { code: 'EJWTAUDIENCE' });
+  }
+  return payload;
+}
+
+module.exports = {
+  signJwt,
+  verifyJwt,
+};

--- a/tests/api/traits.auth.test.js
+++ b/tests/api/traits.auth.test.js
@@ -1,0 +1,79 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs/promises');
+const request = require('supertest');
+
+const { createApp } = require('../../server/app');
+const { signJwt } = require('../../server/utils/jwt');
+
+const AUTH_SECRET = 'test-secret';
+
+function createToken(roles) {
+  return signJwt({ sub: 'test-user', roles }, AUTH_SECRET, { expiresIn: '1h' });
+}
+
+function createAppWithOptions(options = {}) {
+  const { app } = createApp({
+    traits: {
+      auth: {
+        secret: AUTH_SECRET,
+        ...(options.auth || {}),
+      },
+      ...(options.traits || {}),
+    },
+  });
+  return app;
+}
+
+test('POST /api/traits/validate richiede un token JWT', async () => {
+  const app = createAppWithOptions();
+  await request(app).post('/api/traits/validate').send({ payload: {} }).expect(401);
+});
+
+test('POST /api/traits/validate rifiuta ruoli non autorizzati', async () => {
+  const app = createAppWithOptions();
+  const token = createToken(['viewer']);
+  await request(app)
+    .post('/api/traits/validate')
+    .set('Authorization', `Bearer ${token}`)
+    .send({ payload: {} })
+    .expect(403);
+});
+
+test('DELETE /api/traits/:traitId richiede ruolo admin e registra audit', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'traits-audit-'));
+  const logPath = path.join(tmpDir, 'audit.log');
+  const calls = [];
+  const repository = {
+    deleteTrait: async (traitId) => {
+      calls.push(traitId);
+      return { meta: { id: traitId } };
+    },
+  };
+  const app = createAppWithOptions({
+    auth: { audit: { filePath: logPath } },
+    traits: { repository },
+  });
+  const token = createToken(['admin']);
+
+  await request(app)
+    .delete('/api/traits/alpha_trait')
+    .set('Authorization', `Bearer ${token}`)
+    .expect(200);
+
+  assert.deepEqual(calls, ['alpha_trait']);
+  const content = await fs.readFile(logPath, 'utf8');
+  const entries = content
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].action, 'trait.delete');
+  assert.equal(entries[0].user, 'test-user');
+  assert.deepEqual(entries[0].roles, ['admin']);
+  assert.equal(entries[0].metadata.traitId, 'alpha_trait');
+  assert.ok(entries[0].timestamp, 'timestamp mancante');
+});


### PR DESCRIPTION
## Summary
- add a reusable JWT authentication middleware with RBAC helpers and audit logging support
- enforce role-based access and audit trail recording across trait routes using the new middleware
- cover the new access rules with tests and document the required AUTH_* environment variables

## Testing
- node --test tests/api/traits.validate.test.js *(fails: Cannot find module 'supertest' – dev dependency not available in environment)*
- node --test tests/api/traits.auth.test.js *(fails: Cannot find module 'supertest' – dev dependency not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6910899db638832ab1826a57a8a68002)