### PR TITLE
feat: add automation for Evo tracker registry

### DIFF
--- a/.github/workflows/update-evo-tracker.yml
+++ b/.github/workflows/update-evo-tracker.yml
@@ -1,0 +1,31 @@
+name: Update Evo tracker (check)
+
+on:
+  workflow_call:
+    inputs:
+      batch:
+        description: "Limita il controllo al batch indicato"
+        required: false
+        type: string
+
+jobs:
+  verify-tracker:
+    name: Verify tracker state
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run tracker check
+        run: |
+          make update-tracker TRACKER_CHECK=1
+        env:
+          BATCH: ${{ inputs.batch }}

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 .PHONY: sitemap links report search redirects structured audit \
         evo-tactics-pack dev-stack test-stack ci-stack \
         evo-batch-plan evo-batch-run evo-plan evo-run evo-list evo-lint \
-        evo-help evo-validate evo-backlog traits-review
+        evo-help evo-validate evo-backlog traits-review update-tracker
 
 PYTHON ?= python3
 EVO_AUTOMATION := $(PYTHON) -m tools.automation.evo_batch_runner
+EVO_TRACKER_UPDATE := $(PYTHON) -m tools.automation.update_tracker_registry
 EVO_SCHEMA_LINT := $(PYTHON) -m tools.automation.evo_schema_lint
 SITE_AUDIT_CMD := $(PYTHON) ops/site-audit/run_suite.py
 EVO_VALIDATE_SCRIPT := incoming/scripts/validate.sh
@@ -32,6 +33,8 @@ SITE_AUDIT_TIMEOUT ?= 10
 SITE_AUDIT_CONCURRENCY ?= 10
 EVO_VERBOSE ?=
 EVO_VERBOSE_FLAG := $(strip $(if $(filter 1 true yes on,$(EVO_VERBOSE)),--verbose,))
+TRACKER_CHECK ?=
+TRACKER_CHECK_FLAG := $(strip $(if $(filter 1 true yes on,$(TRACKER_CHECK)),--check,))
 
 sitemap:
 	python ops/site-audit/build_sitemap.py
@@ -80,7 +83,8 @@ evo-help:
         echo "  make evo-validate        # valida trait/species incoming con AJV" && \
         echo "  make evo-backlog         # popola il project board GitHub dal backlog YAML" && \
         echo "  make traits-review       # genera report glossario o CSV di revisione" && \
-        echo "Variabili supportate: EVO_BATCH, EVO_FLAGS, EVO_TASKS_FILE, EVO_LINT_PATH, EVO_VERBOSE"
+        echo "  make update-tracker      # sincronizza lo stato del tracker con integration_batches.yml" && \
+        echo "Variabili supportate: EVO_BATCH, EVO_FLAGS, EVO_TASKS_FILE, EVO_LINT_PATH, EVO_VERBOSE, TRACKER_CHECK"
 
 evo-list:
 	$(EVO_AUTOMATION) --tasks-file "${EVO_TASKS_FILE}" ${EVO_VERBOSE_FLAG} list
@@ -133,3 +137,6 @@ traits-review:
         else \
                 $(PYTHON) ${TRAITS_REVIEW_SCRIPT} --glossary "${TRAITS_REVIEW_GLOSSARY}" --outdir "${TRAITS_REVIEW_OUTDIR}"; \
         fi
+
+update-tracker:
+        $(EVO_TRACKER_UPDATE) ${EVO_VERBOSE_FLAG} $(TRACKER_CHECK_FLAG) $(if $(BATCH),--batch "${BATCH}",)

--- a/docs/tooling/evo.md
+++ b/docs/tooling/evo.md
@@ -35,6 +35,32 @@ L'output operativo viene inviato su stderr tramite il logger condiviso,
 mentre gli elenchi e i piani restano su stdout per facilitare
 piping/reportistica.
 
+## Automazioni tracker
+
+- Script: `python -m tools.automation.update_tracker_registry`
+- Target Makefile: `make update-tracker`
+- Obiettivo: sincronizzare `incoming/lavoro_da_classificare/tasks.yml` e
+  `incoming/lavoro_da_classificare/TASKS_BREAKDOWN.md` con lo stato dei batch
+  registrato in `incoming/lavoro_da_classificare/integration_batches.yml`.
+
+Opzioni principali:
+
+- `BATCH=<id>` limita l'aggiornamento (o il controllo) al batch indicato,
+  mantenendo invariati gli altri.
+- `TRACKER_CHECK=true` esegue una verifica in sola lettura: il comando termina
+  con codice di errore se i file del tracker non risultano sincronizzati.
+- `EVO_VERBOSE=true` abilita il logging di debug dello script.
+
+Esempi:
+
+```bash
+# Aggiorna entrambi i file del tracker in base allo stato corrente dei batch
+make update-tracker
+
+# Controlla che il batch "traits" sia allineato senza modificare i file
+make update-tracker BATCH=traits TRACKER_CHECK=1
+```
+
 ## Lint degli schemi JSON
 
 - Script: `python -m tools.automation.evo_schema_lint [percorso]`

--- a/incoming/lavoro_da_classificare/inventario.yml
+++ b/incoming/lavoro_da_classificare/inventario.yml
@@ -104,6 +104,11 @@ inventario:
     dimensione_byte: 4199
     note: Script confronto enum per DAT-02
     stato: completato
+  - percorso: tools/automation/update_tracker_registry.py
+    tipo: file
+    dimensione_byte: 10208
+    note: 'Automazione per allineare tasks.yml e TASKS_BREAKDOWN.md ai batch (`make update-tracker`).'
+    stato: disponibile
   - percorso: tests/test_species_aliases.py
     tipo: file
     dimensione_byte: 677

--- a/ops/workflow_diff.md
+++ b/ops/workflow_diff.md
@@ -7,6 +7,7 @@
 | `lighthouse.yml` | Configurazione da migrare | Entrambe le versioni risolvono `SITE_BASE_URL`, ma quella importata richiama direttamente `lhci autorun` sul file radice mentre la pipeline ufficiale usa lo script npm condiviso; la configurazione sarà spostata in `config/lighthouse/evo.lighthouserc.json` per uniformare i riferimenti.【F:.github/workflows/lighthouse.yml†L1-L35】【F:incoming/lavoro_da_classificare/workflows/lighthouse.yml†L1-L33】 |
 | `schema-validate.yml` | Allineato | Triggers, permessi e job coincidono: nessuna azione ulteriore.【F:.github/workflows/schema-validate.yml†L1-L30】【F:incoming/lavoro_da_classificare/workflows/schema-validate.yml†L1-L30】 |
 | `search-index.yml` | Allineato | Entrambe le varianti installano Python 3.11, rigenerano l'indice e committano l'output; differenze non rilevate.【F:.github/workflows/search-index.yml†L1-L41】【F:incoming/lavoro_da_classificare/workflows/search-index.yml†L1-L41】 |
+| `update-evo-tracker.yml` | Nuovo | Workflow riutilizzabile che installa le dipendenze Python e verifica che il tracker Evo sia sincronizzato via `make update-tracker TRACKER_CHECK=1` (supporta input opzionale `batch`).【F:.github/workflows/update-evo-tracker.yml†L1-L33】 |
 | `security.yml` | Mancante | La cartella `incoming/` contiene un workflow SAST/secret-scanning non ancora presente in `.github/workflows/`; richiede valutazione per eventuale integrazione futura.【F:incoming/lavoro_da_classificare/workflows/security.yml†L1-L52】 |
 
 **Osservazioni**

--- a/tools/automation/update_tracker_registry.py
+++ b/tools/automation/update_tracker_registry.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Synchronise Evo tracker files from ``integration_batches.yml``.
+
+The script mirrors the conventions used by :mod:`tools.automation.evo_batch_runner`
+by reusing the shared logging helpers and providing a CLI tailored for
+repository automation.  Given the batch registry in
+``incoming/lavoro_da_classificare/integration_batches.yml`` it updates the
+status markers inside ``TASKS_BREAKDOWN.md`` and ``tasks.yml`` so that the
+tracker reflects the current state of each batch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Sequence, Tuple
+
+import yaml
+
+from tools.automation import configure_logging, get_logger
+
+
+LOGGER = get_logger(__name__)
+
+DEFAULT_BATCHES_FILE = Path("incoming/lavoro_da_classificare/integration_batches.yml")
+DEFAULT_TASKS_FILE = Path("incoming/lavoro_da_classificare/tasks.yml")
+DEFAULT_BREAKDOWN_FILE = Path("incoming/lavoro_da_classificare/TASKS_BREAKDOWN.md")
+
+_STATUS_MAP = {
+    "completato": "done",
+    "completata": "done",
+    "in_corso": "in_progress",
+    "in corso": "in_progress",
+    "pianificato": "planned",
+    "pianificata": "planned",
+    "da_fare": "todo",
+    "da fare": "todo",
+    "nuovo": "todo",
+    "bloccato": "blocked",
+    "bloccata": "blocked",
+}
+
+_COMPLETED = {"done", "completed", "shipped", "merged"}
+
+_MARKER_BY_STATUS = {
+    "done": "x",
+    "completed": "x",
+    "shipped": "x",
+    "merged": "x",
+    "in_progress": "~",
+    "planned": " ",
+    "todo": " ",
+    "blocked": "!",
+}
+
+
+@dataclass
+class Batch:
+    """Representation of a batch entry inside ``integration_batches.yml``."""
+
+    batch_id: str
+    status: str
+    completed_at: Optional[_dt.date]
+
+    @property
+    def normalised_status(self) -> str:
+        return normalise_status(self.status)
+
+
+def normalise_status(status: Optional[str]) -> str:
+    """Return the tracker-friendly representation of *status*."""
+
+    if not status:
+        return ""
+    key = status.lower().replace("-", "_").strip()
+    return _STATUS_MAP.get(key, key)
+
+
+def marker_for_status(status: str) -> str:
+    """Return the checkbox marker to use inside the Markdown breakdown."""
+
+    if not status:
+        return " "
+    return _MARKER_BY_STATUS.get(status, "x" if status in _COMPLETED else " ")
+
+
+def load_batches(path: Path) -> Dict[str, Batch]:
+    """Read *path* and return the batches keyed by their identifier."""
+
+    LOGGER.debug("Loading batches from %%s", path)
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except FileNotFoundError as exc:
+        raise SystemExit(f"Unable to locate batches registry: {path}") from exc
+
+    batches: Dict[str, Batch] = {}
+    for entry in data.get("batches", []):
+        batch_id = entry.get("id")
+        status = entry.get("status") or ""
+        completed_at = parse_date(entry.get("completed_at"))
+        if not batch_id:
+            LOGGER.warning("Skipping batch without identifier: %s", entry)
+            continue
+        batches[batch_id] = Batch(batch_id=batch_id, status=status, completed_at=completed_at)
+    LOGGER.debug("Loaded %d batch entries", len(batches))
+    return batches
+
+
+def parse_date(value: Optional[object]) -> Optional[_dt.date]:
+    if not value:
+        return None
+    if isinstance(value, _dt.datetime):
+        return value.date()
+    if isinstance(value, _dt.date):
+        return value
+    try:
+        return _dt.datetime.fromisoformat(value).date()
+    except ValueError:
+        try:
+            return _dt.date.fromisoformat(value)
+        except ValueError:
+            LOGGER.debug("Unable to parse completed_at value: %s", value)
+            return None
+
+
+def select_batches(batches: Dict[str, Batch], names: Optional[Sequence[str]]) -> Dict[str, Batch]:
+    if not names:
+        return batches
+    selected: Dict[str, Batch] = {}
+    for name in names:
+        batch = batches.get(name)
+        if not batch:
+            raise SystemExit(f"Unknown batch '{name}'. Available: {', '.join(sorted(batches))}")
+        selected[name] = batch
+    return selected
+
+
+def update_tasks_yaml(
+    content: str,
+    batches: Dict[str, Batch],
+    *,
+    preserve_trailing_newline: bool,
+    update_meta: bool,
+) -> Tuple[str, bool]:
+    lines = content.splitlines()
+    changed = False
+    current_batch: Optional[str] = None
+
+    latest_date: Optional[_dt.date] = (
+        most_recent_completion(batches.values()) if update_meta else None
+    )
+
+    for idx, line in enumerate(lines):
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+
+        if stripped.startswith("- id:"):
+            current_batch = None
+        elif stripped.startswith("batch:"):
+            current_batch = stripped.split(":", 1)[1].strip()
+        elif stripped.startswith("status:") and current_batch and current_batch in batches:
+            new_status = batches[current_batch].normalised_status or stripped.split(":", 1)[1].strip()
+            if stripped.split(":", 1)[1].strip() != new_status:
+                LOGGER.debug(
+                    "Updating status for task batch %s: %s -> %s",
+                    current_batch,
+                    stripped.split(":", 1)[1].strip(),
+                    new_status,
+                )
+                lines[idx] = f"{' ' * indent}status: {new_status}"
+                changed = True
+
+        if latest_date and stripped.startswith("last_update:"):
+            new_value = latest_date.strftime("%Y-%m-%d")
+            if stripped.split(":", 1)[1].strip() != new_value:
+                LOGGER.debug("Updating tracker last_update: %s", new_value)
+                lines[idx] = f"{' ' * indent}last_update: {new_value}"
+                changed = True
+                latest_date = None  # avoid updating multiple times
+
+    updated = "\n".join(lines)
+    if preserve_trailing_newline and not updated.endswith("\n"):
+        updated += "\n"
+    return updated, changed
+
+
+def most_recent_completion(batches: Iterable[Batch]) -> Optional[_dt.date]:
+    dates = [batch.completed_at for batch in batches if batch.completed_at]
+    if not dates:
+        return None
+    return max(dates)
+
+
+def update_breakdown(
+    content: str,
+    batches: Dict[str, Batch],
+    *,
+    preserve_trailing_newline: bool,
+) -> Tuple[str, bool]:
+    lines = content.splitlines()
+    changed = False
+    current_batch: Optional[str] = None
+
+    for idx, line in enumerate(lines):
+        header = line.strip()
+        if header.startswith("## Batch "):
+            current_batch = extract_batch_from_header(header)
+            continue
+        if not current_batch or current_batch not in batches:
+            continue
+        if line.lstrip().startswith("- ["):
+            marker = marker_for_status(batches[current_batch].normalised_status)
+            prefix, rest = line.split("[", 1)
+            current_marker = rest[:1]
+            if current_marker != marker:
+                LOGGER.debug(
+                    "Updating checkbox for batch %s: %s -> %s",
+                    current_batch,
+                    current_marker,
+                    marker,
+                )
+                lines[idx] = f"{prefix}[{marker}]{rest[1:]}"
+                changed = True
+
+    updated = "\n".join(lines)
+    if preserve_trailing_newline and not updated.endswith("\n"):
+        updated += "\n"
+    return updated, changed
+
+
+def extract_batch_from_header(header: str) -> Optional[str]:
+    start = header.find("`")
+    end = header.rfind("`")
+    if start != -1 and end != -1 and end > start:
+        return header[start + 1 : end]
+    if header.startswith("## Batch "):
+        return header[len("## Batch ") :].strip()
+    return None
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batches-file", type=Path, default=DEFAULT_BATCHES_FILE)
+    parser.add_argument("--tasks-file", type=Path, default=DEFAULT_TASKS_FILE)
+    parser.add_argument("--breakdown-file", type=Path, default=DEFAULT_BREAKDOWN_FILE)
+    parser.add_argument("--batch", action="append", dest="batches", help="Limit the update to the selected batch identifier(s).")
+    parser.add_argument("--check", action="store_true", help="Fail if the tracker files are not up-to-date.")
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging output.")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    configure_logging(verbose=args.verbose, logger=LOGGER)
+
+    batches = load_batches(args.batches_file)
+    if not batches:
+        LOGGER.info("No batches found in registry: nothing to update.")
+        return 0
+
+    selected_batches = select_batches(batches, args.batches)
+
+    tasks_content = args.tasks_file.read_text(encoding="utf-8") if args.tasks_file.exists() else ""
+    update_meta = len(selected_batches) == len(batches)
+
+    tasks_new, tasks_changed = update_tasks_yaml(
+        tasks_content,
+        selected_batches,
+        preserve_trailing_newline=tasks_content.endswith("\n"),
+        update_meta=update_meta,
+    )
+
+    breakdown_content = (
+        args.breakdown_file.read_text(encoding="utf-8") if args.breakdown_file.exists() else ""
+    )
+    breakdown_new, breakdown_changed = update_breakdown(
+        breakdown_content,
+        selected_batches,
+        preserve_trailing_newline=breakdown_content.endswith("\n"),
+    )
+
+    any_change = tasks_changed or breakdown_changed
+
+    if args.check:
+        if any_change:
+            LOGGER.error(
+                "Tracker files are out-of-date. Re-run without --check to apply the updates."
+            )
+            return 1
+        LOGGER.info("Tracker files are up-to-date.")
+        return 0
+
+    if tasks_changed:
+        LOGGER.info("Writing updated tasks file to %s", args.tasks_file)
+        args.tasks_file.write_text(tasks_new, encoding="utf-8")
+    if breakdown_changed:
+        LOGGER.info("Writing updated breakdown file to %s", args.breakdown_file)
+        args.breakdown_file.write_text(breakdown_new, encoding="utf-8")
+
+    if not any_change:
+        LOGGER.info("Tracker already up-to-date.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a Python utility that reads integration_batches.yml to update tasks.yml and TASKS_BREAKDOWN.md
- expose the new helper through make update-tracker, documentation, and the incoming inventory
- add a reusable GitHub Action that runs the tracker check in CI and document it in the workflow diff

## Testing
- python -m tools.automation.update_tracker_registry --check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69134774c36c832893ec81df742f2d35)