### PR TITLE
Restore docs lint workflow and QA trackers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: sitemap links report search redirects structured audit \
-        evo-tactics-pack dev-stack test-stack ci-stack \
-        evo-batch-plan evo-batch-run evo-plan evo-run evo-list evo-lint \
-        evo-help evo-validate evo-backlog traits-review update-tracker
+	evo-tactics-pack dev-stack test-stack ci-stack \
+	evo-batch-plan evo-batch-run evo-plan evo-run evo-list evo-lint \
+	evo-help evo-validate evo-backlog traits-review update-tracker
 
 PYTHON ?= python3
 EVO_AUTOMATION := $(PYTHON) -m tools.automation.evo_batch_runner
@@ -75,16 +75,16 @@ ci-stack:
 	npm run ci:stack
 
 evo-help:
-        @echo "Evo automation targets available:" && \
-        echo "  make evo-list            # elenca i batch registrati" && \
-        echo "  make evo-plan            # pianifica il batch indicato" && \
-        echo "  make evo-run             # esegue il batch indicato" && \
-        echo "  make evo-lint            # valida gli schemi JSON" && \
-        echo "  make evo-validate        # valida trait/species incoming con AJV" && \
-        echo "  make evo-backlog         # popola il project board GitHub dal backlog YAML" && \
-        echo "  make traits-review       # genera report glossario o CSV di revisione" && \
-        echo "  make update-tracker      # sincronizza lo stato del tracker con integration_batches.yml" && \
-        echo "Variabili supportate: EVO_BATCH, EVO_FLAGS, EVO_TASKS_FILE, EVO_LINT_PATH, EVO_VERBOSE, TRACKER_CHECK"
+	@echo "Evo automation targets available:" && \
+	echo "  make evo-list            # elenca i batch registrati" && \
+	echo "  make evo-plan            # pianifica il batch indicato" && \
+	echo "  make evo-run             # esegue il batch indicato" && \
+	echo "  make evo-lint            # valida gli schemi JSON" && \
+	echo "  make evo-validate        # valida trait/species incoming con AJV" && \
+	echo "  make evo-backlog         # popola il project board GitHub dal backlog YAML" && \
+	echo "  make traits-review       # genera report glossario o CSV di revisione" && \
+	echo "  make update-tracker      # sincronizza lo stato del tracker con integration_batches.yml" && \
+	echo "Variabili supportate: EVO_BATCH, EVO_FLAGS, EVO_TASKS_FILE, EVO_LINT_PATH, EVO_VERBOSE, TRACKER_CHECK"
 
 evo-list:
 	$(EVO_AUTOMATION) --tasks-file "${EVO_TASKS_FILE}" ${EVO_VERBOSE_FLAG} list
@@ -106,37 +106,37 @@ evo-batch-plan:
 	$(MAKE) --no-print-directory evo-plan EVO_BATCH="${EVO_BATCH}" EVO_TASKS_FILE="${EVO_TASKS_FILE}"
 
 evo-batch-run:
-        $(MAKE) --no-print-directory evo-run \
-                EVO_BATCH="${EVO_BATCH}" \
-                EVO_FLAGS="${EVO_FLAGS}" \
-                EVO_TASKS_FILE="${EVO_TASKS_FILE}"
+	$(MAKE) --no-print-directory evo-run \
+		EVO_BATCH="${EVO_BATCH}" \
+		EVO_FLAGS="${EVO_FLAGS}" \
+		EVO_TASKS_FILE="${EVO_TASKS_FILE}"
 
 evo-validate:
-        AJV="${EVO_VALIDATE_AJV}" \
-        EVO_TEMPLATES_DIR="${EVO_VALIDATE_TEMPLATES}" \
-        EVO_TRAITS_DIR="${EVO_VALIDATE_TRAITS}" \
-        EVO_SPECIES_DIR="${EVO_VALIDATE_SPECIES}" \
-        bash ${EVO_VALIDATE_SCRIPT}
+	AJV="${EVO_VALIDATE_AJV}" \
+	EVO_TEMPLATES_DIR="${EVO_VALIDATE_TEMPLATES}" \
+	EVO_TRAITS_DIR="${EVO_VALIDATE_TRAITS}" \
+	EVO_SPECIES_DIR="${EVO_VALIDATE_SPECIES}" \
+	bash ${EVO_VALIDATE_SCRIPT}
 
 evo-backlog:
-        @if [ -z "${EVO_BACKLOG_FILE}" ]; then \
-                echo "Errore: impostare EVO_BACKLOG_FILE=<percorso backlog YAML>."; \
-                exit 1; \
-        fi
-        @if [ -z "${EVO_BACKLOG_REPO}" ]; then \
-                echo "Errore: impostare EVO_BACKLOG_REPO=<owner/repo>."; \
-                exit 1; \
-        fi
-        BACKLOG_FILE="${EVO_BACKLOG_FILE}" \
-        REPO="${EVO_BACKLOG_REPO}" \
-        $(PYTHON) ${EVO_BACKLOG_SCRIPT}
+	@if [ -z "${EVO_BACKLOG_FILE}" ]; then \
+		echo "Errore: impostare EVO_BACKLOG_FILE=<percorso backlog YAML>."; \
+		exit 1; \
+	fi
+	@if [ -z "${EVO_BACKLOG_REPO}" ]; then \
+		echo "Errore: impostare EVO_BACKLOG_REPO=<owner/repo>."; \
+		exit 1; \
+	fi
+	BACKLOG_FILE="${EVO_BACKLOG_FILE}" \
+	REPO="${EVO_BACKLOG_REPO}" \
+	$(PYTHON) ${EVO_BACKLOG_SCRIPT}
 
 traits-review:
-        @if [ -n "${TRAITS_REVIEW_INPUT}" ]; then \
-                $(PYTHON) ${TRAITS_REVIEW_SCRIPT} --input "${TRAITS_REVIEW_INPUT}" --baseline "${TRAITS_REVIEW_BASELINE}" --out "${TRAITS_REVIEW_OUT}"; \
-        else \
-                $(PYTHON) ${TRAITS_REVIEW_SCRIPT} --glossary "${TRAITS_REVIEW_GLOSSARY}" --outdir "${TRAITS_REVIEW_OUTDIR}"; \
-        fi
+	@if [ -n "${TRAITS_REVIEW_INPUT}" ]; then \
+	        $(PYTHON) ${TRAITS_REVIEW_SCRIPT} --input "${TRAITS_REVIEW_INPUT}" --baseline "${TRAITS_REVIEW_BASELINE}" --out "${TRAITS_REVIEW_OUT}"; \
+	else \
+	        $(PYTHON) ${TRAITS_REVIEW_SCRIPT} --glossary "${TRAITS_REVIEW_GLOSSARY}" --outdir "${TRAITS_REVIEW_OUTDIR}"; \
+	fi
 
 update-tracker:
-        $(EVO_TRACKER_UPDATE) ${EVO_VERBOSE_FLAG} $(TRACKER_CHECK_FLAG) $(if $(BATCH),--batch "${BATCH}",)
+	$(EVO_TRACKER_UPDATE) ${EVO_VERBOSE_FLAG} $(TRACKER_CHECK_FLAG) $(if $(BATCH),--batch "${BATCH}",)

--- a/docs/test-interface/evogene-deck-cards.html
+++ b/docs/test-interface/evogene-deck-cards.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pannelli EvoGene Deck · Layout di riferimento</title>
     <link rel="stylesheet" href="./evogene-deck-cards.css" />
-    <link rel="stylesheet" href="/webapp/src/styles/evogene-deck.css" />
   </head>
   <body>
     <main class="evogene-deck-demo">

--- a/incoming/lavoro_da_classificare/inventario.yml
+++ b/incoming/lavoro_da_classificare/inventario.yml
@@ -22,8 +22,8 @@ inventario:
   - percorso: docs
     tipo: directory
     dimensione_byte: 4096
-    note: 'Directory; QA `reports/evo/qa/docs.log` evidenzia assenza script `npm run docs:lint` (follow-up richiesto).'
-    stato: in revisione
+    note: 'Directory; QA `reports/evo/qa/docs.log` aggiornato con `npm run docs:lint` → collegamenti interni validi.'
+    stato: validato
   - percorso: ecotypes
     tipo: directory
     dimensione_byte: 4096

--- a/incoming/lavoro_da_classificare/tasks.yml
+++ b/incoming/lavoro_da_classificare/tasks.yml
@@ -31,7 +31,7 @@ tasks:
       - docs/README.md
     commands:
       - npm run docs:lint
-    notes: 'Indice arricchito con sezione Evo-Tactics e link ancorati. QA `reports/evo/qa/docs.log`: `npm run docs:lint` mancante, necessario ripristinare lo script.'
+    notes: 'Indice arricchito con sezione Evo-Tactics e link ancorati. QA `reports/evo/qa/docs.log`: `npm run docs:lint` eseguito con `python tools/check_site_links.py docs` (collegamenti interni validi).'
 
   - id: DOC-03
     batch: documentation

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ci:stack": "npm run lint:stack && npm run test:api && npm run test --workspace webapp && VITE_BASE_PATH=./ npm run build --workspace webapp",
     "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && node --test tests/server/generationSnapshot.spec.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-latency.spec.ts && ./node_modules/.bin/tsx tests/scripts/tune_items.test.ts && ./node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts && node --test tests/tools/deploy-checks.spec.js",
     "start:api": "node server/index.js",
+    "docs:lint": "python tools/check_site_links.py docs",
     "docs:smoke": "node scripts/docs-smoke.js",
     "build:idea-taxonomy": "node scripts/build-idea-taxonomy.js",
     "drive:generate-approved": "node tools/drive/generate-approved-assets.mjs",

--- a/reports/evo/qa/docs.log
+++ b/reports/evo/qa/docs.log
@@ -1,6 +1,6 @@
 npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
-npm error Missing script: "docs:lint"
-npm error
-npm error To see a list of scripts, run:
-npm error   npm run
-npm error A complete log of this run can be found in: /root/.npm/_logs/2025-11-11T14_15_33_101Z-debug-0.log
+
+> docs:lint
+> python tools/check_site_links.py docs
+
+Tutti i collegamenti interni risultano validi.


### PR DESCRIPTION
## Summary
- add a docs:lint npm script that runs the existing internal link checker and clean up the EvoGene deck demo to drop a broken stylesheet include
- normalise Makefile recipe indentation so make update-tracker works reliably for Evo automation targets
- refresh the docs QA log and tracker metadata after the successful lint run

## Testing
- npm run docs:lint > reports/evo/qa/docs.log 2>&1
- make update-tracker

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69136d94f53883289dd7a1b70ac04cb5)