### PR TITLE
Align Evo automation workflows and site audits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,98 +270,6 @@ jobs:
           VITE_BASE_PATH: ./
         run: npm run build --workspace webapp
 
-  site-audit:
-    runs-on: ubuntu-latest
-    needs: paths-filter
-    if: needs.paths-filter.outputs.site_audit == 'true'
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install site audit dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --requirement ops/site-audit/requirements.txt
-
-      - name: Resolve SITE_BASE_URL
-        run: |
-          if [ -n "${{ vars.SITE_BASE_URL }}" ]; then
-            echo "SITE_BASE_URL=${{ vars.SITE_BASE_URL }}" >> $GITHUB_ENV
-          elif [ -n "${{ secrets.SITE_BASE_URL }}" ]; then
-            echo "SITE_BASE_URL=${{ secrets.SITE_BASE_URL }}" >> $GITHUB_ENV
-          else
-            echo "SITE_BASE_URL=" >> $GITHUB_ENV
-          fi
-
-      - name: Run site audit suite
-        if: env.SITE_BASE_URL != ''
-        env:
-          SITE_BASE_URL: ${{ env.SITE_BASE_URL }}
-        run: make audit
-
-      - name: Skip site audit (missing SITE_BASE_URL)
-        if: env.SITE_BASE_URL == ''
-        run: echo "SITE_BASE_URL not configured; skipping site audit checks."
-
-      - name: Upload site audit artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: site-audit
-          path: ops/site-audit/_out
-          if-no-files-found: warn
-
-  lighthouse-ci:
-    runs-on: ubuntu-latest
-    needs: paths-filter
-    if: needs.paths-filter.outputs.stack == 'true'
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install Lighthouse CI
-        run: npm i -g @lhci/cli@0.13.x
-
-      - name: Resolve SITE_BASE_URL
-        run: |
-          if [ -n "${{ vars.SITE_BASE_URL }}" ]; then
-            echo "SITE_BASE_URL=${{ vars.SITE_BASE_URL }}" >> $GITHUB_ENV
-          elif [ -n "${{ secrets.SITE_BASE_URL }}" ]; then
-            echo "SITE_BASE_URL=${{ secrets.SITE_BASE_URL }}" >> $GITHUB_ENV
-          else
-            echo "SITE_BASE_URL=" >> $GITHUB_ENV
-          fi
-
-      - name: Run Lighthouse CI
-        if: env.SITE_BASE_URL != ''
-        env:
-          SITE_BASE_URL: ${{ env.SITE_BASE_URL }}
-        run: npm run lint:lighthouse
-
-      - name: Skip Lighthouse CI (missing SITE_BASE_URL)
-        if: env.SITE_BASE_URL == ''
-        run: echo "SITE_BASE_URL not configured; skipping Lighthouse CI run."
-
-      - name: Upload Lighthouse results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: lighthouse-results
-          path: ./.lighthouseci
-          if-no-files-found: warn
-
   cli-checks:
     runs-on: ubuntu-latest
     needs:
@@ -570,15 +478,33 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Resolve SITE_BASE_URL
+      - name: Resolve site audit options
         run: |
           if [ -n "${{ vars.SITE_BASE_URL }}" ]; then
-            echo "SITE_BASE_URL=${{ vars.SITE_BASE_URL }}" >> $GITHUB_ENV
+            echo "SITE_BASE_URL=${{ vars.SITE_BASE_URL }}" >> "$GITHUB_ENV"
           elif [ -n "${{ secrets.SITE_BASE_URL }}" ]; then
-            echo "SITE_BASE_URL=${{ secrets.SITE_BASE_URL }}" >> $GITHUB_ENV
+            echo "SITE_BASE_URL=${{ secrets.SITE_BASE_URL }}" >> "$GITHUB_ENV"
           else
-            echo "SITE_BASE_URL=" >> $GITHUB_ENV
+            echo "SITE_BASE_URL=" >> "$GITHUB_ENV"
           fi
+
+          max_pages="${{ vars.SITE_AUDIT_MAX_PAGES }}"
+          if [ -z "$max_pages" ]; then
+            max_pages=2000
+          fi
+          echo "SITE_AUDIT_MAX_PAGES=$max_pages" >> "$GITHUB_ENV"
+
+          timeout="${{ vars.SITE_AUDIT_TIMEOUT }}"
+          if [ -z "$timeout" ]; then
+            timeout=10
+          fi
+          echo "SITE_AUDIT_TIMEOUT=$timeout" >> "$GITHUB_ENV"
+
+          concurrency="${{ vars.SITE_AUDIT_CONCURRENCY }}"
+          if [ -z "$concurrency" ]; then
+            concurrency=10
+          fi
+          echo "SITE_AUDIT_CONCURRENCY=$concurrency" >> "$GITHUB_ENV"
 
       - name: Install site audit dependencies
         run: |
@@ -587,12 +513,12 @@ jobs:
 
       - name: Run site audit checks
         run: |
-          if [ -z "$SITE_BASE_URL" ]; then
-            echo "SITE_BASE_URL not configured; skipping site audit." >&2
-            exit 0
-          fi
-          mkdir -p ops/site-audit/_out
-          make audit SITE_BASE_URL="$SITE_BASE_URL"
+          python ops/site-audit/run_suite.py \
+            --repo-root "${GITHUB_WORKSPACE}" \
+            --base-url "$SITE_BASE_URL" \
+            --max-pages "$SITE_AUDIT_MAX_PAGES" \
+            --timeout "$SITE_AUDIT_TIMEOUT" \
+            --concurrency "$SITE_AUDIT_CONCURRENCY"
 
       - name: Upload site audit artifacts
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,23 @@
 .PHONY: sitemap links report search redirects structured audit \
-        evo-tactics-pack dev-stack test-stack ci-stack \
-        evo-batch-plan evo-batch-run evo-plan evo-run evo-list evo-lint
+	evo-tactics-pack dev-stack test-stack ci-stack \
+	evo-batch-plan evo-batch-run evo-plan evo-run evo-list evo-lint \
+	evo-help
+
+PYTHON ?= python3
+EVO_AUTOMATION := $(PYTHON) -m tools.automation.evo_batch_runner
+EVO_SCHEMA_LINT := $(PYTHON) -m tools.automation.evo_schema_lint
+SITE_AUDIT_CMD := $(PYTHON) ops/site-audit/run_suite.py
 
 EVO_BATCH ?= all
 EVO_FLAGS ?=
 EVO_TASKS_FILE ?= incoming/lavoro_da_classificare/tasks.yml
 EVO_LINT_PATH ?=
 SITE_BASE_URL ?=
+SITE_AUDIT_MAX_PAGES ?= 2000
+SITE_AUDIT_TIMEOUT ?= 10
+SITE_AUDIT_CONCURRENCY ?= 10
+EVO_VERBOSE ?=
+EVO_VERBOSE_FLAG := $(strip $(if $(filter 1 true yes on,$(EVO_VERBOSE)),--verbose,))
 
 sitemap:
 	python ops/site-audit/build_sitemap.py
@@ -27,7 +38,12 @@ structured:
 	python ops/site-audit/generate_structured_data.py --base-url "${SITE_BASE_URL}"
 
 audit:
-	python ops/site-audit/run_suite.py --base-url "${SITE_BASE_URL}" --max-pages 2000 --timeout 10
+	$(SITE_AUDIT_CMD) \
+		--repo-root "$(CURDIR)" \
+		--base-url "${SITE_BASE_URL}" \
+		--max-pages "${SITE_AUDIT_MAX_PAGES}" \
+		--timeout "${SITE_AUDIT_TIMEOUT}" \
+		--concurrency "${SITE_AUDIT_CONCURRENCY}"
 
 evo-tactics-pack:
 	node scripts/build_evo_tactics_pack_dist.mjs
@@ -41,24 +57,35 @@ test-stack:
 ci-stack:
 	npm run ci:stack
 
+evo-help:
+	@echo "Evo automation targets available:" && \
+	echo "  make evo-list            # elenca i batch registrati" && \
+	echo "  make evo-plan            # pianifica il batch indicato" && \
+	echo "  make evo-run             # esegue il batch indicato" && \
+	echo "  make evo-lint            # valida gli schemi JSON" && \
+	echo "Variabili supportate: EVO_BATCH, EVO_FLAGS, EVO_TASKS_FILE, EVO_LINT_PATH, EVO_VERBOSE"
+
 evo-list:
-	python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" list
+	$(EVO_AUTOMATION) --tasks-file "${EVO_TASKS_FILE}" ${EVO_VERBOSE_FLAG} list
 
 evo-plan:
-	python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" plan --batch "${EVO_BATCH}"
+	$(EVO_AUTOMATION) --tasks-file "${EVO_TASKS_FILE}" ${EVO_VERBOSE_FLAG} plan --batch "${EVO_BATCH}"
 
 evo-run:
-	python tools/automation/evo_batch_runner.py --tasks-file "${EVO_TASKS_FILE}" run --batch "${EVO_BATCH}" ${EVO_FLAGS}
+	$(EVO_AUTOMATION) --tasks-file "${EVO_TASKS_FILE}" ${EVO_VERBOSE_FLAG} run --batch "${EVO_BATCH}" ${EVO_FLAGS}
 
 evo-lint:
-        @if [ -n "${EVO_LINT_PATH}" ]; then \
-                python tools/automation/evo_schema_lint.py "${EVO_LINT_PATH}"; \
-        else \
-                python tools/automation/evo_schema_lint.py; \
-        fi
+	@if [ -n "${EVO_LINT_PATH}" ]; then \
+		$(EVO_SCHEMA_LINT) ${EVO_VERBOSE_FLAG} "${EVO_LINT_PATH}"; \
+	else \
+		$(EVO_SCHEMA_LINT) ${EVO_VERBOSE_FLAG}; \
+	fi
 
 evo-batch-plan:
 	$(MAKE) --no-print-directory evo-plan EVO_BATCH="${EVO_BATCH}" EVO_TASKS_FILE="${EVO_TASKS_FILE}"
 
 evo-batch-run:
-	$(MAKE) --no-print-directory evo-run EVO_BATCH="${EVO_BATCH}" EVO_FLAGS="${EVO_FLAGS}" EVO_TASKS_FILE="${EVO_TASKS_FILE}"
+	$(MAKE) --no-print-directory evo-run \
+		EVO_BATCH="${EVO_BATCH}" \
+		EVO_FLAGS="${EVO_FLAGS}" \
+		EVO_TASKS_FILE="${EVO_TASKS_FILE}"

--- a/docs/tooling/evo.md
+++ b/docs/tooling/evo.md
@@ -12,11 +12,14 @@ root logger con un formatter minimale e imposta il livello del logger passato.
 Per ottenere un'istanza coerente è sufficiente dichiarare `LOGGER =
 get_logger(__name__)`, che garantisce un nome uniforme anche quando lo script è
 eseguito stand-alone. Tutte le utility riportate di seguito seguono questo
-pattern e scrivono messaggi di stato/errore su stderr.
+pattern e scrivono messaggi di stato/errore su stderr. Entrambi i tool espongono
+un'opzione `--verbose` coerente, utile per esaminare i dettagli delle operazioni
+(lo stesso flag può essere forzato nei target `make` tramite
+`EVO_VERBOSE=true`).
 
 ## Runner dei batch
 
-- Script: `python tools/automation/evo_batch_runner.py`
+- Script: `python -m tools.automation.evo_batch_runner`
 - Obiettivo: pianificare o eseguire i comandi registrati in
   `incoming/lavoro_da_classificare/tasks.yml`.
 - Opzioni principali:
@@ -34,7 +37,7 @@ piping/reportistica.
 
 ## Lint degli schemi JSON
 
-- Script: `python tools/automation/evo_schema_lint.py [percorso]`
+- Script: `python -m tools.automation.evo_schema_lint [percorso]`
 - Obiettivo: validare la struttura degli schemi JSON Evo utilizzando le stesse
   regole del batch runner.
 - Comportamento:
@@ -52,11 +55,14 @@ Il comando è disponibile anche tramite `make evo-lint` (variabili opzionali
 
 I flussi di lavoro descritti sono esposti nel `Makefile` tramite:
 
+- `make evo-help`: riepilogo rapido dei target disponibili e delle variabili
+  supportate.
 - `make evo-list`: elenca i batch disponibili (variabile `EVO_TASKS_FILE`
   opzionale per puntare a un file alternativo).
 - `make evo-plan EVO_BATCH=<nome>`: mostra il piano del batch specificato.
 - `make evo-run EVO_BATCH=<nome> EVO_FLAGS="--execute --auto"`: esegue i
-  comandi con le opzioni desiderate.
+  comandi con le opzioni desiderate; usare `EVO_VERBOSE=true` per abilitare il
+  logging esteso.
 - `make evo-lint [EVO_LINT_PATH=...]`: lancia il lint sugli schemi
   (percorso personalizzabile).
 
@@ -71,7 +77,9 @@ integra gli script ereditati tramite l'orchestratore
 `python ops/site-audit/run_suite.py`. Il target `make audit` utilizza la suite
 passando automaticamente `SITE_BASE_URL` (se definita) e replica la sequenza di
 controlli usata in CI: sitemap, search index, redirect, link checker, report e
-structured data. Gli artefatti sono raccolti in `ops/site-audit/_out/`.
+structured data. Sono disponibili variabili di tuning (`SITE_AUDIT_MAX_PAGES`,
+`SITE_AUDIT_TIMEOUT`, `SITE_AUDIT_CONCURRENCY`) per adattare il crawling alle
+esigenze locali o CI. Gli artefatti sono raccolti in `ops/site-audit/_out/`.
 
 Quando `SITE_BASE_URL` non è impostata, gli step che richiedono lo scraping del
 sito vengono saltati ma gli output generati localmente restano disponibili.

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -15,6 +15,9 @@
         "locale": "it",
         "throttlingMethod": "provided",
         "disableDeviceEmulation": true,
+        "extraHeaders": {
+          "Accept-Language": "it-IT,it;q=0.9"
+        },
         "screenEmulation": {
           "mobile": false,
           "width": 1365,
@@ -23,7 +26,7 @@
           "disabled": false
         },
         "disableStorageReset": true,
-        "chromeFlags": "--no-sandbox --headless=new --ignore-certificate-errors"
+        "chromeFlags": "--no-sandbox --headless=new --ignore-certificate-errors --disable-dev-shm-usage"
       }
     },
     "assert": {
@@ -62,6 +65,24 @@
           "warn",
           {
             "maxNumericValue": 0.15
+          }
+        ],
+        "largest-contentful-paint": [
+          "warn",
+          {
+            "maxNumericValue": 4000
+          }
+        ],
+        "total-blocking-time": [
+          "warn",
+          {
+            "maxNumericValue": 200
+          }
+        ],
+        "first-contentful-paint": [
+          "warn",
+          {
+            "maxNumericValue": 2500
           }
         ],
         "uses-responsive-images": [

--- a/tools/automation/evo_batch_runner.py
+++ b/tools/automation/evo_batch_runner.py
@@ -18,7 +18,6 @@ import argparse
 import dataclasses
 import re
 import subprocess
-import sys
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence, Set
 
@@ -376,12 +375,18 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    """Return the parsed CLI arguments."""
+
     parser = build_parser()
-    args = parser.parse_args(argv)
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
     configure_logging(verbose=args.verbose, logger=LOGGER)
     return args.func(args)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())

--- a/tools/automation/evo_schema_lint.py
+++ b/tools/automation/evo_schema_lint.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Sequence
 
 from jsonschema import RefResolver
 from jsonschema.exceptions import RefResolutionError, SchemaError
@@ -56,7 +56,7 @@ def lint(paths: List[Path]) -> int:
     return failures
 
 
-def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "path",
@@ -73,11 +73,12 @@ def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: List[str] | None = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     configure_logging(verbose=args.verbose, logger=LOGGER)
 
     schema_paths = list(discover_schema_files(args.path))
+    LOGGER.debug("Discovered %s schema files", len(schema_paths))
     if not schema_paths:
         LOGGER.error("No schema files found under %s.", args.path)
         return 1


### PR DESCRIPTION
## Summary
- harmonize the Evo automation CLIs by introducing shared argument parsing, consistent logging, and module-based invocation
- extend the Makefile with reusable Evo variables and tuning knobs plus a helper target, updating the documentation accordingly
- simplify CI by reusing the ops site-audit runner, enriching Lighthouse thresholds, and pruning duplicate jobs

## Testing
- make evo-help

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69125402c5188328b7fe5ed6e9da2dd1)