### PR TITLE
feat: extend Evo Playwright coverage and sitemap

### DIFF
--- a/docs/frontend/mockups_evo.md
+++ b/docs/frontend/mockups_evo.md
@@ -7,17 +7,21 @@ interattivi portati online nella riscrittura AngularJS.
 
 ## Asset visivo
 
-Lo screenshot di riferimento rimane archiviato nella cartella condivisa di
-design (`incoming/lavoro_da_classificare/mockup_evo_tactics.png`). Per le
-revisioni incrociate allegare sempre il file dalla sorgente originale o
-incorporare un link a Figma, evitando di duplicare il binario nella repository.
+- **Mockup console** → `incoming/lavoro_da_classificare/mockup_evo_tactics.png`
+  (versione 2025-11, include Mission Console + drawer esteso). Le annotazioni UX
+  principali sono riportate di seguito nella sezione "Elementi chiave UX" per
+  evitare duplicazione di file binari.
+
+Per le revisioni incrociate allegare sempre il file dalla sorgente originale o
+incorporare un link a Figma, evitando di duplicare i binari nella repository.
 
 ## Elementi chiave UX
 
 - **Navigation rail**: il menù primario si comporta come drawer off-canvas
   persistente. Il toggle in alto a sinistra deve aggiornare gli attributi
   `aria-expanded`/`aria-hidden` e attivare l'overlay per bloccare il contenuto
-  retrostante.
+  retrostante. Il bordo attivo del topbar deve seguire la pagina corrente
+  (Mission Control, Generatore, ecc.) come mostrato nel mockup nav.
 - **Mission dashboard**: la hero area mostra la sintesi delle missioni con i
   contatori *In corso*, *Pianificate*, *Rischio* e *Completate*. I valori vengono
   calcolati dal data store e devono mantenere il formato numerico compatto.
@@ -27,15 +31,28 @@ incorporare un link a Figma, evitando di duplicare il binario nella repository.
   colori e icone.
 - **Mission list**: ogni scheda espone codice missione, riepilogo e azioni
   imminenti. L'etichetta di stato applica classi BEM (`mission-card__status--*`)
-  per garantire leggibilità cromatica anche in modalità high-contrast.
+  per garantire leggibilità cromatica anche in modalità high-contrast. Le azioni
+  prioritarie del pannello Mission Control riutilizzano la stessa struttura di
+  carta con micro-copy operativo dedicato.
 - **Event log**: le entry cronologiche devono evidenziare categoria e impatto.
   Il badge `event-log__impact` supporta tre livelli (high, medium, low) da mappare
-  su palette accessibile WCAG AA.
+  su palette accessibile WCAG AA. Ogni entry conserva timestamp ISO formattato
+  lato client per l'adattamento locale.
+
+- **Ecosystem Pack**: lista i bundle modulari con titoli sintetici e descrizione
+  one-liner. Il mockup indica tre card statiche per il rilascio iniziale (Strategico,
+  Biomi, Supporto AI) con icone dedicate opzionali.
+
+- **Toolkit Generatore**: tre entry primarie (Builder sequenziale, Profiler missione,
+  Calcolo risorse) con descrizione condivisa; il mockup dettaglia il posizionamento
+  nella prima piega della pagina e la gerarchia dei titoli.
 
 ## Note di implementazione
 
-- I test Playwright in `webapp/tests/playwright/evo/` coprono interazione del drawer
-  e la presenza dei contenuti principali (metriche, missioni, quick toolkit).
+- I test Playwright in `webapp/tests/playwright/evo/` coprono interazione del drawer,
+  la propagazione dello stato attivo tra le destinazioni topbar e la presenza dei
+  contenuti principali (metriche, missioni, quick toolkit, azioni Mission Control,
+  pacchetti Ecosystem).
 - La sitemap `public/sitemap.xml` elenca tutte le rotte Evo (`/console/*`),
   incluse le nuove sezioni Mission Control ed Ecosystem Pack, per allineare la
   pubblicazione statica con gli asset documentati.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,42 +2,50 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://console.evo-tactics.example/console/</loc>
-    <lastmod>2025-11-05</lastmod>
+    <lastmod>2025-11-08</lastmod>
     <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://console.evo-tactics.example/console/mission-console</loc>
-    <lastmod>2025-11-05</lastmod>
+    <lastmod>2025-11-08</lastmod>
     <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://console.evo-tactics.example/console/mission-control</loc>
-    <lastmod>2025-11-05</lastmod>
+    <lastmod>2025-11-08</lastmod>
     <changefreq>weekly</changefreq>
-  </url>
-  <url>
-    <loc>https://console.evo-tactics.example/console/atlas</loc>
-    <lastmod>2025-11-05</lastmod>
-    <changefreq>weekly</changefreq>
-  </url>
-  <url>
-    <loc>https://console.evo-tactics.example/console/traits</loc>
-    <lastmod>2025-11-05</lastmod>
-    <changefreq>weekly</changefreq>
-  </url>
-  <url>
-    <loc>https://console.evo-tactics.example/console/nebula</loc>
-    <lastmod>2025-11-05</lastmod>
-    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://console.evo-tactics.example/console/generator</loc>
-    <lastmod>2025-11-05</lastmod>
+    <lastmod>2025-11-08</lastmod>
     <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://console.evo-tactics.example/console/ecosystem-pack</loc>
-    <lastmod>2025-11-05</lastmod>
+    <lastmod>2025-11-08</lastmod>
     <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://console.evo-tactics.example/console/atlas</loc>
+    <lastmod>2025-11-08</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://console.evo-tactics.example/console/traits</loc>
+    <lastmod>2025-11-08</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://console.evo-tactics.example/console/nebula</loc>
+    <lastmod>2025-11-08</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/webapp/tests/playwright/evo/dashboard.spec.ts
+++ b/webapp/tests/playwright/evo/dashboard.spec.ts
@@ -1,8 +1,10 @@
 import { expect, test } from '@playwright/test';
 
+import { pathFor } from './utils';
+
 test.describe('Mission dashboard', () => {
   test('renders mission summary, metrics, and event log entries', async ({ page }) => {
-    await page.goto('/');
+    await page.goto(pathFor('/'));
 
     await expect(page.getByRole('heading', { name: 'Mission Console' })).toBeVisible();
 

--- a/webapp/tests/playwright/evo/ecosystem-pack.spec.ts
+++ b/webapp/tests/playwright/evo/ecosystem-pack.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+
+import { pathFor } from './utils';
+
+test.describe('Ecosystem Pack console', () => {
+  test('lists modular packages with summaries', async ({ page }) => {
+    await page.goto(pathFor('/ecosystem-pack'));
+
+    await expect(page.getByRole('heading', { level: 1, name: 'Ecosystem Pack' })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 2, name: 'Pacchetti disponibili' })).toBeVisible();
+
+    const packages = [
+      'Pack Strategico',
+      'Pack Biomi',
+      'Pack Supporto AI',
+    ];
+
+    for (const label of packages) {
+      await expect(page.getByRole('listitem').filter({ hasText: label })).toBeVisible();
+    }
+  });
+});

--- a/webapp/tests/playwright/evo/generator.spec.ts
+++ b/webapp/tests/playwright/evo/generator.spec.ts
@@ -1,8 +1,10 @@
 import { expect, test } from '@playwright/test';
 
+import { pathFor } from './utils';
+
 test.describe('Mission generator', () => {
   test('exposes quick toolkit entries for Evo operators', async ({ page }) => {
-    await page.goto('/generator');
+    await page.goto(pathFor('/generator'));
 
     await expect(page.getByRole('heading', { name: 'Generatore Operativo' })).toBeVisible();
 

--- a/webapp/tests/playwright/evo/mission-control.spec.ts
+++ b/webapp/tests/playwright/evo/mission-control.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+
+import { pathFor } from './utils';
+
+test.describe('Mission Control console', () => {
+  test('surfaces priority actions for operations', async ({ page }) => {
+    await page.goto(pathFor('/mission-control'));
+
+    await expect(page.getByRole('heading', { level: 1, name: 'Mission Control' })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 2, name: 'Azioni prioritarie' })).toBeVisible();
+
+    const actions = [
+      'Allineamento squadre',
+      'Allocazione vettori',
+      'Protocollo emergenze',
+    ];
+
+    for (const label of actions) {
+      await expect(page.getByRole('listitem').filter({ hasText: label })).toBeVisible();
+    }
+  });
+});

--- a/webapp/tests/playwright/evo/navigation.spec.ts
+++ b/webapp/tests/playwright/evo/navigation.spec.ts
@@ -1,8 +1,10 @@
 import { expect, test } from '@playwright/test';
 
+import { pathFor } from './utils';
+
 test.describe('Evo-Tactics navigation', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/');
+    await page.goto(pathFor('/'));
   });
 
   test('off-canvas menu toggles and highlights the active route', async ({ page }) => {
@@ -12,11 +14,13 @@ test.describe('Evo-Tactics navigation', () => {
 
     await expect(navigation).not.toHaveClass(/navigation--open/);
     await expect(overlay).not.toHaveClass(/app-shell__overlay--visible/);
+    await expect(menuToggle).toHaveAttribute('aria-expanded', 'false');
 
     await menuToggle.click();
 
     await expect(navigation).toHaveClass(/navigation--open/);
     await expect(overlay).toHaveClass(/app-shell__overlay--visible/);
+    await expect(menuToggle).toHaveAttribute('aria-expanded', 'true');
 
     const missionConsoleLink = navigation.getByRole('menuitem', { name: 'Mission Console' });
     await expect(missionConsoleLink).toBeVisible();
@@ -25,6 +29,7 @@ test.describe('Evo-Tactics navigation', () => {
 
     await expect(page).toHaveURL(/\/mission-console$/);
     await expect(navigation).not.toHaveClass(/navigation--open/);
+    await expect(menuToggle).toHaveAttribute('aria-expanded', 'false');
 
     const activeTopbar = navigation.locator('.navigation__topbar-item--active .navigation__topbar-text');
     await expect(activeTopbar).toHaveText('Mission Console');
@@ -47,5 +52,19 @@ test.describe('Evo-Tactics navigation', () => {
     for (const label of expectedLabels) {
       await expect(page.getByRole('button', { name: label }).first()).toBeVisible();
     }
+  });
+
+  test('top navigation updates the active section across pages', async ({ page }) => {
+    await page.getByRole('button', { name: 'Apri il menù Evo-Tactics Console' }).click();
+    await page.getByRole('button', { name: 'Mission Control' }).click();
+
+    await expect(page).toHaveURL(/\/mission-control$/);
+    await page.getByRole('button', { name: 'Apri il menù Evo-Tactics Console' }).click();
+    await expect(page.locator('.navigation__topbar-item--active .navigation__topbar-text')).toHaveText('Mission Control');
+
+    await page.getByRole('button', { name: 'Generatore' }).click();
+    await expect(page).toHaveURL(/\/generator$/);
+    await page.getByRole('button', { name: 'Apri il menù Evo-Tactics Console' }).click();
+    await expect(page.locator('.navigation__topbar-item--active .navigation__topbar-text')).toHaveText('Generatore');
   });
 });

--- a/webapp/tests/playwright/evo/utils.ts
+++ b/webapp/tests/playwright/evo/utils.ts
@@ -1,0 +1,10 @@
+const rawBasePath = process.env.CONSOLE_BASE_PATH ?? '';
+const trimmedBase = rawBasePath === '/' ? '' : rawBasePath.replace(/\/$/, '');
+
+export const pathFor = (route: string = '/'): string => {
+  const normalisedRoute = !route || route === '/' ? '/' : route.startsWith('/') ? route : `/${route}`;
+  if (normalisedRoute === '/') {
+    return trimmedBase ? `${trimmedBase}/` : '/';
+  }
+  return `${trimmedBase}${normalisedRoute}` || normalisedRoute;
+};


### PR DESCRIPTION
## Summary
- add a base path helper for the Evo Playwright suite and extend coverage to navigation, Mission Control, and Ecosystem Pack flows
- refresh the Evo sitemap with updated metadata for the new console routes
- expand the Evo mockup notes with the latest UX guidance and covered surfaces

## Testing
- python tools/sitemap_link_checker.py public/sitemap.xml *(fails: script not present in repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124d64ea0083288ce4d495e9897c59)