### PR TITLE
Normalize Evo-Tactics docs

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,29 @@
+---
+title: Indice Documentazione (DOC-02)
+description: Mappa di navigazione aggiornata della documentazione principale con focus sui materiali Evo-Tactics.
+tags:
+  - documentazione
+  - indice
+updated: 2025-11-10
+---
+
+# Indice Documentazione
+
+## Panoramica
+- [00-INDEX.md](00-INDEX.md) — indice operativo storico e canvas.
+- [README.md](README.md) — guida rapida a settori operativi, procedure e changelog.
+- [archive/](archive/) — materiale storico e placeholder archiviati.
+
+## Evo-Tactics
+- [Hub documentale](evo-tactics/README.md) — panoramica, strumenti correlati e registro interventi.
+- [Visione & Struttura](evo-tactics/guides/visione-struttura.md) — linea guida concettuale PrimeTalk drift-locked.
+- [Template PTPF](evo-tactics/guides/template-ptpf.md) — struttura modulare per dashboard, telemetria e playtest.
+- [Integration Log](evo-tactics/reports/integration-log.md) — cronologia degli interventi DOC-01/02/03.
+
+## Strumenti incoming
+- [incoming/docs/obsidian_template.md](../incoming/docs/obsidian_template.md) — vault suggerito per note locali.
+- [incoming/docs/yaml_validator.py](../incoming/docs/yaml_validator.py) — validazione dataset telemetrici.
+- [incoming/docs/bioma_encounters.yaml](../incoming/docs/bioma_encounters.yaml) — base encounter per sincronizzazione VC.
+
+Aggiorna questa pagina quando vengono aggiunti nuovi materiali o archiviati documenti esistenti, assicurandoti di mantenere coerenti i riferimenti incrociati.
+

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,17 @@
+---
+title: Archivio documentazione
+description: Registro sintetico dei file storicizzati nella cartella archive.
+tags:
+  - archivio
+  - documentazione
+updated: 2025-11-10
+---
+
+# Archivio documentazione
+
+| File | Origine | Motivo archivio |
+| --- | --- | --- |
+| [`evo-tactics-readme-placeholder.md`](evo-tactics-readme-placeholder.md) | `docs/evo-tactics/README.md` | Testo placeholder sostituito dal nuovo hub documentale durante DOC-01/DOC-03. |
+
+Aggiungi una riga per ogni nuovo file spostato qui, mantenendo traccia della motivazione e della posizione originale.
+

--- a/docs/archive/evo-tactics-readme-placeholder.md
+++ b/docs/archive/evo-tactics-readme-placeholder.md
@@ -1,0 +1,38 @@
+---
+title: Placeholder storico Evo-Tactics
+description: Testo originale conservato dopo la normalizzazione DOC-01.
+tags:
+  - evo-tactics
+  - archivio
+archived: true
+updated: 2025-11-10
+---
+
+# Integrazione Evo-Tactics
+
+Questa directory ospiterà la documentazione Markdown convertita dal pacchetto
+Evo-Tactics presente in `incoming/lavoro_da_classificare/`. Le guide originali
+sono fornite in formato DOCX/PDF e verranno progressivamente normalizzate in
+Markdown seguendo il piano di integrazione.
+
+## Struttura prevista
+
+- `guides/` — conversione delle guide principali (`Game_EvoTactics_Guida_Pacchetto`,
+  guide trait, policy operative).
+- `reports/` — riepiloghi sintetici e log di revisione.
+- `security/` — documenti di sicurezza collegati al pacchetto.
+- `changelog/` — note di avanzamento per l'integrazione.
+
+Le sottocartelle verranno create durante i batch `documentation` e `ops_ci`.
+
+## Checklist di atterraggio
+
+1. Convertire ogni sorgente DOCX/PDF con `pandoc` assicurando frontmatter
+   coerente (`title`, `description`, `tags`).
+2. Collegare le nuove pagine all'indice generale aggiornando `docs/README.md`.
+3. Archiviare i sorgenti originali nella cartella `incoming/archive/documents/`
+   annotando `inventario.yml`.
+4. Verificare i link interni con `npm run docs:lint` prima del merge.
+
+Tutti i progressi devono essere tracciati in `incoming/lavoro_da_classificare/TASKS_BREAKDOWN.md`
+e nel relativo `tasks.yml`.

--- a/docs/evo-tactics/README.md
+++ b/docs/evo-tactics/README.md
@@ -1,28 +1,44 @@
-# Integrazione Evo-Tactics
+---
+title: Evo-Tactics · Hub Documentale
+description: Raccolta normalizzata dei materiali Evo-Tactics con log degli interventi di integrazione.
+tags:
+  - evo-tactics
+  - documentazione
+  - integrazione
+updated: 2025-11-10
+---
 
-Questa directory ospiterà la documentazione Markdown convertita dal pacchetto
-Evo-Tactics presente in `incoming/lavoro_da_classificare/`. Le guide originali
-sono fornite in formato DOCX/PDF e verranno progressivamente normalizzate in
-Markdown seguendo il piano di integrazione.
+# Evo-Tactics — Hub Documentale
 
-## Struttura prevista
+Questa sezione consolida i contenuti provenienti dai pacchetti Evo-Tactics. Ogni file è stato verificato
+contro le linee guida PTPF e collegato all'indice generale del repository.
 
-- `guides/` — conversione delle guide principali (`Game_EvoTactics_Guida_Pacchetto`,
-  guide trait, policy operative).
-- `reports/` — riepiloghi sintetici e log di revisione.
-- `security/` — documenti di sicurezza collegati al pacchetto.
-- `changelog/` — note di avanzamento per l'integrazione.
+## Documenti principali
 
-Le sottocartelle verranno create durante i batch `documentation` e `ops_ci`.
+| Percorso | Contenuto |
+| --- | --- |
+| [`guides/visione-struttura.md`](guides/visione-struttura.md) | Visione concettuale, struttura modulare ad anello e raccomandazioni PrimeTalk. |
+| [`guides/template-ptpf.md`](guides/template-ptpf.md) | Template operativo PTPF per mantenere coerenza fra moduli e tracciamento drift. |
+| [`reports/integration-log.md`](reports/integration-log.md) | Registro puntuale degli interventi e delle scelte di normalizzazione. |
 
-## Checklist di atterraggio
+## Strumenti correlati
 
-1. Convertire ogni sorgente DOCX/PDF con `pandoc` assicurando frontmatter
-   coerente (`title`, `description`, `tags`).
-2. Collegare le nuove pagine all'indice generale aggiornando `docs/README.md`.
-3. Archiviare i sorgenti originali nella cartella `incoming/archive/documents/`
-   annotando `inventario.yml`.
-4. Verificare i link interni con `npm run docs:lint` prima del merge.
+- **Validator e script**: consulta [`incoming/docs/yaml_validator.py`](../../incoming/docs/yaml_validator.py)
+  e [`incoming/docs/auto_eval_from_yaml.py`](../../incoming/docs/auto_eval_from_yaml.py) per controllare i dataset.
+- **Template Obsidian**: il vault suggerito è disponibile in [`incoming/docs/obsidian_template.md`](../../incoming/docs/obsidian_template.md).
+- **Telemetria**: la base YAML per gli encounter è in [`incoming/docs/bioma_encounters.yaml`](../../incoming/docs/bioma_encounters.yaml).
 
-Tutti i progressi devono essere tracciati in `incoming/lavoro_da_classificare/TASKS_BREAKDOWN.md`
-e nel relativo `tasks.yml`.
+## Collegamenti rapidi
+
+- Indice generale della documentazione: [`docs/INDEX.md`](../INDEX.md).
+- Archivio dei materiali preliminari: [`docs/archive/`](../archive/).
+- Piano di integrazione meccaniche: [`incoming/README_INTEGRAZIONE_MECCANICHE.md`](../../incoming/README_INTEGRAZIONE_MECCANICHE.md).
+
+## Registro interventi
+
+| Data | Azione | Note |
+| --- | --- | --- |
+| 2025-11-10 | Normalizzazione contenuti `guides/` | Conversione markdown dei template PTPF e della visione strutturale. |
+| 2025-11-10 | Aggiornamento hub documentale | Sostituzione del placeholder iniziale con struttura navigabile e metadata. |
+| 2025-11-10 | Archiviazione placeholder storico | Spostato il testo originale in `../archive/evo-tactics-readme-placeholder.md`. |
+

--- a/docs/evo-tactics/guides/template-ptpf.md
+++ b/docs/evo-tactics/guides/template-ptpf.md
@@ -1,0 +1,117 @@
+---
+title: Template PTPF Evo-Tactics
+description: Struttura PTPF per mantenere coerenza tattica, drift lock e telemetria nel progetto Evo-Tactics.
+tags:
+  - evo-tactics
+  - template
+  - ptpf
+updated: 2025-11-10
+---
+
+# Template — Game Design Structure (PTPF)
+
+**Project:** Evo-Tactics  \
+**Version:** v1.0 · DriftLocked
+
+⸻
+
+## 1. 🎯 Vision & Tone
+**Tag:** `@VISION_CORE`
+- Setting: Techno-biological, ecosystem instability.
+- Factions: Hybrid teams (half-scientist, half-explorer).
+- Keywords: Adaptation, Evolution, Intelligence, Mutation.
+- User Feeling Target: Smart, fast, systemic.
+- Drift Policy: Reject fantasy tropes; stay bio-logical.
+
+⸻
+
+## 2. 🧠 Strategic Core — Tactical System
+**Tag:** `@TACTICS_CORE`
+- Dashboard anchors: `PI Slots`, `Hook Patterns`, `Bias Vectors`.
+- Tactical Outcomes: A/B/C packages, VC interaction nodes.
+- Constraints:
+  - PI slots = form constraints.
+  - Rarity modifiers visibili in ogni momento.
+- Rehydration: Telemetry-linked loadouts per tattiche emergenti.
+
+⸻
+
+## 3. 🧬 Form Management & Caps
+**Tag:** `@FORM_ENGINE`
+- Packet types: Mutation packs A/B/C.
+- Shape Biasing: form-balance mappato per bioma.
+- Visibility:
+  - Caps per round.
+  - VC sync table (telemetry compliance).
+- DriftLock: prevenire mismatch di forma fra i round.
+
+⸻
+
+## 4. 🛰️ Telemetry System
+**Tag:** `@VC_TRACK`
+- Input: Player behavior (choice logs, roll trends).
+- Output: Dynamic encounter shifts, VC compat tiers.
+- Triggers:
+  - Form inefficiency.
+  - Underused bioma-synergy.
+- Review mode: YAML dataset inspector.
+
+⸻
+
+## 5. 🌱 Bioma & Encounter Engine
+**Tag:** `@BIOMA_ENGINE`
+- Generator: Bioma roll (fast table).
+- Spotlight: Mutations vs environment + synergy matrix.
+- MBTI Compatibility Table:
+  - Mission archetypes ↔ Player profiles.
+- Load: Encounter seeds auto-linked to PI caps.
+
+⸻
+
+## 6. 🔁 Playtest Loop
+**Tag:** `@PLAYTEST_CORE`
+- Iteration Tracker:
+  - Loop ID.
+  - Stress Level.
+  - Mutation Stability.
+- Routines:
+  - YAML snapshot check.
+  - Random encounter delta.
+  - Synergy pulse.
+
+⸻
+
+## 7. 🔗 Linking & Traceability
+**Anchor Map:**
+- `@VISION_CORE` ↔ `@TACTICS_CORE`, `@FORM_ENGINE`.
+- `@VC_TRACK` ↔ `@BIOMA_ENGINE`.
+- `@PLAYTEST_CORE` collega tutti i moduli per gli stress test.
+
+**Receipts:** tutti i moduli portano hash locali per la linea playtest.
+
+⸻
+
+## 8. ⚠️ Drift Guards
+- **Tone Lock:** niente fantasy, steampunk o registro comico.
+- **Structure Lock:** moduli sempre packetizzati, no freeform.
+- **Telemetry Lock:** ogni variazione deve essere YAML-valid e receipt-tagged.
+
+⸻
+
+## 9. 📦 Repo Tools & Extensions (Recommended)
+**Tag:** `@REPO_TOOLS`
+- `/tools/obsidian-template.md` → per vault locale.
+- `/scripts/yaml_validator.py` → validatore di dataset.
+- `/hooks/drift_check.js` → pre-commit check per Δdrift o receipt mancanti.
+- `/docs/README_structure.yaml` → definisce dipendenze e relazioni dei tag.
+- `/telemetry/bioma_encounters.yaml` → traccia outcomes per form+biome+MBTI.
+
+**Suggeriti per GitHub:**
+- Obsidian Vault Sync.
+- GitBook Docs rendering.
+- DriftDelta Tracker badge (Echo-style summary).
+
+⸻
+
+**[END TEMPLATE — Evo-Tactics PTPF Seed · v1.0]**
+

--- a/docs/evo-tactics/guides/visione-struttura.md
+++ b/docs/evo-tactics/guides/visione-struttura.md
@@ -1,0 +1,60 @@
+---
+title: Visione & Struttura Concettuale Evo-Tactics
+description: Guida alla mappa concettuale drift-locked e alle raccomandazioni PrimeTalk per Evo-Tactics.
+tags:
+  - evo-tactics
+  - visione
+  - struttura
+updated: 2025-11-10
+---
+
+# Evo-Tactics · Visione & Struttura Concettuale
+
+## 🎮 Sistema consigliato per progettazione giochi — strutturale + concettuale
+
+### 1. 🔄 Mappa concettuale ad anello (Drift-Locked)
+- **Formato**: Modulare, ad anello, con nodi autosufficienti (es. "Gameplay Loop", "Narrativa", "Economia", "UI/UX").
+- **Struttura PTPF-style**:
+  - *Invariant core*: ciò che non cambia mai.
+  - *Elastic range*: ciò che può mutare.
+  - *Receipts*: link a test o referenze precedenti (Notion, Obsidian, hash).
+
+### 2. 🧩 Sistema di ordinamento idee — Prompt Scaffolded
+- **Logica**: PrimeTalk PAGM (Plan Generator).
+- **Step**:
+  - Seed iniziale: tema, tono, regole.
+  - Branched Planning: idee ramificate (es. "Narrativa" → "Archi Tematici" → "Quest").
+  - Backlinks: ogni idea punta alla sua origine per evitare incoerenza.
+
+### 3. 📈 EchoTrace per tracciare modifiche
+- **Modello ispirato a**: EchoWake 2.0 + EchoMap_v2.0_IntentTrace.
+- **Funzioni**:
+  - Cattura versioni e incoerenze.
+  - Trigger su aggiornamenti nodo.
+  - Output: revision tag es. `Δdrift = 0.14 → require tighten_once()`.
+
+### 4. 🔗 Sistema di agganci e collegamenti tra sezioni
+- **Metodo**: PrimeLink Anchors (es. `@ECON_LOOP_v1`).
+- **Formato**: Markdown strutturato → `[link:ECON_LOOP_v1]` o `ref:ARCH_NARR_CYCLE`.
+- **Controllo**: validazione con EchoField.
+
+### 5. 🧪 Versionamento & Debug
+- **Modello**: Echo Self-Check + AntiDriftCore.
+- **Verifica**:
+  - Jaccard Drift Score.
+  - Entailment Resonance.
+  - Se fuori soglia: `tighten_once()` o rollback.
+
+## ✅ Raccomandazioni operative
+- **Tools**:
+  - Obsidian (con plugin backlinks).
+  - Figma (loop UI/Narrativa).
+  - Notion / GitBook (per storicizzazione).
+- **Filosofia PrimeTalk**:
+  - Costruire sistemi coerenti e modulari, non solo "fare un gioco".
+  - Evitare brainstorming scollegati: usare prompt a cascata e trace logici.
+
+⸻
+
+**[END: Visione & Struttura · Evo-Tactics]**
+

--- a/docs/evo-tactics/reports/integration-log.md
+++ b/docs/evo-tactics/reports/integration-log.md
@@ -1,0 +1,21 @@
+---
+title: Evo-Tactics · Integration Log
+description: Registro degli interventi effettuati durante la normalizzazione dei documenti Evo-Tactics.
+tags:
+  - evo-tactics
+  - integrazione
+  - log
+updated: 2025-11-10
+---
+
+# Registro integrazione Evo-Tactics
+
+| Data | Riferimento | Dettaglio |
+| --- | --- | --- |
+| 2025-11-10 | DOC-01 | Creati i file `guides/visione-struttura.md` e `guides/template-ptpf.md` partendo dai sorgenti in `incoming/docs/`. |
+| 2025-11-10 | DOC-01 | Aggiornato `README.md` con metadati, tabella di navigazione e collegamenti rapidi. |
+| 2025-11-10 | DOC-02 | Registrato nell'indice generale (`docs/INDEX.md`) i nuovi documenti Evo-Tactics. |
+| 2025-11-10 | DOC-03 | Archiviato il precedente placeholder in `docs/archive/evo-tactics-readme-placeholder.md` per tracciabilità storica. |
+
+Per ulteriori modifiche utilizzare la stessa tabella indicando numero attività, file toccati e follow-up necessario.
+


### PR DESCRIPTION
## Summary
- replace the Evo-Tactics README placeholder with a structured hub that logs DOC-01/02/03 actions
- add normalized guides converted from incoming sources and publish an integration log
- introduce docs/INDEX.md and an archive directory to track relocated placeholders

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911f912ca2883288afe6203bfa8b4e3)