### PR TITLE
Add Evo automation helpers and expand CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,98 @@ jobs:
           VITE_BASE_PATH: ./
         run: npm run build --workspace webapp
 
+  site-audit:
+    runs-on: ubuntu-latest
+    needs: paths-filter
+    if: needs.paths-filter.outputs.site_audit == 'true'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install site audit dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --requirement ops/site-audit/requirements.txt
+
+      - name: Resolve SITE_BASE_URL
+        run: |
+          if [ -n "${{ vars.SITE_BASE_URL }}" ]; then
+            echo "SITE_BASE_URL=${{ vars.SITE_BASE_URL }}" >> $GITHUB_ENV
+          elif [ -n "${{ secrets.SITE_BASE_URL }}" ]; then
+            echo "SITE_BASE_URL=${{ secrets.SITE_BASE_URL }}" >> $GITHUB_ENV
+          else
+            echo "SITE_BASE_URL=" >> $GITHUB_ENV
+          fi
+
+      - name: Run site audit suite
+        if: env.SITE_BASE_URL != ''
+        env:
+          SITE_BASE_URL: ${{ env.SITE_BASE_URL }}
+        run: make audit
+
+      - name: Skip site audit (missing SITE_BASE_URL)
+        if: env.SITE_BASE_URL == ''
+        run: echo "SITE_BASE_URL not configured; skipping site audit checks."
+
+      - name: Upload site audit artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-audit
+          path: ops/site-audit/_out
+          if-no-files-found: warn
+
+  lighthouse-ci:
+    runs-on: ubuntu-latest
+    needs: paths-filter
+    if: needs.paths-filter.outputs.stack == 'true'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Lighthouse CI
+        run: npm i -g @lhci/cli@0.13.x
+
+      - name: Resolve SITE_BASE_URL
+        run: |
+          if [ -n "${{ vars.SITE_BASE_URL }}" ]; then
+            echo "SITE_BASE_URL=${{ vars.SITE_BASE_URL }}" >> $GITHUB_ENV
+          elif [ -n "${{ secrets.SITE_BASE_URL }}" ]; then
+            echo "SITE_BASE_URL=${{ secrets.SITE_BASE_URL }}" >> $GITHUB_ENV
+          else
+            echo "SITE_BASE_URL=" >> $GITHUB_ENV
+          fi
+
+      - name: Run Lighthouse CI
+        if: env.SITE_BASE_URL != ''
+        env:
+          SITE_BASE_URL: ${{ env.SITE_BASE_URL }}
+        run: lhci autorun --config=./lighthouserc.json
+
+      - name: Skip Lighthouse CI (missing SITE_BASE_URL)
+        if: env.SITE_BASE_URL == ''
+        run: echo "SITE_BASE_URL not configured; skipping Lighthouse CI run."
+
+      - name: Upload Lighthouse results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-results
+          path: ./.lighthouseci
+          if-no-files-found: warn
+
   cli-checks:
     runs-on: ubuntu-latest
     needs:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 .PHONY: sitemap links report search redirects structured audit \
         evo-tactics-pack dev-stack test-stack ci-stack \
-        evo-batch-plan evo-batch-run evo-plan evo-run evo-lint
+        evo-batch-plan evo-batch-run evo-plan evo-run evo-list evo-lint
 
 batch ?= all
 flags ?=
 EVO_TASKS_FILE ?= incoming/lavoro_da_classificare/tasks.yml
+EVO_LINT_PATH ?=
 
 sitemap:
 	python ops/site-audit/build_sitemap.py
@@ -38,18 +39,21 @@ test-stack:
 ci-stack:
 	npm run ci:stack
 
+evo-list:
+        python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" list
+
 evo-plan:
-	python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" plan --batch "${batch}"
+        python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" plan --batch "${batch}"
 
 evo-run:
-	python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" run --batch "${batch}" ${flags}
+        python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" run --batch "${batch}" ${flags}
 
 evo-lint:
-	@if [ -n "${path}" ]; then \
-		python tools/automation/evo_schema_lint.py "${path}"; \
-	else \
-		python tools/automation/evo_schema_lint.py; \
-	fi
+        @if [ -n "${EVO_LINT_PATH}" ]; then \
+                python tools/automation/evo_schema_lint.py "${EVO_LINT_PATH}"; \
+        else \
+                python tools/automation/evo_schema_lint.py; \
+        fi
 
 evo-batch-plan:
 	$(MAKE) --no-print-directory evo-plan batch="${batch}" EVO_TASKS_FILE="${EVO_TASKS_FILE}"

--- a/docs/tooling/evo.md
+++ b/docs/tooling/evo.md
@@ -19,7 +19,8 @@ Evo-Tactics nel repository.
 
 L'output operativo viene inviato su stderr tramite il logger condiviso
 `tools.automation.evo_batch_runner`, mentre gli elenchi e i piani restano su
-stdout per facilitare piping/reportistica.
+stdout per facilitare piping/reportistica. Il logging condiviso è gestito da
+`tools.automation.configure_logging` che uniforma il formato CLI.
 
 ## Lint degli schemi JSON
 
@@ -34,17 +35,21 @@ stdout per facilitare piping/reportistica.
   - Riporta i risultati con gli indicatori ✅/❌ sul logger
     `tools.automation.evo_schema_lint` (usare `--verbose` per il debug).
 
-Il comando è disponibile anche tramite `make evo-lint` (supporta la variabile
-`path=<percorso>` per restringere il controllo a un sottoinsieme di file).
+Il comando è disponibile anche tramite `make evo-lint` (variabile opzionale
+`EVO_LINT_PATH=<percorso>` per restringere il controllo a un sottoinsieme di
+file).
 
 ## Make target di supporto
 
 I flussi di lavoro descritti sono esposti nel `Makefile` tramite:
 
+- `make evo-list`: elenca i batch disponibili (variabile `EVO_TASKS_FILE`
+  opzionale per puntare a un file alternativo).
 - `make evo-plan batch=<nome>`: mostra il piano del batch specificato.
 - `make evo-run batch=<nome> flags="--execute --auto"`: esegue i comandi con le
   opzioni desiderate.
-- `make evo-lint [path=...]`: lancia il lint sugli schemi.
+- `make evo-lint [EVO_LINT_PATH=...]`: lancia il lint sugli schemi
+  (percorso personalizzabile).
 
 I target legacy `evo-batch-plan` ed `evo-batch-run` restano disponibili come
 alias per compatibilità (internamente delegano alle nuove ricette).

--- a/docs/workflows/ci-gap-analysis.md
+++ b/docs/workflows/ci-gap-analysis.md
@@ -13,32 +13,27 @@ scoperte rispetto agli obiettivi Ops.
 - Pipeline ausiliarie gestiscono CLI (`cli-checks`), validazioni Python
   (`python-tests`) e dataset (`dataset-checks`), garantendo la coerenza delle
   fonti dati.
+- Il job `site-audit` installa le dipendenze di `ops/site-audit/` ed esegue
+  `make audit`, caricando gli artifact prodotti per la consultazione Ops.
+- Il job `lighthouse-ci` riusa la configurazione condivisa (`lighthouserc.json`)
+  e lancia LHCI su push/PR quando sono coinvolte modifiche front-end.
 - Altri workflow schedulati coprono aspetti specifici: `lighthouse.yml` esegue
   audit periodici delle metriche web con LHCI, mentre `schema-validate.yml`
   verifica gli schemi JSON in maniera autonoma.
 
 ## Gap individuati
 
-1. **Site audit non integrato in CI** – gli script in `ops/site-audit/` sono
-   richiamati manualmente via `make audit` e non c'è un job dedicato in
-   `ci.yml`.
-2. **Lighthouse confinato alla schedule** – le metriche Lighthouse girano solo
-   sul workflow pianificato; non esiste un controllo automatico su PR o
-   modifiche front-end critiche.
-3. **Strumenti di automazione Evo isolati** – gli script in
-   `tools/automation/` (es. batch runner, lint schemi) non sono coperti da job
-   CI o target Make condivisi, creando disallineamenti operativi.
-4. **Segnalazione centralizzata dei risultati** – non vengono raccolti artefatti
-   standardizzati per audit/Lighthouse che possano alimentare reportistica o QA
-   (download manuale richiesto dagli artifact quando disponibili).
+1. **Strumenti di automazione Evo isolati** – gli script in
+   `tools/automation/` (es. batch runner, lint schemi) sono ora coperti da
+   target Make uniformi (`evo-list`, `evo-plan`, `evo-run`, `evo-lint`), ma non
+   è ancora presente un job CI dedicato alla loro esecuzione programmata.
+2. **Segnalazione centralizzata dei risultati** – gli artifact di site audit e
+   Lighthouse vengono pubblicati automaticamente; resta da valutare
+   l'integrazione di un bucket o dashboard unico per la consultazione storica.
 
 ## Raccomandazioni
 
-1. Aggiungere un job `site-audit` in `ci.yml` che installi le dipendenze
-   richieste e lanci `make audit`, caricando in artifact l'output generato.
-2. Collegare Lighthouse al workflow principale (con guard condizionale su
-   `SITE_BASE_URL`) riutilizzando la configurazione `lighthouserc.json`.
-3. Normalizzare gli script Evo (naming + logging) e pubblicare target Make
-   unificati per pianificazione/esecuzione/lint degli asset.
-4. Consolidare la pubblicazione di artifact per i controlli web (site audit e
-   Lighthouse) così da alimentare automaticamente i report Ops.
+1. Definire un job dedicato che riutilizzi i target `evo-*` per validare i
+   workflow Evo direttamente in CI o su base schedulata.
+2. Valutare una piattaforma di archiviazione/reportistica condivisa che raccolga
+   automaticamente gli artifact generati da site audit e Lighthouse.

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -11,8 +11,16 @@
       "numberOfRuns": 3,
       "settings": {
         "preset": "desktop",
+        "formFactor": "desktop",
+        "screenEmulation": {
+          "mobile": false,
+          "width": 1365,
+          "height": 935,
+          "deviceScaleFactor": 1,
+          "disabled": false
+        },
         "disableStorageReset": true,
-        "chromeFlags": "--no-sandbox --headless=new"
+        "chromeFlags": "--no-sandbox --headless=new --ignore-certificate-errors"
       }
     },
     "assert": {
@@ -39,6 +47,18 @@
           "warn",
           {
             "minScore": 0.9
+          }
+        ],
+        "categories:pwa": [
+          "warn",
+          {
+            "minScore": 0.7
+          }
+        ],
+        "uses-responsive-images": [
+          "warn",
+          {
+            "maxLength": 0
           }
         ]
       }

--- a/tools/automation/README.md
+++ b/tools/automation/README.md
@@ -3,7 +3,8 @@
 Questo spazio è riservato agli script che verranno spostati dal pacchetto
 `incoming/lavoro_da_classificare/scripts/`. Gli script dovranno rispettare le
 linee guida esistenti nel repository (licenza SPDX, permessi `+x` quando
-necessario, lint con `ruff`/`eslint`).
+necessario, lint con `ruff`/`eslint`) e condividono la stessa infrastruttura di
+logging esposta da `tools.automation.configure_logging`.
 
 ## Runner dei batch
 
@@ -11,7 +12,7 @@ Il comando `tools/automation/evo_batch_runner.py` permette di pianificare o
 eseguire automaticamente i comandi registrati in
 `incoming/lavoro_da_classificare/tasks.yml`. Lo script usa un logging uniforme
 (`--verbose` per maggiori dettagli) condiviso con gli altri strumenti di
-automazione.
+automazione grazie all'helper `tools.automation.configure_logging`.
 
 ```bash
 # Elencare i batch disponibili

--- a/tools/automation/__init__.py
+++ b/tools/automation/__init__.py
@@ -1,0 +1,38 @@
+"""Shared helpers for Evo automation scripts."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+__all__ = ["configure_logging", "get_logger"]
+
+
+def configure_logging(*, verbose: bool = False, logger: Optional[logging.Logger] = None) -> logging.Logger:
+    """Configure and return a logger suitable for CLI automation tools.
+
+    The function initialises the root logger with a plain message formatter when no
+    handlers are present, mirroring the conventions used across automation
+    scripts. The ``verbose`` flag toggles the log level between ``INFO`` and
+    ``DEBUG``.
+    """
+
+    level = logging.DEBUG if verbose else logging.INFO
+    root_logger = logging.getLogger()
+    if not root_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        root_logger.addHandler(handler)
+    root_logger.setLevel(level)
+
+    if logger is None:
+        return root_logger
+
+    logger.setLevel(level)
+    return logger
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a child logger using the shared namespace for automation tools."""
+
+    return logging.getLogger(name)

--- a/tools/automation/evo_batch_runner.py
+++ b/tools/automation/evo_batch_runner.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
-import logging
 import re
 import subprocess
 import sys
@@ -25,19 +24,10 @@ from typing import Dict, Iterable, List, Optional, Sequence, Set
 
 import yaml
 
+from tools.automation import configure_logging, get_logger
 
-LOGGER = logging.getLogger("tools.automation.evo_batch_runner")
 
-
-def configure_logging(verbose: bool = False) -> None:
-    """Configure a simple, uniform logging style for automation scripts."""
-
-    level = logging.DEBUG if verbose else logging.INFO
-    root_logger = logging.getLogger()
-    if root_logger.handlers:
-        root_logger.setLevel(level)
-        return
-    logging.basicConfig(level=level, format="%(message)s")
+LOGGER = get_logger("tools.automation.evo_batch_runner")
 
 # Status names considered to be completed and therefore eligible to unblock
 # dependent tasks. The tracker currently uses lowercase strings.

--- a/tools/automation/evo_schema_lint.py
+++ b/tools/automation/evo_schema_lint.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import logging
 from pathlib import Path
 from typing import Dict, Iterable, List
 
@@ -13,17 +12,10 @@ from jsonschema import RefResolver
 from jsonschema.exceptions import RefResolutionError, SchemaError
 from jsonschema.validators import validator_for
 
+from tools.automation import configure_logging, get_logger
 
-LOGGER = logging.getLogger("tools.automation.evo_schema_lint")
 
-
-def configure_logging(verbose: bool = False) -> None:
-    level = logging.DEBUG if verbose else logging.INFO
-    root_logger = logging.getLogger()
-    if root_logger.handlers:
-        root_logger.setLevel(level)
-        return
-    logging.basicConfig(level=level, format="%(message)s")
+LOGGER = get_logger("tools.automation.evo_schema_lint")
 
 
 def discover_schema_files(root: Path) -> Iterable[Path]:


### PR DESCRIPTION
## Summary
- add a shared logging helper for Evo automation scripts and update the batch runner/lint utilities
- extend Makefile and documentation around Evo workflows, refreshing the CI gap analysis
- integrate site audit and Lighthouse checks into the main CI workflow with tighter Lighthouse assertions

## Testing
- python -m compileall tools/automation

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69123daa8f80832890115db8b3e68333)