### PR TITLE
Track Evo-Tactics integration tasks

### DIFF
--- a/incoming/lavoro_da_classificare/INTEGRATION_PLAN.md
+++ b/incoming/lavoro_da_classificare/INTEGRATION_PLAN.md
@@ -1,0 +1,80 @@
+# Piano di integrazione — `incoming/lavoro_da_classificare`
+
+Questo documento raccoglie le azioni operative per completare la revisione e
+l'import del pacchetto Evo‑Tactics presente nella cartella
+`incoming/lavoro_da_classificare/`. L'obiettivo è convertire il materiale grezzo
+in contributi pronti per il branch principale del repository.
+
+## Obiettivi di alto livello
+
+1. **Consolidare la documentazione** in `docs/` e allinearla con le guide
+   ufficiali (How-To Trait, QA, policy di sicurezza).
+2. **Allineare dati e schemi** di specie/ecotipi/trait con il formato stabile
+   (JSON Schema v2, alias specie, dataset aggregati).
+3. **Integrare gli script di tooling** (validazioni, backlog, report) nel
+   toolchain già presente (`incoming/scripts`, `tools/`, workflow CI).
+4. **Aggiornare workflow e test** Playwright per validare UI e reportistica.
+5. **Tenere traccia dei duplicati** (es. copia in `home/oai/share/...`) per
+   evitare import multipli nello stesso branch.
+
+## Batches proposti
+
+| Batch | Scope | Destinazione finale | Dipendenze | Bloccanti |
+| --- | --- | --- | --- | --- |
+| `documentation` | `docs/`, `README*`, guide in PDF/DOCX | `docs/evo-tactics/` + `docs/security/` + `docs/guides/` | Nessuna, solo revisione contenuti | Conversione dei DOCX/PDF in Markdown stabile |
+| `data-models` | `templates/*.schema.json`, `data/aliases/*.json` | `schemas/` e `data/core/species/aliases.json` | Richiede conferma campi con gameplay | Allineare enum/field con versioni in `schemas/` |
+| `species_ecotypes` | `species/*.json`, `ecotypes/*.json`, `species_catalog.md/json` | Nuova cartella `data/external/evo/species/` + indice in `data/external/evo/species_catalog.json` | Dipende da `data-models` | Validazione contro schema v2, aggiornare alias |
+| `traits` | `traits/*.json`, `traits_aggregate.json`, `trait_review.*`, `trait_merge_proposals.md` | `data/external/evo/traits/` + merge in `data/core/traits/glossary.json` | Dipende da `data-models` | Duplicati vs. glossario esistente, conflitti ID `TR-*` |
+| `tooling` | `scripts/*.py`, `scripts/validate.sh`, `setup_backlog.py`, `species_summary_script.py` | `incoming/scripts/` + `tools/automation/` (nuova) | Nessuna | Configurare variabili ambiente, evitare duplicati con `incoming/scripts` |
+| `ops_ci` | `workflows/*.yml`, `ops/site-audit/*`, `security.yml`, `init_security_checks.sh` | `.github/workflows/`, `ops/site-audit/` (armonizzare con esistente) | Dipende da `tooling` | Verificare compatibilità CI esistente, segreti GitHub |
+| `frontend` | `tests/playwright/*`, `lighthouserc.json`, `proposed_sitemap.xml`, `proposed_routes.csv`, `mockup_evo_tactics.png` | `tests/playwright/evo/`, `config/lighthouse/` | Dipende da `ops_ci` | Richiede assets frontend aggiornati |
+
+## Note sui duplicati
+
+* La gerarchia `home/oai/share/evo_tactics_game_creatures_traits_package/`
+  duplica quasi tutto il contenuto principale. Durante la revisione mantenere
+  solo la copia in radice e segnare nel file `inventario.yml` le voci duplicate
+  come "archiviate" una volta validata l'equivalenza.
+* `backlog/backlog_tasks_example.yaml` coincide con il file a livello radice:
+  usiamo la copia radice come sorgente e rimuoviamo la duplicata a import
+  completato.
+
+## Automazioni disponibili
+
+* `scripts/validate.sh` — esegue la validazione JSON Schema per specie e trait
+  usando `ajv`. Da spostare in `incoming/scripts/validate_evo_pack.sh` con
+  percorsi aggiornati.
+* `trait_review.py` e `species_summary_script.py` — generano report CSV/Markdown
+  allineati con l'inventario; prevedere un target `make traits-review` nella
+  radice del progetto per integrarli in CI.
+* `setup_backlog.py` — automatizza la creazione di project board/issue GitHub.
+  Richiede token personale; valutare se convertirlo in comando `just` o script
+  `npm` per facilitare gli stakeholder.
+* Workflow in `workflows/` — replicano pipeline (schema-validate, e2e,
+  lighthouse, security). Confrontarli con `.github/workflows/` e migrare le
+  sezioni mancanti.
+
+## Checklist operativa
+
+1. Convalidare le strutture JSON con `scripts/validate.sh` allineando i path.
+2. Documentare l'esito della verifica nel file `inventario.yml` (`stato:
+   validato`) per i blocchi completati.
+3. Per ogni batch:
+   - spostare i file nella destinazione indicata,
+   - aprire PR dedicata con riferimento a `integration_batches.yml`,
+   - aggiornare i report (`trait_review_report.md`, `species_analysis_report.md`).
+4. Eliminare o archiviare `home/oai/share/...` quando la migrazione è conclusa.
+5. Aggiornare la roadmap nel project board usando `setup_backlog.py` e il
+   template `backlog_tasks_example.yaml`.
+6. Aggiornare la matrice operativa (`TASKS_BREAKDOWN.md`, `tasks.yml`) per
+   tracciare avanzamento, assegnatari e dipendenze.
+
+## Uscite attese per l'import finale
+
+* Nuovi dataset `data/external/evo/` con specie e trait normalizzati.
+* Documentazione consolidata sotto `docs/evo-tactics/` e `docs/security/`.
+* Workflow CI aggiornati in `.github/workflows/` e Playwright test installati.
+* Report aggiornati nella directory `reports/` con link dal `README.md`.
+
+Tenendo traccia di questi passi è possibile completare l'integrazione della
+cartella senza ulteriori interventi manuali esterni.

--- a/incoming/lavoro_da_classificare/TASKS_BREAKDOWN.md
+++ b/incoming/lavoro_da_classificare/TASKS_BREAKDOWN.md
@@ -1,0 +1,103 @@
+# Task board — `incoming/lavoro_da_classificare`
+
+Questo file traduce l'`INTEGRATION_PLAN.md` in attività granulari e
+assegnabili. Ogni sezione indica obiettivi, deliverable e comandi chiave per
+chiudere il batch corrispondente.
+
+> Stato corrente aggiornabile tramite checkmark; sincronizzare anche con
+> `tasks.yml` per l'automazione di report o creazione issue.
+
+## Batch `documentation`
+
+- [ ] **DOC-01 – Conversione sorgenti**  
+  _Output_: Markdown pulito sotto `docs/evo-tactics/` con frontmatter.  
+  _Passi_: eseguire `pandoc` sui `.docx`/`.pdf`, uniformare heading, collegare
+  riferimenti interni.  
+  _Bloccanti_: conferma versioni ufficiali guide trait.
+- [ ] **DOC-02 – Allineamento indice**  
+  _Output_: aggiornata la sezione indice in `docs/README.md` + link nel wiki.  
+  _Passi_: aggiungere anchor `evo-` in stile kebab-case, testare link locali.
+- [ ] **DOC-03 – Archivio duplicati**  
+  _Output_: copia sorgenti spostata in `incoming/archive/documents/` e nota nel
+  file inventario.
+
+## Batch `data-models`
+
+- [ ] **DAT-01 – Lint schemi**  
+  _Output_: esito `npm run schema:lint` senza errori.  
+  _Passi_: aggiornare percorsi, introdurre namespace `evo`.  
+  _Dipendenze_: nessuna.
+- [ ] **DAT-02 – Revisione enum gameplay**  
+  _Output_: commenti dal team gameplay su nuovi valori.  
+  _Passi_: estrarre enum tramite script `tools/schema_enum_diff.py`, allegare
+  diff al ticket.
+- [ ] **DAT-03 – Merge alias**  
+  _Output_: `data/core/species/aliases.json` aggiornato + changelog.  
+  _Passi_: usare `jq` per merge controllato, aggiungere test snapshot se
+  presenti.
+
+## Batch `species_ecotypes`
+
+- [ ] **SPEC-01 – Validazione JSON**  
+  _Output_: report `species_validation.log` in `reports/incoming/`.  
+  _Passi_: eseguire `scripts/validate.sh` con percorsi aggiornati.
+- [ ] **SPEC-02 – Report sommario**  
+  _Output_: `reports/evo/species_summary.md` generato da
+  `species_summary_script.py`.  
+  _Passi_: schedare metriche chiave (count, ecosistemi coperti).
+- [ ] **SPEC-03 – Collegamento ecotipi**  
+  _Output_: mapping in `data/external/evo/species_ecotype_map.json`.  
+  _Passi_: confrontare con `data/ecosystems/` esistente, annotare mismatch nel
+  file inventario.
+
+## Batch `traits`
+
+- [ ] **TRT-01 – Audit duplicati**  
+  _Output_: CSV di `trait_review.py` archiviato in
+  `reports/evo/traits_anomalies.csv`.  
+  _Passi_: eseguire script, commentare righe problematiche.
+- [ ] **TRT-02 – Merge glossario**  
+  _Output_: `data/core/traits/glossary.json` aggiornato con nuovi ID.  
+  _Passi_: assicurare ordine alfabetico, rigenerare documentazione.
+- [ ] **TRT-03 – Aggiornamento analisi**  
+  _Output_: `docs/analysis/trait_merge_proposals.md` completato con esiti.
+
+## Batch `tooling`
+
+- [ ] **TOL-01 – Uniformità script**  
+  _Output_: shebang, licenze e permessi coerenti in `incoming/scripts/`.  
+  _Passi_: `chmod +x`, aggiungere header SPDX, verificare import Python.
+- [ ] **TOL-02 – Target Makefile**  
+  _Output_: nuovi target `make evo-validate` e `make evo-backlog`.  
+  _Passi_: integrare chiamate a script, documentare in `incoming/README.md`.
+- [ ] **TOL-03 – Documentazione tooling**  
+  _Output_: sezione nel wiki o `docs/tooling/evo.md`.  
+  _Passi_: descrivere variabili ambiente, esempi output.
+
+## Batch `ops_ci`
+
+- [ ] **OPS-01 – Confronto workflow**  
+  _Output_: tabella comparativa `ops/workflow_diff.md`.  
+  _Passi_: diff con `.github/workflows/`, evidenziare step mancanti.
+- [ ] **OPS-02 – Site audit**  
+  _Output_: script armonizzati in `ops/site-audit/` con README aggiornato.  
+  _Passi_: integrare dipendenze, verificare esecuzione locale.
+- [ ] **OPS-03 – Config Lighthouse**  
+  _Output_: `config/lighthouse/evo.lighthouserc.json` e test `npm run lint:lighthouse`.
+
+## Batch `frontend`
+
+- [ ] **FRN-01 – Porting test Playwright**  
+  _Output_: suite in `tests/playwright/evo/` eseguibile con `npm run test:e2e`.  
+  _Passi_: adeguare helper, aggiornare fixture.
+- [ ] **FRN-02 – Sitemap**  
+  _Output_: `public/sitemap.xml` e `robots.txt` aggiornati + validazione link.  
+  _Passi_: lanciare `python tools/sitemap_link_checker.py public/sitemap.xml`.
+- [ ] **FRN-03 – Mockup & docs UI**  
+  _Output_: mockup in `docs/wireframes/` con pagina descrittiva.
+
+---
+
+Aggiornare questo file (e `tasks.yml`) al termine di ogni attività per rendere
+tracciabile l'avanzamento e facilitare la creazione di issue dedicate.
+

--- a/incoming/lavoro_da_classificare/integration_batches.yml
+++ b/incoming/lavoro_da_classificare/integration_batches.yml
@@ -1,0 +1,123 @@
+# Piano strutturato per integrare `incoming/lavoro_da_classificare`
+batches:
+  - id: documentation
+    title: Documentazione e guide
+    scope:
+      - docs/**/*
+      - README*.md
+      - "Guida Ai tratti *.docx"
+      - "Progetto unico e fonti (*.pdf)"
+    destination:
+      primary: docs/evo-tactics/
+      security: docs/security/
+      archives: incoming/archive/documents/
+    status: pronti_per_revisione
+    actions:
+      - Convertire i file DOCX/PDF in Markdown usando pandoc e aggiungere metadata frontmatter.
+      - Uniformare titoli e slug alla convenzione `docs/` (kebab-case, prefisso `evo-`).
+      - Aggiornare `docs/README.md` con indice alle nuove sezioni.
+    blockers:
+      - Conferma stakeholder su versioni ufficiali delle guide trait.
+  - id: data-models
+    title: Schemi e alias
+    scope:
+      - templates/*.schema.json
+      - data/aliases/*.json
+    destination:
+      schemas: schemas/evo/
+      data: data/core/species/aliases.json
+    status: in_analisi
+    actions:
+      - Validare gli schema con `npm run schema:lint` e verificare compatibilità con pipeline AJV esistente.
+      - Allineare i campi `sentience_index` e `ecotypes` alle enum globali (`data/core/traits/glossary.json`).
+      - Inserire gli alias confermati in `data/core/species/aliases.json` e aggiornare la documentazione.
+    blockers:
+      - Revisione con team gameplay per i nuovi enum.
+  - id: species_ecotypes
+    title: Specie ed ecotipi
+    scope:
+      - species/*.json
+      - ecotypes/*.json
+      - species_catalog.*
+    destination:
+      data: data/external/evo/species/
+      catalog: data/external/evo/species_catalog.json
+    status: pronti_per_validazione
+    actions:
+      - Validare i JSON con `scripts/validate.sh` (aggiornare i path).
+      - Generare il report aggregato con `species_summary_script.py` e allegarlo in `reports/`.
+      - Collegare gli ecotipi al registry esistente in `data/ecosystems/`.
+    blockers:
+      - Decisione su naming finale (latino vs. alias italiano).
+  - id: traits
+    title: Trait atomici e aggregati
+    scope:
+      - traits/TR-*.json
+      - traits/traits_aggregate.json
+      - docs/analysis/trait_*.
+    destination:
+      data: data/external/evo/traits/
+      glossary: data/core/traits/glossary.json
+    status: pronti_per_validazione
+    actions:
+      - Lanciare `trait_review.py` per generare CSV con anomalie e duplicati.
+      - Integrare i nuovi trait nel glossario assicurando unicità degli ID `TR-####`.
+      - Aggiornare `docs/analysis/trait_merge_proposals.md` con gli esiti della revisione.
+    blockers:
+      - Risoluzione conflitti con trait già presenti in `data/core/traits/glossary.json`.
+  - id: tooling
+    title: Script di automazione
+    scope:
+      - scripts/*.py
+      - scripts/validate.sh
+      - setup_backlog.py
+      - species_summary_script.py
+      - trait_review.py
+    destination:
+      incoming_scripts: incoming/scripts/
+      tools: tools/automation/
+    status: in_corso
+    actions:
+      - Uniformare intestazioni shebang e licenze.
+      - Aggiungere target dedicati nel `Makefile` (`make evo-validate`, `make evo-backlog`).
+      - Documentare l'uso in `incoming/README.md` e nel wiki interno.
+    blockers:
+      - Definizione credenziali/secret per GitHub API (setup backlog).
+  - id: ops_ci
+    title: Workflow CI e site audit
+    scope:
+      - workflows/*.yml
+      - security.yml
+      - init_security_checks.sh
+      - ops/site-audit/**/*
+      - lighthouserc.json
+    destination:
+      workflows: .github/workflows/
+      ops: ops/site-audit/
+      config: config/lighthouse/
+    status: da_revisionare
+    actions:
+      - Confrontare ogni workflow con l'equivalente in `.github/workflows/` e fondere solo gli step mancanti.
+      - Integrare gli script site-audit nel tooling esistente (`tools/site-audit`).
+      - Aggiornare `config/lighthouserc.json` e predisporre test `npm run lint:lighthouse`.
+    blockers:
+      - Disponibilità ambienti CI per Playwright/Lighthouse.
+  - id: frontend
+    title: Test end-to-end e sitemap
+    scope:
+      - tests/playwright/**/*
+      - proposed_routes.csv
+      - proposed_sitemap.xml
+      - mockup_evo_tactics.png
+      - robots.txt
+    destination:
+      tests: tests/playwright/evo/
+      sitemap: public/
+      docs: docs/wireframes/
+    status: pianificato
+    actions:
+      - Trasporre gli spec Playwright nel formato usato da `tests/e2e` (vitest + playwright).
+      - Verificare la sitemap con `sitemap_link_checker.py` e aggiornare `public/sitemap.xml`.
+      - Allegare i mockup nella documentazione UI (`docs/wireframes/`).
+    blockers:
+      - Coordinamento con il team webapp per URL definitivi.

--- a/incoming/lavoro_da_classificare/tasks.yml
+++ b/incoming/lavoro_da_classificare/tasks.yml
@@ -1,0 +1,256 @@
+# task registry derivato da `INTEGRATION_PLAN.md`
+
+meta:
+  version: 1
+  last_update: 2024-05-24
+  notes: "Aggiornare status e assegnatari quando i task vengono presi in carico."
+
+tasks:
+  - id: DOC-01
+    batch: documentation
+    title: Conversione sorgenti Evo-Tactics
+    description: "Convertire file DOCX/PDF in Markdown con frontmatter conforme."
+    status: todo
+    owner: null
+    depends_on: []
+    deliverables:
+      - docs/evo-tactics/*.md
+    commands:
+      - pandoc <input.docx> -o docs/evo-tactics/<slug>.md --metadata title="<Titolo>"
+
+  - id: DOC-02
+    batch: documentation
+    title: Aggiornare indice documentazione
+    description: "Integrare le nuove guide nel README principale e nel wiki."
+    status: todo
+    owner: null
+    depends_on:
+      - DOC-01
+    deliverables:
+      - docs/README.md
+    commands:
+      - npm run docs:lint
+
+  - id: DOC-03
+    batch: documentation
+    title: Archiviazione duplicati documentazione
+    description: "Spostare copie sorgenti in incoming/archive e aggiornare inventario."
+    status: todo
+    owner: null
+    depends_on:
+      - DOC-01
+    deliverables:
+      - incoming/archive/documents/
+      - incoming/lavoro_da_classificare/inventario.yml
+
+  - id: DAT-01
+    batch: data-models
+    title: Lint schemi Evo
+    description: "Eseguire lint sugli schema JSON e introdurre namespace evo."
+    status: in_progress
+    owner: null
+    depends_on: []
+    deliverables:
+      - schemas/evo/*.schema.json
+    commands:
+      - npm run schema:lint
+
+  - id: DAT-02
+    batch: data-models
+    title: Revisione enum con gameplay
+    description: "Validare nuovi enum con il team gameplay e registrare feedback."
+    status: blocked
+    owner: gameplay-team
+    depends_on:
+      - DAT-01
+    deliverables:
+      - docs/meeting-notes/evo-enum-review.md
+    blockers:
+      - "Disponibilità team gameplay"
+
+  - id: DAT-03
+    batch: data-models
+    title: Merge alias specie
+    description: "Inserire alias confermati in data/core/species/aliases.json."
+    status: todo
+    owner: null
+    depends_on:
+      - DAT-02
+    deliverables:
+      - data/core/species/aliases.json
+    commands:
+      - jq '. + input' data/core/species/aliases.json \
+          incoming/lavoro_da_classificare/data/aliases/new_aliases.json
+
+  - id: SPEC-01
+    batch: species_ecotypes
+    title: Validazione JSON specie/ecotipi
+    description: "Validare file specie ed ecotipi con lo script aggiornato."
+    status: todo
+    owner: null
+    depends_on:
+      - DAT-01
+    deliverables:
+      - reports/incoming/species_validation.log
+    commands:
+      - ./scripts/validate.sh --dataset evo-species
+
+  - id: SPEC-02
+    batch: species_ecotypes
+    title: Generazione report sommario specie
+    description: "Creare report riepilogativo con species_summary_script.py."
+    status: todo
+    owner: null
+    depends_on:
+      - SPEC-01
+    deliverables:
+      - reports/evo/species_summary.md
+
+  - id: SPEC-03
+    batch: species_ecotypes
+    title: Mappatura ecotipi
+    description: "Collegare gli ecotipi Evo agli ecosistemi esistenti."
+    status: todo
+    owner: null
+    depends_on:
+      - SPEC-01
+    deliverables:
+      - data/external/evo/species_ecotype_map.json
+
+  - id: TRT-01
+    batch: traits
+    title: Audit duplicati trait
+    description: "Eseguire trait_review.py e classificare le anomalie."
+    status: todo
+    owner: null
+    depends_on:
+      - DAT-01
+    deliverables:
+      - reports/evo/traits_anomalies.csv
+    commands:
+      - python incoming/lavoro_da_classificare/scripts/trait_review.py
+
+  - id: TRT-02
+    batch: traits
+    title: Merge glossario trait
+    description: "Integrare nuovi trait nel glossario mantenendo gli ID univoci."
+    status: todo
+    owner: null
+    depends_on:
+      - TRT-01
+    deliverables:
+      - data/core/traits/glossary.json
+
+  - id: TRT-03
+    batch: traits
+    title: Aggiornare analisi merge trait
+    description: "Riassumere esiti revisione nel documento di analisi."
+    status: todo
+    owner: null
+    depends_on:
+      - TRT-02
+    deliverables:
+      - docs/analysis/trait_merge_proposals.md
+
+  - id: TOL-01
+    batch: tooling
+    title: Uniformare script
+    description: "Allineare header, permessi e licenze degli script importati."
+    status: in_progress
+    owner: devops
+    depends_on: []
+    deliverables:
+      - incoming/scripts/*.py
+      - incoming/scripts/validate_evo_pack.sh
+
+  - id: TOL-02
+    batch: tooling
+    title: Target Makefile per Evo
+    description: "Aggiungere target make per validazione e backlog."
+    status: todo
+    owner: null
+    depends_on:
+      - TOL-01
+    deliverables:
+      - Makefile
+
+  - id: TOL-03
+    batch: tooling
+    title: Documentare tooling Evo
+    description: "Scrivere guida all'uso degli script Evo."
+    status: todo
+    owner: null
+    depends_on:
+      - TOL-01
+    deliverables:
+      - docs/tooling/evo.md
+
+  - id: OPS-01
+    batch: ops_ci
+    title: Gap analysis workflow CI
+    description: "Confrontare workflow importati con pipeline esistenti."
+    status: todo
+    owner: qa
+    depends_on:
+      - TOL-01
+    deliverables:
+      - ops/workflow_diff.md
+
+  - id: OPS-02
+    batch: ops_ci
+    title: Site audit integration
+    description: "Integrare script site-audit e aggiornare README."
+    status: todo
+    owner: qa
+    depends_on:
+      - OPS-01
+    deliverables:
+      - ops/site-audit/
+
+  - id: OPS-03
+    batch: ops_ci
+    title: Configurazione Lighthouse Evo
+    description: "Aggiornare configurazione lighthouse e test correlati."
+    status: todo
+    owner: qa
+    depends_on:
+      - OPS-02
+    deliverables:
+      - config/lighthouse/evo.lighthouserc.json
+    commands:
+      - npm run lint:lighthouse
+
+  - id: FRN-01
+    batch: frontend
+    title: Porting test Playwright
+    description: "Adattare gli test E2E al setup vitest/playwright del repo."
+    status: planned
+    owner: frontend
+    depends_on:
+      - OPS-01
+    deliverables:
+      - tests/playwright/evo/
+
+  - id: FRN-02
+    batch: frontend
+    title: Aggiornare sitemap
+    description: "Integrare sitemap e robots aggiornati e verificarli."
+    status: planned
+    owner: frontend
+    depends_on:
+      - FRN-01
+    deliverables:
+      - public/sitemap.xml
+      - public/robots.txt
+
+  - id: FRN-03
+    batch: frontend
+    title: Documentare mockup Evo
+    description: "Pubblicare mockup nella documentazione wireframe."
+    status: planned
+    owner: frontend
+    depends_on:
+      - FRN-01
+    deliverables:
+      - docs/wireframes/evo/
+


### PR DESCRIPTION
## Summary
- add a markdown task board that breaks the Evo-Tactics integration plan into assignable deliverables
- provide a machine-readable `tasks.yml` registry with dependencies and commands for each batch
- reference the new task artifacts from the integration checklist to keep progress in sync

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911c4f6f3a0832886ad7eee15a91f51)