### PR TITLE
Add Evo automation tooling and integrate web audits into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       deploy: ${{ steps.filter.outputs.deploy }}
       styleguide: ${{ steps.filter.outputs.styleguide }}
       stack: ${{ steps.filter.outputs.stack }}
+      site_audit: ${{ steps.filter.outputs.site_audit }}
 
     steps:
       - name: Checkout repository
@@ -69,6 +70,9 @@ jobs:
               - 'tests/**/*.js'
               - 'webapp/**'
               - 'Trait Editor/**'
+            site_audit:
+              - 'ops/site-audit/**'
+              - 'Makefile'
 
   playwright-bundle:
     runs-on: ubuntu-latest
@@ -454,6 +458,102 @@ jobs:
           path: |
             reports/trait_style/ci_trait_style_report.json
             reports/trait_style/ci_trait_style_report.md
+          if-no-files-found: warn
+
+  site-audit:
+    runs-on: ubuntu-latest
+    needs:
+      - paths-filter
+    if: >-
+      needs.paths-filter.outputs.site_audit == 'true' ||
+      needs.paths-filter.outputs.deploy == 'true' ||
+      needs.paths-filter.outputs.stack == 'true'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Resolve SITE_BASE_URL
+        run: |
+          if [ -n "${{ vars.SITE_BASE_URL }}" ]; then
+            echo "SITE_BASE_URL=${{ vars.SITE_BASE_URL }}" >> $GITHUB_ENV
+          elif [ -n "${{ secrets.SITE_BASE_URL }}" ]; then
+            echo "SITE_BASE_URL=${{ secrets.SITE_BASE_URL }}" >> $GITHUB_ENV
+          else
+            echo "SITE_BASE_URL=" >> $GITHUB_ENV
+          fi
+
+      - name: Install site audit dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --requirement ops/site-audit/requirements.txt
+
+      - name: Run site audit checks
+        run: |
+          if [ -z "$SITE_BASE_URL" ]; then
+            echo "SITE_BASE_URL not configured; skipping site audit." >&2
+            exit 0
+          fi
+          mkdir -p ops/site-audit/_out
+          make audit SITE_BASE_URL="$SITE_BASE_URL"
+
+      - name: Upload site audit artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-audit
+          path: ops/site-audit/_out
+          if-no-files-found: warn
+
+  lighthouse-ci:
+    runs-on: ubuntu-latest
+    needs:
+      - paths-filter
+    if: >-
+      needs.paths-filter.outputs.ts == 'true' ||
+      needs.paths-filter.outputs.deploy == 'true'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Lighthouse CI
+        run: npm i -g @lhci/cli@0.13.x
+
+      - name: Resolve SITE_BASE_URL
+        run: |
+          if [ -n "${{ vars.SITE_BASE_URL }}" ]; then
+            echo "SITE_BASE_URL=${{ vars.SITE_BASE_URL }}" >> $GITHUB_ENV
+          elif [ -n "${{ secrets.SITE_BASE_URL }}" ]; then
+            echo "SITE_BASE_URL=${{ secrets.SITE_BASE_URL }}" >> $GITHUB_ENV
+          else
+            echo "SITE_BASE_URL=" >> $GITHUB_ENV
+          fi
+
+      - name: Run Lighthouse CI (remote)
+        run: |
+          if [ -z "$SITE_BASE_URL" ]; then
+            echo "SITE_BASE_URL not configured; skipping Lighthouse audit." >&2
+            exit 0
+          fi
+          lhci autorun --config=./lighthouserc.json
+
+      - name: Upload Lighthouse artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-results
+          path: ./.lighthouseci
           if-no-files-found: warn
 
   styleguide-compliance:

--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,58 @@
+.PHONY: sitemap links report search redirects structured audit \
+        evo-tactics-pack dev-stack test-stack ci-stack \
+        evo-batch-plan evo-batch-run evo-plan evo-run evo-lint
 
-.PHONY: sitemap links report search redirects structured audit evo-tactics-pack dev-stack test-stack ci-stack evo-batch-plan evo-batch-run
+batch ?= all
+flags ?=
+EVO_TASKS_FILE ?= incoming/lavoro_da_classificare/tasks.yml
 
 sitemap:
-\tpython ops/site-audit/build_sitemap.py
+	python ops/site-audit/build_sitemap.py
 
 links:
-\tpython ops/site-audit/check_links.py --start-url "$${SITE_BASE_URL}" --max-pages 2000 --timeout 10 --out ops/site-audit/_out/link_report.csv
+	python ops/site-audit/check_links.py --start-url "${SITE_BASE_URL}" --max-pages 2000 --timeout 10 --out ops/site-audit/_out/link_report.csv
 
 report:
-\tpython ops/site-audit/report_links.py --site "$${SITE_BASE_URL}"
+	python ops/site-audit/report_links.py --site "${SITE_BASE_URL}"
 
 search:
-\tpython ops/site-audit/generate_search_index.py --repo-root .
+	python ops/site-audit/generate_search_index.py --repo-root .
 
 redirects:
-\tpython ops/site-audit/build_redirects.py
+	python ops/site-audit/build_redirects.py
 
 structured:
-\tpython ops/site-audit/generate_structured_data.py --base-url "$${SITE_BASE_URL}"
+	python ops/site-audit/generate_structured_data.py --base-url "${SITE_BASE_URL}"
 
 audit: sitemap links report search redirects structured
 
 evo-tactics-pack:
-node scripts/build_evo_tactics_pack_dist.mjs
+	node scripts/build_evo_tactics_pack_dist.mjs
 
 dev-stack:
-npm run dev:stack
+	npm run dev:stack
 
 test-stack:
-npm run test:stack
+	npm run test:stack
 
 ci-stack:
-npm run ci:stack
+	npm run ci:stack
+
+evo-plan:
+	python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" plan --batch "${batch}"
+
+evo-run:
+	python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" run --batch "${batch}" ${flags}
+
+evo-lint:
+	@if [ -n "${path}" ]; then \
+		python tools/automation/evo_schema_lint.py "${path}"; \
+	else \
+		python tools/automation/evo_schema_lint.py; \
+	fi
 
 evo-batch-plan:
-	python tools/automation/evo_batch_runner.py plan --batch "$(batch)"
+	$(MAKE) --no-print-directory evo-plan batch="${batch}" EVO_TASKS_FILE="${EVO_TASKS_FILE}"
 
 evo-batch-run:
-	python tools/automation/evo_batch_runner.py run --batch "$(batch)" $(flags)
+	$(MAKE) --no-print-directory evo-run batch="${batch}" flags="${flags}" EVO_TASKS_FILE="${EVO_TASKS_FILE}"

--- a/docs/tooling/evo.md
+++ b/docs/tooling/evo.md
@@ -1,0 +1,50 @@
+# Tooling Evo
+
+Questa pagina descrive i flussi di lavoro disponibili per supportare le attività
+Evo-Tactics nel repository.
+
+## Runner dei batch
+
+- Script: `python tools/automation/evo_batch_runner.py`
+- Obiettivo: pianificare o eseguire i comandi registrati in
+  `incoming/lavoro_da_classificare/tasks.yml`.
+- Opzioni principali:
+  - `list` per visualizzare i batch disponibili.
+  - `plan --batch <nome>` per riepilogare i task (dry-run).
+  - `run --batch <nome>` per eseguire i comandi (di default in dry-run; usare
+    `--execute` per lanciarli, `--auto` per bypassare gli stati bloccanti,
+    `--ignore-errors` per proseguire anche se un comando fallisce).
+  - `--tasks-file` consente di puntare a un registro alternativo, mentre
+    `--verbose` abilita il logging esteso.
+
+L'output operativo viene inviato su stderr tramite il logger condiviso
+`tools.automation.evo_batch_runner`, mentre gli elenchi e i piani restano su
+stdout per facilitare piping/reportistica.
+
+## Lint degli schemi JSON
+
+- Script: `python tools/automation/evo_schema_lint.py [percorso]`
+- Obiettivo: validare la struttura degli schemi JSON Evo utilizzando le stesse
+  regole del batch runner.
+- Comportamento:
+  - Cerca ricorsivamente i file `.json` nella directory indicata (default
+    `schemas/evo`).
+  - Esegue `jsonschema.validator_for` con un archivio condiviso di documenti per
+    risolvere i riferimenti locali.
+  - Riporta i risultati con gli indicatori ✅/❌ sul logger
+    `tools.automation.evo_schema_lint` (usare `--verbose` per il debug).
+
+Il comando è disponibile anche tramite `make evo-lint` (supporta la variabile
+`path=<percorso>` per restringere il controllo a un sottoinsieme di file).
+
+## Make target di supporto
+
+I flussi di lavoro descritti sono esposti nel `Makefile` tramite:
+
+- `make evo-plan batch=<nome>`: mostra il piano del batch specificato.
+- `make evo-run batch=<nome> flags="--execute --auto"`: esegue i comandi con le
+  opzioni desiderate.
+- `make evo-lint [path=...]`: lancia il lint sugli schemi.
+
+I target legacy `evo-batch-plan` ed `evo-batch-run` restano disponibili come
+alias per compatibilità (internamente delegano alle nuove ricette).

--- a/docs/workflows/ci-gap-analysis.md
+++ b/docs/workflows/ci-gap-analysis.md
@@ -1,0 +1,44 @@
+# CI gap analysis (OPS-01)
+
+Questa analisi sintetizza lo stato attuale dei workflow CI e identifica le aree
+scoperte rispetto agli obiettivi Ops.
+
+## Copertura attuale
+
+- `ci.yml` esegue un filtro sui percorsi e attiva job dedicati per stack web,
+  CLI, dataset e test Python/TypeScript in base alle modifiche introdotte
+  (`paths-filter`).
+- Il job `webapp-quality` si concentra su lint, test e build della webapp
+  principale, mentre `stack-quality` replica l'intero pacchetto full-stack.
+- Pipeline ausiliarie gestiscono CLI (`cli-checks`), validazioni Python
+  (`python-tests`) e dataset (`dataset-checks`), garantendo la coerenza delle
+  fonti dati.
+- Altri workflow schedulati coprono aspetti specifici: `lighthouse.yml` esegue
+  audit periodici delle metriche web con LHCI, mentre `schema-validate.yml`
+  verifica gli schemi JSON in maniera autonoma.
+
+## Gap individuati
+
+1. **Site audit non integrato in CI** – gli script in `ops/site-audit/` sono
+   richiamati manualmente via `make audit` e non c'è un job dedicato in
+   `ci.yml`.
+2. **Lighthouse confinato alla schedule** – le metriche Lighthouse girano solo
+   sul workflow pianificato; non esiste un controllo automatico su PR o
+   modifiche front-end critiche.
+3. **Strumenti di automazione Evo isolati** – gli script in
+   `tools/automation/` (es. batch runner, lint schemi) non sono coperti da job
+   CI o target Make condivisi, creando disallineamenti operativi.
+4. **Segnalazione centralizzata dei risultati** – non vengono raccolti artefatti
+   standardizzati per audit/Lighthouse che possano alimentare reportistica o QA
+   (download manuale richiesto dagli artifact quando disponibili).
+
+## Raccomandazioni
+
+1. Aggiungere un job `site-audit` in `ci.yml` che installi le dipendenze
+   richieste e lanci `make audit`, caricando in artifact l'output generato.
+2. Collegare Lighthouse al workflow principale (con guard condizionale su
+   `SITE_BASE_URL`) riutilizzando la configurazione `lighthouserc.json`.
+3. Normalizzare gli script Evo (naming + logging) e pubblicare target Make
+   unificati per pianificazione/esecuzione/lint degli asset.
+4. Consolidare la pubblicazione di artifact per i controlli web (site audit e
+   Lighthouse) così da alimentare automaticamente i report Ops.

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -8,7 +8,12 @@
         "$SITE_BASE_URL/biomi"
       ],
       "startServerCommand": "",
-      "numberOfRuns": 1
+      "numberOfRuns": 3,
+      "settings": {
+        "preset": "desktop",
+        "disableStorageReset": true,
+        "chromeFlags": "--no-sandbox --headless=new"
+      }
     },
     "assert": {
       "assertions": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:web": "npm run test:web --workspace tools/ts",
     "test:stack": "npm run test:api && npm run test --workspace webapp",
     "lint:stack": "node scripts/lint-stack.mjs",
-    "schema:lint": "python tools/automation/schema_lint.py schemas/evo",
+    "schema:lint": "python tools/automation/evo_schema_lint.py schemas/evo",
     "ci:stack": "npm run lint:stack && npm run test:api && npm run test --workspace webapp && VITE_BASE_PATH=./ npm run build --workspace webapp",
     "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && node --test tests/server/generationSnapshot.spec.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-latency.spec.ts && ./node_modules/.bin/tsx tests/scripts/tune_items.test.ts && ./node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts && node --test tests/tools/deploy-checks.spec.js",
     "start:api": "node server/index.js",

--- a/tools/automation/README.md
+++ b/tools/automation/README.md
@@ -9,7 +9,9 @@ necessario, lint con `ruff`/`eslint`).
 
 Il comando `tools/automation/evo_batch_runner.py` permette di pianificare o
 eseguire automaticamente i comandi registrati in
-`incoming/lavoro_da_classificare/tasks.yml`.
+`incoming/lavoro_da_classificare/tasks.yml`. Lo script usa un logging uniforme
+(`--verbose` per maggiori dettagli) condiviso con gli altri strumenti di
+automazione.
 
 ```bash
 # Elencare i batch disponibili
@@ -25,6 +27,14 @@ python tools/automation/evo_batch_runner.py run --batch data-models --execute
 I comandi che contengono placeholder (`<...>`) vengono saltati e marcati come
 interventi manuali. Per evitare che un singolo fallimento interrompa l'intero
 batch, è possibile passare `--ignore-errors`.
+
+## Lint degli schemi
+
+`tools/automation/evo_schema_lint.py` esegue i controlli strutturali degli
+schemi JSON Evo sfruttando la stessa configurazione di logging del batch runner
+(`--verbose` abilita i messaggi di debug). Il comando accetta un percorso come
+argomento opzionale (file singolo o directory) e viene esposto anche tramite
+`make evo-lint`.
 
 ## Step di preparazione
 


### PR DESCRIPTION
## Summary
- unify the Evo automation scripts around a shared logging configuration, renaming the schema lint entry point and updating package and docs references
- document the Evo tooling flows and publish a CI gap analysis for OPS-01
- expose Evo make targets, integrate site audit and Lighthouse checks into the main CI workflow, and tune the LHCI configuration

## Testing
- python -m compileall tools/automation

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911fe4d8a5883289ce8d5cf0a02e32f)