### PR TITLE
docs: update trait editor deployment guidance

### DIFF
--- a/Trait Editor/docs/quickstart-standalone.md
+++ b/Trait Editor/docs/quickstart-standalone.md
@@ -8,7 +8,7 @@ Questa guida sintetizza i passaggi minimi per avviare l'editor e verificare una 
 - Clona o scarica il pacchetto `Trait Editor/` insieme alla cartella `data/traits/` del monorepo.
 - Copia eventuali file di configurazione (`.env.local`) che puntano al dataset condiviso.
 - Verifica la presenza di Node.js 18+ con `node --version` e di npm 9+.
-- Controlla di poter raggiungere la CDN Google di AngularJS (`ajax.googleapis.com`) oppure prepara un mirror locale seguendo la [nota sulle dipendenze front-end](../README.md#nota-sul-caricamento-di-angularjs).
+- Installa le dipendenze JavaScript con `npm install` (AngularJS e i relativi moduli vengono ora inclusi automaticamente nel bundle Vite).
 
 ## 2. Configura l'accesso ai dati
 1. Se lavori con il dataset ufficiale, posiziona `data/traits/index.json` a un livello superiore rispetto al pacchetto.
@@ -30,7 +30,7 @@ Questa guida sintetizza i passaggi minimi per avviare l'editor e verificare una 
 ## 4. Checklist rapida
 - [ ] Mock disattivati o aggiornati (`src/data/traits.sample.ts`) se usi dati reali.
 - [ ] Variabili `VITE_*` definite (`printenv | grep VITE_`).
-- [ ] Dipendenze front-end disponibili (CDN consentita o mirror locale configurato).
+- [ ] Dipendenze installate (`npm install`) e build verificata (`npm run build`).
 - [ ] Log del browser puliti: nessun errore di fetch o validazione.
 - [ ] Outputs dei passi 5–7 verificati: indice/baseline/coverage rigenerati, `logs/trait_audit.md` aggiornato, checklist PR completate.
 - [ ] Screenshots aggiornati allegati alla PR (se richiesti).

--- a/docs/trait-editor.md
+++ b/docs/trait-editor.md
@@ -5,7 +5,7 @@ Il pacchetto [`Trait Editor/`](../Trait%20Editor/) fornisce un editor AngularJS 
 ## Prerequisiti
 
 - **Node.js 18+** e **npm 9+** (il pacchetto sfrutta Vite 5).
-- Accesso alla CDN Google per AngularJS **oppure** mirror locale configurato (vedi nota nel [`Trait Editor/README.md`](../Trait%20Editor/README.md#nota-sul-caricamento-di-angularjs)).
+- Dipendenze JavaScript installate con `npm install` (AngularJS e moduli correlati sono risolti via npm e inclusi nella build).
 - Dataset trait aggiornato in `data/traits/` quando si lavora con sorgente remota (`VITE_TRAIT_DATA_SOURCE=remote`).
 
 Suggerimenti rapidi:
@@ -82,9 +82,10 @@ Il comando `npm run test:stack` esegue sia la suite API (`npm run test:api`) sia
 ## Deploy statico
 
 1. Imposta le variabili `VITE_TRAIT_DATA_SOURCE`, `VITE_TRAIT_DATA_URL` e (se necessario) `VITE_BASE_PATH`.
-2. Genera la build:
+2. Genera la build dopo aver installato le dipendenze:
    ```bash
    cd "Trait Editor"
+   npm install
    VITE_BASE_PATH=/trait-editor/ npm run build
    ```
 3. Distribuisci il contenuto di `dist/` su hosting statico (GitHub Pages, Netlify, S3, ecc.).
@@ -94,6 +95,6 @@ Per pipeline automatiche puoi riutilizzare lo script `npm run ci:stack` dalla ro
 
 ## Troubleshooting rapido
 
-- **AngularJS da CDN bloccata** → Replica gli asset in `public/vendor/angular/` e aggiorna i tag `<script>` come descritto nel [`Trait Editor/README.md`](../Trait%20Editor/README.md#strategia-2-bundle-localemirror-degli-asset-angularjs).
+- **Dipendenze AngularJS non installate** → Esegui `npm install` nella root di `Trait Editor/` per ripristinare i moduli (`angular`, `angular-route`, `angular-animate`, `angular-sanitize`) prima di lanciare `npm run build`.
 - **Dataset remoto non raggiungibile** → Controlla il log del browser: l'app registra `console.error('Impossibile caricare i tratti:', error)` e fa fallback ai mock con `console.warn('Falling back to sample traits after remote fetch failure:', error)`.
 - **Deploy in sottocartella** → Verifica che `VITE_BASE_PATH`/`BASE_PATH` combaci con il percorso pubblicato; riesegui `npm run build` se cambi il prefisso.


### PR DESCRIPTION
## Summary
- rewrite the Trait Editor publication workflow to cover npm-based installs, build commands, base path handling, and CI guidance
- update the AngularJS dependency note to reflect npm-managed bundles with a legacy CDN fallback section
- refresh the quickstart and global Trait Editor docs to drop the CDN prerequisite and highlight the new build requirements

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691154d8a2b08328b79c84cf30bcf9f9)