### PR TITLE
Add Evo schema linting and species reports

### DIFF
--- a/data/species_aliases.json
+++ b/data/species_aliases.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "aliases": [
+    {
+      "from": "Hydrogluteus pinguis",
+      "to": "Gulogluteus scutiger"
+    },
+    {
+      "from": "Glutogulo scutatus",
+      "to": "Gulogluteus scutiger"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:web": "npm run test:web --workspace tools/ts",
     "test:stack": "npm run test:api && npm run test --workspace webapp",
     "lint:stack": "node scripts/lint-stack.mjs",
+    "schema:lint": "python tools/automation/schema_lint.py schemas/evo",
     "ci:stack": "npm run lint:stack && npm run test:api && npm run test --workspace webapp && VITE_BASE_PATH=./ npm run build --workspace webapp",
     "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && node --test tests/server/generationSnapshot.spec.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-latency.spec.ts && ./node_modules/.bin/tsx tests/scripts/tune_items.test.ts && ./node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts && node --test tests/tools/deploy-checks.spec.js",
     "start:api": "node server/index.js",

--- a/reports/species/species_ecotype_map.json
+++ b/reports/species/species_ecotype_map.json
@@ -1,0 +1,62 @@
+{
+  "Canopy Ombrosa": [
+    "Umbra alaris"
+  ],
+  "Canyon Notturno": [
+    "Umbra alaris"
+  ],
+  "Cavernicolo": [
+    "Perfusuas pedes"
+  ],
+  "Cenge Calcarenitiche": [
+    "Rupicapra sensoria"
+  ],
+  "Chioma Elettrofilo": [
+    "Chemnotela toxica"
+  ],
+  "Chioma Umida": [
+    "Gulogluteus scutiger"
+  ],
+  "Dorsali Ventose": [
+    "Rupicapra sensoria"
+  ],
+  "Estuario Torbido": [
+    "Anguis magnetica"
+  ],
+  "Forre Umide": [
+    "Gulogluteus scutiger"
+  ],
+  "Gole Ventose": [
+    "Elastovaranus hydrus"
+  ],
+  "Laguna Quieta": [
+    "Anguis magnetica"
+  ],
+  "Letti Fluviali": [
+    "Elastovaranus hydrus"
+  ],
+  "Oasi Termica": [
+    "Soniptera resonans"
+  ],
+  "Pianure Ventose": [
+    "Terracetus ambulator"
+  ],
+  "Prateria Arbustiva": [
+    "Soniptera resonans"
+  ],
+  "Radura Acida": [
+    "Chemnotela toxica"
+  ],
+  "Radura Notturna": [
+    "Perfusuas pedes"
+  ],
+  "Savanicola Notturno": [
+    "Terracetus ambulator"
+  ],
+  "Stagno Quieto": [
+    "Proteus plasma"
+  ],
+  "Torrente Lento": [
+    "Proteus plasma"
+  ]
+}

--- a/reports/species/species_summary.md
+++ b/reports/species/species_summary.md
@@ -1,0 +1,46 @@
+# Evo Species Summary
+
+*Source*: `incoming/lavoro_da_classificare/species`
+*Total species analysed*: **10**
+
+## Macro class distribution
+| Value | Count |
+| --- | ---: |
+| Mammalia | 3 |
+| Reptilia/Pisces | 1 |
+| Artropode | 1 |
+| Reptilia | 1 |
+| Mammalo-artropode | 1 |
+| Protista complesso | 1 |
+| Insecta | 1 |
+| Aves | 1 |
+
+## Sentience tiers
+| Value | Count |
+| --- | ---: |
+| T1 | 6 |
+| T0 | 2 |
+| T3 | 1 |
+| T2 | 1 |
+
+## Danger levels
+| Value | Count |
+| --- | ---: |
+| 2 | 5 |
+| 3 | 3 |
+| 1 | 2 |
+
+## Habitat coverage
+| Value | Count |
+| --- | ---: |
+| corsi d’acqua e coste sabbiose | 1 |
+| foreste tropicali | 1 |
+| savana calda con gole rocciose | 1 |
+| foreste umide con corsi d'acqua | 1 |
+| foreste e sistemi carsici | 1 |
+| zone umide, acque dolci | 1 |
+| falesie e praterie montane | 1 |
+| savanes e bacini termici | 1 |
+| steppe e savane aperte | 1 |
+| foreste pluviali e canyon notturni | 1 |
+

--- a/reports/species/species_validation.log
+++ b/reports/species/species_validation.log
@@ -1,0 +1,5 @@
+Validation report for incoming/lavoro_da_classificare/species
+Files checked: 10
+Failures: 0
+
+All species payloads passed validation.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pyyaml
 numpy
 pymongo
+jsonschema>=4.22.0

--- a/schemas/evo/enums.json
+++ b/schemas/evo/enums.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://game.example.com/schemas/evo/enums.json",
+  "title": "Evo Tactics Enumerations",
+  "description": "Shared enumeration sets used by the Evo Tactics JSON schemas.",
+  "type": "object",
+  "$defs": {
+    "macro_class": {
+      "type": "string",
+      "enum": [
+        "Artropode",
+        "Aves",
+        "Insecta",
+        "Mammalia",
+        "Mammalo-artropode",
+        "Protista complesso",
+        "Reptilia",
+        "Reptilia/Pisces"
+      ]
+    },
+    "habitat_profile": {
+      "type": "string",
+      "enum": [
+        "corsi d’acqua e coste sabbiose",
+        "falesie e praterie montane",
+        "foreste e sistemi carsici",
+        "foreste pluviali e canyon notturni",
+        "foreste tropicali",
+        "foreste umide con corsi d'acqua",
+        "savana calda con gole rocciose",
+        "savanes e bacini termici",
+        "steppe e savane aperte",
+        "zone umide, acque dolci"
+      ]
+    },
+    "sentience_tier": {
+      "type": "string",
+      "enum": [
+        "T0",
+        "T1",
+        "T2",
+        "T3",
+        "T4",
+        "T5",
+        "T6"
+      ]
+    },
+    "energy_upkeep_level": {
+      "type": "string",
+      "enum": [
+        "Basso",
+        "Medio",
+        "Alto"
+      ]
+    },
+    "danger_level": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 5
+    },
+    "metric_unit": {
+      "type": "string",
+      "enum": [
+        "1",
+        "1/season",
+        "A",
+        "Cel",
+        "Hz",
+        "J",
+        "K",
+        "K/W",
+        "L",
+        "L/min",
+        "Pa",
+        "T",
+        "V",
+        "W/kg",
+        "dB",
+        "dB·s",
+        "m",
+        "m/s",
+        "m/s2",
+        "mm",
+        "s"
+      ]
+    },
+    "ecotype_cluster": {
+      "type": "string",
+      "enum": [
+        "Canopy Ombrosa",
+        "Canyon Notturno",
+        "Cavernicolo",
+        "Cenge Calcarenitiche",
+        "Chioma Elettrofilo",
+        "Chioma Umida",
+        "Dorsali Ventose",
+        "Estuario Torbido",
+        "Forre Umide",
+        "Gole Ventose",
+        "Laguna Quieta",
+        "Letti Fluviali",
+        "Oasi Termica",
+        "Pianure Ventose",
+        "Prateria Arbustiva",
+        "Radura Acida",
+        "Radura Notturna",
+        "Savanicola Notturno",
+        "Stagno Quieto",
+        "Torrente Lento"
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/evo/species.schema.json
+++ b/schemas/evo/species.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://game.example.com/schemas/evo/species.schema.json",
+  "title": "Evo Tactics Species",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "species"
+  ],
+  "properties": {
+    "species": {
+      "type": "object",
+      "title": "Species payload",
+      "additionalProperties": false,
+      "required": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "trait_refs",
+        "sentience_index"
+      ],
+      "properties": {
+        "scientific_name": {
+          "type": "string",
+          "minLength": 3
+        },
+        "common_names": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "classification": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "macro_class",
+            "habitat"
+          ],
+          "properties": {
+            "macro_class": {
+              "$ref": "enums.json#/$defs/macro_class"
+            },
+            "habitat": {
+              "$ref": "enums.json#/$defs/habitat_profile"
+            }
+          }
+        },
+        "functional_signature": {
+          "type": "string",
+          "minLength": 8
+        },
+        "visual_description": {
+          "type": "string"
+        },
+        "risk_profile": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "danger_level": {
+              "$ref": "enums.json#/$defs/danger_level"
+            },
+            "vectors": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "uniqueItems": true
+            }
+          }
+        },
+        "interactions": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "predates_on": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "predated_by": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "symbiosis": {
+              "type": "string"
+            }
+          }
+        },
+        "constraints": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 4
+          }
+        },
+        "sentience_index": {
+          "$ref": "enums.json#/$defs/sentience_tier"
+        },
+        "ecotypes": {
+          "type": "array",
+          "items": {
+            "$ref": "enums.json#/$defs/ecotype_cluster"
+          },
+          "uniqueItems": true
+        },
+        "trait_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": "^TR-\\d{4}$"
+          },
+          "uniqueItems": true
+        }
+      }
+    }
+  }
+}

--- a/schemas/evo/trait.schema.json
+++ b/schemas/evo/trait.schema.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://game.example.com/schemas/evo/trait.schema.json",
+  "title": "Evo Tactics Trait",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "trait_code",
+    "label",
+    "tier",
+    "metrics"
+  ],
+  "properties": {
+    "trait_code": {
+      "type": "string",
+      "pattern": "^TR-\\d{4}$"
+    },
+    "label": {
+      "type": "string",
+      "minLength": 3
+    },
+    "famiglia_tipologia": {
+      "type": "string"
+    },
+    "fattore_mantenimento_energetico": {
+      "$ref": "enums.json#/$defs/energy_upkeep_level"
+    },
+    "tier": {
+      "$ref": "enums.json#/$defs/sentience_tier"
+    },
+    "slot": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Z]$"
+      },
+      "uniqueItems": true
+    },
+    "sinergie": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^TR-\\d{4}$"
+      },
+      "uniqueItems": true
+    },
+    "conflitti": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^TR-\\d{4}$"
+      },
+      "uniqueItems": true
+    },
+    "requisiti_ambientali": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "capacita_richieste": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "condizioni": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "biome_class": {
+                "type": "string"
+              }
+            }
+          },
+          "fonte": {
+            "type": "string"
+          },
+          "meta": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "expansion": {
+                "type": "string"
+              },
+              "tier": {
+                "$ref": "enums.json#/$defs/sentience_tier"
+              },
+              "notes": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "mutazione_indotta": {
+      "type": "string"
+    },
+    "uso_funzione": {
+      "type": "string"
+    },
+    "spinta_selettiva": {
+      "type": "string"
+    },
+    "metrics": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "value",
+          "unit"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number"
+          },
+          "unit": {
+            "$ref": "enums.json#/$defs/metric_unit"
+          }
+        }
+      }
+    },
+    "cost_profile": {
+      "type": "object"
+    },
+    "testability": {
+      "type": "object"
+    },
+    "applicability": {
+      "type": "object"
+    },
+    "version": {
+      "type": "string"
+    },
+    "versioning": {
+      "type": "object"
+    }
+  }
+}

--- a/tools/automation/schema_lint.py
+++ b/tools/automation/schema_lint.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Lint Evo JSON schema files for structural issues."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from jsonschema import RefResolver
+from jsonschema.exceptions import RefResolutionError, SchemaError
+from jsonschema.validators import validator_for
+
+
+def discover_schema_files(root: Path) -> Iterable[Path]:
+    if root.is_file():
+        yield root
+        return
+    for path in sorted(root.rglob("*.json")):
+        yield path
+
+
+def load_schema(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def build_store(paths: Iterable[Path]) -> Dict[str, dict]:
+    store: Dict[str, dict] = {}
+    for path in paths:
+        store[path.resolve().as_uri()] = load_schema(path)
+    return store
+
+
+def lint(paths: List[Path]) -> int:
+    store = build_store(paths)
+    failures = 0
+    for path in paths:
+        schema = store[path.resolve().as_uri()]
+        validator_cls = validator_for(schema)
+        resolver = RefResolver.from_schema(schema, store=store)
+        try:
+            validator_cls.check_schema(schema)
+            # Instantiate the validator once to ensure references can be resolved.
+            validator_cls(schema, resolver=resolver)
+            print(f"✅ {path}")
+        except (SchemaError, RefResolutionError, json.JSONDecodeError) as exc:
+            failures += 1
+            print(f"❌ {path} -> {exc}")
+    return failures
+
+
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "path",
+        type=Path,
+        nargs="?",
+        default=Path("schemas/evo"),
+        help="File or directory containing schema JSON documents",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = parse_args(argv)
+    schema_paths = list(discover_schema_files(args.path))
+    if not schema_paths:
+        print(f"No schema files found under {args.path}.")
+        return 1
+    failures = lint(schema_paths)
+    if failures:
+        return 1
+    print("All schemas passed structural validation.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/species/generate_reports.py
+++ b/tools/species/generate_reports.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Generate Evo species summary and ecotype mapping reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+
+def collect_species(root: Path) -> List[Dict[str, object]]:
+    species: List[Dict[str, object]] = []
+    for path in sorted(root.glob("*.json")):
+        if path.name.startswith("species_catalog"):
+            continue
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        entry = payload.get("species")
+        if isinstance(entry, dict):
+            species.append(entry)
+    return species
+
+
+def summarise_species(records: Iterable[Dict[str, object]]) -> Dict[str, Counter]:
+    macro_counter: Counter[str] = Counter()
+    sentience_counter: Counter[str] = Counter()
+    danger_counter: Counter[str] = Counter()
+    habitat_counter: Counter[str] = Counter()
+    for record in records:
+        classification = record.get("classification", {}) or {}
+        macro = classification.get("macro_class")
+        if macro:
+            macro_counter[macro] += 1
+        habitat = classification.get("habitat")
+        if habitat:
+            habitat_counter[habitat] += 1
+        sentience = record.get("sentience_index")
+        if sentience:
+            sentience_counter[sentience] += 1
+        risk_profile = record.get("risk_profile") or {}
+        danger = risk_profile.get("danger_level")
+        if danger is not None:
+            danger_counter[str(danger)] += 1
+    return {
+        "macro": macro_counter,
+        "sentience": sentience_counter,
+        "danger": danger_counter,
+        "habitat": habitat_counter,
+    }
+
+
+def build_ecotype_map(records: Iterable[Dict[str, object]]) -> Dict[str, List[str]]:
+    mapping: Dict[str, List[str]] = defaultdict(list)
+    for record in records:
+        name = record.get("scientific_name") or "unknown"
+        for ecotype in record.get("ecotypes") or []:
+            mapping[ecotype].append(name)
+    for key in mapping:
+        mapping[key] = sorted(set(mapping[key]))
+    return dict(sorted(mapping.items()))
+
+
+def render_table(counter: Counter[str]) -> str:
+    lines = ["| Value | Count |", "| --- | ---: |"]
+    for key, count in counter.most_common():
+        lines.append(f"| {key} | {count} |")
+    return "\n".join(lines)
+
+
+def write_summary(path: Path, species_count: int, summary: Dict[str, Counter], source: Path) -> None:
+    lines = [
+        "# Evo Species Summary",
+        "",
+        f"*Source*: `{source}`",
+        f"*Total species analysed*: **{species_count}**",
+        "",
+        "## Macro class distribution",
+        render_table(summary["macro"]),
+        "",
+        "## Sentience tiers",
+        render_table(summary["sentience"]),
+        "",
+        "## Danger levels",
+        render_table(summary["danger"]),
+        "",
+        "## Habitat coverage",
+        render_table(summary["habitat"]),
+        ""
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_ecotype_map(path: Path, mapping: Dict[str, List[str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    serialisable = {key: value for key, value in mapping.items()}
+    path.write_text(json.dumps(serialisable, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--species-root",
+        type=Path,
+        default=Path("incoming/lavoro_da_classificare/species"),
+        help="Directory containing Evo species JSON files.",
+    )
+    parser.add_argument(
+        "--summary",
+        type=Path,
+        default=Path("reports/species/species_summary.md"),
+        help="Path where the Markdown summary will be written.",
+    )
+    parser.add_argument(
+        "--ecotypes",
+        type=Path,
+        default=Path("reports/species/species_ecotype_map.json"),
+        help="Path where the ecotype mapping JSON will be written.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = parse_args(argv)
+    if not args.species_root.exists():
+        raise SystemExit(f"Species directory not found: {args.species_root}")
+    records = collect_species(args.species_root)
+    summary = summarise_species(records)
+    mapping = build_ecotype_map(records)
+    write_summary(args.summary, len(records), summary, args.species_root)
+    write_ecotype_map(args.ecotypes, mapping)
+    print(f"Generated summary for {len(records)} species from {args.species_root}.")
+    print(f"Summary: {args.summary}")
+    print(f"Ecotype map: {args.ecotypes}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/species/validate.py
+++ b/tools/species/validate.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Validate Evo species JSON files against the canonical schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from jsonschema import RefResolver, ValidationError
+from jsonschema.validators import validator_for
+
+
+@dataclass
+class ValidationIssue:
+    file: Path
+    message: str
+    json_path: str
+
+
+def collect_species_files(root: Path) -> Iterable[Path]:
+    for path in sorted(root.glob("*.json")):
+        if path.name.startswith("species_catalog"):
+            continue
+        yield path
+
+
+def build_validator(schema_path: Path) -> object:
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    validator_cls = validator_for(schema)
+    store: Dict[str, dict] = {}
+    schema_id = schema.get("$id")
+    if schema_id:
+        store[schema_id] = schema
+    enums_path = schema_path.with_name("enums.json")
+    if enums_path.exists():
+        enums_schema = json.loads(enums_path.read_text(encoding="utf-8"))
+        enums_id = enums_schema.get("$id")
+        if enums_id:
+            store[enums_id] = enums_schema
+    resolver = RefResolver.from_schema(schema, store=store)
+    validator = validator_cls(schema, resolver=resolver)
+    return validator
+
+
+def validate_species(validator, files: Iterable[Path]) -> List[ValidationIssue]:
+    issues: List[ValidationIssue] = []
+    for path in files:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            issues.append(ValidationIssue(file=path, message=f"Invalid JSON: {exc}", json_path=""))
+            continue
+        if "species" not in payload:
+            continue
+        try:
+            validator.validate(payload)
+        except ValidationError as exc:
+            issues.append(
+                ValidationIssue(
+                    file=path,
+                    message=exc.message,
+                    json_path=str(exc.json_path),
+                )
+            )
+    return issues
+
+
+def format_report(root: Path, files_checked: int, issues: List[ValidationIssue]) -> str:
+    lines = [
+        f"Validation report for {root}",
+        f"Files checked: {files_checked}",
+        f"Failures: {len(issues)}",
+        ""
+    ]
+    if issues:
+        lines.append("Detailed issues:")
+        for issue in issues:
+            location = f" ({issue.json_path})" if issue.json_path else ""
+            lines.append(f"- {issue.file}: {issue.message}{location}")
+    else:
+        lines.append("All species payloads passed validation.")
+    return "\n".join(lines)
+
+
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--species-root",
+        type=Path,
+        default=Path("incoming/lavoro_da_classificare/species"),
+        help="Directory containing Evo species JSON files.",
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=Path("schemas/evo/species.schema.json"),
+        help="Path to the Evo species JSON schema.",
+    )
+    parser.add_argument(
+        "--log",
+        type=Path,
+        default=Path("reports/species/species_validation.log"),
+        help="Destination for the validation report.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = parse_args(argv)
+    if not args.species_root.exists():
+        raise SystemExit(f"Species directory not found: {args.species_root}")
+    args.log.parent.mkdir(parents=True, exist_ok=True)
+    validator = build_validator(args.schema)
+    files = list(collect_species_files(args.species_root))
+    issues = validate_species(validator, files)
+    report = format_report(args.species_root, len(files), issues)
+    args.log.write_text(report + "\n", encoding="utf-8")
+    print(report)
+    return 1 if issues else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add Evo JSON schemas for species, traits, and shared enums with a lint automation entry point
- depend on jsonschema for the new tooling, merge confirmed species aliases, and add a CLI schema linter
- validate Evo species payloads and generate summary plus ecotype mapping reports under reports/species

## Testing
- npm run schema:lint
- python tools/species/validate.py --log reports/species/species_validation.log
- python tools/species/generate_reports.py --summary reports/species/species_summary.md --ecotypes reports/species/species_ecotype_map.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911fa4f342c832896d3f96b22b51dbe)