### PR TITLE
feat: secure trait editor mutations with auth refresh

### DIFF
--- a/Trait Editor/src/services/__tests__/trait-data.service.spec.ts
+++ b/Trait Editor/src/services/__tests__/trait-data.service.spec.ts
@@ -102,3 +102,359 @@ describe('TraitDataService caching behaviour', () => {
     } as Partial<Trait>);
   });
 });
+
+describe('TraitDataService remote mutations', () => {
+  let originalFetch: typeof fetch | undefined;
+
+  const createJsonResponse = (status: number, body: unknown): Response =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    }) as unknown as Response;
+
+  beforeEach(() => {
+    vi.stubEnv('VITE_TRAIT_DATA_SOURCE', 'remote');
+    vi.stubEnv('VITE_TRAIT_DATA_URL', 'https://example.com/data/traits/index.json?auth=1');
+    vi.stubEnv('VITE_TRAIT_DATA_TOKEN_URL', 'https://example.com/api/auth/token');
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+    } else {
+      delete (globalThis as typeof globalThis & { fetch?: typeof fetch }).fetch;
+    }
+  });
+
+  it('refreshes the token after a 401 and updates metadata from the response', async () => {
+    const deltaEntry = {
+      id: 'delta',
+      label: 'Delta',
+      tier: 'T1',
+      famiglia_tipologia: 'Skirmisher',
+      slot_profile: { core: 'Assalto', complementare: 'Supporto' },
+      slot: ['assalto'],
+      usage_tags: ['rapid'],
+      completion_flags: {
+        has_biome: true,
+        has_data_origin: true,
+        has_species_link: true,
+        has_usage_tags: true,
+      },
+      data_origin: 'remote_index',
+      debolezza: 'Esposizione a fuoco incrociato.',
+      mutazione_indotta: 'Stimola riflessi e controllo vettoriale.',
+      requisiti_ambientali: [],
+      sinergie: ['Arc Shot'],
+      sinergie_pi: { co_occorrenze: [], combo_totale: 1, forme: [], tabelle_random: [] },
+      species_affinity: [],
+      spinta_selettiva: 'Assalto mirato.',
+      uso_funzione: 'Colpire e disimpegnarsi rapidamente.',
+      fattore_mantenimento_energetico: 'Basso',
+      conflitti: [],
+    };
+
+    let currentEtag = 'etag-1';
+    let currentVersion = 'v1';
+    let latestEntry = { ...deltaEntry };
+    let tokenCounter = 0;
+    let putAttempts = 0;
+
+    const fetchMock = vi.fn<Parameters<typeof fetch>, Promise<Response>>(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url === 'https://example.com/api/auth/token') {
+        tokenCounter += 1;
+        return createJsonResponse(200, { token: `token-${tokenCounter}`, expiresIn: 60 });
+      }
+      if (url === 'https://example.com/data/traits/index.json?auth=1') {
+        return createJsonResponse(200, {
+          schema_version: '2.0',
+          trait_glossary: 'remote/glossary.json',
+          traits: { delta: latestEntry },
+        });
+      }
+      if (url === 'https://example.com/api/traits/delta?auth=1' && (!init || init.method === 'GET')) {
+        return createJsonResponse(200, {
+          trait: latestEntry,
+          meta: { etag: currentEtag, version: currentVersion },
+        });
+      }
+      if (url === 'https://example.com/api/traits/delta?auth=1' && init?.method === 'PUT') {
+        putAttempts += 1;
+        const body = init.body ? JSON.parse(String(init.body)) : {};
+        if (putAttempts === 1) {
+          expect(body?.meta).toEqual({ etag: 'etag-1', version: 'v1' });
+          return createJsonResponse(401, { error: 'token expired' });
+        }
+        currentEtag = 'etag-2';
+        currentVersion = 'v2';
+        latestEntry = { ...latestEntry, uso_funzione: body.entry?.uso_funzione ?? latestEntry.uso_funzione };
+        return createJsonResponse(200, {
+          trait: latestEntry,
+          meta: { etag: currentEtag, version: currentVersion },
+        });
+      }
+      throw new Error(`Unexpected fetch call ${url}`);
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const service = new TraitDataService(createFakeQ());
+    await service.getTraits();
+    const remoteTrait = await service.getTraitById('delta');
+    expect(remoteTrait).not.toBeNull();
+
+    const updatedTrait = {
+      ...remoteTrait!,
+      description: 'Aggiornato',
+      entry: { ...remoteTrait!.entry, uso_funzione: 'Aggiornato' },
+    } as Trait;
+
+    const result = await service.saveTrait(updatedTrait);
+    expect(result.entry.uso_funzione).toBe('Aggiornato');
+
+    const secondUpdate = {
+      ...result,
+      description: 'Aggiornato due volte',
+      entry: { ...result.entry, uso_funzione: 'Aggiornato due volte' },
+    } as Trait;
+    await service.saveTrait(secondUpdate);
+
+    const putCalls = fetchMock.mock.calls.filter(
+      ([input, init]) =>
+        typeof input === 'string' &&
+        input === 'https://example.com/api/traits/delta?auth=1' &&
+        init?.method === 'PUT',
+    );
+    expect(putCalls).toHaveLength(3);
+    expect(putCalls[0][1]?.headers).toMatchObject({ Authorization: 'Bearer token-1' });
+    expect(putCalls[1][1]?.headers).toMatchObject({
+      Authorization: 'Bearer token-2',
+      'If-Match': 'etag-1',
+      'X-Trait-Version': 'v1',
+    });
+    expect(putCalls[2][1]?.headers).toMatchObject({
+      Authorization: 'Bearer token-2',
+      'If-Match': 'etag-2',
+      'X-Trait-Version': 'v2',
+    });
+  });
+
+  it('handles 412 responses by syncing metadata and surfacing the backend message', async () => {
+    const deltaEntry = {
+      id: 'delta',
+      label: 'Delta',
+      tier: 'T1',
+      famiglia_tipologia: 'Skirmisher',
+      slot_profile: { core: 'Assalto', complementare: 'Supporto' },
+      slot: ['assalto'],
+      usage_tags: ['rapid'],
+      completion_flags: {
+        has_biome: true,
+        has_data_origin: true,
+        has_species_link: true,
+        has_usage_tags: true,
+      },
+      data_origin: 'remote_index',
+      debolezza: 'Esposizione a fuoco incrociato.',
+      mutazione_indotta: 'Stimola riflessi e controllo vettoriale.',
+      requisiti_ambientali: [],
+      sinergie: ['Arc Shot'],
+      sinergie_pi: { co_occorrenze: [], combo_totale: 1, forme: [], tabelle_random: [] },
+      species_affinity: [],
+      spinta_selettiva: 'Assalto mirato.',
+      uso_funzione: 'Colpire e disimpegnarsi rapidamente.',
+      fattore_mantenimento_energetico: 'Basso',
+      conflitti: [],
+    };
+
+    let currentEtag = 'etag-10';
+    let currentVersion = 'v10';
+    let latestEntry = { ...deltaEntry };
+    let tokenCounter = 0;
+    let syncTriggered = 0;
+
+    const fetchMock = vi.fn<Parameters<typeof fetch>, Promise<Response>>(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url === 'https://example.com/api/auth/token') {
+        tokenCounter += 1;
+        return createJsonResponse(200, { token: `token-${tokenCounter}`, expiresIn: 60 });
+      }
+      if (url === 'https://example.com/data/traits/index.json?auth=1') {
+        return createJsonResponse(200, {
+          schema_version: '2.0',
+          trait_glossary: 'remote/glossary.json',
+          traits: { delta: latestEntry },
+        });
+      }
+      if (url === 'https://example.com/api/traits/delta?auth=1' && (!init || init.method === 'GET')) {
+        syncTriggered += 1;
+        return createJsonResponse(200, {
+          trait: latestEntry,
+          meta: { etag: currentEtag, version: currentVersion },
+        });
+      }
+      if (url === 'https://example.com/api/traits/delta?auth=1' && init?.method === 'PUT') {
+        const body = init.body ? JSON.parse(String(init.body)) : {};
+        if (syncTriggered === 1) {
+          currentEtag = 'etag-11';
+          currentVersion = 'v11';
+          return createJsonResponse(412, {
+            error: 'Versione del trait non aggiornata',
+            meta: { etag: currentEtag, version: currentVersion },
+          });
+        }
+        currentEtag = 'etag-11';
+        currentVersion = 'v11';
+        latestEntry = { ...latestEntry, uso_funzione: body.entry?.uso_funzione ?? latestEntry.uso_funzione };
+        return createJsonResponse(200, {
+          trait: latestEntry,
+          meta: { etag: currentEtag, version: currentVersion },
+        });
+      }
+      throw new Error(`Unexpected fetch call ${url}`);
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const service = new TraitDataService(createFakeQ());
+    await service.getTraits();
+    const remoteTrait = await service.getTraitById('delta');
+    expect(remoteTrait).not.toBeNull();
+
+    const updatedTrait = {
+      ...remoteTrait!,
+      entry: { ...remoteTrait!.entry, uso_funzione: 'Aggiornato' },
+    } as Trait;
+
+    await expect(service.saveTrait(updatedTrait)).rejects.toThrow('Versione del trait non aggiornata');
+
+    const secondAttempt = {
+      ...updatedTrait,
+      description: 'Aggiornato due volte',
+      entry: { ...updatedTrait.entry, uso_funzione: 'Aggiornato due volte' },
+    } as Trait;
+    await service.saveTrait(secondAttempt);
+
+    const putCalls = fetchMock.mock.calls.filter(
+      ([input, init]) =>
+        typeof input === 'string' &&
+        input === 'https://example.com/api/traits/delta?auth=1' &&
+        init?.method === 'PUT',
+    );
+    expect(putCalls).toHaveLength(2);
+    expect(putCalls[1][1]?.headers).toMatchObject({ 'If-Match': 'etag-11', 'X-Trait-Version': 'v11' });
+    expect(syncTriggered).toBeGreaterThanOrEqual(2);
+  });
+
+  it('handles 428 responses by requesting fresh metadata and propagating the error', async () => {
+    const deltaEntry = {
+      id: 'delta',
+      label: 'Delta',
+      tier: 'T1',
+      famiglia_tipologia: 'Skirmisher',
+      slot_profile: { core: 'Assalto', complementare: 'Supporto' },
+      slot: ['assalto'],
+      usage_tags: ['rapid'],
+      completion_flags: {
+        has_biome: true,
+        has_data_origin: true,
+        has_species_link: true,
+        has_usage_tags: true,
+      },
+      data_origin: 'remote_index',
+      debolezza: 'Esposizione a fuoco incrociato.',
+      mutazione_indotta: 'Stimola riflessi e controllo vettoriale.',
+      requisiti_ambientali: [],
+      sinergie: ['Arc Shot'],
+      sinergie_pi: { co_occorrenze: [], combo_totale: 1, forme: [], tabelle_random: [] },
+      species_affinity: [],
+      spinta_selettiva: 'Assalto mirato.',
+      uso_funzione: 'Colpire e disimpegnarsi rapidamente.',
+      fattore_mantenimento_energetico: 'Basso',
+      conflitti: [],
+    };
+
+    let currentEtag = 'etag-a';
+    let currentVersion = 'v-a';
+    let latestEntry = { ...deltaEntry };
+    let tokenCounter = 0;
+    let detailCalls = 0;
+
+    const fetchMock = vi.fn<Parameters<typeof fetch>, Promise<Response>>(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url === 'https://example.com/api/auth/token') {
+        tokenCounter += 1;
+        return createJsonResponse(200, { token: `token-${tokenCounter}`, expiresIn: 60 });
+      }
+      if (url === 'https://example.com/data/traits/index.json?auth=1') {
+        return createJsonResponse(200, {
+          schema_version: '2.0',
+          trait_glossary: 'remote/glossary.json',
+          traits: { delta: latestEntry },
+        });
+      }
+      if (url === 'https://example.com/api/traits/delta?auth=1' && (!init || init.method === 'GET')) {
+        detailCalls += 1;
+        return createJsonResponse(200, {
+          trait: latestEntry,
+          meta: { etag: currentEtag, version: currentVersion },
+        });
+      }
+      if (url === 'https://example.com/api/traits/delta?auth=1' && init?.method === 'PUT') {
+        const body = init.body ? JSON.parse(String(init.body)) : {};
+        if (detailCalls === 1) {
+          return createJsonResponse(428, {
+            error: 'Versione o ETag richiesto per aggiornare il trait',
+          });
+        }
+        currentEtag = 'etag-b';
+        currentVersion = 'v-b';
+        latestEntry = { ...latestEntry, uso_funzione: body.entry?.uso_funzione ?? latestEntry.uso_funzione };
+        return createJsonResponse(200, {
+          trait: latestEntry,
+          meta: { etag: currentEtag, version: currentVersion },
+        });
+      }
+      throw new Error(`Unexpected fetch call ${url}`);
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const service = new TraitDataService(createFakeQ());
+    await service.getTraits();
+    const remoteTrait = await service.getTraitById('delta');
+    expect(remoteTrait).not.toBeNull();
+
+    const updatedTrait = {
+      ...remoteTrait!,
+      description: 'Aggiornato',
+      entry: { ...remoteTrait!.entry, uso_funzione: 'Aggiornato' },
+    } as Trait;
+
+    await expect(service.saveTrait(updatedTrait)).rejects.toThrow(
+      'Versione o ETag richiesto per aggiornare il trait',
+    );
+
+    const secondAttempt = {
+      ...updatedTrait,
+      description: 'Aggiornato due volte',
+      entry: { ...updatedTrait.entry, uso_funzione: 'Aggiornato due volte' },
+    } as Trait;
+    await service.saveTrait(secondAttempt);
+
+    const putCalls = fetchMock.mock.calls.filter(
+      ([input, init]) =>
+        typeof input === 'string' &&
+        input === 'https://example.com/api/traits/delta?auth=1' &&
+        init?.method === 'PUT',
+    );
+    expect(putCalls).toHaveLength(2);
+    expect(putCalls[1][1]?.headers).toMatchObject({ 'If-Match': 'etag-a', 'X-Trait-Version': 'v-a' });
+    expect(detailCalls).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/Trait Editor/src/services/trait-data.service.ts
+++ b/Trait Editor/src/services/trait-data.service.ts
@@ -3,7 +3,7 @@ import {
   fetchTraitsFromMonorepo,
   getSampleTraits,
 } from '../data/traits.sample';
-import type { Trait } from '../types/trait';
+import type { Trait, TraitIndexEntry } from '../types/trait';
 import { cloneTrait, cloneTraits, synchroniseTraitPresentation } from '../utils/trait-helpers';
 
 export const FALLBACK_CACHE_TTL_MS = 60_000;
@@ -21,7 +21,14 @@ export class TraitDataService {
   private fallbackExpiry: number | null = null;
   private readonly useRemoteSource: boolean;
   private readonly endpointOverride?: string;
+  private readonly tokenEndpoint?: string;
+  private readonly staticToken: string | null = null;
+  private readonly locationOrigin: string | null = null;
   private lastError: Error | null = null;
+  private authToken: string | null = null;
+  private tokenExpiresAt: number | null = null;
+  private tokenRefreshPromise: Promise<string | null> | null = null;
+  private readonly traitMeta: Map<string, { etag: string | null; version: string | null }> = new Map();
 
   static $inject = ['$q'];
 
@@ -32,6 +39,24 @@ export class TraitDataService {
     const endpoint = import.meta.env.VITE_TRAIT_DATA_URL;
     if (typeof endpoint === 'string' && endpoint.trim().length > 0) {
       this.endpointOverride = endpoint.trim();
+    }
+
+    const tokenEndpoint = import.meta.env.VITE_TRAIT_DATA_TOKEN_URL;
+    if (typeof tokenEndpoint === 'string' && tokenEndpoint.trim().length > 0) {
+      this.tokenEndpoint = tokenEndpoint.trim();
+    }
+
+    const staticToken = import.meta.env.VITE_TRAIT_DATA_TOKEN;
+    if (typeof staticToken === 'string' && staticToken.trim().length > 0) {
+      this.staticToken = staticToken.trim();
+    }
+
+    if (typeof window !== 'undefined' && typeof window.location?.origin === 'string') {
+      this.locationOrigin = window.location.origin;
+    } else if (typeof globalThis !== 'undefined' && typeof globalThis.location?.origin === 'string') {
+      this.locationOrigin = globalThis.location.origin;
+    } else {
+      this.locationOrigin = null;
     }
   }
 
@@ -52,6 +77,7 @@ export class TraitDataService {
   invalidateCache(): void {
     this.cache = null;
     this.fallbackExpiry = null;
+    this.traitMeta.clear();
   }
 
   getCacheSource(): TraitCacheSource | null {
@@ -63,17 +89,41 @@ export class TraitDataService {
   }
 
   getTraitById(id: string): Promise<Trait | null> {
-    return this.getTraits().then((traits) => {
-      const trait = traits.find((item) => item.id === id);
-      return trait ? cloneTrait(trait) : null;
-    });
+    if (!id || id.trim() === '') {
+      return this.$q.resolve(null);
+    }
+
+    const resolveFromCache = (): Trait | null => {
+      if (!this.cache) {
+        return null;
+      }
+      const cached = this.cache.traits.find((item) => item.id === id);
+      return cached ? cloneTrait(cached) : null;
+    };
+
+    if (!this.useRemoteSource) {
+      return this.getTraits().then(() => resolveFromCache());
+    }
+
+    return this.$q
+      .when(this.fetchTraitDetailFromApi(id))
+      .then((result) => {
+        if (result) {
+          return cloneTrait(result);
+        }
+        return resolveFromCache();
+      })
+      .catch((error: Error) => {
+        console.warn('Impossibile recuperare il tratto remoto, uso cache locale', error);
+        return resolveFromCache();
+      });
   }
 
   saveTrait(updatedTrait: Trait): Promise<Trait> {
     const traitCopy = cloneTrait(updatedTrait);
     synchroniseTraitPresentation(traitCopy);
 
-    const persist = async (): Promise<void> => {
+    const persist = async (): Promise<{ trait?: Trait; meta?: { etag: string | null; version: string | null } } | void> => {
       if (!this.useRemoteSource) {
         return;
       }
@@ -85,29 +135,40 @@ export class TraitDataService {
         throw new Error('Endpoint remoto non configurato per il salvataggio dei tratti.');
       }
 
-      if (typeof fetch !== 'function') {
-        throw new Error('Fetch API non disponibile per completare il salvataggio remoto.');
-      }
+      const payload = this.createMutationPayload(traitCopy);
+      const headers = this.buildMutationHeaders(traitCopy.id);
+      headers['Content-Type'] = 'application/json';
 
-      const response = await fetch(target, {
+      const response = await this.fetchWithAuth(target, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(traitCopy),
+        headers,
+        body: JSON.stringify(payload),
       });
 
+      if (response.status === 412 || response.status === 428) {
+        await this.handleConcurrencyFailure(traitCopy.id, response);
+      }
+
       if (!response.ok) {
-        throw new Error(`Il salvataggio remoto è fallito con stato ${response.status}.`);
+        throw await this.buildRemoteError(response, traitCopy.id);
+      }
+
+      const result = await this.parseMutationResponse(response, traitCopy.id);
+      if (result) {
+        return result;
       }
     };
 
     return this.$q
       .when(persist())
-      .then(() => {
+      .then((result) => {
         this.lastError = null;
-        this.updateLocalCache(traitCopy);
-        return cloneTrait(traitCopy);
+        const finalTrait = result?.trait ?? traitCopy;
+        if (result?.meta) {
+          this.updateTraitMeta(finalTrait.id, result.meta);
+        }
+        this.updateLocalCache(finalTrait);
+        return cloneTrait(finalTrait);
       })
       .catch((error: Error) => {
         const err = error instanceof Error ? error : new Error(String(error));
@@ -194,15 +255,431 @@ export class TraitDataService {
       return null;
     }
 
-    if (baseEndpoint.endsWith('/')) {
-      return `${baseEndpoint}${id}`;
+    const trimmed = baseEndpoint.trim();
+    if (!trimmed) {
+      return null;
     }
 
-    if (baseEndpoint.endsWith('.json')) {
-      return baseEndpoint.replace(/\/[^/]*$/, `/${id}.json`);
+    const safeId = encodeURIComponent(id);
+    const queryIndex = trimmed.indexOf('?');
+    const query = queryIndex >= 0 ? trimmed.slice(queryIndex) : '';
+    const cleanQuery = query && !query.startsWith('?') ? `?${query}` : query;
+    const apiPath = `/api/traits/${safeId}`;
+
+    if (this.isAbsoluteUrl(trimmed)) {
+      try {
+        const base = new URL(trimmed);
+        const target = new URL(apiPath, `${base.protocol}//${base.host}`);
+        target.search = cleanQuery;
+        return target.toString();
+      } catch (error) {
+        console.warn('Impossibile costruire endpoint mutazione assoluto', error);
+        return null;
+      }
     }
 
-    return `${baseEndpoint}/${id}`;
+    if (trimmed.startsWith('/')) {
+      return `${apiPath}${cleanQuery}`;
+    }
+
+    if (this.locationOrigin) {
+      try {
+        const base = new URL(trimmed, this.locationOrigin);
+        const target = new URL(apiPath, this.locationOrigin);
+        target.search = cleanQuery || base.search;
+        return target.toString();
+      } catch (error) {
+        console.warn('Impossibile costruire endpoint mutazione relativo', error);
+      }
+    }
+
+    return `${apiPath}${cleanQuery}`;
+  }
+
+  private isAbsoluteUrl(candidate: string): boolean {
+    return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(candidate);
+  }
+
+  private createMutationPayload(trait: Trait): Record<string, unknown> {
+    const payload = JSON.parse(JSON.stringify(trait)) as Record<string, unknown>;
+    const storedMeta = this.traitMeta.get(trait.id);
+    if (storedMeta && (storedMeta.etag || storedMeta.version)) {
+      const existingMeta =
+        payload.meta && typeof payload.meta === 'object' && payload.meta !== null
+          ? (payload.meta as Record<string, unknown>)
+          : {};
+      payload.meta = {
+        ...existingMeta,
+        ...(storedMeta.etag ? { etag: storedMeta.etag } : {}),
+        ...(storedMeta.version ? { version: storedMeta.version } : {}),
+      };
+    }
+    return payload;
+  }
+
+  private buildMutationHeaders(id: string): Record<string, string> {
+    const headers: Record<string, string> = {};
+    const storedMeta = this.traitMeta.get(id);
+    if (storedMeta?.etag) {
+      headers['If-Match'] = storedMeta.etag;
+    }
+    if (storedMeta?.version) {
+      headers['X-Trait-Version'] = storedMeta.version;
+    }
+    return headers;
+  }
+
+  private async parseMutationResponse(
+    response: Response,
+    id: string,
+  ): Promise<{ trait?: Trait; meta?: { etag: string | null; version: string | null }} | null> {
+    try {
+      const payload = await response.json();
+      const meta = payload?.meta ?? null;
+      const remoteTrait = payload?.trait ?? null;
+      const result: { trait?: Trait; meta?: { etag: string | null; version: string | null } } = {};
+      if (meta) {
+        result.meta = {
+          etag: typeof meta.etag === 'string' && meta.etag.trim() ? meta.etag.trim() : null,
+          version:
+            typeof meta.version === 'string' && meta.version.trim() ? meta.version.trim() : null,
+        };
+      }
+      const normalisedTrait = this.normaliseRemoteTrait(remoteTrait, id);
+      if (normalisedTrait) {
+        result.trait = normalisedTrait;
+      }
+      if (result.trait || result.meta) {
+        return result;
+      }
+      return null;
+    } catch (error) {
+      console.warn('Impossibile analizzare la risposta della mutazione', error);
+      return null;
+    }
+  }
+
+  private normaliseRemoteTrait(raw: unknown, fallbackId: string): Trait | null {
+    if (!raw || typeof raw !== 'object') {
+      return null;
+    }
+
+    if ((raw as Trait).entry && typeof (raw as Trait).entry === 'object') {
+      const trait = cloneTrait(raw as Trait);
+      return synchroniseTraitPresentation(trait);
+    }
+
+    const entry = raw as TraitIndexEntry;
+    const signatureMoves = Array.isArray(entry?.sinergie) ? [...entry.sinergie] : [];
+    const trait: Trait = {
+      id: typeof entry.id === 'string' && entry.id ? entry.id : fallbackId,
+      name: typeof entry.label === 'string' ? entry.label : fallbackId,
+      description:
+        typeof entry.uso_funzione === 'string' && entry.uso_funzione
+          ? entry.uso_funzione
+          : typeof entry.mutazione_indotta === 'string'
+            ? entry.mutazione_indotta
+            : '',
+      archetype: typeof entry.famiglia_tipologia === 'string' ? entry.famiglia_tipologia : '',
+      playstyle: typeof entry.spinta_selettiva === 'string' ? entry.spinta_selettiva : '',
+      signatureMoves,
+      entry: {
+        ...(entry as TraitIndexEntry),
+        sinergie: [...signatureMoves],
+      },
+    };
+
+    return synchroniseTraitPresentation(trait);
+  }
+
+  private updateTraitMeta(
+    id: string,
+    meta: { etag: string | null; version: string | null } | null | undefined,
+  ): void {
+    if (!id) {
+      return;
+    }
+    const etag = meta?.etag && meta.etag.trim() ? meta.etag.trim() : null;
+    const version = meta?.version && meta.version.trim() ? meta.version.trim() : null;
+    if (!etag && !version) {
+      this.traitMeta.delete(id);
+      return;
+    }
+    this.traitMeta.set(id, { etag, version });
+  }
+
+  private async fetchTraitDetailFromApi(id: string): Promise<Trait | null> {
+    const endpoint = this.endpointOverride ?? TRAIT_DATA_ENDPOINT;
+    const target = this.buildRemoteMutationEndpoint(endpoint, id);
+    if (!target) {
+      return null;
+    }
+
+    const response = await this.fetchWithAuth(target, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      throw await this.buildRemoteError(response, id);
+    }
+
+    try {
+      const payload = await response.json();
+      if (payload?.meta) {
+        this.updateTraitMeta(id, {
+          etag:
+            typeof payload.meta.etag === 'string' && payload.meta.etag.trim()
+              ? payload.meta.etag.trim()
+              : null,
+          version:
+            typeof payload.meta.version === 'string' && payload.meta.version.trim()
+              ? payload.meta.version.trim()
+              : null,
+        });
+      }
+
+      if (payload?.trait) {
+        const trait = this.normaliseRemoteTrait(payload.trait, id);
+        if (trait) {
+          this.updateLocalCache(trait);
+          return trait;
+        }
+      }
+    } catch (error) {
+      console.warn('Impossibile analizzare il dettaglio remoto del tratto', error);
+    }
+
+    return null;
+  }
+
+  private async fetchWithAuth(url: string, init: RequestInit): Promise<Response> {
+    if (typeof fetch !== 'function') {
+      throw new Error('Fetch API non disponibile per completare il salvataggio remoto.');
+    }
+
+    const firstAttemptHeaders = this.mergeHeaders(init.headers);
+    const token = await this.ensureAuthToken();
+    if (token) {
+      firstAttemptHeaders['Authorization'] = `Bearer ${token}`;
+    }
+
+    const firstResponse = await fetch(url, { ...init, headers: firstAttemptHeaders });
+    if (firstResponse.status !== 401) {
+      return firstResponse;
+    }
+
+    await this.refreshAuthToken(true);
+    const retryHeaders = this.mergeHeaders(init.headers);
+    const refreshedToken = await this.ensureAuthToken();
+    if (refreshedToken) {
+      retryHeaders['Authorization'] = `Bearer ${refreshedToken}`;
+    }
+    return fetch(url, { ...init, headers: retryHeaders });
+  }
+
+  private mergeHeaders(headers: RequestInit['headers']): Record<string, string> {
+    const result: Record<string, string> = {};
+    if (!headers) {
+      return result;
+    }
+
+    if (Array.isArray(headers)) {
+      headers.forEach(([key, value]) => {
+        if (key && value) {
+          result[String(key)] = String(value);
+        }
+      });
+      return result;
+    }
+
+    if (headers instanceof Headers) {
+      headers.forEach((value, key) => {
+        if (key && value) {
+          result[key] = value;
+        }
+      });
+      return result;
+    }
+
+    Object.entries(headers as Record<string, string>).forEach(([key, value]) => {
+      if (key && value) {
+        result[key] = value;
+      }
+    });
+    return result;
+  }
+
+  private async ensureAuthToken(): Promise<string | null> {
+    try {
+      return await this.refreshAuthToken(false);
+    } catch (error) {
+      console.warn('Impossibile aggiornare il token di autenticazione', error);
+      return null;
+    }
+  }
+
+  private async refreshAuthToken(force: boolean): Promise<string | null> {
+    if (this.staticToken) {
+      this.authToken = this.staticToken;
+      this.tokenExpiresAt = null;
+      return this.authToken;
+    }
+
+    if (!force && this.authToken) {
+      if (this.tokenExpiresAt === null || this.tokenExpiresAt - Date.now() > 5_000) {
+        return this.authToken;
+      }
+    }
+
+    if (!this.tokenEndpoint) {
+      this.authToken = null;
+      this.tokenExpiresAt = null;
+      return null;
+    }
+
+    if (this.tokenRefreshPromise) {
+      return this.tokenRefreshPromise;
+    }
+
+    const request = this.requestAuthToken().then(
+      (result) => {
+        const token = result?.token ?? null;
+        this.authToken = token;
+        this.tokenExpiresAt = result?.expiresAt ?? null;
+        return token;
+      },
+      (error) => {
+        this.authToken = null;
+        this.tokenExpiresAt = null;
+        throw error;
+      },
+    );
+
+    this.tokenRefreshPromise = request;
+    try {
+      return await request;
+    } finally {
+      this.tokenRefreshPromise = null;
+    }
+  }
+
+  private async requestAuthToken(): Promise<{ token: string | null; expiresAt: number | null }> {
+    if (!this.tokenEndpoint) {
+      return { token: null, expiresAt: null };
+    }
+
+    if (typeof fetch !== 'function') {
+      throw new Error('Fetch API non disponibile per il recupero del token.');
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(this.tokenEndpoint, { method: 'POST' });
+    } catch (error) {
+      throw new Error(`Impossibile recuperare il token di autenticazione: ${String(error)}`);
+    }
+
+    if (!response.ok) {
+      throw new Error(`Recupero token fallito con stato ${response.status}.`);
+    }
+
+    try {
+      const payload = await response.json();
+      const tokenCandidate =
+        typeof payload?.token === 'string'
+          ? payload.token
+          : typeof payload?.access_token === 'string'
+            ? payload.access_token
+            : null;
+      const expiresAt = this.resolveTokenExpiry(payload);
+      return { token: tokenCandidate, expiresAt };
+    } catch (error) {
+      console.warn('Impossibile interpretare la risposta del token', error);
+      return { token: null, expiresAt: null };
+    }
+  }
+
+  private resolveTokenExpiry(payload: unknown): number | null {
+    if (!payload || typeof payload !== 'object') {
+      return null;
+    }
+    const record = payload as Record<string, unknown>;
+    const expiresAt = record.expiresAt ?? record.expires_at ?? null;
+    if (typeof expiresAt === 'string') {
+      const parsed = Date.parse(expiresAt);
+      return Number.isNaN(parsed) ? null : parsed;
+    }
+    if (typeof expiresAt === 'number') {
+      if (expiresAt > 1_000_000_000_000) {
+        return expiresAt;
+      }
+      return Date.now() + expiresAt * 1000;
+    }
+    const expiresIn = record.expiresIn ?? record.expires_in ?? null;
+    if (typeof expiresIn === 'number') {
+      return Date.now() + expiresIn * 1000;
+    }
+    if (typeof expiresIn === 'string') {
+      const parsed = Number(expiresIn);
+      if (!Number.isNaN(parsed)) {
+        return Date.now() + parsed * 1000;
+      }
+    }
+    return null;
+  }
+
+  private async handleConcurrencyFailure(id: string, response: Response): Promise<never> {
+    let message = `Il salvataggio remoto è fallito con stato ${response.status}.`;
+    try {
+      const payload = await response.json();
+      if (payload?.error && typeof payload.error === 'string') {
+        message = payload.error;
+      }
+      if (payload?.meta) {
+        this.updateTraitMeta(id, {
+          etag:
+            typeof payload.meta.etag === 'string' && payload.meta.etag.trim()
+              ? payload.meta.etag.trim()
+              : null,
+          version:
+            typeof payload.meta.version === 'string' && payload.meta.version.trim()
+              ? payload.meta.version.trim()
+              : null,
+        });
+      }
+    } catch (error) {
+      console.warn('Impossibile interpretare la risposta di conflitto', error);
+    }
+
+    await this.syncTraitWithServer(id);
+    throw new Error(message);
+  }
+
+  private async syncTraitWithServer(id: string): Promise<void> {
+    try {
+      await this.fetchTraitDetailFromApi(id);
+    } catch (error) {
+      console.warn('Impossibile sincronizzare il tratto dopo un conflitto', error);
+    }
+  }
+
+  private async buildRemoteError(response: Response, id: string): Promise<Error> {
+    let message = `Il salvataggio remoto è fallito con stato ${response.status}.`;
+    try {
+      const payload = await response.json();
+      if (payload?.error && typeof payload.error === 'string') {
+        message = payload.error;
+      }
+    } catch (error) {
+      console.warn('Impossibile leggere il messaggio di errore remoto', error);
+    }
+    await this.syncTraitWithServer(id);
+    return new Error(message);
   }
 }
 


### PR DESCRIPTION
## Summary
- route trait editor mutations through the /api/traits/:id endpoints while persisting concurrency metadata for PUT requests
- add token acquisition/refresh logic and remote detail sync to recover from 401/412/428 responses
- cover the authenticated mutation flow with new TraitDataService tests

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69110918a7ec832ab554d3ac1e88bd73)