### PR TITLE
Aggiorna documentazione audit duplicati trait

### DIFF
--- a/reports/traits/audit_duplicates_TRT-01.md
+++ b/reports/traits/audit_duplicates_TRT-01.md
@@ -1,0 +1,8 @@
+# Audit duplicati trait (`TRT-01`)
+
+- **Comando**: `python traits/scripts/audit_duplicates.py`
+- **Data esecuzione**: 2025-11-10T21:02:42Z (UTC)
+- **Output CLI**: `Nessun duplicato individuato.`
+- **Report CSV**: `reports/traits/duplicates.csv` (solo intestazione, nessuna riga di conflitto).
+
+Non sono stati individuati gruppi di etichette duplicate nel dataset di riferimento.

--- a/reports/traits/merge_analysis.md
+++ b/reports/traits/merge_analysis.md
@@ -5,8 +5,9 @@
 - **Fonte primaria**: `incoming/lavoro_da_classificare/traits/traits_aggregate.json`
   (50 trait con codici `TR-11xx` → `TR-20xx`).
 - **Audit duplicati**: `python traits/scripts/audit_duplicates.py`
-  (esecuzione 2025-11-10T20:48:25Z UTC) → nessun duplicato rilevato, report
-  vuoto in `reports/traits/duplicates.csv` (output CLI: "Nessun duplicato individuato.").
+  (esecuzione 2025-11-10T21:02:42Z UTC) → nessun duplicato rilevato, report
+  vuoto in `reports/traits/duplicates.csv` e log `reports/traits/audit_duplicates_TRT-01.md`
+  (output CLI: "Nessun duplicato individuato.").
 - **Documentazione di supporto**: inventario normalizzato in
   [`traits/glossary.md`](../../traits/glossary.md).
 

--- a/traits/glossary.md
+++ b/traits/glossary.md
@@ -10,11 +10,12 @@ l'integrazione nel glossario canonico.
 ## Sintesi audit duplicati (TRT-01)
 
 - **Comando eseguito**: `python traits/scripts/audit_duplicates.py`
-- **Data ultima esecuzione**: 2025-11-10T20:48:25Z (UTC)
+- **Data ultima esecuzione**: 2025-11-10T21:02:42Z (UTC)
 - **Esito**: nessun gruppo di etichette duplicate individuato.
 - **Messaggio CLI**: `Nessun duplicato individuato.`
 - **Output strutturato**: `reports/traits/duplicates.csv` (solo intestazione,
-  nessuna riga di conflitto).
+  nessuna riga di conflitto) e log sintetico in
+  `reports/traits/audit_duplicates_TRT-01.md`.
 
 ## Copertura del dataset
 


### PR DESCRIPTION
## Descrizione
- Registra l'esecuzione di `TRT-01` in un nuovo log sintetico con timestamp e output della CLI.
- Allinea il glossario dei trait alle ultime evidenze dell'audit duplicati.
- Aggiorna il report di merge (`TRT-03`) con i riferimenti al log dell'audit più recente.

## Checklist guida stile & QA
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato
- [x] Documentazione/processi aggiornati ove necessario

## Testing
- [x] Altro: `python traits/scripts/audit_duplicates.py`

## Note
- Output completo disponibile in `reports/traits/audit_duplicates_TRT-01.md`.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691252d2017c8328a1135e9c5c986945)