### PR TITLE
Plan integration for Evo-Tactics incoming pack

### DIFF
--- a/incoming/lavoro_da_classificare/INTEGRATION_PLAN.md
+++ b/incoming/lavoro_da_classificare/INTEGRATION_PLAN.md
@@ -1,0 +1,78 @@
+# Piano di integrazione — `incoming/lavoro_da_classificare`
+
+Questo documento raccoglie le azioni operative per completare la revisione e
+l'import del pacchetto Evo‑Tactics presente nella cartella
+`incoming/lavoro_da_classificare/`. L'obiettivo è convertire il materiale grezzo
+in contributi pronti per il branch principale del repository.
+
+## Obiettivi di alto livello
+
+1. **Consolidare la documentazione** in `docs/` e allinearla con le guide
+   ufficiali (How-To Trait, QA, policy di sicurezza).
+2. **Allineare dati e schemi** di specie/ecotipi/trait con il formato stabile
+   (JSON Schema v2, alias specie, dataset aggregati).
+3. **Integrare gli script di tooling** (validazioni, backlog, report) nel
+   toolchain già presente (`incoming/scripts`, `tools/`, workflow CI).
+4. **Aggiornare workflow e test** Playwright per validare UI e reportistica.
+5. **Tenere traccia dei duplicati** (es. copia in `home/oai/share/...`) per
+   evitare import multipli nello stesso branch.
+
+## Batches proposti
+
+| Batch | Scope | Destinazione finale | Dipendenze | Bloccanti |
+| --- | --- | --- | --- | --- |
+| `documentation` | `docs/`, `README*`, guide in PDF/DOCX | `docs/evo-tactics/` + `docs/security/` + `docs/guides/` | Nessuna, solo revisione contenuti | Conversione dei DOCX/PDF in Markdown stabile |
+| `data-models` | `templates/*.schema.json`, `data/aliases/*.json` | `schemas/` e `data/core/species/aliases.json` | Richiede conferma campi con gameplay | Allineare enum/field con versioni in `schemas/` |
+| `species_ecotypes` | `species/*.json`, `ecotypes/*.json`, `species_catalog.md/json` | Nuova cartella `data/external/evo/species/` + indice in `data/external/evo/species_catalog.json` | Dipende da `data-models` | Validazione contro schema v2, aggiornare alias |
+| `traits` | `traits/*.json`, `traits_aggregate.json`, `trait_review.*`, `trait_merge_proposals.md` | `data/external/evo/traits/` + merge in `data/core/traits/glossary.json` | Dipende da `data-models` | Duplicati vs. glossario esistente, conflitti ID `TR-*` |
+| `tooling` | `scripts/*.py`, `scripts/validate.sh`, `setup_backlog.py`, `species_summary_script.py` | `incoming/scripts/` + `tools/automation/` (nuova) | Nessuna | Configurare variabili ambiente, evitare duplicati con `incoming/scripts` |
+| `ops_ci` | `workflows/*.yml`, `ops/site-audit/*`, `security.yml`, `init_security_checks.sh` | `.github/workflows/`, `ops/site-audit/` (armonizzare con esistente) | Dipende da `tooling` | Verificare compatibilità CI esistente, segreti GitHub |
+| `frontend` | `tests/playwright/*`, `lighthouserc.json`, `proposed_sitemap.xml`, `proposed_routes.csv`, `mockup_evo_tactics.png` | `tests/playwright/evo/`, `config/lighthouse/` | Dipende da `ops_ci` | Richiede assets frontend aggiornati |
+
+## Note sui duplicati
+
+* La gerarchia `home/oai/share/evo_tactics_game_creatures_traits_package/`
+  duplica quasi tutto il contenuto principale. Durante la revisione mantenere
+  solo la copia in radice e segnare nel file `inventario.yml` le voci duplicate
+  come "archiviate" una volta validata l'equivalenza.
+* `backlog/backlog_tasks_example.yaml` coincide con il file a livello radice:
+  usiamo la copia radice come sorgente e rimuoviamo la duplicata a import
+  completato.
+
+## Automazioni disponibili
+
+* `scripts/validate.sh` — esegue la validazione JSON Schema per specie e trait
+  usando `ajv`. Da spostare in `incoming/scripts/validate_evo_pack.sh` con
+  percorsi aggiornati.
+* `trait_review.py` e `species_summary_script.py` — generano report CSV/Markdown
+  allineati con l'inventario; prevedere un target `make traits-review` nella
+  radice del progetto per integrarli in CI.
+* `setup_backlog.py` — automatizza la creazione di project board/issue GitHub.
+  Richiede token personale; valutare se convertirlo in comando `just` o script
+  `npm` per facilitare gli stakeholder.
+* Workflow in `workflows/` — replicano pipeline (schema-validate, e2e,
+  lighthouse, security). Confrontarli con `.github/workflows/` e migrare le
+  sezioni mancanti.
+
+## Checklist operativa
+
+1. Convalidare le strutture JSON con `scripts/validate.sh` allineando i path.
+2. Documentare l'esito della verifica nel file `inventario.yml` (`stato:
+   validato`) per i blocchi completati.
+3. Per ogni batch:
+   - spostare i file nella destinazione indicata,
+   - aprire PR dedicata con riferimento a `integration_batches.yml`,
+   - aggiornare i report (`trait_review_report.md`, `species_analysis_report.md`).
+4. Eliminare o archiviare `home/oai/share/...` quando la migrazione è conclusa.
+5. Aggiornare la roadmap nel project board usando `setup_backlog.py` e il
+   template `backlog_tasks_example.yaml`.
+
+## Uscite attese per l'import finale
+
+* Nuovi dataset `data/external/evo/` con specie e trait normalizzati.
+* Documentazione consolidata sotto `docs/evo-tactics/` e `docs/security/`.
+* Workflow CI aggiornati in `.github/workflows/` e Playwright test installati.
+* Report aggiornati nella directory `reports/` con link dal `README.md`.
+
+Tenendo traccia di questi passi è possibile completare l'integrazione della
+cartella senza ulteriori interventi manuali esterni.

--- a/incoming/lavoro_da_classificare/integration_batches.yml
+++ b/incoming/lavoro_da_classificare/integration_batches.yml
@@ -1,0 +1,123 @@
+# Piano strutturato per integrare `incoming/lavoro_da_classificare`
+batches:
+  - id: documentation
+    title: Documentazione e guide
+    scope:
+      - docs/**/*
+      - README*.md
+      - "Guida Ai tratti *.docx"
+      - "Progetto unico e fonti (*.pdf)"
+    destination:
+      primary: docs/evo-tactics/
+      security: docs/security/
+      archives: incoming/archive/documents/
+    status: pronti_per_revisione
+    actions:
+      - Convertire i file DOCX/PDF in Markdown usando pandoc e aggiungere metadata frontmatter.
+      - Uniformare titoli e slug alla convenzione `docs/` (kebab-case, prefisso `evo-`).
+      - Aggiornare `docs/README.md` con indice alle nuove sezioni.
+    blockers:
+      - Conferma stakeholder su versioni ufficiali delle guide trait.
+  - id: data-models
+    title: Schemi e alias
+    scope:
+      - templates/*.schema.json
+      - data/aliases/*.json
+    destination:
+      schemas: schemas/evo/
+      data: data/core/species/aliases.json
+    status: in_analisi
+    actions:
+      - Validare gli schema con `npm run schema:lint` e verificare compatibilità con pipeline AJV esistente.
+      - Allineare i campi `sentience_index` e `ecotypes` alle enum globali (`data/core/traits/glossary.json`).
+      - Inserire gli alias confermati in `data/core/species/aliases.json` e aggiornare la documentazione.
+    blockers:
+      - Revisione con team gameplay per i nuovi enum.
+  - id: species_ecotypes
+    title: Specie ed ecotipi
+    scope:
+      - species/*.json
+      - ecotypes/*.json
+      - species_catalog.*
+    destination:
+      data: data/external/evo/species/
+      catalog: data/external/evo/species_catalog.json
+    status: pronti_per_validazione
+    actions:
+      - Validare i JSON con `scripts/validate.sh` (aggiornare i path).
+      - Generare il report aggregato con `species_summary_script.py` e allegarlo in `reports/`.
+      - Collegare gli ecotipi al registry esistente in `data/ecosystems/`.
+    blockers:
+      - Decisione su naming finale (latino vs. alias italiano).
+  - id: traits
+    title: Trait atomici e aggregati
+    scope:
+      - traits/TR-*.json
+      - traits/traits_aggregate.json
+      - docs/analysis/trait_*.
+    destination:
+      data: data/external/evo/traits/
+      glossary: data/core/traits/glossary.json
+    status: pronti_per_validazione
+    actions:
+      - Lanciare `trait_review.py` per generare CSV con anomalie e duplicati.
+      - Integrare i nuovi trait nel glossario assicurando unicità degli ID `TR-####`.
+      - Aggiornare `docs/analysis/trait_merge_proposals.md` con gli esiti della revisione.
+    blockers:
+      - Risoluzione conflitti con trait già presenti in `data/core/traits/glossary.json`.
+  - id: tooling
+    title: Script di automazione
+    scope:
+      - scripts/*.py
+      - scripts/validate.sh
+      - setup_backlog.py
+      - species_summary_script.py
+      - trait_review.py
+    destination:
+      incoming_scripts: incoming/scripts/
+      tools: tools/automation/
+    status: in_corso
+    actions:
+      - Uniformare intestazioni shebang e licenze.
+      - Aggiungere target dedicati nel `Makefile` (`make evo-validate`, `make evo-backlog`).
+      - Documentare l'uso in `incoming/README.md` e nel wiki interno.
+    blockers:
+      - Definizione credenziali/secret per GitHub API (setup backlog).
+  - id: ops_ci
+    title: Workflow CI e site audit
+    scope:
+      - workflows/*.yml
+      - security.yml
+      - init_security_checks.sh
+      - ops/site-audit/**/*
+      - lighthouserc.json
+    destination:
+      workflows: .github/workflows/
+      ops: ops/site-audit/
+      config: config/lighthouse/
+    status: da_revisionare
+    actions:
+      - Confrontare ogni workflow con l'equivalente in `.github/workflows/` e fondere solo gli step mancanti.
+      - Integrare gli script site-audit nel tooling esistente (`tools/site-audit`).
+      - Aggiornare `config/lighthouserc.json` e predisporre test `npm run lint:lighthouse`.
+    blockers:
+      - Disponibilità ambienti CI per Playwright/Lighthouse.
+  - id: frontend
+    title: Test end-to-end e sitemap
+    scope:
+      - tests/playwright/**/*
+      - proposed_routes.csv
+      - proposed_sitemap.xml
+      - mockup_evo_tactics.png
+      - robots.txt
+    destination:
+      tests: tests/playwright/evo/
+      sitemap: public/
+      docs: docs/wireframes/
+    status: pianificato
+    actions:
+      - Trasporre gli spec Playwright nel formato usato da `tests/e2e` (vitest + playwright).
+      - Verificare la sitemap con `sitemap_link_checker.py` e aggiornare `public/sitemap.xml`.
+      - Allegare i mockup nella documentazione UI (`docs/wireframes/`).
+    blockers:
+      - Coordinamento con il team webapp per URL definitivi.


### PR DESCRIPTION
## Summary
- add an operational integration plan for the Evo-Tactics materials stored in `incoming/lavoro_da_classificare`
- describe the integration batches, automation hooks, and duplicate handling guidance in a dedicated Markdown guide
- provide a structured YAML mapping of batches with destinations, actions, and blockers to drive follow-up work

## Testing
- not run (documentation and planning changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911c4f6f3a0832886ad7eee15a91f51)