### PR TITLE
Make seed generator importable in tests

### DIFF
--- a/scripts/db/__init__.py
+++ b/scripts/db/__init__.py
@@ -1,0 +1,13 @@
+"""Pacchetto di supporto per gli script legati al database."""
+
+import sys
+
+from . import config_loader as _config_loader
+
+# Gli script della cartella erano pensati per essere eseguiti come moduli
+# stand-alone e importano ``config_loader`` come modulo di primo livello. Qui
+# pubblichiamo lo stesso modulo in ``sys.modules`` così che gli import esistenti
+# continuino a funzionare anche quando il pacchetto viene importato.
+sys.modules.setdefault("config_loader", _config_loader)
+
+__all__ = ["_config_loader"]


### PR DESCRIPTION
## Summary
- add an importable package for the database scripts and expose `config_loader`
- load the Evo seed generator module in tests without touching `sys.path`
- replace manual pymongo stubs with monkeypatched modules

## Testing
- pytest tests/scripts/test_seed_evo_generator.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69114794b7648328a1667182527b7733)