### PR TITLE
docs: expand evo-tactics guidance and archive security placeholder

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,7 +4,7 @@ description: Mappa di navigazione aggiornata della documentazione principale con
 tags:
   - documentazione
   - indice
-updated: 2025-11-12
+updated: 2025-11-13
 ---
 
 # Indice Documentazione
@@ -18,6 +18,7 @@ updated: 2025-11-12
 - [Hub documentale](evo-tactics/README.md) — panoramica aggiornata, strumenti correlati e registro interventi.
 - [Visione & Struttura](evo-tactics/guides/visione-struttura.md) — visione di prodotto, pilastri tattici e workflow di integrazione.
 - [Template PTPF](evo-tactics/guides/template-ptpf.md) — struttura compilabile con checklist per missioni, specie e loop telemetrici.
+- [Security & Ops Playbook](evo-tactics/guides/security-ops.md) — audit CI/locali, rotazioni credenziali e incident response.
 - [Integration Log](evo-tactics/reports/integration-log.md) — cronologia delle attività DOC-01/02/03.
 - [Archivio storico](archive/evo-tactics/README.md) — testo introduttivo pre-normalizzazione conservato per contesto.
 
@@ -25,5 +26,6 @@ updated: 2025-11-12
 - [incoming/docs/obsidian_template.md](../incoming/docs/obsidian_template.md) — vault suggerito per note locali.
 - [incoming/docs/yaml_validator.py](../incoming/docs/yaml_validator.py) — validazione dataset telemetrici.
 - [incoming/docs/bioma_encounters.yaml](../incoming/docs/bioma_encounters.yaml) — base encounter per sincronizzazione VC.
+- [incoming/lavoro_da_classificare/security.yml](../incoming/lavoro_da_classificare/security.yml) — workflow CI per audit Bandit/npm audit/gitleaks.
 
 Aggiorna questa pagina quando vengono aggiunti nuovi materiali o archiviati documenti esistenti, assicurandoti di mantenere coerenti i riferimenti incrociati.

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -4,7 +4,7 @@ description: Registro sintetico dei file storicizzati nella cartella archive.
 tags:
   - archivio
   - documentazione
-updated: 2025-11-12
+updated: 2025-11-13
 ---
 
 # Archivio documentazione
@@ -12,5 +12,6 @@ updated: 2025-11-12
 | File | Origine | Motivo archivio |
 | --- | --- | --- |
 | [`evo-tactics/README.md`](evo-tactics/README.md) | `docs/evo-tactics/README.md` | Testo placeholder sostituito dal nuovo hub documentale durante DOC-01/DOC-03. |
+| [`evo-tactics/security-readme.md`](evo-tactics/security-readme.md) | `docs/security/README.md` | Placeholder spostato dopo la creazione di `guides/security-ops.md` (DOC-03). |
 
 Aggiungi una riga per ogni nuovo file spostato qui, mantenendo traccia della motivazione e della posizione originale.

--- a/docs/archive/evo-tactics/README.md
+++ b/docs/archive/evo-tactics/README.md
@@ -5,7 +5,7 @@ tags:
   - evo-tactics
   - archivio
 archived: true
-updated: 2025-11-12
+updated: 2025-11-13
 ---
 
 # Integrazione Evo-Tactics (storico)

--- a/docs/archive/evo-tactics/security-readme.md
+++ b/docs/archive/evo-tactics/security-readme.md
@@ -1,4 +1,14 @@
-# Sicurezza Evo-Tactics
+---
+title: Placeholder sicurezza Evo-Tactics
+description: Testo storico archiviato dopo l'introduzione del playbook Security & Ops.
+tags:
+  - evo-tactics
+  - archivio
+archived: true
+updated: 2025-11-13
+---
+
+# Sicurezza Evo-Tactics (storico)
 
 Questa cartella conterrà gli aggiornamenti di sicurezza e le procedure di
 incident response collegate all'import Evo-Tactics. I documenti originali sono
@@ -14,3 +24,7 @@ reperibili in `incoming/lavoro_da_classificare/incident_response.md` e
 
 Fino al completamento della migrazione, utilizzare questa directory come punto
 unico di raccolta delle decisioni di sicurezza.
+
+> **Nota archivio 2025-11-13:** il contenuto operativo è stato sostituito da
+> [`docs/evo-tactics/guides/security-ops.md`](../../evo-tactics/guides/security-ops.md)
+> nell'ambito di DOC-03.

--- a/docs/evo-tactics/README.md
+++ b/docs/evo-tactics/README.md
@@ -5,7 +5,7 @@ tags:
   - evo-tactics
   - documentazione
   - integrazione
-updated: 2025-11-12
+updated: 2025-11-13
 ---
 
 # Evo-Tactics — Hub Documentale
@@ -22,6 +22,7 @@ design, telemetria e produzione.
 | --- | --- |
 | [`guides/visione-struttura.md`](guides/visione-struttura.md) | Sintesi della visione di prodotto, dei pilastri tattici e della struttura ad anello che governa missioni, specie e loop di gioco. |
 | [`guides/template-ptpf.md`](guides/template-ptpf.md) | Template operativo PTPF con sezioni compilabili, esempi pratici e checklist di qualità per i deliverable Evo-Tactics. |
+| [`guides/security-ops.md`](guides/security-ops.md) | Playbook Security & Ops con workflow CI, audit locali e rotazione credenziali. |
 | [`reports/integration-log.md`](reports/integration-log.md) | Registro puntuale delle attività di integrazione, incluse le normalizzazioni DOC-01/02/03 e i follow-up previsti. |
 
 ## Processi operativi
@@ -33,6 +34,9 @@ design, telemetria e produzione.
 - **Telemetria**: la base YAML per gli encounter è in
   [`incoming/docs/bioma_encounters.yaml`](../../incoming/docs/bioma_encounters.yaml) ed è coerente con gli output del
   pack Evo-Tactics (`docs/evo-tactics-pack/catalog_data.json`).
+- **Security & Ops**: per audit, rotazioni e incident response fai riferimento a
+  [`guides/security-ops.md`](guides/security-ops.md) e ai report generati in
+  `reports/security/`.
 
 ## Collegamenti rapidi
 
@@ -44,6 +48,10 @@ design, telemetria e produzione.
 
 | Data | Azione | Note |
 | --- | --- | --- |
+| 2025-11-13 | DOC-01 | Aggiornati `guides/template-ptpf.md` e `guides/visione-struttura.md` con esempi reali e sezione Security Alignment. |
+| 2025-11-13 | DOC-01 | Aggiunta la guida `guides/security-ops.md` sostituendo il precedente placeholder generale. |
+| 2025-11-13 | DOC-03 | Spostato `docs/security/README.md` in `docs/archive/evo-tactics/security-readme.md` e aggiornato l'indice archivio. |
+| 2025-11-13 | DOC-02 | Esteso `docs/INDEX.md` con il playbook Security & Ops e i riferimenti aggiornati. |
 | 2025-11-12 | Ristrutturazione contenuti `guides/` | Sostituiti i placeholder con sezioni descrittive, esempi compilabili e riferimenti al pack Evo-Tactics. |
 | 2025-11-12 | Aggiornamento hub documentale | Navigazione rivista, riferimenti incrociati aggiornati e collegamento al nuovo archivio dedicato. |
 | 2025-11-12 | Riordino archivio storico | Spostato il placeholder originale in `../archive/evo-tactics/README.md` mantenendo le note contestuali. |

--- a/docs/evo-tactics/guides/security-ops.md
+++ b/docs/evo-tactics/guides/security-ops.md
@@ -1,0 +1,68 @@
+---
+title: Evo-Tactics · Security & Ops Playbook
+description: Linee guida operative per audit, rotazione credenziali e response collegati al pacchetto Evo-Tactics.
+tags:
+  - evo-tactics
+  - security
+  - operations
+updated: 2025-11-13
+---
+
+# Security & Ops Playbook — Evo-Tactics
+
+Questa guida consolida i controlli di sicurezza e le procedure operative dedicate al
+pacchetto Evo-Tactics. Le indicazioni estendono la visione tattica descritta in
+[`guides/visione-struttura.md`](visione-struttura.md) e sostituiscono il precedente
+placeholder generale.
+
+## 1. Scope & Responsabilità
+
+| Squadra | Ruolo | Artefatti collegati |
+| --- | --- | --- |
+| **Design Ops** | Garantire coerenza dei deliverable. | `docs/evo-tactics/README.md`, `docs/evo-tactics-pack/README.md`. |
+| **Security Engineering** | Esegue auditing e secret scanning. | `incoming/lavoro_da_classificare/security.yml`, `incoming/lavoro_da_classificare/init_security_checks.sh`. |
+| **Support/QA Bridge** | Gestisce rotazione token e validazioni CLI. | `config/cli/support.yaml`, `docs/support/token-rotation.md`. |
+
+## 2. Workflow di validazione
+
+1. **Pipeline CI** — la configurazione GitHub Actions in
+   `incoming/lavoro_da_classificare/security.yml` esegue `bandit`, `npm audit` e
+   `gitleaks` su `main` e `develop`. I report vengono salvati come artefatti.
+2. **Audit locale** — `incoming/lavoro_da_classificare/init_security_checks.sh`
+   produce report HTML/JSON in `reports/security/` replicando la pipeline CI.
+3. **Allineamento telemetry** — eseguire `scripts/api/telemetry_alerts.py` in
+   modalità lint (funzione `validate_alert_context`) sulle nuove missioni per
+   assicurare soglie coerenti con `reports/trait_balance_summary.md`.
+4. **Rotazione credenziali** — seguire la checklist documentata in
+   `docs/support/token-rotation.md`, aggiornando `config/cli/support.yaml` con
+   `last_completed` e `next_window`.
+
+## 3. Controlli applicativi
+
+| Controllo | Obiettivo | Script/Documento |
+| --- | --- | --- |
+| **Static Analysis** | Individuare regressioni Python/Node. | `incoming/lavoro_da_classificare/security.yml`, `reports/trait_balance_summary.md` (per correlare impatti). |
+| **Trait Drift Alerting** | Normalizzare soglie e payload. | `scripts/api/telemetry_alerts.py`, `reports/daily_tracker_summary.json`. |
+| **Vault & Token Ops** | Assicurare rotazione settimanale dei segreti. | `docs/support/token-rotation.md`, `config/cli/support.yaml`. |
+| **Dataset Integrity** | Validare YAML/JSON condivisi. | `incoming/docs/yaml_validator.py`, `reports/pathfinder_trait_gap.csv`. |
+
+## 4. Incident Response
+
+- Aprire ticket con label `SEC-EVO` nel tracker e registrarlo in
+  `reports/qa-changelog.md`.
+- Collegare i log prodotti dagli script (`reports/security/*.json`) agli spazi
+  condivisi, indicando riferimenti commit.
+- Aggiornare il registro [`reports/integration-log.md`](../reports/integration-log.md)
+  con il numero attività (DOC-XX) e le follow-up note.
+
+## 5. Checklist di rilascio
+
+- [ ] Verificare che `incoming/lavoro_da_classificare/security.yml` sia stato
+      rieseguito con esito positivo (Bandit, npm audit, gitleaks).
+- [ ] Aggiornare `reports/daily_tracker_summary.json` con l'esito degli alert
+      drift/adozione.
+- [ ] Documentare il turno di rotazione su `docs/support/token-rotation.md`.
+- [ ] Archiviare eventuali placeholder rimossi in `docs/archive/evo-tactics/` con
+      nota motivazionale.
+
+**[END · Security & Ops Playbook]**

--- a/docs/evo-tactics/guides/template-ptpf.md
+++ b/docs/evo-tactics/guides/template-ptpf.md
@@ -5,17 +5,18 @@ tags:
   - evo-tactics
   - template
   - ptpf
-updated: 2025-11-12
+updated: 2025-11-13
 ---
 
 # Template — Game Design Structure (PTPF)
 
 Questo template fornisce i campi minimi da compilare quando si introdurrà un nuovo
 modulo Evo-Tactics (missione, specie, rituale di telemetria). Ogni sezione include
-esempi, note di completamento e riferimenti diretti agli asset del pack.
+esempi concreti, note di completamento e riferimenti diretti agli asset del pack.
 
 > **Come usarlo**: duplica il file, sostituisci le parti in corsivo e conserva le
-> checklist per assicurare la qualità del deliverable.
+> checklist per assicurare la qualità del deliverable. Gli esempi riportati derivano
+> dagli asset attivi (`docs/evo-tactics-pack/`) e possono essere copiati come base.
 
 ## 1. Vision & Tone
 
@@ -32,74 +33,74 @@ esempi, note di completamento e riferimenti diretti agli asset del pack.
 
 ## 2. Tactical System
 
-| Campo | Descrizione |
-| --- | --- |
-| **Dashboard anchors** | Widget o viste UI da aggiornare (es. `Loadout Slots`, `Encounter Timeline`). |
-| **Outcome attesi** | Risultati misurabili (es. "ridurre drift > 0.20"). |
-| **Vincoli** | Limiti hard (slot PI, rarità, timer). |
-| **Rehydration** | Processo per reiniettare i dati in telemetria o sessioni successive. |
+| Campo | Descrizione | Esempio Evo-Tactics |
+| --- | --- | --- |
+| **Dashboard anchors** | Widget o viste UI da aggiornare. | `Encounter Timeline`, `VC Alert Panel`, `Loadout Slots`. |
+| **Outcome attesi** | Risultati misurabili. | "Ridurre drift medio < 0.16" (ref `reports/trait_balance_summary.md`). |
+| **Vincoli** | Limiti hard (slot PI, rarità, timer). | "Max 2 trait `@VC_ALERT` per missione", timer 12' (coordinato con `docs/mission-console/data/flow/validators/biome.json`). |
+| **Rehydration** | Processo per reiniettare i dati. | Pipeline `incoming/docs/bioma_encounters.yaml` → aggiornamento `packs/evo_tactics_pack/data/species.yaml`. |
 
 **Checklist**
-- [ ] Aggiornare `docs/evo-tactics-pack/ui/` se servono nuovi componenti.
-- [ ] Documentare i vincoli in `mission-console/strategic.md`.
+- [ ] Aggiornare `docs/evo-tactics-pack/ui/elements.ts` con eventuali nuovi componenti o parametri.
+- [ ] Documentare i vincoli in `docs/mission-console/data/flow/validators/biome.json` e sincronizzarli con `docs/process/traits_checklist.md`.
 
 ## 3. Form & Mutation Management
 
-| Campo | Descrizione |
-| --- | --- |
-| **Packet Types** | Gruppi di mutazioni coinvolte (`Mutation Pack A/B/C`). |
-| **Shape Biasing** | Regole per distribuzione delle forme per bioma. |
-| **Visibility** | Come i giocatori percepiscono i limiti (UI, log, tooltip). |
-| **DriftLock** | Condizioni che invalidano la missione se superate. |
+| Campo | Descrizione | Esempio Evo-Tactics |
+| --- | --- | --- |
+| **Packet Types** | Gruppi di mutazioni coinvolte. | `Mutation Pack C` (sinergia Support/Analyst) definito in `packs/evo_tactics_pack/data/species.yaml`. |
+| **Shape Biasing** | Regole per distribuzione delle forme per bioma. | Matrice `biomes/terraforming_bands.yaml` con pesi 0.2/0.35/0.45. |
+| **Visibility** | Come i giocatori percepiscono i limiti. | Dashboard `docs/mission-console/index.html` + diagnostica `docs/mission-console/data/flow/traits/diagnostics.json`. |
+| **DriftLock** | Condizioni che invalidano la missione. | Drift cumulativo > 0.18 → fallback `scripts/drift_check.js`. |
 
 **Checklist**
-- [ ] Inserire i nuovi trait in `packs/evo_tactics_pack/traits/*.json`.
-- [ ] Aggiornare la tabella di compatibilità in `docs/evo-tactics-pack/env-traits.json`.
+- [ ] Inserire i nuovi trait in `packs/evo_tactics_pack/data/species.yaml` e aggiornarne i metadata.
+- [ ] Aggiornare la tabella di compatibilità in `docs/evo-tactics-pack/env-traits.json` e validare con `npm run docs:lint`.
 
 ## 4. Telemetry & VC Tracking
 
-| Campo | Descrizione |
-| --- | --- |
-| **Input** | Fonti dati (log scelte, trend lanci dadi, ecc.). |
-| **Output** | Report o trigger generati. |
-| **Alert Thresholds** | Valori soglia e azioni conseguenti. |
-| **Review Mode** | Strumenti di analisi (`analytics/`, dashboard esterne). |
+| Campo | Descrizione | Esempio Evo-Tactics |
+| --- | --- | --- |
+| **Input** | Fonti dati operative. | Export `reports/trait_progress.md`, dataset `reports/pathfinder_trait_gap.csv`. |
+| **Output** | Report o trigger generati. | Ticket `QA-VC-214` + diff `reports/daily_tracker_summary.json`. |
+| **Alert Thresholds** | Valori soglia e azioni. | Drift > 0.18 → attivare `scripts/api/telemetry_alerts.py`; adozione trait < 55% → aggiornare `reports/trait_balance_summary.md`. |
+| **Review Mode** | Strumenti di analisi. | Dashboard `analytics/dashboards/campaignProgress.vue`, CLI `incoming/docs/yaml_validator.py`. |
 
 **Checklist**
-- [ ] Validare i dataset con `incoming/docs/yaml_validator.py`.
-- [ ] Aggiornare le pipeline VC in `services/telemetry-vc/` se presenti impatti server.
+- [ ] Validare i dataset con `incoming/docs/yaml_validator.py` e registrare l'esito in `docs/playtest/`.
+- [ ] Aggiornare gli script di analisi in `analytics/` e sincronizzare i report in `reports/trait_progress.md`.
 
 ## 5. Encounter & Biome Engine
 
-| Campo | Descrizione |
-| --- | --- |
-| **Generator** | Algoritmo o script usato (`bioma roll`, `mission seeds`). |
-| **Spotlight** | Focus meccanico (mutazioni vs ambiente, puzzle, ecc.). |
-| **Compatibilità MBTI** | Mappatura missione ↔ profili giocatore. |
-| **Load** | Come vengono caricati gli encounter (runtime vs precompilati). |
+| Campo | Descrizione | Esempio Evo-Tactics |
+| --- | --- | --- |
+| **Generator** | Algoritmo o script usato. | `docs/mission-console/data/flow/generation/species.json` (seed `mission-helix-023`). |
+| **Spotlight** | Focus meccanico. | Scontro "Cavitation Rift" che premia mutazioni Aquatic Support. |
+| **Compatibilità MBTI** | Mappatura missione ↔ profili giocatore. | Vanguard → ENTJ, Support → INFJ (ref `docs/evo-tactics-pack/species-index.json`). |
+| **Load** | Come vengono caricati gli encounter. | Precompilati via `docs/mission-console/data/flow/generation/species-preview.json` con fallback runtime. |
 
 **Checklist**
-- [ ] Sincronizzare `incoming/docs/bioma_encounters.yaml` con gli aggiornamenti.
-- [ ] Verificare la difficoltà attraverso almeno due run QA.
+- [ ] Sincronizzare `incoming/docs/bioma_encounters.yaml` con gli aggiornamenti e rigenerare `catalog_data.json`.
+- [ ] Verificare la difficoltà con due run QA registrate in `docs/playtest/SESSION-*/`.
 
 ## 6. Playtest Loop
 
-| Campo | Descrizione |
-| --- | --- |
-| **Iteration Tracker** | Parametri registrati (Loop ID, Stress Level, Mutation Stability). |
-| **Routine** | Sequenza di test automatici/manuali. |
-| **Entry Criteria** | Requisiti per iniziare il playtest. |
-| **Exit Criteria** | Condizioni per chiudere il ciclo. |
+| Campo | Descrizione | Esempio Evo-Tactics |
+| --- | --- | --- |
+| **Iteration Tracker** | Parametri registrati. | Loop `PT-EVO-019`, `stress_level: 0.63`, `mutation_stability: 0.78`. |
+| **Routine** | Sequenza di test automatici/manuali. | `npm run docs:lint`, `scripts/run_playtest_ci.sh`, sessione manuale 30'. |
+| **Entry Criteria** | Requisiti iniziali. | Catalogo sincronizzato (`docs/evo-tactics-pack/catalog_data.json`) e seed `docs/mission-console/data/flow/generation/species.json`. |
+| **Exit Criteria** | Condizioni di chiusura. | Zero blocker, drift < 0.18, esiti QA caricati in `docs/playtest/SESSION-2025-11-12/feedback/README.md`. |
 
 **Checklist**
-- [ ] Registrare gli esiti in `docs/playtest/` seguendo la guida dedicata.
-- [ ] Allegare i log telemetrici pertinenti.
+- [ ] Registrare gli esiti in `docs/playtest/` seguendo la guida dedicata e allegare i log telemetrici pertinenti.
+- [ ] Aggiornare il tracker `docs/qa-checklist.md` con i risultati del ciclo.
 
 ## 7. Linking & Traceability
 
-- **Anchor Map**: elenca le relazioni principali (`@VISION_CORE ↔ @TACTICS_CORE`).
-- **Receipts**: link a commit, issue tracker o report QA.
-- **Altre note**: strumenti usati, esperimenti non adottati, follow-up.
+- **Anchor Map**: elenca le relazioni principali (`@VISION_CORE ↔ @TACTICS_CORE`) citando gli ID missione da `catalog_data.json`.
+- **Receipts**: link a commit, issue tracker o report QA e registra il riferimento in `reports/integration-log.md` con tag `DOC-XX`.
+- **Altre note**: strumenti usati, esperimenti non adottati, follow-up (es. link a `incoming/lavoro_da_classificare/security.yml`).
 
 ## 8. Drift Guards
 
@@ -116,5 +117,6 @@ esempi, note di completamento e riferimenti diretti agli asset del pack.
 - `/hooks/drift_check.js` — pre-commit check per delta drift.
 - `/docs/structure_overview.md` — mappa generale per cross-repo linking.
 - `/docs/evo-tactics-pack/README.md` — riepilogo degli asset sincronizzati.
+- `/incoming/lavoro_da_classificare/init_security_checks.sh` — audit sicurezza per i deploy Evo-Tactics.
 
 **[END TEMPLATE — Evo-Tactics PTPF Seed · v1.1]**

--- a/docs/evo-tactics/guides/visione-struttura.md
+++ b/docs/evo-tactics/guides/visione-struttura.md
@@ -5,7 +5,7 @@ tags:
   - evo-tactics
   - visione
   - struttura
-updated: 2025-11-12
+updated: 2025-11-13
 ---
 
 # Evo-Tactics · Visione & Struttura Concettuale
@@ -43,7 +43,7 @@ PTPF.
 
 | Loop | Input | Output | Note |
 | --- | --- | --- | --- |
-| **Strategic Loop** | Briefing missione + stato ecosistema | Obiettivi dinamici e vincoli PI | Aggiorna la tabella `mission-console/strategic.md`. |
+| **Strategic Loop** | Briefing missione + stato ecosistema | Obiettivi dinamici e vincoli PI | Aggiorna `docs/mission-console/data/flow/validators/biome.json`. |
 | **Mutation Loop** | Trait equipaggiati + log telemetria | Nuove forme/limitazioni | Sincronizzato con `packs/evo_tactics_pack/traits/`. |
 | **Encounter Loop** | Seed bioma + modulatore difficoltà | Sequenza incontri adattiva | Basato su `incoming/docs/bioma_encounters.yaml`. |
 | **Review Loop** | Dati post-missione | Report delta drift + suggerimenti bilanciamento | Alimenta il canale QA e `reports/` del pack. |
@@ -85,5 +85,17 @@ PTPF.
 - `docs/evo-tactics-pack/README.md` — panoramica degli asset distribuiti con il pack.
 - `docs/playtest-log-guidelines.md` — formato unico per i log di playtest.
 - `tools/drift-check/` — utilità per calcolare rapidamente il drift index su file JSON.
+
+## 8. Security & Ops Alignment
+
+| Ambito | Artefatto | Note operative |
+| --- | --- | --- |
+| **Automazione sicurezza** | `incoming/lavoro_da_classificare/security.yml` | Definisce job Bandit, npm audit e gitleaks per le branch `main`/`develop`. |
+| **Script locali** | `incoming/lavoro_da_classificare/init_security_checks.sh` | Esegue bandit, semgrep, npm audit e gitleaks generando report in `reports/security/`. |
+| **Rotazione credenziali** | `config/cli/support.yaml` & `docs/support/token-rotation.md` | Coordina finestra settimanale (lunedì) con notifiche `#support-ops`. |
+| **Alert telemetrici** | `scripts/api/telemetry_alerts.py` | Normalizza i payload `telemetry.alert_context` per il controllo drift/adozione trait. |
+
+- Annotare gli esiti delle rotazioni in `reports/qa-changelog.md` per garantire tracciabilità.
+- In caso di incident response, collegare i ticket Ops al registro `reports/daily_tracker_summary.json` con tag `SEC-EVO`.
 
 **[END: Visione & Struttura · Evo-Tactics]**

--- a/docs/evo-tactics/reports/integration-log.md
+++ b/docs/evo-tactics/reports/integration-log.md
@@ -5,13 +5,17 @@ tags:
   - evo-tactics
   - integrazione
   - log
-updated: 2025-11-12
+updated: 2025-11-13
 ---
 
 # Registro integrazione Evo-Tactics
 
 | Data | Riferimento | Dettaglio |
 | --- | --- | --- |
+| 2025-11-13 | DOC-01 | Aggiornati `guides/template-ptpf.md` e `guides/visione-struttura.md` con esempi concreti e sezione Security Alignment. |
+| 2025-11-13 | DOC-01 | Aggiunta la guida `guides/security-ops.md` per consolidare workflow e checklist Security/Ops. |
+| 2025-11-13 | DOC-02 | Esteso `docs/INDEX.md` con riferimenti al playbook Security & Ops e al nuovo archivio. |
+| 2025-11-13 | DOC-03 | Spostato il placeholder `docs/security/README.md` in `docs/archive/evo-tactics/security-readme.md` aggiornando i link. |
 | 2025-11-12 | DOC-01 | Riscritti `guides/visione-struttura.md` e `guides/template-ptpf.md` con contenuti operativi e checklist. |
 | 2025-11-12 | DOC-02 | Allineato `docs/INDEX.md` al nuovo hub e aggiornati i riferimenti incrociati. |
 | 2025-11-12 | DOC-03 | Spostato il placeholder storico in `docs/archive/evo-tactics/README.md` aggiornando collegamenti e registro. |


### PR DESCRIPTION
## Summary
- replace residual placeholders in the Evo-Tactics guides with concrete examples and add a security alignment section
- introduce a dedicated Security & Ops playbook and link it through the hub and global index
- archive the legacy security placeholder under docs/archive with updated references and tracking entries

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124347929c8328b45f89686dc9532d)