### PR TITLE
Improve Evo seed generator tests for ReplaceOne usage

### DIFF
--- a/tests/scripts/test_seed_evo_generator.py
+++ b/tests/scripts/test_seed_evo_generator.py
@@ -3,12 +3,28 @@ import importlib.util
 import sys
 import types
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 
 class FakeCollection:
     def __init__(self, name: str):
         self.name = name
+        self._bulk_write_calls: List[List[object]] = []
+
+    @property
+    def bulk_write_calls(self) -> List[List[object]]:
+        return self._bulk_write_calls
+
+    def bulk_write(self, requests, ordered=False):  # pragma: no cover - behaviour tested via side effects
+        ops = list(requests)
+        self._bulk_write_calls.append(ops)
+
+        class _Result:
+            def __init__(self, upserted: int, modified: int):
+                self.upserted_count = upserted
+                self.modified_count = modified
+
+        return _Result(upserted=len(ops), modified=0)
 
 
 class FakeDatabase:
@@ -42,9 +58,10 @@ def test_seed_database_populates_biome_pools(monkeypatch):
             pass
 
     class _StubReplaceOne:
-        def __init__(self, *args, **kwargs):
-            self.args = args
-            self.kwargs = kwargs
+        def __init__(self, filter_doc, replacement, **kwargs):
+            self.filter = filter_doc
+            self.replacement = replacement
+            self.options = kwargs
 
     pymongo_stub.MongoClient = _StubMongoClient
     pymongo_stub.ReplaceOne = _StubReplaceOne
@@ -80,24 +97,76 @@ def test_seed_database_populates_biome_pools(monkeypatch):
 
     import scripts.db.seed_evo_generator as seed_evo_generator
 
-    calls: List[Tuple[str, List[dict]]] = []
-
-    def fake_bulk_upsert(collection, documents):
-        docs = list(documents)
-        calls.append((collection.name, docs))
-
-    monkeypatch.setattr(seed_evo_generator, "bulk_upsert", fake_bulk_upsert)
-
     client = FakeMongoClient()
     seed_evo_generator.seed_database(client, "test-database", dry_run=False)
 
-    assert calls, "bulk_upsert deve essere invocato per le collezioni principali"
-    collection_names = [name for name, _ in calls]
-    assert "biome_pools" in collection_names, "il seed deve scrivere la collezione biome_pools"
+    biome_collection = client["test-database"]["biome_pools"]
+    assert biome_collection.bulk_write_calls, "bulk_write deve essere invocato per biome_pools"
 
-    biome_pool_docs = next(docs for name, docs in calls if name == "biome_pools")
-    assert biome_pool_docs, "biome_pools non deve essere vuota"
+    operations = biome_collection.bulk_write_calls[0]
+    assert operations, "biome_pools non deve essere vuota"
 
-    metadata = biome_pool_docs[0].get("metadata", {})
+    first_replacement = operations[0].replacement
+    metadata = first_replacement.get("metadata", {})
     assert metadata.get("schema_version"), "il metadata deve riportare la versione di schema"
     assert isinstance(metadata.get("updated_at"), datetime.datetime)
+
+    for op in operations:
+        replacement_id = op.replacement.get("_id")
+        assert replacement_id, "ogni documento deve avere un _id impostato"
+        assert op.filter == {"_id": replacement_id}
+        assert op.options.get("upsert") is True
+
+
+def test_seed_database_dry_run_skips_writes(monkeypatch):
+    pymongo_stub = types.ModuleType("pymongo")
+
+    class _StubMongoClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class _StubReplaceOne:
+        def __init__(self, filter_doc, replacement, **kwargs):
+            self.filter = filter_doc
+            self.replacement = replacement
+            self.options = kwargs
+
+    pymongo_stub.MongoClient = _StubMongoClient
+    pymongo_stub.ReplaceOne = _StubReplaceOne
+    monkeypatch.setitem(sys.modules, "pymongo", pymongo_stub)
+
+    collection_module = types.ModuleType("pymongo.collection")
+
+    class _StubCollection:  # pragma: no cover - type placeholder
+        pass
+
+    collection_module.Collection = _StubCollection
+    monkeypatch.setitem(sys.modules, "pymongo.collection", collection_module)
+
+    scripts_root = Path(__file__).resolve().parents[2] / "scripts"
+    scripts_spec = importlib.util.spec_from_file_location(
+        "scripts", scripts_root / "__init__.py", submodule_search_locations=[str(scripts_root)]
+    )
+    scripts_module = importlib.util.module_from_spec(scripts_spec)
+    monkeypatch.setitem(sys.modules, "scripts", scripts_module)
+    assert scripts_spec.loader is not None
+    scripts_spec.loader.exec_module(scripts_module)
+
+    db_root = scripts_root / "db"
+    db_spec = importlib.util.spec_from_file_location(
+        "scripts.db", db_root / "__init__.py", submodule_search_locations=[str(db_root)]
+    )
+    db_module = importlib.util.module_from_spec(db_spec)
+    monkeypatch.setitem(sys.modules, "scripts.db", db_module)
+    assert db_spec.loader is not None
+    db_spec.loader.exec_module(db_module)
+
+    sys.modules.pop("scripts.db.seed_evo_generator", None)
+
+    import scripts.db.seed_evo_generator as seed_evo_generator
+
+    client = FakeMongoClient()
+    seed_evo_generator.seed_database(client, "test-database", dry_run=True)
+
+    biome_collection = client["test-database"]["biome_pools"]
+    assert biome_collection.bulk_write_calls == [], "dry_run deve saltare le scritture su MongoDB"


### PR DESCRIPTION
## Summary
- extend the fake MongoDB collection used in the tests to record bulk_write calls and return counters
- check that seed_database builds ReplaceOne operations with _id filters and upsert enabled for biome pools
- cover the dry-run scenario to ensure no bulk writes occur

## Testing
- pytest tests/scripts/test_seed_evo_generator.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691149988ad48328a2aec38438ddb6b7)