### PR TITLE
feat: normalise trait data and improve fallback handling

### DIFF
--- a/Trait Editor/package.json
+++ b/Trait Editor/package.json
@@ -5,10 +5,12 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "devDependencies": {
     "patch-package": "^6.5.1",
+    "vitest": "^2.1.1",
     "typescript": "^5.9.3",
     "vite": "^5.4.8"
   }

--- a/Trait Editor/src/data/traits.sample.ts
+++ b/Trait Editor/src/data/traits.sample.ts
@@ -1,63 +1,127 @@
-import type { Trait } from '../types/trait';
+import type { Trait, TraitIndexDocument } from '../types/trait';
+import { parseTraitIndexDocument, parseTraitPayload } from '../services/trait-parser';
 
 export const TRAIT_DATA_ENDPOINT = '../data/traits/index.json';
 
-const traitsSample: Trait[] = [
-  {
-    id: 'spectre-3',
-    name: 'Spectre-3',
-    description:
-      'Adaptive infiltrator specialising in precision sabotage and split-second decision cycles.',
-    archetype: 'Infiltrator Savant',
-    playstyle: 'High tempo, precision takedowns, opportunistic reroutes.',
-    signatureMoves: ['Phase-Locked Entry', 'Ghostline Relay', 'Vector Cancel'],
+const sampleIndex: TraitIndexDocument = {
+  schema_version: '2.0',
+  trait_glossary: 'data/core/traits/glossary.json',
+  traits: {
+    'spectre-3': {
+      id: 'spectre-3',
+      label: 'Spectre-3',
+      tier: 'T2',
+      famiglia_tipologia: 'Infiltrator Savant',
+      slot_profile: { core: 'Infiltratore', complementare: 'Sabotatore' },
+      slot: ['assalto', 'sabotaggio'],
+      usage_tags: ['burst', 'control'],
+      completion_flags: {
+        has_biome: true,
+        has_data_origin: true,
+        has_species_link: true,
+        has_usage_tags: true,
+      },
+      data_origin: 'mock_reference',
+      debolezza: 'Sensibile a contrattacchi coordinati.',
+      mutazione_indotta: 'Innestata rete di sensori adattivi multi-spettro.',
+      requisiti_ambientali: [
+        {
+          capacita_richieste: ['furtività'],
+          condizioni: { biome_class: 'urbano' },
+          fonte: 'mock',
+          meta: { expansion: 'demo', tier: 'T2' },
+        },
+      ],
+      sinergie: ['Phase-Locked Entry', 'Ghostline Relay', 'Vector Cancel'],
+      sinergie_pi: {
+        co_occorrenze: ['scia_quantica'],
+        combo_totale: 2,
+        forme: ['sequenza_infiltrazione'],
+        tabelle_random: [],
+      },
+      species_affinity: [
+        {
+          roles: ['scout'],
+          species_id: 'spectre_line',
+          weight: 0.6,
+        },
+      ],
+      spinta_selettiva: 'Alta intensità, decisioni istantanee.',
+      uso_funzione: 'Infiltra punti critici e disarticola linee di difesa.',
+      fattore_mantenimento_energetico: 'Moderato',
+      conflitti: ['nova-lead'],
+      biome_tags: ['urbano', 'notturno'],
+    },
+    'nova-lead': {
+      id: 'nova-lead',
+      label: 'Nova-Lead',
+      tier: 'T3',
+      famiglia_tipologia: 'Command Vanguard',
+      slot_profile: { core: 'Comando', complementare: 'Supporto' },
+      slot: ['strategia', 'supporto'],
+      usage_tags: ['coordinamento', 'buffer'],
+      completion_flags: {
+        has_biome: true,
+        has_data_origin: true,
+        has_species_link: true,
+        has_usage_tags: true,
+      },
+      data_origin: 'mock_reference',
+      debolezza: 'Richiede linea di comando stabile.',
+      mutazione_indotta: 'Amplifica reti neurali per coordinamento multi-squadra.',
+      requisiti_ambientali: [
+        {
+          capacita_richieste: ['leadership'],
+          condizioni: { biome_class: 'frontline' },
+          fonte: 'mock',
+          meta: { expansion: 'demo', tier: 'T3' },
+        },
+      ],
+      sinergie: ['Solaris Surge', 'Command Relay Burst', 'Zero Hour Anchor'],
+      sinergie_pi: {
+        co_occorrenze: ['focus_comando'],
+        combo_totale: 3,
+        forme: ['ondata_di_controllo'],
+        tabelle_random: [],
+      },
+      species_affinity: [
+        {
+          roles: ['commander'],
+          species_id: 'nova_command',
+          weight: 0.75,
+        },
+      ],
+      spinta_selettiva: 'Coordinamento aggressivo e resilienza.',
+      uso_funzione: 'Orchestra spinta multi-nodo e mantiene l’equilibrio tattico.',
+      fattore_mantenimento_energetico: 'Elevato',
+      conflitti: ['spectre-3'],
+      biome_tags: ['frontline'],
+    },
   },
-  {
-    id: 'nova-lead',
-    name: 'Nova-Lead',
-    description:
-      'Command tactician orchestrating multi-squad pushes and dynamic risk balancing in contested zones.',
-    archetype: 'Command Vanguard',
-    playstyle: 'Coordinated aggression, distributed command, fallback elasticity.',
-    signatureMoves: ['Solaris Surge', 'Command Relay Burst', 'Zero Hour Anchor'],
-  },
-  {
-    id: 'helix-warden',
-    name: 'Helix Warden',
-    description:
-      'Containment specialist who anchors anomaly perimeters while orchestrating stabiliser arrays.',
-    archetype: 'Anomaly Custodian',
-    playstyle: 'Territory denial, layered defences, sustained countermeasures.',
-    signatureMoves: ['Tidewall Invocation', 'Gravitic Shear', 'Containment Pulse'],
-  },
-  {
-    id: 'echo-ridge',
-    name: 'Echo Ridge',
-    description:
-      'Recon collective that threads deep behind enemy lines to surface actionable telemetry.',
-    archetype: 'Recon Collective',
-    playstyle: 'Stealth scouting, asynchronous reporting, tactical adaptation.',
-    signatureMoves: ['Silent Parallax', 'Data Loom', 'Ridgeback Cascade'],
-  },
-];
+};
 
-export const getSampleTraits = (): Trait[] =>
-  traitsSample.map((trait) => ({ ...trait, signatureMoves: [...trait.signatureMoves] }));
+export const getSampleTraits = (): Trait[] => parseTraitIndexDocument(sampleIndex);
 
 export const fetchTraitsFromMonorepo = async (
   endpoint: string = TRAIT_DATA_ENDPOINT,
 ): Promise<Trait[]> => {
   if (typeof fetch !== 'function') {
-    throw new Error('Fetch API non disponibile nell\'ambiente corrente.');
+    throw new Error("Fetch API non disponibile nell'ambiente corrente.");
   }
 
-  const response = await fetch(endpoint, { cache: 'no-cache' });
+  let response: Response;
+  try {
+    response = await fetch(endpoint, { cache: 'no-cache' });
+  } catch (error) {
+    throw new Error(`Errore di rete durante il recupero dei tratti: ${String(error)}`);
+  }
+
   if (!response.ok) {
     throw new Error(`Impossibile recuperare i tratti da ${endpoint}: ${response.status}`);
   }
 
-  const data = (await response.json()) as Trait[];
-  return data.map((trait) => ({ ...trait, signatureMoves: [...trait.signatureMoves] }));
+  const data = await response.json();
+  return parseTraitPayload(data);
 };
 
 export const resolveTraitSource = async (
@@ -68,10 +132,5 @@ export const resolveTraitSource = async (
     return getSampleTraits();
   }
 
-  try {
-    return await fetchTraitsFromMonorepo(endpoint ?? TRAIT_DATA_ENDPOINT);
-  } catch (error) {
-    console.warn('Falling back to sample traits after remote fetch failure:', error);
-    return getSampleTraits();
-  }
+  return fetchTraitsFromMonorepo(endpoint ?? TRAIT_DATA_ENDPOINT);
 };

--- a/Trait Editor/src/services/__tests__/trait-data.service.spec.ts
+++ b/Trait Editor/src/services/__tests__/trait-data.service.spec.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FALLBACK_CACHE_TTL_MS, TraitDataService } from '../trait-data.service';
+import { getSampleTraits } from '../../data/traits.sample';
+import type { Trait } from '../../types/trait';
+
+const createFakeQ = () => ({
+  resolve: <T>(value: T) => Promise.resolve(value),
+  reject: <T>(value: T) => Promise.reject(value),
+  when: <T>(value: T | Promise<T>) => Promise.resolve(value),
+});
+
+describe('TraitDataService caching behaviour', () => {
+  let originalFetch: typeof fetch | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    vi.stubEnv('VITE_TRAIT_DATA_SOURCE', 'remote');
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete (globalThis as typeof globalThis & { fetch?: typeof fetch }).fetch;
+    }
+  });
+
+  it('falls back to mocks temporarily and retries the remote source after TTL', async () => {
+    const remotePayload = {
+      schema_version: '2.0',
+      trait_glossary: 'remote/glossary.json',
+      traits: {
+        delta: {
+          id: 'delta',
+          label: 'Delta',
+          tier: 'T1',
+          famiglia_tipologia: 'Skirmisher',
+          slot_profile: { core: 'Assalto', complementare: 'Supporto' },
+          slot: ['assalto'],
+          usage_tags: ['rapid'],
+          completion_flags: {
+            has_biome: false,
+            has_data_origin: true,
+            has_species_link: false,
+            has_usage_tags: true,
+          },
+          data_origin: 'remote_index',
+          debolezza: 'Esposizione a fuoco incrociato.',
+          mutazione_indotta: 'Stimola riflessi e controllo vettoriale.',
+          requisiti_ambientali: [],
+          sinergie: ['Arc Shot'],
+          sinergie_pi: {
+            co_occorrenze: [],
+            combo_totale: 1,
+            forme: [],
+            tabelle_random: [],
+          },
+          species_affinity: [],
+          spinta_selettiva: 'Assalto mirato.',
+          uso_funzione: 'Colpire e disimpegnarsi rapidamente.',
+          fattore_mantenimento_energetico: 'Basso',
+          conflitti: [],
+        },
+      },
+    };
+
+    const fetchMock = vi
+      .fn<Parameters<typeof fetch>, Promise<Response>>()
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValue({
+        ok: true,
+        json: async () => remotePayload,
+      } as unknown as Response);
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const service = new TraitDataService(createFakeQ());
+    const firstLoad = await service.getTraits();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(service.isUsingFallback()).toBe(true);
+    expect(service.getLastError()).toBeInstanceOf(Error);
+    expect(firstLoad.map((trait) => trait.id)).toEqual(getSampleTraits().map((trait) => trait.id));
+
+    vi.advanceTimersByTime(FALLBACK_CACHE_TTL_MS + 1);
+
+    const secondLoad = await service.getTraits();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(service.isUsingFallback()).toBe(false);
+    expect(service.getLastError()).toBeNull();
+    expect(secondLoad.find((trait) => trait.id === 'delta')).toMatchObject({
+      name: 'Delta',
+      entry: expect.objectContaining({ uso_funzione: 'Colpire e disimpegnarsi rapidamente.' }),
+    } as Partial<Trait>);
+  });
+});

--- a/Trait Editor/src/services/__tests__/trait-parser.spec.ts
+++ b/Trait Editor/src/services/__tests__/trait-parser.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseTraitPayload, parseTraitIndexDocument } from '../trait-parser';
+import type { TraitIndexDocument } from '../../types/trait';
+
+describe('trait parser', () => {
+  it('parses trait index documents preserving nested structures', () => {
+    const document: TraitIndexDocument = {
+      schema_version: '2.0',
+      trait_glossary: 'path/to/glossary.json',
+      traits: {
+        alpha: {
+          id: 'alpha',
+          label: 'Alpha',
+          tier: 'T1',
+          famiglia_tipologia: 'Sentinel',
+          slot_profile: { core: 'Defender', complementare: 'Sensor' },
+          slot: ['defence'],
+          usage_tags: ['hold'],
+          completion_flags: {
+            has_biome: true,
+            has_data_origin: true,
+            has_species_link: false,
+            has_usage_tags: true,
+          },
+          data_origin: 'unit_test',
+          debolezza: 'Requires stabilised perimeter.',
+          mutazione_indotta: 'Reinforces perimeter sensing lattice.',
+          requisiti_ambientali: [
+            {
+              capacita_richieste: ['stability'],
+              condizioni: { biome_class: 'canyon', extra: 'value' },
+              fonte: 'test',
+              meta: { expansion: 'qa', tier: 'T1', custom: 'keep' },
+            },
+          ],
+          sinergie: ['Shield Pulse'],
+          sinergie_pi: {
+            co_occorrenze: ['core-sync'],
+            combo_totale: 1,
+            forme: ['triad'],
+            tabelle_random: ['table-1'],
+          },
+          species_affinity: [
+            {
+              roles: ['guardian'],
+              species_id: 'sentinel-01',
+              weight: 0.42,
+            },
+          ],
+          spinta_selettiva: 'Hold position at all costs.',
+          uso_funzione: 'Lock down the area and project shielding.',
+          fattore_mantenimento_energetico: 'Moderato',
+          conflitti: ['beta'],
+          biome_tags: ['canyon'],
+        },
+      },
+    };
+
+    const traits = parseTraitIndexDocument(document);
+    expect(traits).toHaveLength(1);
+    const [trait] = traits;
+    expect(trait.id).toBe('alpha');
+    expect(trait.name).toBe('Alpha');
+    expect(trait.signatureMoves).toEqual(['Shield Pulse']);
+    expect(trait.entry.requisiti_ambientali[0].condizioni).toHaveProperty('extra', 'value');
+    expect(trait.entry.requisiti_ambientali[0].meta).toHaveProperty('custom', 'keep');
+    expect(trait.entry.sinergie_pi.combo_totale).toBe(1);
+  });
+
+  it('parses array payloads into traits', () => {
+    const payload = [
+      {
+        id: 'legacy-1',
+        label: 'Legacy Entry',
+        famiglia_tipologia: 'Archivist',
+        slot_profile: { core: 'Archivio', complementare: 'Supporto' },
+        slot: [],
+        usage_tags: [],
+        completion_flags: {},
+        data_origin: 'legacy',
+        debolezza: '',
+        mutazione_indotta: '',
+        requisiti_ambientali: [],
+        sinergie: [],
+        sinergie_pi: {},
+        species_affinity: [],
+        spinta_selettiva: '',
+        uso_funzione: 'Legacy description',
+        fattore_mantenimento_energetico: '',
+        conflitti: [],
+      },
+    ];
+
+    const traits = parseTraitPayload(payload);
+    expect(traits).toHaveLength(1);
+    expect(traits[0].id).toBe('legacy-1');
+    expect(traits[0].description).toBe('Legacy description');
+  });
+
+  it('throws on unsupported payloads', () => {
+    expect(() => parseTraitPayload({})).toThrowError();
+  });
+});

--- a/Trait Editor/src/services/trait-data.service.ts
+++ b/Trait Editor/src/services/trait-data.service.ts
@@ -1,8 +1,24 @@
-import { TRAIT_DATA_ENDPOINT, getSampleTraits, resolveTraitSource } from '../data/traits.sample';
+import {
+  TRAIT_DATA_ENDPOINT,
+  fetchTraitsFromMonorepo,
+  getSampleTraits,
+} from '../data/traits.sample';
 import type { Trait } from '../types/trait';
+import { cloneTrait, cloneTraits, synchroniseTraitPresentation } from '../utils/trait-helpers';
+
+export const FALLBACK_CACHE_TTL_MS = 60_000;
+
+type TraitCacheSource = 'remote' | 'fallback' | 'mock';
+
+interface TraitCacheEntry {
+  traits: Trait[];
+  source: TraitCacheSource;
+  timestamp: number;
+}
 
 export class TraitDataService {
-  private cache: Trait[] | null = null;
+  private cache: TraitCacheEntry | null = null;
+  private fallbackExpiry: number | null = null;
   private readonly useRemoteSource: boolean;
   private readonly endpointOverride?: string;
   private lastError: Error | null = null;
@@ -19,36 +35,43 @@ export class TraitDataService {
     }
   }
 
-  getTraits(): Promise<Trait[]> {
-    if (this.cache) {
-      return this.$q.resolve(this.cloneTraits(this.cache));
+  getTraits(options?: { forceRemote?: boolean }): Promise<Trait[]> {
+    const forceRemote = options?.forceRemote ?? false;
+
+    if (this.cache && this.isCacheUsable(forceRemote)) {
+      return this.$q.resolve(cloneTraits(this.cache.traits));
     }
 
-    return this.$q
-      .when(resolveTraitSource(this.useRemoteSource, this.endpointOverride))
-      .then((traits) => {
-        this.cache = traits;
-        this.lastError = null;
-        return this.cloneTraits(traits);
-      })
-      .catch((error) => {
-        console.error('Impossibile caricare i tratti:', error);
-        this.lastError = error instanceof Error ? error : new Error(String(error));
-        const fallback = getSampleTraits();
-        this.cache = fallback;
-        return this.cloneTraits(fallback);
-      });
+    return this.$q.when(this.loadTraits()).then((traits) => cloneTraits(traits));
+  }
+
+  refreshTraitsFromRemote(): Promise<Trait[]> {
+    return this.getTraits({ forceRemote: true });
+  }
+
+  invalidateCache(): void {
+    this.cache = null;
+    this.fallbackExpiry = null;
+  }
+
+  getCacheSource(): TraitCacheSource | null {
+    return this.cache?.source ?? null;
+  }
+
+  isUsingFallback(): boolean {
+    return this.cache?.source === 'fallback';
   }
 
   getTraitById(id: string): Promise<Trait | null> {
     return this.getTraits().then((traits) => {
       const trait = traits.find((item) => item.id === id);
-      return trait ? this.cloneTrait(trait) : null;
+      return trait ? cloneTrait(trait) : null;
     });
   }
 
   saveTrait(updatedTrait: Trait): Promise<Trait> {
-    const traitCopy = this.cloneTrait(updatedTrait);
+    const traitCopy = cloneTrait(updatedTrait);
+    synchroniseTraitPresentation(traitCopy);
 
     const persist = async (): Promise<void> => {
       if (!this.useRemoteSource) {
@@ -83,17 +106,8 @@ export class TraitDataService {
       .when(persist())
       .then(() => {
         this.lastError = null;
-        if (!this.cache) {
-          this.cache = [traitCopy];
-        } else {
-          const index = this.cache.findIndex((trait) => trait.id === traitCopy.id);
-          if (index >= 0) {
-            this.cache.splice(index, 1, traitCopy);
-          } else {
-            this.cache.push(traitCopy);
-          }
-        }
-        return this.cloneTrait(traitCopy);
+        this.updateLocalCache(traitCopy);
+        return cloneTrait(traitCopy);
       })
       .catch((error: Error) => {
         const err = error instanceof Error ? error : new Error(String(error));
@@ -106,12 +120,73 @@ export class TraitDataService {
     return this.lastError;
   }
 
-  private cloneTraits(traits: Trait[]): Trait[] {
-    return traits.map((trait) => ({ ...trait, signatureMoves: [...trait.signatureMoves] }));
+  private async loadTraits(): Promise<Trait[]> {
+    if (!this.useRemoteSource) {
+      return this.updateCache(getSampleTraits(), 'mock');
+    }
+
+    try {
+      const endpoint = this.endpointOverride ?? TRAIT_DATA_ENDPOINT;
+      const traits = await fetchTraitsFromMonorepo(endpoint);
+      this.lastError = null;
+      return this.updateCache(traits, 'remote');
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.lastError = err;
+      const fallback = getSampleTraits();
+      return this.updateCache(fallback, 'fallback');
+    }
   }
 
-  private cloneTrait(trait: Trait): Trait {
-    return { ...trait, signatureMoves: [...trait.signatureMoves] };
+  private updateCache(traits: Trait[], source: TraitCacheSource): Trait[] {
+    const canonical = cloneTraits(traits);
+    this.cache = {
+      traits: canonical,
+      source,
+      timestamp: Date.now(),
+    };
+    this.fallbackExpiry = source === 'fallback' ? Date.now() + FALLBACK_CACHE_TTL_MS : null;
+    return cloneTraits(this.cache.traits);
+  }
+
+  private updateLocalCache(trait: Trait): void {
+    if (!this.cache) {
+      const source: TraitCacheSource = this.useRemoteSource ? 'remote' : 'mock';
+      this.cache = { traits: [cloneTrait(trait)], source, timestamp: Date.now() };
+      this.fallbackExpiry = source === 'fallback' ? Date.now() + FALLBACK_CACHE_TTL_MS : null;
+      return;
+    }
+
+    const updated = cloneTrait(trait);
+    const index = this.cache.traits.findIndex((item) => item.id === updated.id);
+    if (index >= 0) {
+      this.cache.traits.splice(index, 1, updated);
+    } else {
+      this.cache.traits.push(updated);
+    }
+    this.cache.timestamp = Date.now();
+    if (this.cache.source === 'fallback') {
+      this.fallbackExpiry = Date.now() + FALLBACK_CACHE_TTL_MS;
+    }
+  }
+
+  private isCacheUsable(forceRemote: boolean): boolean {
+    if (!this.cache) {
+      return false;
+    }
+
+    if (forceRemote) {
+      return false;
+    }
+
+    if (this.cache.source === 'fallback') {
+      if (this.fallbackExpiry === null) {
+        return false;
+      }
+      return Date.now() <= this.fallbackExpiry;
+    }
+
+    return true;
   }
 
   private buildRemoteMutationEndpoint(baseEndpoint: string, id: string): string | null {

--- a/Trait Editor/src/services/trait-parser.ts
+++ b/Trait Editor/src/services/trait-parser.ts
@@ -1,0 +1,241 @@
+import type {
+  Trait,
+  TraitCompletionFlags,
+  TraitIndexDocument,
+  TraitIndexEntry,
+  TraitRequirement,
+  TraitRequirementConditions,
+  TraitRequirementMeta,
+  TraitSlotProfile,
+  TraitSpeciesAffinity,
+  TraitSynergyPi,
+} from '../types/trait';
+import { synchroniseTraitPresentation } from '../utils/trait-helpers';
+
+const ensureString = (value: unknown, fallback = ''): string =>
+  typeof value === 'string' ? value : fallback;
+
+const ensureNumber = (value: unknown, fallback = 0): number =>
+  typeof value === 'number' ? value : Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+const ensureBoolean = (value: unknown): boolean => value === true;
+
+const ensureStringArray = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+
+const cloneConditions = (value: unknown): TraitRequirementConditions => {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+
+  const source = value as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(source)) {
+    result[key] = source[key];
+  }
+  return result as TraitRequirementConditions;
+};
+
+const cloneMeta = (value: unknown): TraitRequirementMeta | undefined => {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const source = value as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(source)) {
+    result[key] = source[key];
+  }
+  return result as TraitRequirementMeta;
+};
+
+const normaliseRequirement = (value: unknown): TraitRequirement => {
+  if (!value || typeof value !== 'object') {
+    return {
+      capacita_richieste: [],
+      condizioni: {},
+      fonte: '',
+    };
+  }
+
+  const source = value as Record<string, unknown>;
+  return {
+    capacita_richieste: ensureStringArray(source.capacita_richieste),
+    condizioni: cloneConditions(source.condizioni),
+    fonte: ensureString(source.fonte),
+    meta: cloneMeta(source.meta),
+  };
+};
+
+const normaliseSlotProfile = (value: unknown): TraitSlotProfile => {
+  if (!value || typeof value !== 'object') {
+    return { core: '', complementare: '' };
+  }
+
+  const source = value as Record<string, unknown>;
+  return {
+    core: ensureString(source.core),
+    complementare: ensureString(source.complementare),
+  };
+};
+
+const normaliseCompletionFlags = (value: unknown): TraitCompletionFlags => {
+  if (!value || typeof value !== 'object') {
+    return {
+      has_biome: false,
+      has_data_origin: false,
+      has_species_link: false,
+      has_usage_tags: false,
+    };
+  }
+
+  const source = value as Record<string, unknown>;
+  return {
+    has_biome: ensureBoolean(source.has_biome),
+    has_data_origin: ensureBoolean(source.has_data_origin),
+    has_species_link: ensureBoolean(source.has_species_link),
+    has_usage_tags: ensureBoolean(source.has_usage_tags),
+  };
+};
+
+const normaliseSynergyPi = (value: unknown): TraitSynergyPi => {
+  if (!value || typeof value !== 'object') {
+    return {
+      co_occorrenze: [],
+      combo_totale: 0,
+      forme: [],
+      tabelle_random: [],
+    };
+  }
+
+  const source = value as Record<string, unknown>;
+  return {
+    co_occorrenze: ensureStringArray(source.co_occorrenze),
+    combo_totale: ensureNumber(source.combo_totale, 0),
+    forme: ensureStringArray(source.forme),
+    tabelle_random: ensureStringArray(source.tabelle_random),
+  };
+};
+
+const normaliseSpeciesAffinity = (value: unknown): TraitSpeciesAffinity => {
+  if (!value || typeof value !== 'object') {
+    return {
+      roles: [],
+      species_id: '',
+      weight: 0,
+    };
+  }
+
+  const source = value as Record<string, unknown>;
+  return {
+    roles: ensureStringArray(source.roles),
+    species_id: ensureString(source.species_id),
+    weight: ensureNumber(source.weight, 0),
+  };
+};
+
+const normaliseTraitIndexEntry = (value: unknown, fallbackId?: string): TraitIndexEntry => {
+  if (!value || typeof value !== 'object') {
+    const id = fallbackId ?? '';
+    return {
+      id,
+      label: id,
+      tier: '',
+      famiglia_tipologia: '',
+      slot_profile: { core: '', complementare: '' },
+      slot: [],
+      usage_tags: [],
+      completion_flags: normaliseCompletionFlags(undefined),
+      data_origin: '',
+      debolezza: '',
+      mutazione_indotta: '',
+      requisiti_ambientali: [],
+      sinergie: [],
+      sinergie_pi: normaliseSynergyPi(undefined),
+      species_affinity: [],
+      spinta_selettiva: '',
+      uso_funzione: '',
+      fattore_mantenimento_energetico: '',
+      conflitti: [],
+      biome_tags: undefined,
+    };
+  }
+
+  const source = value as Record<string, unknown>;
+  const id = ensureString(source.id, fallbackId ?? '');
+  const requisiti = Array.isArray(source.requisiti_ambientali)
+    ? source.requisiti_ambientali.map((item) => normaliseRequirement(item))
+    : [];
+  const sinergiePi = normaliseSynergyPi(source.sinergie_pi);
+  const speciesAffinity = Array.isArray(source.species_affinity)
+    ? source.species_affinity.map((item) => normaliseSpeciesAffinity(item))
+    : [];
+
+  const entry: TraitIndexEntry = {
+    id,
+    label: ensureString(source.label, id),
+    tier: ensureString(source.tier),
+    famiglia_tipologia: ensureString(source.famiglia_tipologia),
+    slot_profile: normaliseSlotProfile(source.slot_profile),
+    slot: ensureStringArray(source.slot),
+    usage_tags: ensureStringArray(source.usage_tags),
+    completion_flags: normaliseCompletionFlags(source.completion_flags),
+    data_origin: ensureString(source.data_origin),
+    debolezza: ensureString(source.debolezza),
+    mutazione_indotta: ensureString(source.mutazione_indotta),
+    requisiti_ambientali: requisiti,
+    sinergie: ensureStringArray(source.sinergie),
+    sinergie_pi: sinergiePi,
+    species_affinity: speciesAffinity,
+    spinta_selettiva: ensureString(source.spinta_selettiva),
+    uso_funzione: ensureString(source.uso_funzione),
+    fattore_mantenimento_energetico: ensureString(source.fattore_mantenimento_energetico),
+    conflitti: ensureStringArray(source.conflitti),
+    biome_tags: Array.isArray(source.biome_tags) ? ensureStringArray(source.biome_tags) : undefined,
+  };
+
+  return entry;
+};
+
+const createTraitFromEntry = (entry: TraitIndexEntry): Trait => {
+  const signatureMoves = [...entry.sinergie];
+  const trait: Trait = {
+    id: entry.id,
+    name: entry.label,
+    description: entry.uso_funzione || entry.mutazione_indotta || '',
+    archetype: entry.famiglia_tipologia,
+    playstyle: entry.spinta_selettiva,
+    signatureMoves,
+    entry: {
+      ...entry,
+      sinergie: [...signatureMoves],
+    },
+  };
+
+  return synchroniseTraitPresentation(trait);
+};
+
+export const parseTraitIndexDocument = (document: TraitIndexDocument): Trait[] => {
+  const entries = document?.traits ?? {};
+  return Object.entries(entries).map(([key, raw]) => createTraitFromEntry(normaliseTraitIndexEntry(raw, key)));
+};
+
+export const parseTraitPayload = (payload: unknown): Trait[] => {
+  if (Array.isArray(payload)) {
+    return payload.map((entry, index) => createTraitFromEntry(normaliseTraitIndexEntry(entry, `legacy-${index}`)));
+  }
+
+  if (payload && typeof payload === 'object') {
+    const container = payload as Record<string, unknown>;
+    if (container.traits && typeof container.traits === 'object') {
+      const document: TraitIndexDocument = {
+        schema_version: ensureString(container.schema_version),
+        trait_glossary: ensureString(container.trait_glossary),
+        traits: container.traits as Record<string, TraitIndexEntry>,
+      };
+      return parseTraitIndexDocument(document);
+    }
+  }
+
+  throw new Error('Formato della risposta dei tratti non riconosciuto.');
+};

--- a/Trait Editor/src/services/trait-state.service.ts
+++ b/Trait Editor/src/services/trait-state.service.ts
@@ -1,4 +1,5 @@
 import type { Trait } from '../types/trait';
+import { cloneTrait } from '../utils/trait-helpers';
 
 export interface TraitStatus {
   message: string;
@@ -44,7 +45,7 @@ export class TraitStateService {
   }
 
   setPreviewTrait(trait: Trait | null): void {
-    this.state.previewTrait = trait ? this.cloneTrait(trait) : null;
+    this.state.previewTrait = trait ? cloneTrait(trait) : null;
     this.broadcast();
   }
 
@@ -61,13 +62,10 @@ export class TraitStateService {
     return {
       isLoading: this.state.isLoading,
       status: this.state.status ? { ...this.state.status } : null,
-      previewTrait: this.state.previewTrait ? this.cloneTrait(this.state.previewTrait) : null,
+      previewTrait: this.state.previewTrait ? cloneTrait(this.state.previewTrait) : null,
     };
   }
 
-  private cloneTrait(trait: Trait): Trait {
-    return { ...trait, signatureMoves: [...trait.signatureMoves] };
-  }
 }
 
 export const registerTraitStateService = (module: any): void => {

--- a/Trait Editor/src/types/trait.ts
+++ b/Trait Editor/src/types/trait.ts
@@ -1,3 +1,76 @@
+export interface TraitCompletionFlags {
+  has_biome: boolean;
+  has_data_origin: boolean;
+  has_species_link: boolean;
+  has_usage_tags: boolean;
+}
+
+export interface TraitRequirementMeta {
+  expansion?: string;
+  notes?: string;
+  tier?: string;
+  [key: string]: unknown;
+}
+
+export interface TraitRequirementConditions {
+  biome_class?: string;
+  [key: string]: unknown;
+}
+
+export interface TraitRequirement {
+  capacita_richieste: string[];
+  condizioni: TraitRequirementConditions;
+  fonte: string;
+  meta?: TraitRequirementMeta;
+}
+
+export interface TraitSlotProfile {
+  core: string;
+  complementare: string;
+}
+
+export interface TraitSynergyPi {
+  co_occorrenze: string[];
+  combo_totale: number;
+  forme: string[];
+  tabelle_random: string[];
+}
+
+export interface TraitSpeciesAffinity {
+  roles: string[];
+  species_id: string;
+  weight: number;
+}
+
+export interface TraitIndexEntry {
+  id: string;
+  label: string;
+  tier: string;
+  famiglia_tipologia: string;
+  slot_profile: TraitSlotProfile;
+  slot: string[];
+  usage_tags: string[];
+  completion_flags: TraitCompletionFlags;
+  data_origin: string;
+  debolezza: string;
+  mutazione_indotta: string;
+  requisiti_ambientali: TraitRequirement[];
+  sinergie: string[];
+  sinergie_pi: TraitSynergyPi;
+  species_affinity: TraitSpeciesAffinity[];
+  spinta_selettiva: string;
+  uso_funzione: string;
+  fattore_mantenimento_energetico: string;
+  conflitti: string[];
+  biome_tags?: string[];
+}
+
+export interface TraitIndexDocument {
+  schema_version: string;
+  trait_glossary: string;
+  traits: Record<string, TraitIndexEntry>;
+}
+
 export interface Trait {
   id: string;
   name: string;
@@ -5,4 +78,5 @@ export interface Trait {
   archetype: string;
   playstyle: string;
   signatureMoves: string[];
+  entry: TraitIndexEntry;
 }

--- a/Trait Editor/src/utils/trait-helpers.ts
+++ b/Trait Editor/src/utils/trait-helpers.ts
@@ -1,0 +1,49 @@
+import type { Trait, TraitIndexEntry } from '../types/trait';
+
+const deepClone = <T>(value: T): T => {
+  if (Array.isArray(value)) {
+    return (value.map((item) => deepClone(item)) as unknown) as T;
+  }
+
+  if (value && typeof value === 'object') {
+    if (value === null) {
+      return value;
+    }
+
+    const source = value as Record<string, unknown>;
+    const clone: Record<string, unknown> = {};
+    for (const key of Object.keys(source)) {
+      clone[key] = deepClone(source[key]);
+    }
+    return clone as T;
+  }
+
+  return value;
+};
+
+export const cloneTraitEntry = (entry: TraitIndexEntry): TraitIndexEntry => deepClone(entry);
+
+export const synchroniseTraitPresentation = (trait: Trait): Trait => {
+  trait.entry.label = trait.name;
+  trait.entry.famiglia_tipologia = trait.archetype;
+  trait.entry.spinta_selettiva = trait.playstyle;
+  trait.entry.uso_funzione = trait.description;
+  trait.entry.sinergie = [...trait.signatureMoves];
+  return trait;
+};
+
+export const cloneTrait = (trait: Trait): Trait => {
+  const signatureMoves = [...trait.signatureMoves];
+  const entryClone = cloneTraitEntry(trait.entry);
+  entryClone.sinergie = [...signatureMoves];
+
+  const traitClone: Trait = {
+    ...trait,
+    signatureMoves,
+    entry: entryClone,
+  };
+
+  return synchroniseTraitPresentation(traitClone);
+};
+
+export const cloneTraits = (traits: Trait[]): Trait[] => traits.map((trait) => cloneTrait(trait));

--- a/Trait Editor/vitest.config.ts
+++ b/Trait Editor/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    globals: true,
+    setupFiles: [],
+  },
+});


### PR DESCRIPTION
## Summary
- parse trait index documents into DTOs that preserve nested schema data and expose presentation fields
- refresh the trait data service to normalise remote responses, manage fallback cache TTLs, and provide retry helpers
- add reusable trait cloning utilities and update editor/state flows to keep schema data in sync
- supply sample traits aligned to the real index and introduce vitest unit tests for parsing and caching logic

## Testing
- ../node_modules/.bin/vitest run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6910941b8fa4832abb59cd16992e7893)