### PR TITLE
Stabilize Evo-Tactics docs and archive integration log

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,7 +4,7 @@ description: Mappa di navigazione aggiornata della documentazione principale con
 tags:
   - documentazione
   - indice
-updated: 2025-11-13
+updated: 2025-11-14
 ---
 
 # Indice Documentazione
@@ -15,11 +15,11 @@ updated: 2025-11-13
 - [archive/](archive/) — materiale storico e placeholder archiviati, incluso l'ex hub Evo-Tactics.
 
 ## Evo-Tactics
-- [Hub documentale](evo-tactics/README.md) — panoramica aggiornata, strumenti correlati e registro interventi.
+- [Hub documentale](evo-tactics/README.md) — panoramica aggiornata, strumenti correlati e accesso rapido all'archivio log.
 - [Visione & Struttura](evo-tactics/guides/visione-struttura.md) — visione di prodotto, pilastri tattici e workflow di integrazione.
 - [Template PTPF](evo-tactics/guides/template-ptpf.md) — struttura compilabile con checklist per missioni, specie e loop telemetrici.
 - [Security & Ops Playbook](evo-tactics/guides/security-ops.md) — audit CI/locali, rotazioni credenziali e incident response.
-- [Integration Log](evo-tactics/reports/integration-log.md) — cronologia delle attività DOC-01/02/03.
+- [Integration Log (archivio)](archive/evo-tactics/integration-log.md) — cronologia DOC-01/DOC-02/DOC-03 conservata per riferimento storico.
 - [Archivio storico](archive/evo-tactics/README.md) — testo introduttivo pre-normalizzazione conservato per contesto.
 
 ## Strumenti incoming

--- a/docs/archive/evo-tactics/README.md
+++ b/docs/archive/evo-tactics/README.md
@@ -5,7 +5,7 @@ tags:
   - evo-tactics
   - archivio
 archived: true
-updated: 2025-11-13
+updated: 2025-11-14
 ---
 
 # Integrazione Evo-Tactics (storico)
@@ -21,6 +21,7 @@ integrazione dei pacchetti provenienti da `incoming/lavoro_da_classificare/`.
 - `reports/` — riepiloghi sintetici e log di revisione.
 - `security/` — documenti di sicurezza collegati al pacchetto.
 - `changelog/` — note di avanzamento per l'integrazione.
+- `integration-log.md` — registro DOC-01/02/03 consolidato nell'archivio.
 
 Le sottocartelle sarebbero state create durante i batch `documentation` e `ops_ci`.
 

--- a/docs/archive/evo-tactics/integration-log.md
+++ b/docs/archive/evo-tactics/integration-log.md
@@ -1,14 +1,17 @@
 ---
-title: Evo-Tactics · Integration Log
-description: Registro degli interventi effettuati durante la normalizzazione dei documenti Evo-Tactics.
+title: Evo-Tactics · Integration Log (archivio)
+description: Registro archiviato degli interventi effettuati durante la normalizzazione dei documenti Evo-Tactics.
 tags:
   - evo-tactics
   - integrazione
   - log
-updated: 2025-11-13
+archived: true
+updated: 2025-11-14
 ---
 
 # Registro integrazione Evo-Tactics
+
+> **Nota archivio:** questo registro è stato spostato in `docs/archive/evo-tactics/` per evitare duplicazione con l'hub attivo. Utilizzare questa pagina come fonte canonica delle attività DOC-01/DOC-02/DOC-03.
 
 | Data | Riferimento | Dettaglio |
 | --- | --- | --- |

--- a/docs/evo-tactics/README.md
+++ b/docs/evo-tactics/README.md
@@ -5,7 +5,7 @@ tags:
   - evo-tactics
   - documentazione
   - integrazione
-updated: 2025-11-13
+updated: 2025-11-14
 ---
 
 # Evo-Tactics — Hub Documentale
@@ -23,7 +23,6 @@ design, telemetria e produzione.
 | [`guides/visione-struttura.md`](guides/visione-struttura.md) | Sintesi della visione di prodotto, dei pilastri tattici e della struttura ad anello che governa missioni, specie e loop di gioco. |
 | [`guides/template-ptpf.md`](guides/template-ptpf.md) | Template operativo PTPF con sezioni compilabili, esempi pratici e checklist di qualità per i deliverable Evo-Tactics. |
 | [`guides/security-ops.md`](guides/security-ops.md) | Playbook Security & Ops con workflow CI, audit locali e rotazione credenziali. |
-| [`reports/integration-log.md`](reports/integration-log.md) | Registro puntuale delle attività di integrazione, incluse le normalizzazioni DOC-01/02/03 e i follow-up previsti. |
 
 ## Processi operativi
 
@@ -42,21 +41,9 @@ design, telemetria e produzione.
 
 - Indice generale della documentazione: [`docs/INDEX.md`](../INDEX.md).
 - Archivio dei materiali preliminari: [`docs/archive/evo-tactics/`](../archive/evo-tactics/).
+- Registro integrazione (archivio): [`docs/archive/evo-tactics/integration-log.md`](../archive/evo-tactics/integration-log.md).
 - Piano di integrazione meccaniche: [`incoming/README_INTEGRAZIONE_MECCANICHE.md`](../../incoming/README_INTEGRAZIONE_MECCANICHE.md).
 
 ## Registro interventi
 
-| Data | Azione | Note |
-| --- | --- | --- |
-| 2025-11-13 | DOC-01 | Aggiornati `guides/template-ptpf.md` e `guides/visione-struttura.md` con esempi reali e sezione Security Alignment. |
-| 2025-11-13 | DOC-01 | Aggiunta la guida `guides/security-ops.md` sostituendo il precedente placeholder generale. |
-| 2025-11-13 | DOC-03 | Spostato `docs/security/README.md` in `docs/archive/evo-tactics/security-readme.md` e aggiornato l'indice archivio. |
-| 2025-11-13 | DOC-02 | Esteso `docs/INDEX.md` con il playbook Security & Ops e i riferimenti aggiornati. |
-| 2025-11-12 | Ristrutturazione contenuti `guides/` | Sostituiti i placeholder con sezioni descrittive, esempi compilabili e riferimenti al pack Evo-Tactics. |
-| 2025-11-12 | Aggiornamento hub documentale | Navigazione rivista, riferimenti incrociati aggiornati e collegamento al nuovo archivio dedicato. |
-| 2025-11-12 | Riordino archivio storico | Spostato il placeholder originale in `../archive/evo-tactics/README.md` mantenendo le note contestuali. |
-| 2025-11-10 | Normalizzazione contenuti `guides/` | Conversione markdown dei template PTPF e della visione strutturale. |
-| 2025-11-10 | Aggiornamento hub documentale | Sostituzione del placeholder iniziale con struttura navigabile e metadata. |
-| 2025-11-10 | Archiviazione placeholder storico | Spostato il testo originale in `../archive/evo-tactics/README.md`. |
-
-Annota qui ogni modifica futura, includendo numero attività e follow-up necessario.
+Il registro dettagliato delle attività è stato consolidato nell'archivio storico: consulta [`docs/archive/evo-tactics/integration-log.md`](../archive/evo-tactics/integration-log.md) per lo storico completo DOC-01/DOC-02/DOC-03. L'ultima voce registrata (2025-11-13 · DOC-02) documenta l'estensione di `docs/INDEX.md` con il playbook Security & Ops.

--- a/docs/evo-tactics/guides/security-ops.md
+++ b/docs/evo-tactics/guides/security-ops.md
@@ -52,7 +52,7 @@ placeholder generale.
   `reports/qa-changelog.md`.
 - Collegare i log prodotti dagli script (`reports/security/*.json`) agli spazi
   condivisi, indicando riferimenti commit.
-- Aggiornare il registro [`reports/integration-log.md`](../reports/integration-log.md)
+- Aggiornare il registro [`docs/archive/evo-tactics/integration-log.md`](../../archive/evo-tactics/integration-log.md)
   con il numero attività (DOC-XX) e le follow-up note.
 
 ## 5. Checklist di rilascio

--- a/docs/evo-tactics/guides/template-ptpf.md
+++ b/docs/evo-tactics/guides/template-ptpf.md
@@ -99,7 +99,7 @@ esempi concreti, note di completamento e riferimenti diretti agli asset del pack
 ## 7. Linking & Traceability
 
 - **Anchor Map**: elenca le relazioni principali (`@VISION_CORE ↔ @TACTICS_CORE`) citando gli ID missione da `catalog_data.json`.
-- **Receipts**: link a commit, issue tracker o report QA e registra il riferimento in `reports/integration-log.md` con tag `DOC-XX`.
+- **Receipts**: link a commit, issue tracker o report QA e registra il riferimento in `docs/archive/evo-tactics/integration-log.md` con tag `DOC-XX`.
 - **Altre note**: strumenti usati, esperimenti non adottati, follow-up (es. link a `incoming/lavoro_da_classificare/security.yml`).
 
 ## 8. Drift Guards

--- a/docs/evo-tactics/guides/visione-struttura.md
+++ b/docs/evo-tactics/guides/visione-struttura.md
@@ -60,7 +60,7 @@ PTPF.
 ## 5. Playtest & Metriche
 
 - **Playtest Loop**
-  - Identificatore: `PT-EVO-<numero>` con link a `docs/playtest/`.
+  - Identificatore: `PT-EVO-021` con link a [`docs/playtest/SESSION-2025-11-12.md`](../../playtest/SESSION-2025-11-12.md).
   - Parametri da tracciare: `stress_level`, `mutation_stability`, `encounter_delta`.
   - Checklist: replicare almeno due missioni per livello di difficoltà, verificare
     la presenza di tutorial inline per nuove specie.


### PR DESCRIPTION
## Summary
- replace the remaining playtest placeholder in the Evo-Tactics vision guide with the concrete PT-EVO-021 reference
- streamline the Evo-Tactics hub and main index to point at the archived integration log
- move the integration log into the Evo-Tactics archive and update related guides to reference the new canonical location

## Testing
- Not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691250ba912c8328a49c5eef8c4019d8)