### PR TITLE
Add trait duplicate audit tooling and docs

### DIFF
--- a/reports/traits/duplicates.csv
+++ b/reports/traits/duplicates.csv
@@ -1,0 +1,1 @@
+label_key,labels,trait_codes

--- a/reports/traits/merge_analysis.md
+++ b/reports/traits/merge_analysis.md
@@ -1,0 +1,57 @@
+# Analisi merge trait – aggiornamento TRT-03
+
+## Contesto del batch
+
+- **Fonte primaria**: `incoming/lavoro_da_classificare/traits/traits_aggregate.json`
+  (50 trait con codici `TR-11xx` → `TR-20xx`).
+- **Audit duplicati**: `python traits/scripts/audit_duplicates.py` → nessun
+  duplicato rilevato, report vuoto in `reports/traits/duplicates.csv`.
+- **Documentazione di supporto**: inventario normalizzato in
+  [`traits/glossary.md`](../../traits/glossary.md).
+
+## Risultati principali
+
+| Indicatore | Valore |
+| --- | --- |
+| Trait totali analizzati | 50 |
+| Famiglie con almeno un trait | 27 |
+| Tier distribuiti | T2 (14) · T3 (26) · T4 (10) |
+| Fattore energetico | Basso (22) · Medio (24) · Alto (4) |
+| Trait con >1 sinergia | 5 |
+| Trait con conflitti dichiarati | 4 |
+
+### Distribuzione sinergie e conflitti
+
+- La maggior parte dei trait (45/50) definisce una sola sinergia diretta,
+  favorendo catene lineari facili da integrare nel catalogo esistente.
+- Quattro trait (`TR-1103`, `TR-1105`, `TR-1303`, `TR-1305`) espongono conflitti
+  espliciti che andranno verificati contro le regole già presenti in
+  `data/traits/index.json` per evitare inconsistenze nelle build automatiche.
+
+### Copertura famiglie
+
+Le famiglie `Locomotivo/Terrestre`, `Cognitivo/Sociale`,
+`Difensivo/Camuffamento`, `Fisiologico/Metabolico`, `Offensivo/Controllo` e
+`Sensoriale/Visivo` coprono da tre a sette trait ciascuna, offrendo materiale
+sufficiente per creare pacchetti tematici senza duplicazioni semantiche.
+
+## Raccomandazioni per il merge
+
+1. **Creazione slug** – Convertire le etichette in chiavi kebab-case per
+   allinearsi alla struttura di `data/core/traits/glossary.json` (es.:
+   `Rostro Emostatico-Litico` → `rostro-emostatico-litico`).
+2. **Arricchimento descrizioni** – Popolare i campi `description_it` e
+   `description_en` usando i testi `uso_funzione` e `mutazione_indotta` quando
+   disponibili, mantenendo l'attuale convenzione del glossario.
+3. **Validazione incrociata** – Eseguire `python tools/py/validate_registry_naming.py`
+   indicando il nuovo glossario per garantire coerenza con gli ID esistenti.
+4. **Aggiornamento report** – Rigenerare `tools/py/report_trait_coverage.py`
+   dopo l'import per aggiornare i KPI di copertura (`trait_coverage_report.json`).
+
+## Prossimi passi
+
+- Pianificare il merge in `data/core/traits/glossary.json` applicando le
+  raccomandazioni sopra.
+- Annotare le sinergie multiple in `traits/glossary.md` (se emergono nuove
+  dipendenze) e aprire un ticket per gestire eventuali conflitti non risolvibili
+  automaticamente.

--- a/traits/glossary.md
+++ b/traits/glossary.md
@@ -1,0 +1,117 @@
+# Glossario trait – consolidamento TRT-02
+
+Questo documento raccoglie i risultati del controllo duplicati (`TRT-01`) e
+normalizza i cinquanta nuovi trait consegnati nel pacchetto
+`incoming/lavoro_da_classificare/traits`. I dati sono stati verificati con lo
+script [`traits/scripts/audit_duplicates.py`](scripts/audit_duplicates.py) e
+riassunti per agevolare l'integrazione nel glossario canonico.
+
+## Sintesi audit duplicati (TRT-01)
+
+- **Comando eseguito**: `python traits/scripts/audit_duplicates.py`
+- **Esito**: nessun gruppo di etichette duplicate individuato.
+- **Output strutturato**: `reports/traits/duplicates.csv` (solo intestazione,
+  nessuna riga di conflitto).
+
+## Copertura del dataset
+
+| Tier | Conteggio |
+| --- | --- |
+| T3 | 26 |
+| T2 | 14 |
+| T4 | 10 |
+
+| Fattore energetico | Conteggio |
+| --- | --- |
+| Medio | 24 |
+| Basso | 22 |
+| Alto | 4 |
+
+| Famiglia | Conteggio |
+| --- | --- |
+| Locomotivo/Terrestre | 7 |
+| Cognitivo/Sociale | 3 |
+| Difensivo/Camuffamento | 3 |
+| Fisiologico/Metabolico | 3 |
+| Offensivo/Controllo | 3 |
+| Sensoriale/Visivo | 3 |
+| Alimentazione/Digestione | 2 |
+| Difensivo/Resistenze | 2 |
+| Fisiologico/Termico | 2 |
+| Locomotivo/Arboricolo | 2 |
+| Offensivo/Chimico | 2 |
+| Offensivo/Elettrico | 2 |
+| Riproduttivo/Cicli | 2 |
+| Cognitivo/Apprendimento | 1 |
+| Difensivo/Corazza | 1 |
+| Difensivo/Termoregolazione | 1 |
+| Fisiologico/Idrico | 1 |
+| Fisiologico/Respiratorio | 1 |
+| Locomotivo/Aereo | 1 |
+| Locomotivo/Balistico | 1 |
+| Manipolativo/Alimentare | 1 |
+| Offensivo/Contusivo | 1 |
+| Offensivo/Perforante | 1 |
+| Offensivo/Termico | 1 |
+| Sensoriale/Magneto-ricettivo | 1 |
+| Sensoriale/Tatto-Vibro | 1 |
+| Sensoriale/Uditivo-Olfattivo | 1 |
+
+## Trait normalizzati
+
+| Trait | Etichetta | Famiglia | Tier | Sinergie | Conflitti |
+| --- | --- | --- | --- | --- | --- |
+| TR-1101 | Rostro Emostatico-Litico | Offensivo/Perforante | T4 | TR-1102 | — |
+| TR-1102 | Scheletro Idraulico a Pistoni | Locomotivo/Balistico | T4 | TR-1101, TR-1103 | — |
+| TR-1103 | Ipertrofia Muscolare Massiva | Fisiologico/Metabolico | T3 | TR-1102 | TR-1105 |
+| TR-1104 | Ectotermia Dinamica | Fisiologico/Termico | T3 | TR-1103 | — |
+| TR-1105 | Organi Sismici Cutanei | Sensoriale/Tatto-Vibro | T2 | TR-1101 | TR-1103 |
+| TR-1201 | Pelage Idrorepellente Avanzato | Difensivo/Termoregolazione | T2 | TR-1202, TR-1204 | — |
+| TR-1202 | Scudo Gluteale Cheratinizzato | Difensivo/Corazza | T3 | TR-1201 | — |
+| TR-1203 | Articolazioni Multiassiali | Locomotivo/Terrestre | T3 | TR-1204 | — |
+| TR-1204 | Coda Prensile Muscolare | Locomotivo/Arboricolo | T3 | TR-1203, TR-1205 | — |
+| TR-1205 | Rostro Linguale Prensile | Manipolativo/Alimentare | T3 | TR-1204 | — |
+| TR-1301 | Ermafroditismo Cronologico | Riproduttivo/Cicli | T3 | TR-1302 | — |
+| TR-1302 | Locomozione Miriapode Ibrida | Locomotivo/Terrestre | T3 | TR-1304 | — |
+| TR-1303 | Estroflessione Gastrica Acida | Offensivo/Chimico | T4 | TR-1304 | TR-1305 |
+| TR-1304 | Artiglio Cinetico a Urto | Offensivo/Contusivo | T4 | TR-1302 | — |
+| TR-1305 | Sistemi Chimio-Sonici | Sensoriale/Uditivo-Olfattivo | T3 | TR-1302 | TR-1303 |
+| TR-1401 | Scheletro Pneumatico a Maglie | Locomotivo/Terrestre | T3 | TR-1402 | — |
+| TR-1402 | Cinghia Iper-Ciliare | Locomotivo/Terrestre | T3 | TR-1401 | — |
+| TR-1403 | Rete Filtro-Polmonare | Fisiologico/Respiratorio | T3 | TR-1401 | — |
+| TR-1404 | Canto Infrasonico Tattico | Offensivo/Controllo | T4 | TR-1401 | — |
+| TR-1405 | Siero Anti-Gelo Naturale | Fisiologico/Termico | T2 | TR-1401 | — |
+| TR-1501 | Zanne Idracida | Offensivo/Chimico | T4 | TR-1502, TR-1503 | — |
+| TR-1502 | Seta Conduttiva Elettrica | Offensivo/Elettrico | T4 | TR-1501 | — |
+| TR-1503 | Articolazioni a Leva Idraulica | Locomotivo/Terrestre | T3 | TR-1501 | — |
+| TR-1504 | Filtrazione Osmotica | Fisiologico/Idrico | T2 | TR-1501 | — |
+| TR-1505 | Occhi Analizzatori di Tensione | Sensoriale/Visivo | T2 | TR-1502 | — |
+| TR-1601 | Membrana Plastica Continua | Difensivo/Camuffamento | T3 | TR-1602 | — |
+| TR-1602 | Flusso Ameboide Controllato | Locomotivo/Terrestre | T2 | TR-1601 | — |
+| TR-1603 | Fagocitosi Assorbente | Alimentazione/Digestione | T3 | TR-1601 | — |
+| TR-1604 | Moltiplicazione per Fusione | Riproduttivo/Cicli | T2 | TR-1601 | — |
+| TR-1605 | Cisti di Ibernazione Minerale | Difensivo/Resistenze | T2 | TR-1604 | — |
+| TR-1701 | Ali Fono-Risonanti | Locomotivo/Aereo | T3 | TR-1702, TR-1703 | — |
+| TR-1702 | Cannone Sonico a Raggio | Offensivo/Controllo | T4 | TR-1701 | — |
+| TR-1703 | Campo di Interferenza Acustica | Difensivo/Camuffamento | T3 | TR-1701 | — |
+| TR-1704 | Cervello a Bassa Latenza | Cognitivo/Apprendimento | T3 | TR-1701 | — |
+| TR-1705 | Occhi Cinetici | Sensoriale/Visivo | T2 | TR-1702 | — |
+| TR-1801 | Integumento Bipolare | Sensoriale/Magneto-ricettivo | T3 | TR-1803 | — |
+| TR-1802 | Elettromagnete Biologico | Offensivo/Elettrico | T4 | TR-1801 | — |
+| TR-1803 | Scivolamento Magnetico | Locomotivo/Terrestre | T3 | TR-1801 | — |
+| TR-1804 | Filtro Metallofago | Alimentazione/Digestione | T2 | TR-1802 | — |
+| TR-1805 | Bozzolo Magnetico | Difensivo/Resistenze | T2 | TR-1801 | — |
+| TR-1901 | Vello di Assorbimento Totale | Difensivo/Camuffamento | T3 | TR-1902 | — |
+| TR-1902 | Visione Multi-Spettrale Amplificata | Sensoriale/Visivo | T3 | TR-1901 | — |
+| TR-1903 | Motore Biologico Silenzioso | Fisiologico/Metabolico | T2 | TR-1901 | — |
+| TR-1904 | Artigli Ipo-Termici | Offensivo/Termico | T3 | TR-1902 | — |
+| TR-1905 | Comunicazione Fotonica Coda-Coda | Cognitivo/Sociale | T2 | TR-1901 | — |
+| TR-2001 | Corna Psico-Conduttive | Cognitivo/Sociale | T3 | TR-2002 | — |
+| TR-2002 | Coscienza d’Alveare Diffusa | Cognitivo/Sociale | T4 | TR-2001 | — |
+| TR-2003 | Aura di Dispersione Mentale | Offensivo/Controllo | T3 | TR-2001 | — |
+| TR-2004 | Metabolismo di Condivisione Energetica | Fisiologico/Metabolico | T3 | TR-2001 | — |
+| TR-2005 | Unghie a Micro-Adesione | Locomotivo/Arboricolo | T2 | TR-2001 | — |
+
+Le etichette sono pronte per essere mappate a identificatori canonicali nel
+`data/core/traits/glossary.json` (es. conversione in slug kebab-case) durante la
+fase di import.

--- a/traits/scripts/audit_duplicates.py
+++ b/traits/scripts/audit_duplicates.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Audit trait glossary duplicates.
+
+This utility loads the incoming trait payloads and reports duplicate labels
+(based on a case-insensitive, whitespace-normalised comparison). The report is
+written as CSV and printed to stdout to simplify manual reviews.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable, Iterator, Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SOURCE = REPO_ROOT / "incoming" / "lavoro_da_classificare" / "traits" / "traits_aggregate.json"
+DEFAULT_OUTPUT = REPO_ROOT / "reports" / "traits" / "duplicates.csv"
+
+
+class DuplicateRecord(Mapping[str, object]):
+    """Row payload describing duplicate trait labels."""
+
+    def __init__(self, label_key: str, labels: Sequence[str], trait_codes: Sequence[str]) -> None:
+        self.label_key = label_key
+        self.labels = tuple(labels)
+        self.trait_codes = tuple(trait_codes)
+
+    def __iter__(self) -> Iterator[str]:
+        yield from ("label_key", "labels", "trait_codes")
+
+    def __len__(self) -> int:  # pragma: no cover - trivial container API
+        return 3
+
+    def __getitem__(self, key: str) -> object:  # pragma: no cover - trivial container API
+        if key == "label_key":
+            return self.label_key
+        if key == "labels":
+            return list(self.labels)
+        if key == "trait_codes":
+            return list(self.trait_codes)
+        raise KeyError(key)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=DEFAULT_SOURCE,
+        help="Path to a JSON file (or directory containing JSON files) with trait definitions.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Destination CSV file that will store duplicate label findings.",
+    )
+    parser.add_argument(
+        "--min-size",
+        type=int,
+        default=2,
+        help="Minimum number of traits that must share the same label to be reported.",
+    )
+    return parser.parse_args(argv)
+
+
+def _normalise_label(raw_label: str) -> str:
+    return " ".join(raw_label.split()).casefold()
+
+
+def _iter_trait_payloads(source: Path) -> Iterable[Mapping[str, object]]:
+    if source.is_dir():
+        for candidate in sorted(source.glob("*.json")):
+            if candidate.name == "traits_aggregate.json":
+                continue
+            data = json.loads(candidate.read_text(encoding="utf-8"))
+            if isinstance(data, Mapping):
+                yield data
+            else:
+                raise ValueError(f"Unexpected payload in {candidate}: expected an object")
+        return
+
+    if not source.exists():
+        raise FileNotFoundError(source)
+
+    payload = json.loads(source.read_text(encoding="utf-8"))
+    if isinstance(payload, Mapping):
+        entries = payload.get("traits")
+        if isinstance(entries, Sequence):
+            for entry in entries:
+                if isinstance(entry, Mapping):
+                    yield entry
+            return
+        if isinstance(entries, Mapping):
+            yield entries
+            return
+        raise ValueError(f"Unsupported structure in {source}: missing 'traits' list")
+
+    if isinstance(payload, Sequence):
+        for entry in payload:
+            if isinstance(entry, Mapping):
+                yield entry
+        return
+
+    raise ValueError(f"Unsupported payload type in {source}: {type(payload)!r}")
+
+
+def _extract_identity(entry: Mapping[str, object]) -> tuple[str | None, str | None]:
+    trait_code = None
+    for key in ("trait_code", "trait_id", "id", "code"):
+        value = entry.get(key)
+        if isinstance(value, str) and value.strip():
+            trait_code = value.strip()
+            break
+
+    label = entry.get("label")
+    if not isinstance(label, str) or not label.strip():
+        # try alternative localisation keys
+        for key in ("label_it", "label_en", "nome", "name"):
+            alt = entry.get(key)
+            if isinstance(alt, str) and alt.strip():
+                label = alt
+                break
+        else:
+            label = None
+    return trait_code, label
+
+
+def build_duplicate_index(entries: Iterable[Mapping[str, object]], min_size: int = 2) -> list[DuplicateRecord]:
+    buckets: dict[str, set[str]] = defaultdict(set)
+    labels: dict[str, set[str]] = defaultdict(set)
+    for entry in entries:
+        trait_code, label = _extract_identity(entry)
+        if not trait_code or not label:
+            continue
+        label_key = _normalise_label(label)
+        buckets[label_key].add(trait_code)
+        labels[label_key].add(label.strip())
+
+    records: list[DuplicateRecord] = []
+    for label_key, codes in sorted(buckets.items()):
+        if len(codes) < min_size:
+            continue
+        label_variants = sorted(labels[label_key])
+        records.append(DuplicateRecord(label_key=label_key, labels=label_variants, trait_codes=sorted(codes)))
+    return records
+
+
+def write_csv(records: Sequence[DuplicateRecord], destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["label_key", "labels", "trait_codes"])
+        for record in records:
+            writer.writerow([
+                record.label_key,
+                " | ".join(record.labels),
+                ", ".join(record.trait_codes),
+            ])
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        args = parse_args(argv)
+        entries = list(_iter_trait_payloads(args.source))
+        records = build_duplicate_index(entries, min_size=max(args.min_size, 2))
+        write_csv(records, args.output)
+    except Exception as exc:  # pragma: no cover - CLI convenience
+        print(f"[audit_duplicates] errore: {exc}", file=sys.stderr)
+        return 1
+
+    if not records:
+        print("Nessun duplicato individuato.")
+        return 0
+
+    print(f"Trovati {len(records)} gruppi di etichette duplicate.")
+    for record in records:
+        print(f"- {record.label_key}: {', '.join(record.trait_codes)}")
+    print(f"Report salvato in {args.output}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a reusable `traits/scripts/audit_duplicates.py` utility to check new payloads
- document the consolidated glossary results in `traits/glossary.md`
- capture merge recommendations and audit metrics in `reports/traits/merge_analysis.md`

## Testing
- python traits/scripts/audit_duplicates.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911fccf443483288fa852ac0b552591)