### PR TITLE
Add biome pool migration and seed integration

### DIFF
--- a/migrations/evo_tactics_pack/202411050003_add_biome_pools_collection.py
+++ b/migrations/evo_tactics_pack/202411050003_add_biome_pools_collection.py
@@ -1,0 +1,55 @@
+"""Create biome_pools collection and indexes for Evo Tactics Pack."""
+
+from __future__ import annotations
+
+from pymongo.database import Database
+
+MIGRATION_ID = "202411050003"
+DESCRIPTION = "Create biome_pools collection with query indexes"
+
+
+def _ensure_collection(db: Database, name: str):
+    if name in db.list_collection_names():
+        return db[name]
+    db.create_collection(name)
+    return db[name]
+
+
+def upgrade(db: Database) -> None:
+    collection = _ensure_collection(db, "biome_pools")
+
+    collection.create_index(
+        [("hazard.severity", 1)],
+        name="hazard_severity_idx",
+    )
+    collection.create_index(
+        [("climate_tags", 1)],
+        name="climate_tags_idx",
+    )
+    collection.create_index(
+        [("role_templates.role", 1)],
+        name="role_templates_role_idx",
+    )
+    collection.create_index(
+        [("traits.core", 1)],
+        name="traits_core_idx",
+    )
+
+
+def downgrade(db: Database) -> None:
+    indexes = [
+        "hazard_severity_idx",
+        "climate_tags_idx",
+        "role_templates_role_idx",
+        "traits_core_idx",
+    ]
+    collection = db["biome_pools"]
+    for index in indexes:
+        try:
+            collection.drop_index(index)
+        except Exception:
+            pass
+    try:
+        db.drop_collection("biome_pools")
+    except Exception:
+        pass

--- a/tests/api/biome-generation-mongo.test.js
+++ b/tests/api/biome-generation-mongo.test.js
@@ -7,6 +7,7 @@ const request = require('supertest');
 
 const { createApp } = require('../../server/app');
 const { closeMongo } = require('../../server/db/mongo');
+const { createCatalogService } = require('../../server/services/catalog');
 
 function createTraitDocument(id, label, extras = {}) {
   return {
@@ -120,6 +121,13 @@ test('POST /api/v1/generation/biomes utilizza i dati MongoDB quando disponibili'
   await client.connect();
   const db = client.db(databaseName);
   await seedMongo(db);
+
+  const catalogService = createCatalogService({
+    useMongo: true,
+    mongo: { uri: mongoUri, dbName: databaseName },
+  });
+  const readiness = await catalogService.ensureReady();
+  assert.ok(readiness.poolCount > 0, 'il seed Mongo deve popolare almeno un biome pool');
 
   const previousMongoUrl = process.env.MONGO_URL;
   const previousMongoDb = process.env.MONGO_DB_NAME;


### PR DESCRIPTION
## Summary
- add a MongoDB migration that creates the `biome_pools` collection with indexes for common generator filters
- extend the Evo generator seeding script to import the biome pool dataset and upsert it alongside biomes, species, and traits
- update the Mongo-backed biome generation test to assert the catalog service reports seeded biome pools

## Testing
- node --test tests/api/biome-generation-mongo.test.js *(fails: missing dev dependency mongodb-memory-server in sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691142c3e1688328b481824d563e541e)