### PR TITLE
docs: add contributing guide and QA workflow

### DIFF
--- a/docs/CONTRIBUTING_SITE.md
+++ b/docs/CONTRIBUTING_SITE.md
@@ -1,0 +1,64 @@
+# Come contribuire al sito e alla documentazione
+
+Questa guida raccoglie le istruzioni operative per contribuire alle pagine statiche pubblicate in `/docs`. È pensata per chi aggiorna il Support Hub, l'Idea Engine o la documentazione correlata e deve assicurarsi che l'esperienza resti coerente con il blueprint del progetto.
+
+## Prerequisiti
+
+- Node.js LTS (18+) e npm installati nel repository (`npm install`).
+- Accesso ai dataset che alimentano il widget Idea Engine (`npm run build:idea-taxonomy`).
+- Facoltativo ma consigliato: backend Idea Engine in locale (`npm run start:api`).
+
+## Struttura cartelle chiave
+
+| Percorso                           | Contenuto                                                     | Note                                          |
+| ---------------------------------- | ------------------------------------------------------------- | --------------------------------------------- |
+| `docs/`                            | Sorgente GitHub Pages (HTML, CSS, JS, Markdown).              | Entry point `docs/index.html` e Support Hub.  |
+| `docs/assets/styles/`              | Token, componenti e stili pagina condivisi.                   | Importati da `docs/site.css`.                 |
+| `docs/ideas/`                      | Hub Idea Engine (index, changelog, feedback, asset dedicati). | Collega widget e tassonomie.                  |
+| `docs/public/`                     | Asset condivisi (widget JS, tassonomie, script).              | Il widget Idea Engine vive qui.               |
+| `config/idea_engine_taxonomy.json` | Sorgente tassonomie Idea Engine.                              | Rigenerare con `npm run build:idea-taxonomy`. |
+| `scripts/docs-smoke.js`            | Utility per il smoke test locale.                             | Invocato tramite `npm run docs:smoke`.        |
+
+## Flusso di lavoro consigliato
+
+1. Crea un branch dedicato (`feature/<descrizione>`).
+2. Allinea i contenuti con il design system (`docs/assets/styles/tokens.css`, `docs/assets/styles/components.css`).
+3. Se modifichi tassonomie o dataset, esegui `npm run build:idea-taxonomy` prima del commit.
+4. Verifica i contenuti in locale:
+   - **Statico**: `npx serve docs -l 5000` oppure `npm run docs:smoke`.
+   - **Con backend**: apri `http://127.0.0.1:5000/ideas/index.html?apiBase=http://localhost:3333` dopo aver avviato `npm run start:api`.
+5. Controlla link interni, breadcrumb e microcopy aggiornati (Idea Engine, tutorial, changelog, FAQ).
+6. Aggiorna changelog o README collegati se introduci nuove funzionalità o percorsi.
+7. Prepara uno screenshot o una registrazione rapida quando modifichi l'interfaccia.
+
+## QA e smoke test obbligatori
+
+| Check               | Comando                                                                                                                  | Note                                                                                                                              |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| Smoke test completo | `npm run docs:smoke`                                                                                                     | Avvia static server su `http://127.0.0.1:5000` e backend su `http://localhost:3333`. Interrompi con <kbd>Ctrl</kbd>+<kbd>C</kbd>. |
+| Validazione HTML    | `npx html-validate docs/index.html docs/ideas/index.html`                                                                | Aggiungi eventuali altre pagine modificate.                                                                                       |
+| Lighthouse desktop  | `SITE_BASE_URL=http://127.0.0.1:5000 npx lhci collect --url=$SITE_BASE_URL/index.html --collect.settings.preset=desktop` | Richiede server statico attivo. Registrare punteggi Performance ≥ 0.80, Accessibilità ≥ 0.90.                                     |
+| Lighthouse mobile   | `SITE_BASE_URL=http://127.0.0.1:5000 npx lhci collect --url=$SITE_BASE_URL/index.html --collect.settings.preset=mobile`  | Verifica anche con backend inattivo per fallback export.                                                                          |
+| A11y manuale        | Test focus visibile, ruoli ARIA e contrasto su pagine toccate.                                                           | Annotare outcome nella checklist QA.                                                                                              |
+
+## Checklist PR
+
+- [ ] Nessun errore in console durante il smoke test.
+- [ ] Widget Idea Engine funziona con e senza backend.
+- [ ] Documentazione correlata (README_IDEAS, changelog, tutorial) aggiornata.
+- [ ] `npx html-validate` e gli audit Lighthouse desktop/mobile superati.
+- [ ] Allegati screenshot o note QA rilevanti alla pull request.
+- [ ] Aggiornato `docs/qa-checklist.md` con i risultati dell'ultimo ciclo.
+
+## Risorse utili
+
+- `docs/README.md` – panoramica dei flussi principali e link rapidi.
+- `README_IDEAS.md` – istruzioni per il widget e il backend Idea Engine.
+- `docs/ideas/changelog.md` – storico delle release del widget.
+- `docs/qa-checklist.md` – stato dei controlli QA e follow-up.
+
+## Supporto e feedback
+
+- Per segnalare problemi o proporre miglioramenti apri una issue GitHub e tagga il maintainer di riferimento.
+- Canale Slack `#feedback-enhancements` per domande rapide sul widget e sulle pagine statiche.
+- Aggiorna questa guida dopo retrospettive o cambi di workflow significativi.

--- a/docs/index.html
+++ b/docs/index.html
@@ -639,6 +639,11 @@
               <a href="checklist/action-items.md" class="button button--ghost">Apri checklist</a>
             </article>
             <article class="card card--link">
+              <h3>Guida contributori</h3>
+              <p>Processo completo per aggiornare il sito e l'Idea Engine in sicurezza.</p>
+              <a href="CONTRIBUTING_SITE.md" class="button button--ghost">Leggi la guida</a>
+            </article>
+            <article class="card card--link">
               <h3>Registro manutenzione tool</h3>
               <p>Storico delle operazioni effettuate sugli strumenti interni.</p>
               <a href="tool_run_report.md" class="button button--ghost">Visualizza log</a>

--- a/docs/qa-checklist.md
+++ b/docs/qa-checklist.md
@@ -1,0 +1,39 @@
+# QA checklist – Support Hub & Idea Engine
+
+Questa checklist centralizza i controlli da eseguire prima di pubblicare modifiche al Support Hub (`docs/index.html`) e all'Idea Engine.
+
+## Controlli obbligatori
+
+- [ ] Smoke test locale (`npm run docs:smoke`).
+- [ ] Validazione HTML con `npx html-validate` sulle pagine toccate.
+- [ ] Audit Lighthouse desktop (Performance ≥ 0.80, Accessibilità ≥ 0.90).
+- [ ] Audit Lighthouse mobile (Performance ≥ 0.80, Accessibilità ≥ 0.90).
+- [ ] Verifica accessibilità manuale (focus visibile, landmark, ruoli ARIA, contrasto).
+- [ ] Aggiornare questo file con l'esito del ciclo QA.
+
+## Comandi rapidi
+
+| Check                 | Comando                                                                                                                  | Note                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| Smoke test            | `npm run docs:smoke`                                                                                                     | Avvia server statico (porta 5000) e backend Idea Engine (porta 3333). |
+| Validazione HTML      | `npx html-validate docs/index.html docs/ideas/index.html`                                                                | Aggiungere eventuali file modificati.                                 |
+| Lighthouse desktop    | `SITE_BASE_URL=http://127.0.0.1:5000 npx lhci collect --url=$SITE_BASE_URL/index.html --collect.settings.preset=desktop` | Richiede Chrome/Chromium installato.                                  |
+| Lighthouse mobile     | `SITE_BASE_URL=http://127.0.0.1:5000 npx lhci collect --url=$SITE_BASE_URL/index.html --collect.settings.preset=mobile`  | Assicurarsi che il backend sia opzionalmente attivo.                  |
+| Accessibilità manuale | Navigazione tastiera + strumenti (es. axe, contrast checker).                                                            | Annotare note e follow-up.                                            |
+
+## Storico esecuzioni
+
+### 2025-11-04 – Ciclo 1
+
+| Tipo               | Stato         | Dettagli                                                                                                                                        | Riferimenti                                                                                                |
+| ------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Smoke test         | ✅ Completato | `npm run docs:smoke` avvia server statico e API; pagina principale raggiungibile.                                                               | `curl -I http://127.0.0.1:5000/index.html` 【428577†L1-L6】, avvio server 【19f465†L1-L8】【6dcfd3†L1-L5】 |
+| Validazione HTML   | ⚠️ Bloccato   | `npx html-validate` fallisce con `npm ERR! 403 Forbidden` (registry non accessibile offline). Follow-up: predisporre dipendenza locale o cache. | 【eecccb†L1-L8】                                                                                           |
+| Lighthouse desktop | ⚠️ Bloccato   | `npx lhci collect` non eseguito: pacchetto non disponibile senza accesso al registry. Da ripetere in ambiente con cache.                        | —                                                                                                          |
+| Lighthouse mobile  | ⚠️ Bloccato   | Come sopra, impossibile installare `lhci`.                                                                                                      | —                                                                                                          |
+| A11y manuale       | ✅ Parziale   | Verificati landmark `<main>` e `<nav>` e bottoni focusabili in `docs/index.html`; struttura coerente con blueprint. Nessun errore evidente.     | 【F:docs/index.html†L33-L109】【F:docs/index.html†L204-L247】                                              |
+
+**Follow-up aperti:**
+
+1. Pre-caricare le dipendenze `html-validate` e `@lhci/cli` per ambienti offline o aggiungere mirror interno.
+2. Rieseguire gli audit Lighthouse (desktop/mobile) appena le dipendenze risultano disponibili.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:web": "npm run test:web --workspace tools/ts",
     "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && node --test tests/server/generationSnapshot.spec.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-latency.spec.ts && ./node_modules/.bin/tsx tests/scripts/tune_items.test.ts && ./node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts && node --test tests/tools/deploy-checks.spec.js",
     "start:api": "node server/index.js",
+    "docs:smoke": "node scripts/docs-smoke.js",
     "build:idea-taxonomy": "node scripts/build-idea-taxonomy.js",
     "drive:generate-approved": "node tools/drive/generate-approved-assets.mjs",
     "drive:push-approved": "node tools/drive/push-approved-assets.mjs",

--- a/scripts/docs-smoke.js
+++ b/scripts/docs-smoke.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+const DOCS_ROOT = path.resolve(__dirname, '..', 'docs');
+const HOST = '0.0.0.0';
+const PORT = Number(process.env.DOCS_PORT || 5000);
+const API_COMMAND = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const API_ARGS = ['run', 'start:api'];
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.htm': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8',
+  '.md': 'text/markdown; charset=utf-8',
+  '.pdf': 'application/pdf',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+};
+
+function send404(res) {
+  res.statusCode = 404;
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.end('404 – File non trovato');
+}
+
+function send500(res, error) {
+  console.error('[docs] Errore server statico:', error);
+  res.statusCode = 500;
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.end('500 – Errore interno server statico');
+}
+
+function createStaticServer() {
+  return http.createServer((req, res) => {
+    const parsedUrl = url.parse(req.url);
+    const safePath = decodeURIComponent(parsedUrl.pathname || '/');
+    const requestedPath = path.normalize(safePath).replace(/^\/+/, '');
+    const resolvedPath = path.join(DOCS_ROOT, requestedPath);
+
+    if (!resolvedPath.startsWith(DOCS_ROOT)) {
+      send404(res);
+      return;
+    }
+
+    let finalPath = resolvedPath;
+    fs.stat(finalPath, (err, stats) => {
+      if (err) {
+        if (err.code === 'ENOENT') {
+          // Se non ha estensione prova con .html
+          const candidateHtml = `${resolvedPath}.html`;
+          fs.stat(candidateHtml, (htmlErr, htmlStats) => {
+            if (htmlErr || !htmlStats.isFile()) {
+              send404(res);
+              return;
+            }
+            streamFile(candidateHtml, res);
+          });
+        } else {
+          send500(res, err);
+        }
+        return;
+      }
+
+      if (stats.isDirectory()) {
+        const indexPath = path.join(finalPath, 'index.html');
+        fs.stat(indexPath, (indexErr, indexStats) => {
+          if (indexErr || !indexStats.isFile()) {
+            send404(res);
+            return;
+          }
+          streamFile(indexPath, res);
+        });
+        return;
+      }
+
+      if (stats.isFile()) {
+        streamFile(finalPath, res);
+        return;
+      }
+
+      send404(res);
+    });
+  });
+}
+
+function streamFile(filePath, res) {
+  const ext = path.extname(filePath).toLowerCase();
+  const type = MIME_TYPES[ext] || 'application/octet-stream';
+  res.statusCode = 200;
+  res.setHeader('Content-Type', type);
+  const stream = fs.createReadStream(filePath);
+  stream.on('error', (error) => {
+    send500(res, error);
+  });
+  stream.pipe(res);
+}
+
+function startApi() {
+  const child = spawn(API_COMMAND, API_ARGS, {
+    stdio: 'inherit',
+    env: process.env,
+  });
+
+  child.on('exit', (code, signal) => {
+    if (code !== 0) {
+      console.error(`\n[api] terminato con codice ${code ?? `signal ${signal}`}`);
+    }
+    shutdown(code ?? (signal ? 1 : 0));
+  });
+
+  child.on('error', (error) => {
+    console.error('[api] errore di avvio:', error);
+    shutdown(1);
+  });
+
+  return child;
+}
+
+const server = createStaticServer();
+let apiProcess;
+let shuttingDown = false;
+
+server.listen(PORT, HOST, () => {
+  console.log(`Server statico attivo su http://127.0.0.1:${PORT}`);
+  console.log('Avvio backend Idea Engine...');
+  apiProcess = startApi();
+});
+
+function shutdown(exitCode = 0) {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+
+  if (apiProcess && !apiProcess.killed) {
+    apiProcess.kill('SIGINT');
+  }
+
+  server.close(() => {
+    process.exit(exitCode);
+  });
+
+  setTimeout(() => {
+    process.exit(exitCode);
+  }, 500).unref();
+}
+
+process.on('SIGINT', () => shutdown(0));
+process.on('SIGTERM', () => shutdown(0));


### PR DESCRIPTION
## Summary
- add the Support Hub contributing guide derived from the blueprint and link it from the docs landing page
- publish a reusable QA checklist with the first audit cycle recorded
- provide an offline-friendly smoke test script and npm alias for serving the docs alongside the API

## Testing
- npm run docs:smoke
- npx prettier --check docs/CONTRIBUTING_SITE.md docs/qa-checklist.md scripts/docs-smoke.js
- npx html-validate docs/index.html docs/ideas/index.html *(fails: npm 403 – registry not reachable in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690a7f421aa8832aa3756f2004911ade)