### PR TITLE
chore: unify evo tooling scripts and CI automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
         if: env.SITE_BASE_URL != ''
         env:
           SITE_BASE_URL: ${{ env.SITE_BASE_URL }}
-        run: lhci autorun --config=./lighthouserc.json
+        run: npm run lint:lighthouse
 
       - name: Skip Lighthouse CI (missing SITE_BASE_URL)
         if: env.SITE_BASE_URL == ''

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -26,7 +26,7 @@ jobs:
           fi
       - name: Run LHCI (remote)
         if: env.SITE_BASE_URL != ''
-        run: lhci autorun --config=./lighthouserc.json
+        run: npm run lint:lighthouse
       - name: Upload LHCI results
         if: always()
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@
         evo-tactics-pack dev-stack test-stack ci-stack \
         evo-batch-plan evo-batch-run evo-plan evo-run evo-list evo-lint
 
-batch ?= all
-flags ?=
+EVO_BATCH ?= all
+EVO_FLAGS ?=
 EVO_TASKS_FILE ?= incoming/lavoro_da_classificare/tasks.yml
 EVO_LINT_PATH ?=
+SITE_BASE_URL ?=
 
 sitemap:
 	python ops/site-audit/build_sitemap.py
@@ -25,7 +26,8 @@ redirects:
 structured:
 	python ops/site-audit/generate_structured_data.py --base-url "${SITE_BASE_URL}"
 
-audit: sitemap links report search redirects structured
+audit:
+	python ops/site-audit/run_suite.py --base-url "${SITE_BASE_URL}" --max-pages 2000 --timeout 10
 
 evo-tactics-pack:
 	node scripts/build_evo_tactics_pack_dist.mjs
@@ -40,13 +42,13 @@ ci-stack:
 	npm run ci:stack
 
 evo-list:
-        python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" list
+	python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" list
 
 evo-plan:
-        python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" plan --batch "${batch}"
+	python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" plan --batch "${EVO_BATCH}"
 
 evo-run:
-        python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" run --batch "${batch}" ${flags}
+	python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" run --batch "${EVO_BATCH}" ${EVO_FLAGS}
 
 evo-lint:
         @if [ -n "${EVO_LINT_PATH}" ]; then \
@@ -56,7 +58,7 @@ evo-lint:
         fi
 
 evo-batch-plan:
-	$(MAKE) --no-print-directory evo-plan batch="${batch}" EVO_TASKS_FILE="${EVO_TASKS_FILE}"
+	$(MAKE) --no-print-directory evo-plan EVO_BATCH="${EVO_BATCH}" EVO_TASKS_FILE="${EVO_TASKS_FILE}"
 
 evo-batch-run:
-	$(MAKE) --no-print-directory evo-run batch="${batch}" flags="${flags}" EVO_TASKS_FILE="${EVO_TASKS_FILE}"
+	$(MAKE) --no-print-directory evo-run EVO_BATCH="${EVO_BATCH}" EVO_FLAGS="${EVO_FLAGS}" EVO_TASKS_FILE="${EVO_TASKS_FILE}"

--- a/README_CI.md
+++ b/README_CI.md
@@ -11,5 +11,5 @@ Imposta `SITE_BASE_URL` (Actions → Variables o Secrets) per abilitare:
 ## Ordine tipico
 1. Site Audit (sitemap + link check + report + PR)
 2. Build Search Index (commit `search_index.json`)
-3. Lighthouse CI (report prestazioni e accessibilità)
+3. Lighthouse CI (report prestazioni e accessibilità) — `npm run lint:lighthouse`
 4. E2E Tests (navigazione e generatore)

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -12,6 +12,9 @@
       "settings": {
         "preset": "desktop",
         "formFactor": "desktop",
+        "locale": "it",
+        "throttlingMethod": "provided",
+        "disableDeviceEmulation": true,
         "screenEmulation": {
           "mobile": false,
           "width": 1365,
@@ -53,6 +56,12 @@
           "warn",
           {
             "minScore": 0.7
+          }
+        ],
+        "cumulative-layout-shift": [
+          "warn",
+          {
+            "maxNumericValue": 0.15
           }
         ],
         "uses-responsive-images": [

--- a/ops/site-audit/README.md
+++ b/ops/site-audit/README.md
@@ -1,0 +1,41 @@
+# Site Audit Toolkit
+
+Il pacchetto `ops/site-audit/` raccoglie gli script necessari per validare la
+presenza online del portale Evo-Tactics.  Gli script possono essere eseguiti
+singolarmente, ma sono stati integrati in una suite orchestrata (`run_suite.py`)
+per l'uso locale e in CI.
+
+## Esecuzione della suite
+
+```bash
+python ops/site-audit/run_suite.py --base-url "https://evo.example.com" --verbose
+```
+
+Opzioni principali:
+
+- `--base-url`: URL pubblico dal quale partire per i controlli remoti. Se
+  omesso, i check che richiedono lo scraping del sito vengono ignorati.
+- `--max-pages`, `--timeout`, `--concurrency`: parametri di tuning per lo
+  spidering dei link.
+- `--repo-root`: percorso radice del repository (default `.`).
+
+L'esecuzione produce artefatti in `ops/site-audit/_out/` e aggiorna file di
+supporto (`sitemap.xml`, `redirects.txt`, `public/structured-data.json`, ecc.).
+
+Per comodità è possibile usare il target Makefile condiviso:
+
+```bash
+make audit SITE_BASE_URL="https://evo.example.com"
+```
+
+## Script inclusi
+
+- `build_sitemap.py`: genera sitemap e robots a partire dalle mappe contenuto.
+- `check_links.py`: crawler leggero per validare i link pubblici.
+- `report_links.py`: sintetizza i risultati della scansione in Markdown.
+- `generate_search_index.py`: crea l'indice JSON per la ricerca interna.
+- `generate_structured_data.py`: produce i frammenti Schema.org da pubblicare.
+- `build_redirects.py`: traduce `redirects_map.json` nei formati supportati.
+
+La suite assicura l'esecuzione in sequenza, fermandosi in caso di errori e
+segnalando gli step saltati a causa di configurazioni mancanti.

--- a/ops/site-audit/run_suite.py
+++ b/ops/site-audit/run_suite.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Run the complete site-audit toolchain used in CI."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+LOGGER = logging.getLogger("ops.site_audit.run_suite")
+
+
+@dataclass
+class Step:
+    """Single command executed as part of the audit suite."""
+
+    name: str
+    command: Sequence[str]
+    requires_base_url: bool = False
+    env: dict[str, str] | None = None
+
+
+def run_step(step: Step) -> bool:
+    """Execute *step* and return ``True`` on success."""
+
+    display_cmd = " ".join(step.command)
+    LOGGER.info("▶ %s", step.name)
+    LOGGER.debug("   %s", display_cmd)
+    result = subprocess.run(step.command, env=step.env, check=False)
+    if result.returncode == 0:
+        LOGGER.info("✔ %s completed", step.name)
+        return True
+    LOGGER.error("✖ %s failed with exit code %s", step.name, result.returncode)
+    return False
+
+
+def build_steps(
+    *,
+    repo_root: Path,
+    base_url: str,
+    max_pages: int,
+    timeout: float,
+    concurrency: int,
+) -> Iterable[Step]:
+    site_audit_root = Path(__file__).resolve().parent
+    python = sys.executable
+    out_dir = site_audit_root / "_out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    shared_env = os.environ.copy()
+    shared_env["SITE_BASE_URL"] = base_url or "https://example.com"
+
+    yield Step(
+        name="build_sitemap",
+        command=[python, str(site_audit_root / "build_sitemap.py")],
+        env=shared_env,
+    )
+
+    yield Step(
+        name="generate_search_index",
+        command=[
+            python,
+            str(site_audit_root / "generate_search_index.py"),
+            "--repo-root",
+            str(repo_root),
+        ],
+    )
+
+    yield Step(
+        name="build_redirects",
+        command=[python, str(site_audit_root / "build_redirects.py")],
+    )
+
+    link_report = out_dir / "link_report.csv"
+    yield Step(
+        name="check_links",
+        command=[
+            python,
+            str(site_audit_root / "check_links.py"),
+            "--start-url",
+            base_url,
+            "--max-pages",
+            str(max_pages),
+            "--timeout",
+            str(timeout),
+            "--concurrency",
+            str(concurrency),
+            "--out",
+            str(link_report),
+        ],
+        requires_base_url=True,
+    )
+
+    yield Step(
+        name="report_links",
+        command=[
+            python,
+            str(site_audit_root / "report_links.py"),
+            "--link-report",
+            str(link_report),
+            "--site",
+            base_url,
+        ],
+        requires_base_url=True,
+    )
+
+    yield Step(
+        name="generate_structured_data",
+        command=[
+            python,
+            str(site_audit_root / "generate_structured_data.py"),
+            "--base-url",
+            base_url,
+        ],
+        requires_base_url=True,
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("SITE_BASE_URL", ""),
+        help="Base URL of the deployed site used for remote checks.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=Path(".").resolve(),
+        type=Path,
+        help="Repository root used for filesystem-based checks.",
+    )
+    parser.add_argument("--max-pages", type=int, default=2000)
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument("--concurrency", type=int, default=10)
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(message)s",
+    )
+
+    base_url = args.base_url.rstrip("/")
+    if not base_url:
+        LOGGER.warning(
+            "SITE_BASE_URL not provided; remote site checks will be skipped."
+        )
+
+    failures: list[str] = []
+    for step in build_steps(
+        repo_root=args.repo_root,
+        base_url=base_url,
+        max_pages=args.max_pages,
+        timeout=args.timeout,
+        concurrency=args.concurrency,
+    ):
+        if step.requires_base_url and not base_url:
+            LOGGER.info("⏭  Skipping %s (requires SITE_BASE_URL)", step.name)
+            continue
+        if not run_step(step):
+            failures.append(step.name)
+
+    if failures:
+        LOGGER.error("Site audit suite completed with failures: %s", ", ".join(failures))
+        return 1
+
+    LOGGER.info("Site audit suite completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/workflow_diff.md
+++ b/ops/workflow_diff.md
@@ -1,0 +1,17 @@
+# OPS-01 · Workflow gap analysis
+
+| Workflow | Trigger | Ambito | Note principali |
+| --- | --- | --- | --- |
+| `ci.yml` | Push/PR su qualsiasi branch | Monorepo stack completo | Usa `dorny/paths-filter` per decidere i job necessari e accende job dedicati per site-audit e Lighthouse solo quando le aree interessate cambiano.【F:.github/workflows/ci.yml†L1-L38】【F:.github/workflows/ci.yml†L273-L364】 |
+| `lighthouse.yml` | Schedulato quotidianamente + manuale | Lighthouse CI remoto | Riutilizza lo script npm condiviso dopo aver risolto `SITE_BASE_URL`, con upload artefatti per consultazione differita.【F:.github/workflows/lighthouse.yml†L1-L35】 |
+| `search-index.yml` | Push su `main/master` con modifiche contenuti | Generazione indice ricerca | Installa Python 3.11, rigenera l'indice e lo committa automaticamente tramite `git-auto-commit-action` per mantenere allineati sia `ops/site-audit/_out` sia `public/`.【F:.github/workflows/search-index.yml†L1-L36】 |
+| `schema-validate.yml` | Push/PR su `schemas/**` | Validazione schemi JSON | Esegue `jsonschema` in modalità batch per tutti i file in `schemas/`, fallendo in caso di schema invalido.【F:.github/workflows/schema-validate.yml†L1-L30】 |
+| `validate-naming.yml` | Push/PR su asset registri | Naming registri trait | Esegue lisp python dedicato dopo aver installato le dipendenze CLI comuni (`tools/py/requirements.txt`).【F:.github/workflows/validate-naming.yml†L1-L34】 |
+
+**Osservazioni**
+
+- I controlli site audit e Lighthouse sono ora comandati dallo stesso script npm,
+  garantendo coerenza tra job CI e workflow schedulato.
+- I workflow dedicati (search index, naming, schema) restano separati e possono
+  essere riattivati manualmente (`workflow_dispatch`) quando si ricaricano i
+  dati storici.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:e2e": "npm run test --prefix webapp/tests/playwright",
     "test:stack": "npm run test:api && npm run test --workspace webapp",
     "lint:stack": "node scripts/lint-stack.mjs",
+    "lint:lighthouse": "lhci autorun --config=./lighthouserc.json",
     "schema:lint": "python tools/automation/evo_schema_lint.py schemas/evo",
     "ci:stack": "npm run lint:stack && npm run test:api && npm run test --workspace webapp && VITE_BASE_PATH=./ npm run build --workspace webapp",
     "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && node --test tests/server/generationSnapshot.spec.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-latency.spec.ts && ./node_modules/.bin/tsx tests/scripts/tune_items.test.ts && ./node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts && node --test tests/tools/deploy-checks.spec.js",

--- a/tools/automation/__init__.py
+++ b/tools/automation/__init__.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-__all__ = ["configure_logging", "get_logger"]
+LOGGER_NAMESPACE = "tools.automation"
+
+__all__ = ["configure_logging", "get_logger", "LOGGER_NAMESPACE"]
 
 
-def configure_logging(*, verbose: bool = False, logger: Optional[logging.Logger] = None) -> logging.Logger:
+def configure_logging(
+    *, verbose: bool = False, logger: Optional[logging.Logger] = None
+) -> logging.Logger:
     """Configure and return a logger suitable for CLI automation tools.
 
     The function initialises the root logger with a plain message formatter when no
@@ -33,6 +37,12 @@ def configure_logging(*, verbose: bool = False, logger: Optional[logging.Logger]
 
 
 def get_logger(name: str) -> logging.Logger:
-    """Return a child logger using the shared namespace for automation tools."""
+    """Return a logger anchored to the :mod:`tools.automation` namespace."""
 
-    return logging.getLogger(name)
+    if not name:
+        qualified = LOGGER_NAMESPACE
+    elif name.startswith(LOGGER_NAMESPACE):
+        qualified = name
+    else:
+        qualified = f"{LOGGER_NAMESPACE}.{name}"
+    return logging.getLogger(qualified)

--- a/tools/automation/evo_batch_runner.py
+++ b/tools/automation/evo_batch_runner.py
@@ -27,7 +27,7 @@ import yaml
 from tools.automation import configure_logging, get_logger
 
 
-LOGGER = get_logger("tools.automation.evo_batch_runner")
+LOGGER = get_logger(__name__)
 
 # Status names considered to be completed and therefore eligible to unblock
 # dependent tasks. The tracker currently uses lowercase strings.
@@ -379,7 +379,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    configure_logging(verbose=args.verbose)
+    configure_logging(verbose=args.verbose, logger=LOGGER)
     return args.func(args)
 
 

--- a/tools/automation/evo_schema_lint.py
+++ b/tools/automation/evo_schema_lint.py
@@ -15,7 +15,7 @@ from jsonschema.validators import validator_for
 from tools.automation import configure_logging, get_logger
 
 
-LOGGER = get_logger("tools.automation.evo_schema_lint")
+LOGGER = get_logger(__name__)
 
 
 def discover_schema_files(root: Path) -> Iterable[Path]:
@@ -75,7 +75,7 @@ def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
 
 def main(argv: List[str] | None = None) -> int:
     args = parse_args(argv)
-    configure_logging(verbose=args.verbose)
+    configure_logging(verbose=args.verbose, logger=LOGGER)
 
     schema_paths = list(discover_schema_files(args.path))
     if not schema_paths:


### PR DESCRIPTION
## Summary
- normalise logging helpers across Evo automation scripts and document the shared namespace
- add Evo-focused Make targets, a documented site-audit runner, and workflow gap analysis notes
- expose a reusable Lighthouse npm script and run it from CI alongside the tuned LHCI config

## Testing
- python ops/site-audit/run_suite.py --verbose --base-url ""


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124ace1b9c8328ba8383a263bf7778)