### PR TITLE
Expand trait editor to support full entry payload

### DIFF
--- a/Trait Editor/src/pages/trait-editor/trait-editor.page.ts
+++ b/Trait Editor/src/pages/trait-editor/trait-editor.page.ts
@@ -1,7 +1,7 @@
-import type { Trait } from '../../types/trait';
+import type { Trait, TraitRequirement, TraitSpeciesAffinity } from '../../types/trait';
 import { TraitDataService } from '../../services/trait-data.service';
 import { TraitStateService, type TraitUiState } from '../../services/trait-state.service';
-import { cloneTrait, synchroniseTraitPresentation } from '../../utils/trait-helpers';
+import { cloneTrait, mergeTrait, synchroniseTraitPresentation } from '../../utils/trait-helpers';
 
 interface TraitFormModel extends Trait {}
 
@@ -39,16 +39,194 @@ class TraitEditorController {
   addSignatureMove(): void {
     if (this.formModel) {
       this.formModel.signatureMoves.push('');
-      this.syncFormModel();
-      this.propagatePreview();
+      this.onFormChange();
     }
   }
 
   removeSignatureMove(index: number): void {
     if (this.formModel) {
       this.formModel.signatureMoves.splice(index, 1);
-      this.syncFormModel();
-      this.propagatePreview();
+      this.onFormChange();
+    }
+  }
+
+  onLabelChange(): void {
+    if (!this.formModel) {
+      return;
+    }
+
+    this.formModel.name = this.formModel.entry.label;
+    this.onFormChange();
+  }
+
+  addSlot(): void {
+    if (this.formModel) {
+      this.formModel.entry.slot.push('');
+      this.onFormChange();
+    }
+  }
+
+  removeSlot(index: number): void {
+    if (this.formModel) {
+      this.formModel.entry.slot.splice(index, 1);
+      this.onFormChange();
+    }
+  }
+
+  addUsageTag(): void {
+    if (this.formModel) {
+      this.formModel.entry.usage_tags.push('');
+      this.onFormChange();
+    }
+  }
+
+  removeUsageTag(index: number): void {
+    if (this.formModel) {
+      this.formModel.entry.usage_tags.splice(index, 1);
+      this.onFormChange();
+    }
+  }
+
+  addConflict(): void {
+    if (this.formModel) {
+      this.formModel.entry.conflitti.push('');
+      this.onFormChange();
+    }
+  }
+
+  removeConflict(index: number): void {
+    if (this.formModel) {
+      this.formModel.entry.conflitti.splice(index, 1);
+      this.onFormChange();
+    }
+  }
+
+  addBiomeTag(): void {
+    if (this.formModel) {
+      this.formModel.entry.biome_tags.push('');
+      this.onFormChange();
+    }
+  }
+
+  removeBiomeTag(index: number): void {
+    if (this.formModel) {
+      this.formModel.entry.biome_tags.splice(index, 1);
+      this.onFormChange();
+    }
+  }
+
+  addSynergyPiCoOccurrence(): void {
+    if (this.formModel) {
+      this.formModel.entry.sinergie_pi.co_occorrenze.push('');
+      this.onFormChange();
+    }
+  }
+
+  removeSynergyPiCoOccurrence(index: number): void {
+    if (this.formModel) {
+      this.formModel.entry.sinergie_pi.co_occorrenze.splice(index, 1);
+      this.onFormChange();
+    }
+  }
+
+  addSynergyPiForm(): void {
+    if (this.formModel) {
+      this.formModel.entry.sinergie_pi.forme.push('');
+      this.onFormChange();
+    }
+  }
+
+  removeSynergyPiForm(index: number): void {
+    if (this.formModel) {
+      this.formModel.entry.sinergie_pi.forme.splice(index, 1);
+      this.onFormChange();
+    }
+  }
+
+  addSynergyPiRandomTable(): void {
+    if (this.formModel) {
+      this.formModel.entry.sinergie_pi.tabelle_random.push('');
+      this.onFormChange();
+    }
+  }
+
+  removeSynergyPiRandomTable(index: number): void {
+    if (this.formModel) {
+      this.formModel.entry.sinergie_pi.tabelle_random.splice(index, 1);
+      this.onFormChange();
+    }
+  }
+
+  addSpeciesAffinity(): void {
+    if (this.formModel) {
+      this.formModel.entry.species_affinity.push({ roles: [''], species_id: '', weight: 0 });
+      this.onFormChange();
+    }
+  }
+
+  removeSpeciesAffinity(index: number): void {
+    if (this.formModel) {
+      this.formModel.entry.species_affinity.splice(index, 1);
+      this.onFormChange();
+    }
+  }
+
+  addSpeciesAffinityRole(index: number): void {
+    if (this.formModel) {
+      const affinity = this.formModel.entry.species_affinity[index];
+      if (affinity) {
+        affinity.roles.push('');
+        this.onFormChange();
+      }
+    }
+  }
+
+  removeSpeciesAffinityRole(index: number, roleIndex: number): void {
+    if (this.formModel) {
+      const affinity = this.formModel.entry.species_affinity[index];
+      if (affinity) {
+        affinity.roles.splice(roleIndex, 1);
+        this.onFormChange();
+      }
+    }
+  }
+
+  addRequirement(): void {
+    if (this.formModel) {
+      this.formModel.entry.requisiti_ambientali.push({
+        capacita_richieste: [''],
+        condizioni: {},
+        fonte: '',
+        meta: {},
+      });
+      this.onFormChange();
+    }
+  }
+
+  removeRequirement(index: number): void {
+    if (this.formModel) {
+      this.formModel.entry.requisiti_ambientali.splice(index, 1);
+      this.onFormChange();
+    }
+  }
+
+  addRequirementCapability(index: number): void {
+    if (this.formModel) {
+      const requirement = this.formModel.entry.requisiti_ambientali[index];
+      if (requirement) {
+        requirement.capacita_richieste.push('');
+        this.onFormChange();
+      }
+    }
+  }
+
+  removeRequirementCapability(index: number, capabilityIndex: number): void {
+    if (this.formModel) {
+      const requirement = this.formModel.entry.requisiti_ambientali[index];
+      if (requirement) {
+        requirement.capacita_richieste.splice(capabilityIndex, 1);
+        this.onFormChange();
+      }
     }
   }
 
@@ -66,7 +244,8 @@ class TraitEditorController {
       return;
     }
 
-    const payload = cloneTrait(this.formModel);
+    const payload = mergeTrait(this.trait, this.formModel);
+    synchroniseTraitPresentation(payload);
     this.stateService.setStatus(null);
     this.stateService.setLoading(true);
 
@@ -74,8 +253,8 @@ class TraitEditorController {
       .saveTrait(payload)
       .then((savedTrait) => {
         this.trait = savedTrait;
-        this.formModel = cloneTrait(savedTrait);
-        this.stateService.setPreviewTrait(savedTrait);
+        this.formModel = this.prepareFormModel(savedTrait);
+        this.stateService.setPreviewTrait(this.formModel);
         this.stateService.setStatus('Modifiche salvate con successo.', 'success');
         this.$timeout(() => this.stateService.setStatus(null), 3000);
         this.$location.path(`/traits/${savedTrait.id}`);
@@ -97,8 +276,8 @@ class TraitEditorController {
       return;
     }
 
-    this.formModel = cloneTrait(this.trait);
-    this.stateService.setPreviewTrait(this.trait);
+    this.formModel = this.prepareFormModel(this.trait);
+    this.stateService.setPreviewTrait(this.formModel);
     this.stateService.setStatus(null);
     this.$location.path(`/traits/${this.trait.id}`);
   }
@@ -127,8 +306,8 @@ class TraitEditorController {
         }
 
         this.trait = trait;
-        this.formModel = cloneTrait(trait);
-        this.stateService.setPreviewTrait(trait);
+        this.formModel = this.prepareFormModel(trait);
+        this.stateService.setPreviewTrait(this.formModel);
         const lastError = this.dataService.getLastError();
         if (lastError) {
           this.stateService.setStatus('Modifica locale: la sorgente remota non è stata raggiunta.', 'info');
@@ -143,6 +322,63 @@ class TraitEditorController {
       .finally(() => {
         this.stateService.setLoading(false);
       });
+  }
+
+  private prepareFormModel(trait: Trait): TraitFormModel {
+    const model = this.ensureCollections(cloneTrait(trait));
+    return synchroniseTraitPresentation(model);
+  }
+
+  private ensureCollections(model: TraitFormModel): TraitFormModel {
+    model.signatureMoves = Array.isArray(model.signatureMoves) ? [...model.signatureMoves] : [];
+    const entry = model.entry;
+    entry.label = entry.label ?? model.name;
+    entry.slot_profile = { ...entry.slot_profile };
+    entry.slot = Array.isArray(entry.slot) ? [...entry.slot] : [];
+    entry.usage_tags = Array.isArray(entry.usage_tags) ? [...entry.usage_tags] : [];
+    entry.conflitti = Array.isArray(entry.conflitti) ? [...entry.conflitti] : [];
+    entry.biome_tags = Array.isArray(entry.biome_tags) ? [...entry.biome_tags] : [];
+    entry.completion_flags = { ...entry.completion_flags };
+    entry.sinergie = Array.isArray(entry.sinergie) ? [...entry.sinergie] : [];
+    entry.sinergie_pi = {
+      co_occorrenze: Array.isArray(entry.sinergie_pi.co_occorrenze)
+        ? [...entry.sinergie_pi.co_occorrenze]
+        : [],
+      combo_totale: Number.isFinite(entry.sinergie_pi.combo_totale)
+        ? entry.sinergie_pi.combo_totale
+        : 0,
+      forme: Array.isArray(entry.sinergie_pi.forme) ? [...entry.sinergie_pi.forme] : [],
+      tabelle_random: Array.isArray(entry.sinergie_pi.tabelle_random)
+        ? [...entry.sinergie_pi.tabelle_random]
+        : [],
+    };
+    entry.species_affinity = Array.isArray(entry.species_affinity)
+      ? entry.species_affinity.map((affinity) => this.normaliseSpeciesAffinity(affinity))
+      : [];
+    entry.requisiti_ambientali = Array.isArray(entry.requisiti_ambientali)
+      ? entry.requisiti_ambientali.map((requirement) => this.normaliseRequirement(requirement))
+      : [];
+
+    return model;
+  }
+
+  private normaliseSpeciesAffinity(affinity: TraitSpeciesAffinity): TraitSpeciesAffinity {
+    return {
+      species_id: affinity.species_id,
+      weight: affinity.weight,
+      roles: Array.isArray(affinity.roles) ? [...affinity.roles] : [],
+    };
+  }
+
+  private normaliseRequirement(requirement: TraitRequirement): TraitRequirement {
+    return {
+      capacita_richieste: Array.isArray(requirement.capacita_richieste)
+        ? [...requirement.capacita_richieste]
+        : [],
+      condizioni: requirement.condizioni ? { ...requirement.condizioni } : {},
+      fonte: requirement.fonte,
+      meta: requirement.meta ? { ...requirement.meta } : {},
+    };
   }
 
   statusIcon(): string {
@@ -164,7 +400,6 @@ class TraitEditorController {
 
   private propagatePreview(): void {
     if (this.formModel) {
-      this.syncFormModel();
       this.stateService.setPreviewTrait(this.formModel);
     }
   }
@@ -289,6 +524,541 @@ export const registerTraitEditorPage = (module: any): void => {
                   La descrizione deve contenere almeno 10 caratteri.
                 </p>
               </div>
+            </fieldset>
+
+            <fieldset class="trait-form__section">
+              <legend class="trait-form__legend">Indice e classificazione</legend>
+
+              <div
+                class="form-field"
+                ng-class="{ 'form-field--invalid': editorForm.entryLabel.$invalid && editorForm.entryLabel.$touched }"
+              >
+                <label for="trait-label">Label indice</label>
+                <input
+                  id="trait-label"
+                  name="entryLabel"
+                  type="text"
+                  ng-model="$ctrl.formModel.entry.label"
+                  ng-change="$ctrl.onLabelChange()"
+                  required
+                />
+                <p class="form-field__error" ng-if="editorForm.entryLabel.$error.required && editorForm.entryLabel.$touched">
+                  Il label è obbligatorio.
+                </p>
+              </div>
+
+              <div
+                class="form-field"
+                ng-class="{ 'form-field--invalid': editorForm.entryTier.$invalid && editorForm.entryTier.$touched }"
+              >
+                <label for="trait-tier">Tier</label>
+                <input
+                  id="trait-tier"
+                  name="entryTier"
+                  type="text"
+                  ng-model="$ctrl.formModel.entry.tier"
+                  ng-change="$ctrl.onFormChange()"
+                  required
+                />
+                <p class="form-field__error" ng-if="editorForm.entryTier.$error.required && editorForm.entryTier.$touched">
+                  Il tier è obbligatorio.
+                </p>
+              </div>
+
+              <div class="form-field-group">
+                <div class="form-field">
+                  <label for="slot-core">Slot core</label>
+                  <input
+                    id="slot-core"
+                    name="slotCore"
+                    type="text"
+                    ng-model="$ctrl.formModel.entry.slot_profile.core"
+                    ng-change="$ctrl.onFormChange()"
+                    required
+                  />
+                </div>
+                <div class="form-field">
+                  <label for="slot-complementare">Slot complementare</label>
+                  <input
+                    id="slot-complementare"
+                    name="slotComplementare"
+                    type="text"
+                    ng-model="$ctrl.formModel.entry.slot_profile.complementare"
+                    ng-change="$ctrl.onFormChange()"
+                    required
+                  />
+                </div>
+              </div>
+            </fieldset>
+
+            <fieldset class="trait-form__section">
+              <legend class="trait-form__legend">Slot e tag</legend>
+
+              <div class="signature-moves">
+                <div
+                  class="signature-moves__item"
+                  ng-repeat="slot in $ctrl.formModel.entry.slot track by $index"
+                >
+                  <label class="signature-moves__label" for="slot-{{$index}}">Slot {{$index + 1}}</label>
+                  <div class="signature-moves__controls">
+                    <input
+                      id="slot-{{$index}}"
+                      name="slot{{$index}}"
+                      type="text"
+                      ng-model="$ctrl.formModel.entry.slot[$index]"
+                      ng-change="$ctrl.onFormChange()"
+                      required
+                    />
+                    <button type="button" class="button button--icon" ng-click="$ctrl.removeSlot($index)">
+                      <span aria-hidden="true">✕</span>
+                      <span class="visually-hidden">Rimuovi slot {{$index + 1}}</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <button type="button" class="button button--ghost" ng-click="$ctrl.addSlot()">
+                Aggiungi slot
+              </button>
+
+              <div class="signature-moves">
+                <div
+                  class="signature-moves__item"
+                  ng-repeat="tag in $ctrl.formModel.entry.usage_tags track by $index"
+                >
+                  <label class="signature-moves__label" for="tag-{{$index}}">Tag {{$index + 1}}</label>
+                  <div class="signature-moves__controls">
+                    <input
+                      id="tag-{{$index}}"
+                      name="tag{{$index}}"
+                      type="text"
+                      ng-model="$ctrl.formModel.entry.usage_tags[$index]"
+                      ng-change="$ctrl.onFormChange()"
+                      required
+                    />
+                    <button type="button" class="button button--icon" ng-click="$ctrl.removeUsageTag($index)">
+                      <span aria-hidden="true">✕</span>
+                      <span class="visually-hidden">Rimuovi tag {{$index + 1}}</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <button type="button" class="button button--ghost" ng-click="$ctrl.addUsageTag()">
+                Aggiungi tag
+              </button>
+            </fieldset>
+
+            <fieldset class="trait-form__section">
+              <legend class="trait-form__legend">Flag di completamento</legend>
+
+              <div class="form-field form-field--checkbox">
+                <label>
+                  <input
+                    type="checkbox"
+                    ng-model="$ctrl.formModel.entry.completion_flags.has_biome"
+                    ng-change="$ctrl.onFormChange()"
+                  />
+                  Bioma definito
+                </label>
+              </div>
+              <div class="form-field form-field--checkbox">
+                <label>
+                  <input
+                    type="checkbox"
+                    ng-model="$ctrl.formModel.entry.completion_flags.has_data_origin"
+                    ng-change="$ctrl.onFormChange()"
+                  />
+                  Origine dati presente
+                </label>
+              </div>
+              <div class="form-field form-field--checkbox">
+                <label>
+                  <input
+                    type="checkbox"
+                    ng-model="$ctrl.formModel.entry.completion_flags.has_species_link"
+                    ng-change="$ctrl.onFormChange()"
+                  />
+                  Collegamento specie
+                </label>
+              </div>
+              <div class="form-field form-field--checkbox">
+                <label>
+                  <input
+                    type="checkbox"
+                    ng-model="$ctrl.formModel.entry.completion_flags.has_usage_tags"
+                    ng-change="$ctrl.onFormChange()"
+                  />
+                  Tag d'uso definiti
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset class="trait-form__section">
+              <legend class="trait-form__legend">Contestualizzazione</legend>
+
+              <div class="form-field">
+                <label for="trait-data-origin">Origine dati</label>
+                <input
+                  id="trait-data-origin"
+                  name="dataOrigin"
+                  type="text"
+                  ng-model="$ctrl.formModel.entry.data_origin"
+                  ng-change="$ctrl.onFormChange()"
+                  required
+                />
+              </div>
+
+              <div class="form-field">
+                <label for="trait-weakness">Debolezza</label>
+                <textarea
+                  id="trait-weakness"
+                  name="weakness"
+                  rows="3"
+                  ng-model="$ctrl.formModel.entry.debolezza"
+                  ng-change="$ctrl.onFormChange()"
+                ></textarea>
+              </div>
+
+              <div class="form-field">
+                <label for="trait-mutation">Mutazione indotta</label>
+                <textarea
+                  id="trait-mutation"
+                  name="mutation"
+                  rows="3"
+                  ng-model="$ctrl.formModel.entry.mutazione_indotta"
+                  ng-change="$ctrl.onFormChange()"
+                ></textarea>
+              </div>
+
+              <div class="form-field">
+                <label for="trait-energy">Fattore di mantenimento energetico</label>
+                <input
+                  id="trait-energy"
+                  name="energyFactor"
+                  type="text"
+                  ng-model="$ctrl.formModel.entry.fattore_mantenimento_energetico"
+                  ng-change="$ctrl.onFormChange()"
+                />
+              </div>
+
+              <div class="signature-moves">
+                <div
+                  class="signature-moves__item"
+                  ng-repeat="conflict in $ctrl.formModel.entry.conflitti track by $index"
+                >
+                  <label class="signature-moves__label" for="conflict-{{$index}}">Conflitto {{$index + 1}}</label>
+                  <div class="signature-moves__controls">
+                    <input
+                      id="conflict-{{$index}}"
+                      name="conflict{{$index}}"
+                      type="text"
+                      ng-model="$ctrl.formModel.entry.conflitti[$index]"
+                      ng-change="$ctrl.onFormChange()"
+                    />
+                    <button type="button" class="button button--icon" ng-click="$ctrl.removeConflict($index)">
+                      <span aria-hidden="true">✕</span>
+                      <span class="visually-hidden">Rimuovi conflitto {{$index + 1}}</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <button type="button" class="button button--ghost" ng-click="$ctrl.addConflict()">
+                Aggiungi conflitto
+              </button>
+
+              <div class="signature-moves">
+                <div
+                  class="signature-moves__item"
+                  ng-repeat="tag in $ctrl.formModel.entry.biome_tags track by $index"
+                >
+                  <label class="signature-moves__label" for="biome-tag-{{$index}}">Biome tag {{$index + 1}}</label>
+                  <div class="signature-moves__controls">
+                    <input
+                      id="biome-tag-{{$index}}"
+                      name="biomeTag{{$index}}"
+                      type="text"
+                      ng-model="$ctrl.formModel.entry.biome_tags[$index]"
+                      ng-change="$ctrl.onFormChange()"
+                    />
+                    <button type="button" class="button button--icon" ng-click="$ctrl.removeBiomeTag($index)">
+                      <span aria-hidden="true">✕</span>
+                      <span class="visually-hidden">Rimuovi biome tag {{$index + 1}}</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <button type="button" class="button button--ghost" ng-click="$ctrl.addBiomeTag()">
+                Aggiungi biome tag
+              </button>
+            </fieldset>
+
+            <fieldset class="trait-form__section">
+              <legend class="trait-form__legend">Sinergie approfondite</legend>
+
+              <div class="form-field">
+                <label for="combo-totale">Combo totale</label>
+                <input
+                  id="combo-totale"
+                  name="comboTotale"
+                  type="number"
+                  min="0"
+                  ng-model="$ctrl.formModel.entry.sinergie_pi.combo_totale"
+                  ng-change="$ctrl.onFormChange()"
+                />
+              </div>
+
+              <div class="signature-moves">
+                <div
+                  class="signature-moves__item"
+                  ng-repeat="item in $ctrl.formModel.entry.sinergie_pi.co_occorrenze track by $index"
+                >
+                  <label class="signature-moves__label" for="co-occur-{{$index}}">Co-occorrenza {{$index + 1}}</label>
+                  <div class="signature-moves__controls">
+                    <input
+                      id="co-occur-{{$index}}"
+                      name="coOccorrenza{{$index}}"
+                      type="text"
+                      ng-model="$ctrl.formModel.entry.sinergie_pi.co_occorrenze[$index]"
+                      ng-change="$ctrl.onFormChange()"
+                    />
+                    <button type="button" class="button button--icon" ng-click="$ctrl.removeSynergyPiCoOccurrence($index)">
+                      <span aria-hidden="true">✕</span>
+                      <span class="visually-hidden">Rimuovi co-occorrenza {{$index + 1}}</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <button type="button" class="button button--ghost" ng-click="$ctrl.addSynergyPiCoOccurrence()">
+                Aggiungi co-occorrenza
+              </button>
+
+              <div class="signature-moves">
+                <div
+                  class="signature-moves__item"
+                  ng-repeat="forma in $ctrl.formModel.entry.sinergie_pi.forme track by $index"
+                >
+                  <label class="signature-moves__label" for="forma-{{$index}}">Forma {{$index + 1}}</label>
+                  <div class="signature-moves__controls">
+                    <input
+                      id="forma-{{$index}}"
+                      name="forma{{$index}}"
+                      type="text"
+                      ng-model="$ctrl.formModel.entry.sinergie_pi.forme[$index]"
+                      ng-change="$ctrl.onFormChange()"
+                    />
+                    <button type="button" class="button button--icon" ng-click="$ctrl.removeSynergyPiForm($index)">
+                      <span aria-hidden="true">✕</span>
+                      <span class="visually-hidden">Rimuovi forma {{$index + 1}}</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <button type="button" class="button button--ghost" ng-click="$ctrl.addSynergyPiForm()">
+                Aggiungi forma
+              </button>
+
+              <div class="signature-moves">
+                <div
+                  class="signature-moves__item"
+                  ng-repeat="table in $ctrl.formModel.entry.sinergie_pi.tabelle_random track by $index"
+                >
+                  <label class="signature-moves__label" for="random-table-{{$index}}">Tabella casuale {{$index + 1}}</label>
+                  <div class="signature-moves__controls">
+                    <input
+                      id="random-table-{{$index}}"
+                      name="randomTable{{$index}}"
+                      type="text"
+                      ng-model="$ctrl.formModel.entry.sinergie_pi.tabelle_random[$index]"
+                      ng-change="$ctrl.onFormChange()"
+                    />
+                    <button type="button" class="button button--icon" ng-click="$ctrl.removeSynergyPiRandomTable($index)">
+                      <span aria-hidden="true">✕</span>
+                      <span class="visually-hidden">Rimuovi tabella {{$index + 1}}</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <button type="button" class="button button--ghost" ng-click="$ctrl.addSynergyPiRandomTable()">
+                Aggiungi tabella
+              </button>
+            </fieldset>
+
+            <fieldset class="trait-form__section">
+              <legend class="trait-form__legend">Affinità di specie</legend>
+
+              <div class="nested-list" ng-repeat="affinity in $ctrl.formModel.entry.species_affinity track by $index">
+                <div class="nested-list__header">
+                  <h3 class="nested-list__title">Affinità {{$index + 1}}</h3>
+                  <button type="button" class="button button--ghost" ng-click="$ctrl.removeSpeciesAffinity($index)">
+                    Rimuovi
+                  </button>
+                </div>
+                <div class="form-field">
+                  <label for="species-id-{{$index}}">Specie</label>
+                  <input
+                    id="species-id-{{$index}}"
+                    name="species{{$index}}"
+                    type="text"
+                    ng-model="affinity.species_id"
+                    ng-change="$ctrl.onFormChange()"
+                    required
+                  />
+                </div>
+                <div class="form-field">
+                  <label for="species-weight-{{$index}}">Peso</label>
+                  <input
+                    id="species-weight-{{$index}}"
+                    name="speciesWeight{{$index}}"
+                    type="number"
+                    step="0.01"
+                    ng-model="affinity.weight"
+                    ng-change="$ctrl.onFormChange()"
+                  />
+                </div>
+                <div class="signature-moves">
+                  <div class="signature-moves__item" ng-repeat="role in affinity.roles track by $index">
+                    <label
+                      class="signature-moves__label"
+                      for="species-role-{{$parent.$index}}-{{$index}}"
+                    >
+                      Ruolo {{$index + 1}}
+                    </label>
+                    <div class="signature-moves__controls">
+                      <input
+                        id="species-role-{{$parent.$index}}-{{$index}}"
+                        name="speciesRole{{$parent.$index}}{{$index}}"
+                        type="text"
+                        ng-model="affinity.roles[$index]"
+                        ng-change="$ctrl.onFormChange()"
+                      />
+                      <button
+                        type="button"
+                        class="button button--icon"
+                        ng-click="$ctrl.removeSpeciesAffinityRole($parent.$index, $index)"
+                      >
+                        <span aria-hidden="true">✕</span>
+                        <span class="visually-hidden">Rimuovi ruolo {{$index + 1}}</span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  class="button button--ghost"
+                  ng-click="$ctrl.addSpeciesAffinityRole($index)"
+                >
+                  Aggiungi ruolo
+                </button>
+              </div>
+
+              <button type="button" class="button button--ghost" ng-click="$ctrl.addSpeciesAffinity()">
+                Aggiungi affinità di specie
+              </button>
+            </fieldset>
+
+            <fieldset class="trait-form__section">
+              <legend class="trait-form__legend">Requisiti ambientali</legend>
+
+              <div class="nested-list" ng-repeat="requirement in $ctrl.formModel.entry.requisiti_ambientali track by $index">
+                <div class="nested-list__header">
+                  <h3 class="nested-list__title">Requisito {{$index + 1}}</h3>
+                  <button type="button" class="button button--ghost" ng-click="$ctrl.removeRequirement($index)">
+                    Rimuovi
+                  </button>
+                </div>
+                <div class="form-field">
+                  <label for="requirement-source-{{$index}}">Fonte</label>
+                  <input
+                    id="requirement-source-{{$index}}"
+                    name="requirementSource{{$index}}"
+                    type="text"
+                    ng-model="requirement.fonte"
+                    ng-change="$ctrl.onFormChange()"
+                  />
+                </div>
+                <div class="signature-moves">
+                  <div
+                    class="signature-moves__item"
+                    ng-repeat="capability in requirement.capacita_richieste track by $index"
+                  >
+                    <label
+                      class="signature-moves__label"
+                      for="capability-{{$parent.$index}}-{{$index}}"
+                    >
+                      Capacità {{$index + 1}}
+                    </label>
+                    <div class="signature-moves__controls">
+                      <input
+                        id="capability-{{$parent.$index}}-{{$index}}"
+                        name="capability{{$parent.$index}}{{$index}}"
+                        type="text"
+                        ng-model="requirement.capacita_richieste[$index]"
+                        ng-change="$ctrl.onFormChange()"
+                      />
+                      <button
+                        type="button"
+                        class="button button--icon"
+                        ng-click="$ctrl.removeRequirementCapability($parent.$index, $index)"
+                      >
+                        <span aria-hidden="true">✕</span>
+                        <span class="visually-hidden">Rimuovi capacità {{$index + 1}}</span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  class="button button--ghost"
+                  ng-click="$ctrl.addRequirementCapability($index)"
+                >
+                  Aggiungi capacità
+                </button>
+                <div class="form-field">
+                  <label for="requirement-biome-{{$index}}">Classe di bioma</label>
+                  <input
+                    id="requirement-biome-{{$index}}"
+                    name="requirementBiome{{$index}}"
+                    type="text"
+                    ng-model="requirement.condizioni.biome_class"
+                    ng-change="$ctrl.onFormChange()"
+                  />
+                </div>
+                <div class="form-field">
+                  <label for="requirement-meta-expansion-{{$index}}">Meta - Espansione</label>
+                  <input
+                    id="requirement-meta-expansion-{{$index}}"
+                    name="requirementMetaExpansion{{$index}}"
+                    type="text"
+                    ng-model="requirement.meta.expansion"
+                    ng-change="$ctrl.onFormChange()"
+                  />
+                </div>
+                <div class="form-field">
+                  <label for="requirement-meta-tier-{{$index}}">Meta - Tier</label>
+                  <input
+                    id="requirement-meta-tier-{{$index}}"
+                    name="requirementMetaTier{{$index}}"
+                    type="text"
+                    ng-model="requirement.meta.tier"
+                    ng-change="$ctrl.onFormChange()"
+                  />
+                </div>
+                <div class="form-field">
+                  <label for="requirement-meta-notes-{{$index}}">Meta - Note</label>
+                  <textarea
+                    id="requirement-meta-notes-{{$index}}"
+                    name="requirementMetaNotes{{$index}}"
+                    rows="2"
+                    ng-model="requirement.meta.notes"
+                    ng-change="$ctrl.onFormChange()"
+                  ></textarea>
+                </div>
+              </div>
+
+              <button type="button" class="button button--ghost" ng-click="$ctrl.addRequirement()">
+                Aggiungi requisito
+              </button>
             </fieldset>
 
             <fieldset class="trait-form__section">

--- a/Trait Editor/src/services/__tests__/trait-state.service.spec.ts
+++ b/Trait Editor/src/services/__tests__/trait-state.service.spec.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { TraitStateService } from '../trait-state.service';
+import { getSampleTraits } from '../../data/traits.sample';
+
+const createRootScope = () => {
+  const listeners: Array<() => void> = [];
+  return {
+    $broadcast: (event: string) => {
+      if (event === 'traitStateChanged') {
+        listeners.forEach((callback) => callback());
+      }
+    },
+    $on: (event: string, callback: () => void) => {
+      if (event === 'traitStateChanged') {
+        listeners.push(callback);
+        return () => {
+          const index = listeners.indexOf(callback);
+          if (index >= 0) {
+            listeners.splice(index, 1);
+          }
+        };
+      }
+
+      return () => undefined;
+    },
+  };
+};
+
+const createScope = () => ({
+  $on: (_event: string, _handler: () => void) => () => undefined,
+});
+
+describe('TraitStateService', () => {
+  const sampleTrait = getSampleTraits()[0];
+  let rootScope: ReturnType<typeof createRootScope>;
+  let service: TraitStateService;
+
+  beforeEach(() => {
+    rootScope = createRootScope();
+    service = new TraitStateService(rootScope as any);
+  });
+
+  it('delivers independent preview snapshots to subscribers', () => {
+    const firstScope = createScope();
+    const snapshots: any[] = [];
+    service.subscribe(firstScope as any, (state) => snapshots.push(state));
+
+    service.setPreviewTrait(sampleTrait);
+    expect(snapshots).toHaveLength(2);
+
+    const preview = snapshots[1].previewTrait;
+    expect(preview).not.toBeNull();
+    preview!.entry.completion_flags.has_biome = !preview!.entry.completion_flags.has_biome;
+
+    const secondScope = createScope();
+    let latest: any = null;
+    service.subscribe(secondScope as any, (state) => {
+      latest = state;
+    });
+
+    expect(latest.previewTrait?.entry.completion_flags.has_biome).toBe(
+      sampleTrait.entry.completion_flags.has_biome,
+    );
+  });
+
+  it('resets preview and loading state correctly', () => {
+    const scope = createScope();
+    let latest: any = null;
+    service.subscribe(scope as any, (state) => {
+      latest = state;
+    });
+
+    service.setLoading(true);
+    service.setPreviewTrait(sampleTrait);
+    service.setStatus('Prova', 'info');
+
+    service.reset();
+
+    expect(latest.isLoading).toBe(false);
+    expect(latest.previewTrait).toBeNull();
+    expect(latest.status).toBeNull();
+  });
+});

--- a/Trait Editor/src/styles/main.css
+++ b/Trait Editor/src/styles/main.css
@@ -546,6 +546,30 @@ body {
   color: #ff9d9d;
 }
 
+.form-field-group {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.form-field--checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.form-field--checkbox label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.form-field--checkbox input {
+  width: auto;
+  margin: 0;
+}
+
 .signature-moves {
   display: flex;
   flex-direction: column;
@@ -556,6 +580,27 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+.nested-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.nested-list__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nested-list__title {
+  margin: 0;
+  font-size: 1rem;
 }
 
 .signature-moves__controls {

--- a/Trait Editor/src/utils/__tests__/trait-helpers.spec.ts
+++ b/Trait Editor/src/utils/__tests__/trait-helpers.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSampleTraits } from '../../data/traits.sample';
+import { cloneTrait, mergeTrait, synchroniseTraitPresentation } from '../trait-helpers';
+
+describe('trait helpers', () => {
+  it('cloneTrait produces an independent copy of nested data', () => {
+    const [original] = getSampleTraits();
+    const copy = cloneTrait(original);
+
+    copy.entry.completion_flags.has_biome = !copy.entry.completion_flags.has_biome;
+    copy.entry.species_affinity[0].roles.push('tester');
+
+    expect(copy.entry.completion_flags.has_biome).not.toBe(original.entry.completion_flags.has_biome);
+    expect(original.entry.species_affinity[0].roles).not.toContain('tester');
+  });
+
+  it('mergeTrait preserves untouched fields while applying nested changes', () => {
+    const [original] = getSampleTraits();
+    const baseline = cloneTrait(original);
+    const updates = cloneTrait(original);
+
+    const toggledFlag = !updates.entry.completion_flags.has_biome;
+    updates.entry.tier = 'TX';
+    updates.entry.completion_flags.has_biome = toggledFlag;
+    updates.entry.species_affinity[0].roles.push('supporto');
+    updates.entry.requisiti_ambientali[0].meta.notes = 'Annotazione locale';
+    updates.entry.requisiti_ambientali[0].condizioni.biome_class = 'artico';
+    updates.entry.sinergie_pi.combo_totale = 99;
+
+    const merged = mergeTrait(baseline, updates);
+    synchroniseTraitPresentation(merged);
+
+    expect(merged.entry.tier).toBe('TX');
+    expect(merged.entry.completion_flags.has_biome).toBe(toggledFlag);
+    expect(merged.entry.species_affinity[0].roles).toContain('supporto');
+    expect(merged.entry.species_affinity[0].species_id).toBe(baseline.entry.species_affinity[0].species_id);
+    expect(merged.entry.requisiti_ambientali[0].meta?.notes).toBe('Annotazione locale');
+    expect(merged.entry.requisiti_ambientali[0].condizioni.biome_class).toBe('artico');
+    expect(merged.entry.sinergie_pi.combo_totale).toBe(99);
+
+    merged.entry.species_affinity[0].roles.push('diverso');
+    expect(baseline.entry.species_affinity[0].roles).not.toContain('diverso');
+  });
+});

--- a/Trait Editor/src/utils/trait-helpers.ts
+++ b/Trait Editor/src/utils/trait-helpers.ts
@@ -1,6 +1,6 @@
 import type { Trait, TraitIndexEntry } from '../types/trait';
 
-const deepClone = <T>(value: T): T => {
+export const deepClone = <T>(value: T): T => {
   if (Array.isArray(value)) {
     return (value.map((item) => deepClone(item)) as unknown) as T;
   }
@@ -21,7 +21,41 @@ const deepClone = <T>(value: T): T => {
   return value;
 };
 
+const deepAssign = (target: unknown, source: unknown): unknown => {
+  if (source === undefined) {
+    return target;
+  }
+
+  if (Array.isArray(source)) {
+    return source.map((item) => deepClone(item));
+  }
+
+  if (source && typeof source === 'object') {
+    const sourceObject = source as Record<string, unknown>;
+    const baseObject = (target && typeof target === 'object'
+      ? (target as Record<string, unknown>)
+      : {}) as Record<string, unknown>;
+
+    const result: Record<string, unknown> = { ...baseObject };
+    for (const key of Object.keys(sourceObject)) {
+      result[key] = deepAssign(baseObject[key], sourceObject[key]);
+    }
+    return result;
+  }
+
+  return source;
+};
+
 export const cloneTraitEntry = (entry: TraitIndexEntry): TraitIndexEntry => deepClone(entry);
+
+export const cloneTrait = (trait: Trait): Trait => deepClone(trait);
+
+export const cloneTraits = (traits: Trait[]): Trait[] => traits.map((trait) => cloneTrait(trait));
+
+export const mergeTrait = (baseline: Trait, updates: Trait): Trait => {
+  const baseClone = cloneTrait(baseline);
+  return deepAssign(baseClone, updates) as Trait;
+};
 
 export const synchroniseTraitPresentation = (trait: Trait): Trait => {
   trait.entry.label = trait.name;
@@ -31,19 +65,3 @@ export const synchroniseTraitPresentation = (trait: Trait): Trait => {
   trait.entry.sinergie = [...trait.signatureMoves];
   return trait;
 };
-
-export const cloneTrait = (trait: Trait): Trait => {
-  const signatureMoves = [...trait.signatureMoves];
-  const entryClone = cloneTraitEntry(trait.entry);
-  entryClone.sinergie = [...signatureMoves];
-
-  const traitClone: Trait = {
-    ...trait,
-    signatureMoves,
-    entry: entryClone,
-  };
-
-  return synchroniseTraitPresentation(traitClone);
-};
-
-export const cloneTraits = (traits: Trait[]): Trait[] => traits.map((trait) => cloneTrait(trait));


### PR DESCRIPTION
## Summary
- extend the trait editor controller and template so every required Trait.entry field can be inspected and edited without dropping nested data
- replace shallow cloning logic with deep clone/merge helpers to keep preview and save payloads aligned with the backend schema
- cover the new behaviour with Vitest specs for trait helpers and the state service

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691098a34854832a8073da23bc5f2b66)