### PR TITLE
Add Trait Editor checks to stack-quality CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,18 @@ jobs:
       - name: Run frontend unit tests
         run: npm run test --workspace webapp
 
+      - name: Install Trait Editor dependencies
+        working-directory: Trait Editor
+        run: npm ci --no-audit --no-fund
+
+      - name: Run Trait Editor unit tests
+        working-directory: Trait Editor
+        run: npm run test
+
+      - name: Build Trait Editor
+        working-directory: Trait Editor
+        run: npm run build
+
       - name: Build frontend for production
         env:
           VITE_BASE_PATH: ./


### PR DESCRIPTION
## Summary
- run npm ci inside the Trait Editor workspace during the stack-quality workflow
- execute Trait Editor tests and production build so CI fails when they break

## Testing
- npm ci --no-audit --no-fund (Trait Editor)
- npm run test (Trait Editor)
- npm run build (Trait Editor)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911542349a88328a2e821a9e38272dd)