### PR TITLE
Add Mongo seed integration test and expose catalog pools API

### DIFF
--- a/docs/evo-tactics-pack/deploy.md
+++ b/docs/evo-tactics-pack/deploy.md
@@ -95,6 +95,7 @@ tag `<meta name="evo-api-base">`. I percorsi attesi sono:
 - `GET /api/v1/catalog/biomes`
 - `GET /api/v1/catalog/ecosystem`
 - `GET /api/v1/catalog/species`
+- `GET /api/v1/catalog/pools`
 
 Il servizio `services/data-source.js` gestisce la sequenza di fallback: tenta gli
 endpoint remoti, poi ricade sugli asset statici del bundle e infine attiva un

--- a/server/app.js
+++ b/server/app.js
@@ -776,6 +776,26 @@ function createApp(options = {}) {
   app.use('/api/generation', generationRouter);
   app.post('/api/biomes/generate', generationRoutes.biomes);
 
+  async function sendCatalogPools(req, res) {
+    try {
+      if (catalogService && typeof catalogService.ensureReady === 'function') {
+        await catalogService.ensureReady();
+      }
+      if (!catalogService || typeof catalogService.loadBiomePools !== 'function') {
+        res.status(503).json({ error: 'Catalog service non disponibile' });
+        return;
+      }
+      const biomePools = await catalogService.loadBiomePools();
+      res.json(biomePools);
+    } catch (error) {
+      console.warn('[catalog] errore caricamento biome pools', error);
+      res.status(500).json({ error: 'Errore caricamento pool catalogo' });
+    }
+  }
+
+  app.get('/api/v1/catalog/pools', sendCatalogPools);
+  app.get('/api/catalog/pools', sendCatalogPools);
+
   return { app, repo };
 }
 


### PR DESCRIPTION
## Summary
- add an integration test that seeds Mongo via the evo generator Python script and validates the catalog service output
- expose `/api/v1/catalog/pools` (and legacy alias) so the Express app surfaces Mongo-backed pool data
- document the new catalog pools endpoint alongside the existing Evo Tactics catalog APIs

## Testing
- `node --test tests/api/biome-generation-mongo.test.js` *(fails: MongoDB memory server binary download blocked with HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69114a236ba483288f3f7f68ca323b5a)