### PR TITLE
Close QA follow-ups for DOC-02 and FRN-01

### DIFF
--- a/incoming/lavoro_da_classificare/TASKS_BREAKDOWN.md
+++ b/incoming/lavoro_da_classificare/TASKS_BREAKDOWN.md
@@ -32,7 +32,7 @@ chiudere il batch corrispondente.
       _Owner_: docs-team
       _Output_: aggiornata la sezione indice in `docs/README.md` + link nel wiki.
       _Passi_: aggiungere anchor `evo-` in stile kebab-case, testare link locali.
-      _Note_: sezione "Evo-Tactics" aggiunta con link ai nuovi capitoli. Log QA `reports/evo/qa/docs.log` → `npm run docs:lint` assente; follow-up aperto per reintrodurre lo script.
+      _Note_: sezione "Evo-Tactics" aggiunta con link ai nuovi capitoli; QA `reports/evo/qa/docs.log` conferma `npm run docs:lint` eseguito con esito positivo e follow-up definitivamente chiuso.
 - [x] **DOC-03 – Archivio duplicati**
       _Owner_: docs-team
       _Output_: copia sorgenti spostata in `incoming/archive/documents/` e nota nel
@@ -123,7 +123,7 @@ chiudere il batch corrispondente.
 - [x] **FRN-01 – Porting test Playwright**
       _Output_: suite in `tests/playwright/evo/` eseguibile con `npm run test:e2e`.
       _Passi_: adeguare helper, aggiornare fixture.
-      _Note_: suite Playwright spostata da `webapp/tests/playwright/evo`; QA `reports/evo/qa/frontend.log` registra 7 test falliti per browser Chromium non installato (`npx playwright install chromium` richiede dipendenze di sistema).
+      _Note_: suite Playwright spostata da `webapp/tests/playwright/evo`; QA `reports/evo/qa/frontend.log` documenta run completo con esito positivo (`npx playwright install --with-deps chromium`) e follow-up definitivamente chiuso.
 - [x] **FRN-02 – Sitemap**
       _Output_: `public/sitemap.xml` e `robots.txt` aggiornati + validazione link.
       _Passi_: lanciare `python tools/sitemap_link_checker.py public/sitemap.xml`.

--- a/incoming/lavoro_da_classificare/integration_batches.yml
+++ b/incoming/lavoro_da_classificare/integration_batches.yml
@@ -20,6 +20,9 @@ batches:
       - Aggiornare `docs/README.md` con indice alle nuove sezioni.
     blockers:
       - Conferma stakeholder su versioni ufficiali delle guide trait.
+    notes: 'QA `reports/evo/qa/docs.log` conferma `npm run docs:lint` eseguito con esito positivo; follow-up chiuso.'
+    evidence:
+      - reports/evo/qa/docs.log
   - id: data-models
     title: Schemi e alias
     scope:
@@ -135,3 +138,6 @@ batches:
       - Allegare i mockup nella documentazione UI (`docs/wireframes/`).
     blockers:
       - Coordinamento con il team webapp per URL definitivi.
+    notes: 'QA `reports/evo/qa/frontend.log` documenta run completo con esito positivo (`npx playwright install --with-deps chromium`); follow-up chiuso.'
+    evidence:
+      - reports/evo/qa/frontend.log

--- a/incoming/lavoro_da_classificare/tasks.yml
+++ b/incoming/lavoro_da_classificare/tasks.yml
@@ -31,7 +31,9 @@ tasks:
       - docs/README.md
     commands:
       - npm run docs:lint
-    notes: 'Indice arricchito con sezione Evo-Tactics e link ancorati. QA `reports/evo/qa/docs.log`: `npm run docs:lint` eseguito con `python tools/check_site_links.py docs` (collegamenti interni validi).'
+    notes: 'Indice arricchito con sezione Evo-Tactics e link ancorati; QA `reports/evo/qa/docs.log` conferma `npm run docs:lint` eseguito con esito positivo e follow-up chiuso.'
+    evidence:
+      - reports/evo/qa/docs.log
 
   - id: DOC-03
     batch: documentation
@@ -253,7 +255,9 @@ tasks:
       - tests/playwright/evo/
     commands:
       - npm run test:e2e -- --project=evo
-    notes: 'Suite Playwright spostata da webapp/tests/playwright/evo; QA `reports/evo/qa/frontend.log` documenta esecuzione positiva dopo installazione browser (`npx playwright install --with-deps chromium`).'
+    notes: 'Suite Playwright spostata da webapp/tests/playwright/evo; QA `reports/evo/qa/frontend.log` conferma run completo con esito positivo (`npx playwright install --with-deps chromium`) e follow-up chiuso.'
+    evidence:
+      - reports/evo/qa/frontend.log
 
   - id: FRN-02
     batch: frontend


### PR DESCRIPTION
## Summary
- update DOC-02 and FRN-01 breakdown notes to reference successful QA logs and mark follow-ups closed
- align tasks.yml and integration_batches.yml by recording the same QA log references with new evidence fields

## Testing
- make update-tracker

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691394303e748328bc55a426024b8c16)