### PR TITLE
feat(trait-editor): add trait validation workflow

### DIFF
--- a/Trait Editor/src/app.module.ts
+++ b/Trait Editor/src/app.module.ts
@@ -6,6 +6,7 @@ import { registerTraitDetailPage } from './pages/trait-detail/trait-detail.page'
 import { registerTraitEditorPage } from './pages/trait-editor/trait-editor.page';
 import { registerTraitStateService } from './services/trait-state.service';
 import { registerTraitPreviewComponent } from './components/trait-preview/trait-preview.component';
+import { registerTraitValidationPanelComponent } from './components/trait-validation-panel/trait-validation-panel.component';
 
 export function registerAppModule(): any {
   const module = angular
@@ -42,6 +43,7 @@ export function registerAppModule(): any {
   registerTraitDetailPage(module);
   registerTraitEditorPage(module);
   registerTraitPreviewComponent(module);
+  registerTraitValidationPanelComponent(module);
 
   module.component('appRoot', {
     template: `

--- a/Trait Editor/src/components/trait-validation-panel/trait-validation-panel.component.ts
+++ b/Trait Editor/src/components/trait-validation-panel/trait-validation-panel.component.ts
@@ -1,0 +1,156 @@
+import type {
+  TraitValidationAutoFix,
+  TraitValidationIssue,
+  TraitValidationResult,
+  TraitValidationSeverity,
+} from '../../types/trait-validation';
+
+class TraitValidationPanelController {
+  public result: TraitValidationResult | null = null;
+  public isLoading = false;
+  public error: string | null = null;
+  public canUndo = false;
+  public onApplyFix?: (locals: { fix: TraitValidationAutoFix }) => void;
+  public onUndo?: () => void;
+
+  get hasResult(): boolean {
+    return Boolean(this.result);
+  }
+
+  get hasIssues(): boolean {
+    return Boolean(this.result && this.result.issues.length > 0);
+  }
+
+  get showEmptyState(): boolean {
+    return this.hasResult && !this.isLoading && !this.error && !this.hasIssues;
+  }
+
+  summaryItems(): Array<{ label: string; value: number; severity: TraitValidationSeverity }> {
+    if (!this.result) {
+      return [];
+    }
+
+    return [
+      { label: 'Errori', value: this.result.summary.errors, severity: 'error' },
+      { label: 'Warning', value: this.result.summary.warnings, severity: 'warning' },
+      { label: 'Suggerimenti', value: this.result.summary.suggestions, severity: 'suggestion' },
+    ];
+  }
+
+  severityIcon(severity: TraitValidationSeverity): string {
+    if (severity === 'error') {
+      return '⛔';
+    }
+
+    if (severity === 'warning') {
+      return '⚠️';
+    }
+
+    return '💡';
+  }
+
+  applyFix(fix: TraitValidationAutoFix): void {
+    if (this.onApplyFix) {
+      this.onApplyFix({ fix });
+    }
+  }
+
+  undoLastFix(): void {
+    if (this.onUndo) {
+      this.onUndo();
+    }
+  }
+
+  issueTrack(issue: TraitValidationIssue): string {
+    return issue.id;
+  }
+
+  fixTrack(fix: TraitValidationAutoFix): string {
+    return fix.id;
+  }
+}
+
+export const registerTraitValidationPanelComponent = (module: any): void => {
+  module.component('traitValidationPanel', {
+    bindings: {
+      result: '<',
+      isLoading: '<',
+      error: '<',
+      canUndo: '<',
+      onApplyFix: '&',
+      onUndo: '&',
+    },
+    controller: TraitValidationPanelController,
+    controllerAs: '$ctrl',
+    template: `
+      <section class="validation-panel">
+        <header class="validation-panel__header">
+          <h2 class="validation-panel__title">Validazione</h2>
+          <ul class="validation-panel__summary" ng-if="$ctrl.hasResult">
+            <li
+              class="validation-panel__summary-item"
+              ng-repeat="item in $ctrl.summaryItems() track by item.severity"
+              ng-class="'validation-panel__summary-item--' + item.severity"
+            >
+              <span class="validation-panel__summary-label">{{ item.label }}</span>
+              <span class="validation-panel__summary-value">{{ item.value }}</span>
+            </li>
+          </ul>
+        </header>
+
+        <p class="validation-panel__message" ng-if="$ctrl.isLoading">
+          Validazione in corso...
+        </p>
+
+        <p class="validation-panel__message validation-panel__message--error" ng-if="$ctrl.error && !$ctrl.isLoading">
+          {{ $ctrl.error }}
+        </p>
+
+        <p class="validation-panel__message" ng-if="$ctrl.showEmptyState">
+          Nessun problema rilevato.
+        </p>
+
+        <ul class="validation-panel__issues" ng-if="$ctrl.hasIssues">
+          <li
+            class="validation-issue"
+            ng-repeat="issue in $ctrl.result.issues track by $ctrl.issueTrack(issue)"
+            ng-class="'validation-issue--' + issue.severity"
+          >
+            <div class="validation-issue__summary">
+              <span class="validation-issue__icon" aria-hidden="true">{{ $ctrl.severityIcon(issue.severity) }}</span>
+              <div class="validation-issue__content">
+                <p class="validation-issue__message">{{ issue.message }}</p>
+                <p class="validation-issue__meta" ng-if="issue.code || issue.path">
+                  <span ng-if="issue.code">Codice: {{ issue.code }}</span>
+                  <span ng-if="issue.code && issue.path"> · </span>
+                  <span ng-if="issue.path">Percorso: {{ issue.path }}</span>
+                </p>
+              </div>
+            </div>
+
+            <ul class="validation-issue__fixes" ng-if="issue.autoFixes.length">
+              <li class="validation-issue__fix" ng-repeat="fix in issue.autoFixes track by $ctrl.fixTrack(fix)">
+                <div class="validation-issue__fix-content">
+                  <p class="validation-issue__fix-label">{{ fix.label }}</p>
+                  <p class="validation-issue__fix-description" ng-if="fix.description">{{ fix.description }}</p>
+                </div>
+                <button type="button" class="button button--ghost" ng-click="$ctrl.applyFix(fix)">
+                  Applica
+                </button>
+              </li>
+            </ul>
+          </li>
+        </ul>
+
+        <button
+          type="button"
+          class="button button--ghost validation-panel__undo"
+          ng-if="$ctrl.canUndo"
+          ng-click="$ctrl.undoLastFix()"
+        >
+          Annulla ultima correzione
+        </button>
+      </section>
+    `,
+  });
+};

--- a/Trait Editor/src/pages/trait-editor/__tests__/trait-editor.page.spec.ts
+++ b/Trait Editor/src/pages/trait-editor/__tests__/trait-editor.page.spec.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { TraitEditorController } from '../trait-editor.page';
+import { getSampleTraits } from '../../../data/traits.sample';
+import type { Trait } from '../../../types/trait';
+import type { TraitValidationResult } from '../../../types/trait-validation';
+import type { TraitDataService } from '../../../services/trait-data.service';
+import type { TraitStateService } from '../../../services/trait-state.service';
+
+interface ControllerDeps {
+  dataService: {
+    validateTrait: ReturnType<typeof vi.fn>;
+    saveTrait: ReturnType<typeof vi.fn>;
+    getTraitById: ReturnType<typeof vi.fn>;
+    getLastError: ReturnType<typeof vi.fn>;
+  };
+  stateService: {
+    subscribe: ReturnType<typeof vi.fn>;
+    setPreviewTrait: ReturnType<typeof vi.fn>;
+    setLoading: ReturnType<typeof vi.fn>;
+    setStatus: ReturnType<typeof vi.fn>;
+  };
+  scope: {
+    $on: ReturnType<typeof vi.fn>;
+    $applyAsync: ReturnType<typeof vi.fn>;
+  };
+  location: {
+    path: ReturnType<typeof vi.fn>;
+  };
+  timeout: ReturnType<typeof vi.fn>;
+}
+
+const createController = (trait: Trait, validationResult: TraitValidationResult): { controller: TraitEditorController; deps: ControllerDeps } => {
+  const scope = {
+    $on: vi.fn().mockReturnValue(() => {}),
+    $applyAsync: vi.fn(),
+  };
+
+  const dataService = {
+    validateTrait: vi.fn().mockResolvedValue(validationResult),
+    saveTrait: vi.fn(),
+    getTraitById: vi.fn(),
+    getLastError: vi.fn().mockReturnValue(null),
+  };
+
+  const stateService = {
+    subscribe: vi.fn(),
+    setPreviewTrait: vi.fn(),
+    setLoading: vi.fn(),
+    setStatus: vi.fn(),
+  };
+
+  const location = { path: vi.fn() };
+  const timeout = vi.fn();
+
+  const controller = new TraitEditorController(
+    { id: trait.id },
+    scope,
+    location,
+    timeout,
+    dataService as unknown as TraitDataService,
+    stateService as unknown as TraitStateService,
+  );
+
+  const prepared = (controller as unknown as { prepareFormModel: (value: Trait) => Trait }).prepareFormModel(
+    trait,
+  ) as Trait;
+  controller.trait = JSON.parse(JSON.stringify(trait)) as Trait;
+  controller.formModel = prepared as Trait & { signatureMoves: string[] };
+
+  return {
+    controller,
+    deps: {
+      dataService,
+      stateService,
+      scope,
+      location,
+      timeout,
+    },
+  };
+};
+
+describe('TraitEditorController validation workflow', () => {
+  const [sampleTrait] = getSampleTraits();
+  const emptyResult: TraitValidationResult = { summary: { errors: 0, warnings: 0, suggestions: 0 }, issues: [] };
+
+  it('applies auto fixes, updates the model and triggers validation', async () => {
+    const { controller, deps } = createController(sampleTrait, emptyResult);
+
+    const fix = {
+      id: 'align',
+      label: 'Allinea nome',
+      operations: [
+        { op: 'replace', path: '/name', value: 'Spectre Prime' },
+        { op: 'replace', path: '/entry/label', value: 'Spectre Prime' },
+      ],
+    };
+
+    controller.applyValidationFix(fix);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(controller.formModel?.name).toBe('Spectre Prime');
+    expect(controller.formModel?.entry.label).toBe('Spectre Prime');
+    expect(deps.dataService.validateTrait).toHaveBeenCalledTimes(1);
+    expect(controller.validationResult).toEqual(emptyResult);
+    expect((controller as unknown as { canUndoAutoFix: () => boolean }).canUndoAutoFix()).toBe(true);
+  });
+
+  it('restores the previous snapshot when undoing an auto fix', async () => {
+    const { controller, deps } = createController(sampleTrait, emptyResult);
+
+    const fix = {
+      id: 'align',
+      label: 'Allinea nome',
+      operations: [
+        { op: 'replace', path: '/name', value: 'Spectre Prime' },
+        { op: 'replace', path: '/entry/label', value: 'Spectre Prime' },
+      ],
+    };
+
+    controller.applyValidationFix(fix);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    controller.undoLastAutoFix();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(controller.formModel?.name).toBe(sampleTrait.name);
+    expect(controller.formModel?.entry.label).toBe(sampleTrait.entry.label);
+    expect(deps.dataService.validateTrait).toHaveBeenCalledTimes(2);
+  });
+});

--- a/Trait Editor/src/styles/main.css
+++ b/Trait Editor/src/styles/main.css
@@ -472,6 +472,172 @@ body {
   gap: 1rem;
 }
 
+.validation-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: rgba(9, 14, 32, 0.6);
+  backdrop-filter: blur(12px);
+}
+
+.validation-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.validation-panel__title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.validation-panel__summary {
+  display: flex;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.validation-panel__summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.4rem 0.7rem;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  line-height: 1.1;
+}
+
+.validation-panel__summary-item--error {
+  background: rgba(255, 99, 132, 0.16);
+  color: #ffb3c6;
+}
+
+.validation-panel__summary-item--warning {
+  background: rgba(255, 188, 71, 0.18);
+  color: #ffd8a1;
+}
+
+.validation-panel__summary-item--suggestion {
+  background: rgba(94, 202, 255, 0.16);
+  color: #bde8ff;
+}
+
+.validation-panel__summary-label {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.validation-panel__summary-value {
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.validation-panel__message {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.validation-panel__message--error {
+  color: #ffb3c6;
+}
+
+.validation-panel__issues {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.validation-issue {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(16, 24, 46, 0.55);
+}
+
+.validation-issue--error {
+  border-color: rgba(255, 99, 132, 0.45);
+}
+
+.validation-issue--warning {
+  border-color: rgba(255, 188, 71, 0.45);
+}
+
+.validation-issue--suggestion {
+  border-color: rgba(94, 202, 255, 0.45);
+}
+
+.validation-issue__summary {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.validation-issue__icon {
+  font-size: 1.4rem;
+}
+
+.validation-issue__message {
+  margin: 0;
+  font-weight: 600;
+}
+
+.validation-issue__meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.validation-issue__fixes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.validation-issue__fix {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.validation-issue__fix-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.validation-issue__fix-label {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.validation-issue__fix-description {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.validation-panel__undo {
+  align-self: flex-end;
+}
+
 .editor-layout__title {
   margin: 0;
   font-size: 1.25rem;

--- a/Trait Editor/src/types/trait-validation.ts
+++ b/Trait Editor/src/types/trait-validation.ts
@@ -1,0 +1,34 @@
+export type TraitValidationSeverity = 'error' | 'warning' | 'suggestion';
+
+export interface TraitValidationSummary {
+  errors: number;
+  warnings: number;
+  suggestions: number;
+}
+
+export interface TraitValidationAutoFixOperation {
+  op: 'add' | 'replace' | 'remove';
+  path: string;
+  value?: unknown;
+}
+
+export interface TraitValidationAutoFix {
+  id: string;
+  label: string;
+  description?: string;
+  operations: TraitValidationAutoFixOperation[];
+}
+
+export interface TraitValidationIssue {
+  id: string;
+  severity: TraitValidationSeverity;
+  message: string;
+  code?: string;
+  path?: string;
+  autoFixes: TraitValidationAutoFix[];
+}
+
+export interface TraitValidationResult {
+  summary: TraitValidationSummary;
+  issues: TraitValidationIssue[];
+}


### PR DESCRIPTION
## Summary
- integrate the remote trait validation API with normalization, error handling, and JSON pointer auto-fix support in the data service
- add a validation panel component, hook it into the trait editor UI, and support applying or undoing auto-fixes on the form model
- style the new validation widgets and cover the workflow with dedicated service and controller tests

## Testing
- npm run test (Trait Editor)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69110c5019a8832ab45ab0c403232198)