### PR TITLE
Add Evo Tactics trace hash tooling and audit

### DIFF
--- a/docs/evo-tactics-pack/catalog_data.json
+++ b/docs/evo-tactics-pack/catalog_data.json
@@ -272,7 +272,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -370,7 +370,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -463,7 +463,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -558,7 +558,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -650,7 +650,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -741,7 +741,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -833,7 +833,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -963,7 +963,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1023,7 +1023,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1088,7 +1088,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1150,7 +1150,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -1326,7 +1326,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1395,7 +1395,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1464,7 +1464,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1533,7 +1533,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1602,7 +1602,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -1764,7 +1764,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1831,7 +1831,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1900,7 +1900,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1967,7 +1967,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2034,7 +2034,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -2140,7 +2140,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2224,7 +2224,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2312,7 +2312,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2402,7 +2402,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2489,7 +2489,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2571,7 +2571,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2658,7 +2658,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2723,7 +2723,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2783,7 +2783,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2844,7 +2844,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2906,7 +2906,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2975,7 +2975,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3044,7 +3044,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3113,7 +3113,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3182,7 +3182,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3251,7 +3251,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3318,7 +3318,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3385,7 +3385,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3454,7 +3454,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3521,7 +3521,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3588,7 +3588,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     }

--- a/docs/evo-tactics-pack/db-schema.md
+++ b/docs/evo-tactics-pack/db-schema.md
@@ -117,7 +117,7 @@ I file JSON in `docs/catalog/species/*.json` vengono importati quasi 1:1.
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
   },
   "last_synced_at": ISODate("2025-11-05T18:52:43.280Z")
 }
@@ -136,6 +136,25 @@ I file JSON in `docs/catalog/species/*.json` vengono importati quasi 1:1.
 - `derived_from_environment.suggested_traits`/`optional_traits` → `traits._id`.
 - `sessions.primary_species_id` (campo previsto) → `species._id`.
 - `activity_logs.subject_id` può puntare sia a specie (`subject_type: "species"`) sia a eventi (`flags.event = true`).
+
+### Ricevute e `trace_hash`
+
+Ogni manifest (JSON o YAML) espone un campo `receipt.trace_hash` che consente di
+verificare la coerenza tra le copie pubblicate (cataloghi locali e repliche in
+`public/docs`). L'hash viene calcolato tramite lo script
+[`tools/py/update_trace_hashes.py`](../../tools/py/update_trace_hashes.py):
+
+1. Il payload del manifest viene caricato e normalizzato rimuovendo i campi
+   `trace_hash`, ordinando ricorsivamente le chiavi e serializzando il
+   risultato in JSON compatto.
+2. Sul contenuto normalizzato viene calcolato un digest SHA-256 in formato
+   esadecimale.
+3. Il valore ottenuto viene scritto nel campo `receipt.trace_hash` del manifest
+   sorgente, delle copie documentali (`docs/evo-tactics-pack/species`) e delle
+   repliche aggregate (`catalog_data.json`).
+
+Lo stesso script è utilizzato nella pipeline di audit (`tests/scripts`)
+per garantire che nessun `trace_hash` resti valorizzato a `to-fill`.
 
 ## `traits`
 

--- a/docs/evo-tactics-pack/species/aurora-gull.json
+++ b/docs/evo-tactics-pack/species/aurora-gull.json
@@ -61,7 +61,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/blight-micotico.json
+++ b/docs/evo-tactics-pack/species/blight-micotico.json
@@ -59,7 +59,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/cactus-weaver.json
+++ b/docs/evo-tactics-pack/species/cactus-weaver.json
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/cryo-lynx.json
+++ b/docs/evo-tactics-pack/species/cryo-lynx.json
@@ -61,7 +61,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/dune-stalker.json
+++ b/docs/evo-tactics-pack/species/dune-stalker.json
@@ -89,7 +89,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/echo-wing.json
+++ b/docs/evo-tactics-pack/species/echo-wing.json
@@ -78,7 +78,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/evento-brinastorm.json
+++ b/docs/evo-tactics-pack/species/evento-brinastorm.json
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/evento-ondata-termica.json
+++ b/docs/evo-tactics-pack/species/evento-ondata-termica.json
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/evento-seme-uragano.json
+++ b/docs/evo-tactics-pack/species/evento-seme-uragano.json
@@ -54,7 +54,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/evento-tempesta-ferrosa.json
+++ b/docs/evo-tactics-pack/species/evento-tempesta-ferrosa.json
@@ -77,7 +77,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/ferrocolonia-magnetotattica.json
+++ b/docs/evo-tactics-pack/species/ferrocolonia-magnetotattica.json
@@ -80,7 +80,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/lupus-temperatus.json
+++ b/docs/evo-tactics-pack/species/lupus-temperatus.json
@@ -55,7 +55,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/nano-rust-bloom.json
+++ b/docs/evo-tactics-pack/species/nano-rust-bloom.json
@@ -81,7 +81,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/noctule-termico.json
+++ b/docs/evo-tactics-pack/species/noctule-termico.json
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/rust-scavenger.json
+++ b/docs/evo-tactics-pack/species/rust-scavenger.json
@@ -76,7 +76,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/sand-burrower.json
+++ b/docs/evo-tactics-pack/species/sand-burrower.json
@@ -81,7 +81,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/sentinella-radice.json
+++ b/docs/evo-tactics-pack/species/sentinella-radice.json
@@ -56,7 +56,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/silica-bloom.json
+++ b/docs/evo-tactics-pack/species/silica-bloom.json
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/steppe-bison-mini.json
+++ b/docs/evo-tactics-pack/species/steppe-bison-mini.json
@@ -57,7 +57,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/thaw-rot.json
+++ b/docs/evo-tactics-pack/species/thaw-rot.json
@@ -61,7 +61,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/thermo-raptor.json
+++ b/docs/evo-tactics-pack/species/thermo-raptor.json
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/data/ecosistemi/meta_ecosistema_alpha.yaml
+++ b/packs/evo_tactics_pack/data/ecosistemi/meta_ecosistema_alpha.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 5c41be656dc4e7d12af87aa1e3f0da837c7aca39057b225696204a632f22544c
 links:
   biomi:
     - packs/evo_tactics_pack/data/ecosystems/badlands.biome.yaml

--- a/packs/evo_tactics_pack/data/ecosystems/badlands.biome.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/badlands.biome.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 1ec1c5dd2daf2eb6dc98ceef6acde98da60a88cebf885fd405a91ce5774edad9
 ecosistema:
   metadati:
     nome: Brulle Terre Ferrose (Badlands)

--- a/packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 3e7ac828bdf9e6a97629ad5238c96162ea4486398ca6b6054e09af90bf3c3e56
 ecosistema:
   id: BADLANDS
   label: Brulle Terre Ferrose

--- a/packs/evo_tactics_pack/data/ecosystems/cryosteppe.biome.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/cryosteppe.biome.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: c27ca3359a00d57723bcead415d04b6b1e3e00f4af9b50a202acf5cd838cc966
 ecosistema:
   metadati:
     nome: cryosteppe (scaffold)

--- a/packs/evo_tactics_pack/data/ecosystems/cryosteppe.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/cryosteppe.ecosystem.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 39b77ef0cc8a514b372dee5cb30a5d92bf45b5120dbb9865845288be9838c1ad
 ecosistema:
   id: CRYOSTEPPE
   label: Cryosteppe Magnetica

--- a/packs/evo_tactics_pack/data/ecosystems/deserto_caldo.biome.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/deserto_caldo.biome.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 47d9b5a4e2c6317063ad470e7a0a204b5bf6832da71159e919c057c40ce4cc7d
 ecosistema:
   metadati:
     nome: deserto_caldo (scaffold)

--- a/packs/evo_tactics_pack/data/ecosystems/deserto_caldo.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/deserto_caldo.ecosystem.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: f9378c27e41f40a03e5fb01feb0beee52e23176a066b9e366dc134ea7b26b4c6
 ecosistema:
   id: DESERTO_CALDO
   label: Deserto Caldo Vetrificato

--- a/packs/evo_tactics_pack/data/ecosystems/foresta_temperata.biome.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/foresta_temperata.biome.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: e614d740c3c50af4eb742ab6e44a99f6848ea6f43ccc02151f58fc841051d193
 ecosistema:
   metadati:
     nome: Foresta Temperata Demo

--- a/packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 855c6f966ea766edac4ac36d55828f04081acfbcad998b4a0634173c7f875914
 ecosistema:
   id: FORESTA_TEMPERATA
   label: Foresta Temperata Demo

--- a/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: e362055b1ea59deb44a2b73bfaf8de6d4270dcfe4b1646d57fd79573742de7c2
 links:
   ecosystems:
   - packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml

--- a/packs/evo_tactics_pack/data/ecosystems/rovine_planari.biome.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/rovine_planari.biome.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PF1E.Bestiary.v1
   author: designer
   date: '2025-10-30'
-  trace_hash: to-fill
+  trace_hash: d4aa9795a9a1ae1bac64cb5fe969c9632c7f25ae0e7c39856bcec3176145bf7e
 ecosistema:
   metadati:
     nome: rovine_planari (Pathfinder bridge)

--- a/packs/evo_tactics_pack/data/ecosystems/rovine_planari.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/rovine_planari.ecosystem.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PF1E.Bestiary.v1
   author: designer
   date: '2025-10-30'
-  trace_hash: to-fill
+  trace_hash: 0a5df6b1f7fb8e50dd3bf49326c5133174a7eee0026a6ab1bf024825913d2ffc
 ecosistema:
   id: ROVINE_PLANARI
   label: Rovine Planari Fratturate

--- a/packs/evo_tactics_pack/data/species/abisso_luminescente/abisso-luminescente-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/abisso_luminescente/abisso-luminescente-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 001c13b7a2414458b5bce08913ccf6d19da40aa628187d0756152d93dc30ec54
 id: abisso-luminescente-trait-keeper
 display_name: Abisso Luminescente Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/abisso_vulcanico/abisso-vulcanico-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/abisso_vulcanico/abisso-vulcanico-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 75d708fd26385bf56c40cf8677da83ec7a5315953ba32b32037b4f26f477bb77
 id: abisso-vulcanico-trait-keeper
 display_name: Volcanic Abyss Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/altipiani_solari/altipiani-solari-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/altipiani_solari/altipiani-solari-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 2ea614f526332d38893f5e1fa0f8dcd8f31b4bdf1ab0d404a7fb58bbc12c8311
 id: altipiani-solari-trait-keeper
 display_name: Altipiani Solari Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/badlands/badlands-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/badlands-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: d89061e97b838189b36e2764e486cac3e18707fe2b60765c622f81c642f70e1b
 id: badlands-trait-keeper
 display_name: Badlands Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb
 id: dune-stalker
 display_name: Dune Stalker
 biomes:

--- a/packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8
 id: echo-wing
 display_name: Echo Wing
 biomes:

--- a/packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1
 id: evento-tempesta-ferrosa
 display_name: 'Evento: Tempesta Ferrosa'
 biomes:

--- a/packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497
 id: ferrocolonia-magnetotattica
 display_name: Ferrocolonia Magnetotattica
 biomes:

--- a/packs/evo_tactics_pack/data/species/badlands/magneto-ridge-hunter.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/magneto-ridge-hunter.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-11-05'
-  trace_hash: to-fill
+  trace_hash: 8e0d545852b9f56103c61d7d670fe14b394b76631f6499f4ceaafbc0611e65c2
 id: magneto-ridge-hunter
 display_name: Magneto Ridge Hunter
 biomes:

--- a/packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec
 id: nano-rust-bloom
 display_name: Nano Rust Bloom
 biomes:

--- a/packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654
 id: rust-scavenger
 display_name: Rust Scavenger
 biomes:

--- a/packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356
 id: sand-burrower
 display_name: Sand Burrower
 biomes:

--- a/packs/evo_tactics_pack/data/species/badlands/slag-veil-ambusher.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/slag-veil-ambusher.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-11-05'
-  trace_hash: to-fill
+  trace_hash: b188e147f050c1c9133c87e51c57460e023be047245ed479c7039a8d7d9b33fc
 id: slag-veil-ambusher
 display_name: Slag Veil Ambusher
 biomes:

--- a/packs/evo_tactics_pack/data/species/barriere_coralline_psioniche/barriere-coralline-psioniche-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/barriere_coralline_psioniche/barriere-coralline-psioniche-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 7a971ebf92ab817fb07ccb04da625607fa64a6df4cd6a7f3e99fcf9289b41055
 id: barriere-coralline-psioniche-trait-keeper
 display_name: Barriere Coralline Psioniche Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/caldera_glaciale/caldera-glaciale-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/caldera_glaciale/caldera-glaciale-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: f11a839c3b4f6851d7896f32f927e57f4e47f298ffec2a1b2f23056c21c9dd33
 id: caldera-glaciale-trait-keeper
 display_name: Glacial Caldera Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/calotte_glaciali/calotte-glaciali-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/calotte_glaciali/calotte-glaciali-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 24ecbc3c9713746dd6bb66f200b8e2e54e4e5c936868adbadc6c529539ac084c
 id: calotte-glaciali-trait-keeper
 display_name: Calotte Glaciali Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/canopia_ionica/canopia-ionica-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/canopia_ionica/canopia-ionica-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: bd6ba0b1eb47a1aa726a6be1c09ece391ae29a05dceed667f240399428aaf496
 id: canopia-ionica-trait-keeper
 display_name: Ionic Canopy Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/canopia_psionica_leggera/canopia-psionica-leggera-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/canopia_psionica_leggera/canopia-psionica-leggera-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: c96f0b3f3069a51c654bff75133974e0f4be3f5a28d2d87845451bcee8a68f5d
 id: canopia-psionica-leggera-trait-keeper
 display_name: Canopia Psionica Leggera Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/canopia_psionica_leggera/psionic-canopy-scout.yaml
+++ b/packs/evo_tactics_pack/data/species/canopia_psionica_leggera/psionic-canopy-scout.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-11-10'
-  trace_hash: to-fill
+  trace_hash: 6c33be1f658c8b93de8bd323a46138ee71d44176b09bdfd5cba9223a4c5efab6
 id: psionic-canopy-scout
 display_name: Psionic Canopy Scout
 biomes:

--- a/packs/evo_tactics_pack/data/species/canopie_sospese/canopie-sospese-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/canopie_sospese/canopie-sospese-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: ae369857403a0c7f8b202d1a6d5322919a1d04f96b517871e1aa50dd955ace0e
 id: canopie-sospese-trait-keeper
 display_name: Canopie Sospese Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/caverna_risonante/caverna-risonante-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/caverna_risonante/caverna-risonante-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 6d352ccedadfe13f152c9800e72d28f6f182c06a3ea66896071ea49ee71e7792
 id: caverna-risonante-trait-keeper
 display_name: Resonant Cavern Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/caverna_risonante/resonant-claw-hunter.yaml
+++ b/packs/evo_tactics_pack/data/species/caverna_risonante/resonant-claw-hunter.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 06517600f74c426c7549495203af68412f2cd3a881ee85949aaa52de4919b690
 id: resonant-claw-hunter
 display_name: Resonant Claw Hunter
 biomes:

--- a/packs/evo_tactics_pack/data/species/cicloni_psionici/cicloni-psionici-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/cicloni_psionici/cicloni-psionici-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 0d2591764c64f64c29dde47616ccc376a26691dcb6ced59fd7b70644a573041b
 id: cicloni-psionici-trait-keeper
 display_name: Cicloni Psionici Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/cryosteppe/aurora-bridge-runner.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/aurora-bridge-runner.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-11-05'
-  trace_hash: to-fill
+  trace_hash: d48a26c32ca7fd629c7bf9cd3f42c5b986e98ca4efde54b89cc8571581c84045
 id: aurora-bridge-runner
 display_name: Aurora Bridge Runner
 biomes:

--- a/packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml
@@ -50,7 +50,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde
 environment_affinity:
   biome_class: mezzanotte_orbitale
   koppen:

--- a/packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml
@@ -39,7 +39,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc
 environment_affinity:
   biome_class: mezzanotte_orbitale
   koppen:

--- a/packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml
@@ -43,7 +43,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb
 environment_affinity:
   biome_class: mezzanotte_orbitale
   koppen:

--- a/packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml
@@ -54,7 +54,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e
 environment_affinity:
   biome_class: mezzanotte_orbitale
   koppen:

--- a/packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml
@@ -43,7 +43,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f
 environment_affinity:
   biome_class: mezzanotte_orbitale
   koppen:

--- a/packs/evo_tactics_pack/data/species/cryosteppe/zephyr-spore-courier.yaml
+++ b/packs/evo_tactics_pack/data/species/cryosteppe/zephyr-spore-courier.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-11-05'
-  trace_hash: to-fill
+  trace_hash: dfed3712eb3c6697446f5db35f02b1b177c5ff03c613b2e32a50e15db802bf72
 id: zephyr-spore-courier
 display_name: Zephyr Spore Courier
 biomes:

--- a/packs/evo_tactics_pack/data/species/delta_salmastri/delta-salmastri-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/delta_salmastri/delta-salmastri-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: e0fd897b365ed737a8b8c8c4d91196ea0c3f93938f1b2585670e9fb36aa6d3d2
 id: delta-salmastri-trait-keeper
 display_name: Delta Salmastri Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml
+++ b/packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml
@@ -54,7 +54,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b
 environment_affinity:
   biome_class: abisso_vulcanico
   koppen:

--- a/packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml
+++ b/packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml
@@ -42,7 +42,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7
 environment_affinity:
   biome_class: abisso_vulcanico
   koppen:

--- a/packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml
+++ b/packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml
@@ -50,7 +50,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5
 environment_affinity:
   biome_class: abisso_vulcanico
   koppen:

--- a/packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml
+++ b/packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml
@@ -43,7 +43,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc
 environment_affinity:
   biome_class: abisso_vulcanico
   koppen:

--- a/packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml
+++ b/packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml
@@ -38,7 +38,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257
 environment_affinity:
   biome_class: abisso_vulcanico
   koppen:

--- a/packs/evo_tactics_pack/data/species/dorsale_termale_tropicale/dorsale-termale-tropicale-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/dorsale_termale_tropicale/dorsale-termale-tropicale-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 573311dfa28219f1bbddb62b454737b038db209de0232c97ed00c5f35800a6f3
 id: dorsale-termale-tropicale-trait-keeper
 display_name: Tropical Thermal Ridge Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/dune_cristalline/dune-cristalline-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/dune_cristalline/dune-cristalline-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 3d352f4bbf48d994d32c71081ed5d45340b3a8dc720da4b13a349a3745ba93d8
 id: dune-cristalline-trait-keeper
 display_name: Dune Cristalline Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/falde-magnetiche-psioniche-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/falde-magnetiche-psioniche-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: c56e325ff8f7bb215fa1451491b7f6a521b160e3b64e36c1781b9a6ef8ddd83b
 id: falde-magnetiche-psioniche-trait-keeper
 display_name: Falde Magnetiche Psioniche Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/magnet-fathom-surveyor.yaml
+++ b/packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/magnet-fathom-surveyor.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-11-10'
-  trace_hash: to-fill
+  trace_hash: 45e2186f638d1e7fe85db8259b4a4bbf5f85335fe56b7b1570038fc109848a36
 id: magnet-fathom-surveyor
 display_name: Magnet Fathom Surveyor
 biomes:

--- a/packs/evo_tactics_pack/data/species/foresta_acida/foresta-acida-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_acida/foresta-acida-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 48d1078afa049ab15791f64f3c774a2f914a51415eb61998abbb5c519c557ee9
 id: foresta-acida-trait-keeper
 display_name: Acidic Rainforest Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b
 id: blight-micotico
 display_name: Blight Micotico
 biomes:

--- a/packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e
 id: evento-seme-uragano
 display_name: 'Evento: Seme d''Uragano'
 biomes:

--- a/packs/evo_tactics_pack/data/species/foresta_temperata/glowcap-weaver.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_temperata/glowcap-weaver.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-11-05'
-  trace_hash: to-fill
+  trace_hash: 412a4161dd89872c44165d5df60b35eb28e70a3289a670bd10518bbd6b7b2482
 id: glowcap-weaver
 display_name: Glowcap Weaver
 biomes:

--- a/packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2
 id: lupus-temperatus
 display_name: Lupo della Foresta
 biomes:

--- a/packs/evo_tactics_pack/data/species/foresta_temperata/myco-spire-warden.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_temperata/myco-spire-warden.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-11-05'
-  trace_hash: to-fill
+  trace_hash: 6ce48467eadd300158fcbe4e05584163f440682d05ce33d7ad491c210bab0667
 id: myco-spire-warden
 display_name: Myco Spire warden
 biomes:

--- a/packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce
 id: sentinella-radice
 display_name: Sentinella Radice
 biomes:

--- a/packs/evo_tactics_pack/data/species/foreste_nubose/foreste-nubose-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/foreste_nubose/foreste-nubose-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 776293500da07cf5afeefb8313e802b8f2650bc29f8d0a3082686d75b5c14934
 id: foreste-nubose-trait-keeper
 display_name: Foreste Nubose Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/global/global-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/global/global-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 37297d8e2161957f244ebff574c91c1a32a54f5866e81fd01b8a99780297548f
 id: global-trait-keeper
 display_name: Global Trait Keeper
 biomes: []

--- a/packs/evo_tactics_pack/data/species/gole_ventose/gole-ventose-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/gole_ventose/gole-ventose-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 73d67aa58b5beab8bbed84ed9b2db02b0d612cfc903d2fb850af04e53b232205
 id: gole-ventose-trait-keeper
 display_name: Gole Ventose Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/laghi_alcalini/laghi-alcalini-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/laghi_alcalini/laghi-alcalini-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: eb1bf2322592614a01d3563ba07f51ccb60aab21a9edc4781c269db0cc9ae9a3
 id: laghi-alcalini-trait-keeper
 display_name: Laghi Alcalini Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/laguna_bioreattiva/laguna-bioreattiva-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/laguna_bioreattiva/laguna-bioreattiva-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 4a41995603db5d83278fa8d5e8b6a0637aab07f551100961e57ec226db2a4d26
 id: laguna-bioreattiva-trait-keeper
 display_name: Bioreactive Lagoon Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/mangrovie_risonanti/mangrovie-risonanti-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/mangrovie_risonanti/mangrovie-risonanti-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 859c19dfaa337b4b568d9f1f808e3f45d3ee7507e63cecd90f702451e49c0a70
 id: mangrovie-risonanti-trait-keeper
 display_name: Mangrovie Risonanti Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/mangrovieto_cinetico/mangrovieto-cinetico-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/mangrovieto_cinetico/mangrovieto-cinetico-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 84c1033f60b09cfe3b2dd5ffa704673c9d1bf6d202dc176e96e2c46b06b6a0f1
 id: mangrovieto-cinetico-trait-keeper
 display_name: Kinetic Mangrove Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbita-psionica-inversa-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbita-psionica-inversa-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 7d81926c1c7614fda50ec8f5caa4d4b35a8d89f2f95e925b155b33475fb0a08c
 id: orbita-psionica-inversa-trait-keeper
 display_name: Orbita Psionica Inversa Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbital-ascendant.yaml
+++ b/packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbital-ascendant.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-11-10'
-  trace_hash: to-fill
+  trace_hash: ba3def48e822fc494169d24f6c0c2c8900758493ded9aad74c2199da3303018b
 id: orbital-ascendant
 display_name: Orbital Ascendant
 biomes:

--- a/packs/evo_tactics_pack/data/species/paludi_gas_luminescenti/paludi-gas-luminescenti-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/paludi_gas_luminescenti/paludi-gas-luminescenti-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 926fc655d96506910a0bdb64560cecfbe64a6a27025a1212e6657b8fb0fadd8f
 id: paludi-gas-luminescenti-trait-keeper
 display_name: Paludi Gas Luminescenti Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/permafrost_psionico/permafrost-psionico-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/permafrost_psionico/permafrost-psionico-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 17a890364dca564ae19b7df7df8dd284c10ff1b19eb73c4aec5c5b4c2274f599
 id: permafrost-psionico-trait-keeper
 display_name: Permafrost Psionico Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/pianura_salina_iperarida/pianura-salina-iperarida-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/pianura_salina_iperarida/pianura-salina-iperarida-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 61f10e5cb3b300b783696bfce3a3824048e25242c738e497290a61012b72680d
 id: pianura-salina-iperarida-trait-keeper
 display_name: Hyperarid Salt Flat Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/pianure_magnetiche/pianure-magnetiche-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/pianure_magnetiche/pianure-magnetiche-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 9392d87b466e9688afb6bf70eda1b230fc01997c17a6ff4c1a2c2c896233eb8f
 id: pianure-magnetiche-trait-keeper
 display_name: Pianure Magnetiche Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/picchi_cristallini/picchi-cristallini-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/picchi_cristallini/picchi-cristallini-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 3f6a0fdf8626daf54020a2ecbab231b559b0cce7d3e5c918e53be4ac2e85a5d0
 id: picchi-cristallini-trait-keeper
 display_name: Picchi Cristallini Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/reef_luminescente/reef-luminescente-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/reef_luminescente/reef-luminescente-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: e95fb50354356ac81c55d06a9292534eb85941a43f34a398fc1c1bf24479d15f
 id: reef-luminescente-trait-keeper
 display_name: Luminescent Reef Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/reti_micorriziche/reti-micorriziche-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/reti_micorriziche/reti-micorriziche-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 9268ca33d921f60028b4ac1069e2d4e7bd769a8b5bc80a6bea9eaf65ba06b9a0
 id: reti-micorriziche-trait-keeper
 display_name: Reti Micorriziche Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/rovine_planari/archon-solare.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/archon-solare.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PF1E.Bestiary.v1
   author: designer
   date: '2025-10-30'
-  trace_hash: to-fill
+  trace_hash: 24d857d1a1ff25ab704156f02b4b61f5df2b2ecdd9d1f760a143421739ff784c
 id: archon-solare
 display_name: Archon Solare Custode
 biomes:

--- a/packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PF1E.Bestiary.v1
   author: designer
   date: '2025-10-30'
-  trace_hash: to-fill
+  trace_hash: e300bb3c457a32a1d02f2d1d24e4f8e7e93919d3ac6c57847caee3f789945be5
 id: balor-fission
 display_name: Balor a Fissione
 biomes:

--- a/packs/evo_tactics_pack/data/species/rovine_planari/banshee-risonante.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/banshee-risonante.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PF1E.Bestiary.v1
   author: designer
   date: '2025-10-30'
-  trace_hash: to-fill
+  trace_hash: 6ad1db6176039b9b95b058d71cd389ea8cf008b5b5f1bea28ed9d1be10d2e0ef
 id: banshee-risonante
 display_name: Banshee Risonante
 biomes:

--- a/packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PF1E.Bestiary.v1
   author: designer
   date: '2025-10-30'
-  trace_hash: to-fill
+  trace_hash: 82f0fd302ed964e9cc1e8b9725d11129e09b8b1c711b39b2c6dbb8aa3eeb7ce7
 id: bulette-fase
 display_name: Bulette di Fase
 biomes:

--- a/packs/evo_tactics_pack/data/species/rovine_planari/couatl-aurora.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/couatl-aurora.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PF1E.Bestiary.v1
   author: designer
   date: '2025-10-30'
-  trace_hash: to-fill
+  trace_hash: 04573cf0da854192d12f2cd4f015e3c569684169af5dd08f662693c42da30f24
 id: couatl-aurora
 display_name: Couatl Aurora Custode
 biomes:

--- a/packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PF1E.Bestiary.v1
   author: designer
   date: '2025-10-30'
-  trace_hash: to-fill
+  trace_hash: f47f771787d8d19cc44ceb22efef67e01b481d088b7e74815416c4462deca4cd
 id: golem-runico
 display_name: Golem Runico Custodiale
 biomes:

--- a/packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PF1E.Bestiary.v1
   author: designer
   date: '2025-10-30'
-  trace_hash: to-fill
+  trace_hash: 1b60da12e4d894b757b0ff51e430d0b5dba967196240e374f260c1a19c92175a
 id: marilith-vault
 display_name: Marilith delle Volte
 biomes:

--- a/packs/evo_tactics_pack/data/species/rovine_planari/otyugh-sentinella.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/otyugh-sentinella.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PF1E.Bestiary.v1
   author: designer
   date: '2025-10-30'
-  trace_hash: to-fill
+  trace_hash: 748b10c3e764dbd85f75fccc91284d83b7c6788d2609806719f62f431416b4e4
 id: otyugh-sentinella
 display_name: Otyugh Sentinella delle Fogne Astrali
 biomes:

--- a/packs/evo_tactics_pack/data/species/rovine_planari/rakshasa-corte.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/rakshasa-corte.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PF1E.Bestiary.v1
   author: designer
   date: '2025-10-30'
-  trace_hash: to-fill
+  trace_hash: 936482cdbee7f7bff06c8230d70140e05a26f9c36883d27a5864ead7ba8317c5
 id: rakshasa-corte
 display_name: Rakshasa della Corte Spezzata
 biomes:

--- a/packs/evo_tactics_pack/data/species/rovine_planari/treant-portale.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/treant-portale.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PF1E.Bestiary.v1
   author: designer
   date: '2025-10-30'
-  trace_hash: to-fill
+  trace_hash: 71a56b1b50e317511cff76bbd497bb2aabf153e55e38b0acd3c622f3f12f62e1
 id: treant-portale
 display_name: Treant dei Portali Antichi
 biomes:

--- a/packs/evo_tactics_pack/data/species/sorgenti_geotermiche/sorgenti-geotermiche-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/sorgenti_geotermiche/sorgenti-geotermiche-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: ca6efe1d616e246d360f2d169d25853fc7b272793169a97d5e5530611bbbd847
 id: sorgenti-geotermiche-trait-keeper
 display_name: Sorgenti Geotermiche Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/steppe_algoritmiche/steppe-algoritmiche-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/steppe_algoritmiche/steppe-algoritmiche-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: e946cffe4fc81f913c130f2a64aca76cfdbaf8713ab380221ddb243a88ecae89
 id: steppe-algoritmiche-trait-keeper
 display_name: Algorithmic Steppe Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/steppe_risonanti/steppe-risonanti-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/steppe_risonanti/steppe-risonanti-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 449f5c5a09e04895500c38848e53da0ec9ae03f8d44406caead184b4123708e4
 id: steppe-risonanti-trait-keeper
 display_name: Steppe Risonanti Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/stratosfera_portante/stratosfera-portante-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/stratosfera_portante/stratosfera-portante-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 3a509651a7e2b3a1ed685680eb92b2d8f2599b361c43e7018a8efed04d8c94c0
 id: stratosfera-portante-trait-keeper
 display_name: Stratosfera Portante Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/stratosfera_tempestosa/stratosfera-tempestosa-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/stratosfera_tempestosa/stratosfera-tempestosa-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 00239dc53a01f60083f931eabfaeadfcfcf532e786bf7aff46f81feaa9a5d289
 id: stratosfera-tempestosa-trait-keeper
 display_name: Tempestuous Stratosphere Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/data/species/tundra_risonante/tundra-risonante-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/tundra_risonante/tundra-risonante-trait-keeper.yaml
@@ -3,7 +3,7 @@ receipt:
   source: coverage_autogen
   author: automation
   date: '2025-10-29'
-  trace_hash: to-fill
+  trace_hash: 6782572fd6a2403667fd1d817d8464380f4f516ae838984df6b6899844d357fb
 id: tundra-risonante-trait-keeper
 display_name: Tundra Risonante Trait Keeper
 biomes:

--- a/packs/evo_tactics_pack/docs/catalog/catalog_data.json
+++ b/packs/evo_tactics_pack/docs/catalog/catalog_data.json
@@ -299,7 +299,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -426,7 +426,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -536,7 +536,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -663,7 +663,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -778,7 +778,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -890,7 +890,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1006,7 +1006,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -1159,7 +1159,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1237,7 +1237,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1322,7 +1322,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1410,7 +1410,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -1614,7 +1614,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1702,7 +1702,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1791,7 +1791,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1880,7 +1880,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1970,7 +1970,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -2155,7 +2155,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2247,7 +2247,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2336,7 +2336,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2431,7 +2431,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2521,7 +2521,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -2659,7 +2659,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2786,7 +2786,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2896,7 +2896,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3023,7 +3023,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3138,7 +3138,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3250,7 +3250,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3366,7 +3366,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3450,7 +3450,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3528,7 +3528,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3613,7 +3613,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3701,7 +3701,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3798,7 +3798,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3886,7 +3886,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3975,7 +3975,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4064,7 +4064,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4154,7 +4154,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4244,7 +4244,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4336,7 +4336,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4425,7 +4425,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4520,7 +4520,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4610,7 +4610,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     }

--- a/packs/evo_tactics_pack/docs/catalog/species/aurora-gull.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/aurora-gull.json
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/blight-micotico.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/blight-micotico.json
@@ -78,7 +78,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/cactus-weaver.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/cactus-weaver.json
@@ -91,7 +91,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/cryo-lynx.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/cryo-lynx.json
@@ -86,7 +86,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/dune-stalker.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/dune-stalker.json
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/echo-wing.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/echo-wing.json
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/evento-brinastorm.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/evento-brinastorm.json
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/evento-ondata-termica.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/evento-ondata-termica.json
@@ -82,7 +82,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/evento-seme-uragano.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/evento-seme-uragano.json
@@ -72,7 +72,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/evento-tempesta-ferrosa.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/evento-tempesta-ferrosa.json
@@ -104,7 +104,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/ferrocolonia-magnetotattica.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/ferrocolonia-magnetotattica.json
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/lupus-temperatus.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/lupus-temperatus.json
@@ -79,7 +79,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/nano-rust-bloom.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/nano-rust-bloom.json
@@ -109,7 +109,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/noctule-termico.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/noctule-termico.json
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/rust-scavenger.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/rust-scavenger.json
@@ -106,7 +106,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/sand-burrower.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/sand-burrower.json
@@ -110,7 +110,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/sentinella-radice.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/sentinella-radice.json
@@ -82,7 +82,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/silica-bloom.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/silica-bloom.json
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/steppe-bison-mini.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/steppe-bison-mini.json
@@ -89,7 +89,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/thaw-rot.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/thaw-rot.json
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/thermo-raptor.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/thermo-raptor.json
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/catalog_data.json
+++ b/public/docs/evo-tactics-pack/catalog_data.json
@@ -299,7 +299,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -426,7 +426,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -536,7 +536,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -663,7 +663,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -778,7 +778,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -890,7 +890,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1006,7 +1006,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -1159,7 +1159,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1237,7 +1237,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1322,7 +1322,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1410,7 +1410,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -1614,7 +1614,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1702,7 +1702,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1791,7 +1791,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1880,7 +1880,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1970,7 +1970,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -2155,7 +2155,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2247,7 +2247,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2336,7 +2336,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2431,7 +2431,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2521,7 +2521,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "to-fill"
+            "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -2659,7 +2659,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2786,7 +2786,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2896,7 +2896,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3023,7 +3023,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3138,7 +3138,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3250,7 +3250,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3366,7 +3366,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3450,7 +3450,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3528,7 +3528,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3613,7 +3613,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3701,7 +3701,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3798,7 +3798,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3886,7 +3886,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3975,7 +3975,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4064,7 +4064,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4154,7 +4154,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4244,7 +4244,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4336,7 +4336,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4425,7 +4425,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4520,7 +4520,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4610,7 +4610,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "to-fill"
+        "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     }

--- a/public/docs/evo-tactics-pack/species/aurora-gull.json
+++ b/public/docs/evo-tactics-pack/species/aurora-gull.json
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/blight-micotico.json
+++ b/public/docs/evo-tactics-pack/species/blight-micotico.json
@@ -78,7 +78,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/cactus-weaver.json
+++ b/public/docs/evo-tactics-pack/species/cactus-weaver.json
@@ -91,7 +91,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/cryo-lynx.json
+++ b/public/docs/evo-tactics-pack/species/cryo-lynx.json
@@ -86,7 +86,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/dune-stalker.json
+++ b/public/docs/evo-tactics-pack/species/dune-stalker.json
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/echo-wing.json
+++ b/public/docs/evo-tactics-pack/species/echo-wing.json
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/evento-brinastorm.json
+++ b/public/docs/evo-tactics-pack/species/evento-brinastorm.json
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/evento-ondata-termica.json
+++ b/public/docs/evo-tactics-pack/species/evento-ondata-termica.json
@@ -82,7 +82,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/evento-seme-uragano.json
+++ b/public/docs/evo-tactics-pack/species/evento-seme-uragano.json
@@ -72,7 +72,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/evento-tempesta-ferrosa.json
+++ b/public/docs/evo-tactics-pack/species/evento-tempesta-ferrosa.json
@@ -104,7 +104,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/ferrocolonia-magnetotattica.json
+++ b/public/docs/evo-tactics-pack/species/ferrocolonia-magnetotattica.json
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/lupus-temperatus.json
+++ b/public/docs/evo-tactics-pack/species/lupus-temperatus.json
@@ -79,7 +79,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/nano-rust-bloom.json
+++ b/public/docs/evo-tactics-pack/species/nano-rust-bloom.json
@@ -109,7 +109,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/noctule-termico.json
+++ b/public/docs/evo-tactics-pack/species/noctule-termico.json
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/rust-scavenger.json
+++ b/public/docs/evo-tactics-pack/species/rust-scavenger.json
@@ -106,7 +106,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/sand-burrower.json
+++ b/public/docs/evo-tactics-pack/species/sand-burrower.json
@@ -110,7 +110,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/sentinella-radice.json
+++ b/public/docs/evo-tactics-pack/species/sentinella-radice.json
@@ -82,7 +82,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/silica-bloom.json
+++ b/public/docs/evo-tactics-pack/species/silica-bloom.json
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/steppe-bison-mini.json
+++ b/public/docs/evo-tactics-pack/species/steppe-bison-mini.json
@@ -89,7 +89,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/thaw-rot.json
+++ b/public/docs/evo-tactics-pack/species/thaw-rot.json
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/thermo-raptor.json
+++ b/public/docs/evo-tactics-pack/species/thermo-raptor.json
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "to-fill"
+    "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/tests/scripts/test_trace_hashes.py
+++ b/tests/scripts/test_trace_hashes.py
@@ -1,0 +1,71 @@
+import importlib.util
+import json
+from pathlib import Path
+from typing import Iterable, Iterator, Tuple
+
+import pytest
+import yaml
+
+
+_MODULE_PATH = Path(__file__).resolve().parents[2] / "tools" / "py" / "update_trace_hashes.py"
+_SPEC = importlib.util.spec_from_file_location("update_trace_hashes", _MODULE_PATH)
+assert _SPEC and _SPEC.loader
+_MODULE = importlib.util.module_from_spec(_SPEC)
+import sys
+
+sys.modules[_SPEC.name] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+JSON_DIRECTORIES = _MODULE.JSON_DIRECTORIES
+JSON_AGGREGATES = _MODULE.JSON_AGGREGATES
+YAML_ROOT = _MODULE.YAML_ROOT
+
+
+def _iter_manifest_files() -> Iterator[Path]:
+    for directory in JSON_DIRECTORIES:
+        if directory.exists():
+            yield from sorted(directory.glob("*.json"))
+    for aggregate in JSON_AGGREGATES:
+        if aggregate.exists():
+            yield aggregate
+    if YAML_ROOT.exists():
+        yield from sorted(YAML_ROOT.rglob("*.yaml"))
+        yield from sorted(YAML_ROOT.rglob("*.yml"))
+
+
+def _iter_trace_hashes(payload) -> Iterable[Tuple[Tuple[str, ...], str]]:
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if key == "trace_hash":
+                yield (key,), value
+            else:
+                for sub_path, sub_value in _iter_trace_hashes(value):
+                    yield (key,) + sub_path, sub_value
+    elif isinstance(payload, list):
+        for index, item in enumerate(payload):
+            for sub_path, sub_value in _iter_trace_hashes(item):
+                yield (str(index),) + sub_path, sub_value
+
+
+def _load_manifest(path: Path):
+    if path.suffix.lower() == ".json":
+        with path.open(encoding="utf-8") as handle:
+            return json.load(handle)
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        with path.open(encoding="utf-8") as handle:
+            return yaml.safe_load(handle)
+    raise ValueError(f"Formato non supportato: {path}")
+
+
+@pytest.mark.parametrize("path", list(_iter_manifest_files()))
+def test_trace_hashes_filled(path: Path) -> None:
+    payload = _load_manifest(path)
+    if payload is None:
+        pytest.skip(f"Manifest vuoto: {path}")
+
+    offenders = []
+    for key_path, value in _iter_trace_hashes(payload):
+        if value == "to-fill":
+            offenders.append("/".join(key_path))
+
+    assert not offenders, f"trace_hash non valorizzati in {path}: {offenders}"

--- a/tools/py/update_trace_hashes.py
+++ b/tools/py/update_trace_hashes.py
@@ -1,0 +1,224 @@
+"""Utility per sincronizzare i trace hash dei manifest del pacchetto Evo Tactics.
+
+Lo script normalizza il contenuto dei manifest (JSON e YAML), escludendo i
+campi ``trace_hash``, calcola l'hash SHA-256 del payload risultante e aggiorna
+il valore del campo ``trace_hash`` originale mantenendo il formato del file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, MutableMapping, Sequence
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+JSON_DIRECTORIES: Sequence[Path] = (
+    REPO_ROOT / "packs" / "evo_tactics_pack" / "docs" / "catalog" / "species",
+    REPO_ROOT / "docs" / "evo-tactics-pack" / "species",
+    REPO_ROOT / "public" / "docs" / "evo-tactics-pack" / "species",
+)
+
+JSON_AGGREGATES: Sequence[Path] = (
+    REPO_ROOT / "packs" / "evo_tactics_pack" / "docs" / "catalog" / "catalog_data.json",
+    REPO_ROOT / "docs" / "evo-tactics-pack" / "catalog_data.json",
+    REPO_ROOT / "public" / "docs" / "evo-tactics-pack" / "catalog_data.json",
+)
+
+YAML_ROOT = REPO_ROOT / "packs" / "evo_tactics_pack" / "data"
+
+
+@dataclass
+class UpdateResult:
+    path: Path
+    trace_hashes: List[str]
+
+
+def _remove_trace_hashes(payload):
+    """Remove trace_hash keys recursively from a manifest payload."""
+
+    if isinstance(payload, MutableMapping):
+        cleaned = {}
+        for key, value in payload.items():
+            if key == "trace_hash":
+                continue
+            cleaned[key] = _remove_trace_hashes(value)
+        return cleaned
+    if isinstance(payload, list):
+        return [_remove_trace_hashes(item) for item in payload]
+    return payload
+
+
+def _stable_digest(manifest_payload) -> str:
+    cleaned = _remove_trace_hashes(manifest_payload)
+    normalized = json.dumps(
+        cleaned,
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _update_json_file(path: Path, *, apply: bool) -> UpdateResult | None:
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle, object_pairs_hook=OrderedDict)
+
+    pending_updates: List[tuple[MutableMapping[str, object], str]] = []
+
+    def _process(node) -> None:
+        if isinstance(node, MutableMapping):
+            receipt = node.get("receipt")
+            if isinstance(receipt, MutableMapping) and "trace_hash" in receipt:
+                digest = _stable_digest(node)
+                if receipt.get("trace_hash") != digest:
+                    pending_updates.append((receipt, digest))
+            for value in node.values():
+                _process(value)
+        elif isinstance(node, list):
+            for item in node:
+                _process(item)
+
+    _process(payload)
+
+    if not pending_updates:
+        return None
+
+    if apply:
+        for receipt, digest in pending_updates:
+            receipt["trace_hash"] = digest
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, ensure_ascii=False)
+            handle.write("\n")
+
+    return UpdateResult(path=path, trace_hashes=[digest for _, digest in pending_updates])
+
+
+def _update_yaml_file(path: Path, *, apply: bool) -> UpdateResult | None:
+    text = path.read_text(encoding="utf-8")
+    payload = yaml.safe_load(text)
+
+    if not isinstance(payload, MutableMapping):
+        return None
+
+    digest = _stable_digest(payload)
+
+    updated_text_lines: List[str] = []
+    changed = False
+
+    for line in text.splitlines():
+        if "trace_hash:" not in line:
+            updated_text_lines.append(line)
+            continue
+
+        prefix, sep, suffix = line.partition("trace_hash:")
+        if not sep:
+            updated_text_lines.append(line)
+            continue
+
+        comment = ""
+        value_part = suffix
+        if "#" in suffix:
+            value_part, comment = suffix.split("#", 1)
+            comment = "#" + comment
+
+        leading_ws_len = len(value_part) - len(value_part.lstrip(" "))
+        leading_ws = value_part[:leading_ws_len]
+        value_str = value_part.strip()
+
+        quote = ""
+        if value_str.startswith(("'", '"')) and value_str.endswith(value_str[0]):
+            quote = value_str[0]
+
+        new_line = f"{prefix}trace_hash:{leading_ws}{quote}{digest}{quote}"
+        if comment:
+            if not comment.startswith(" "):
+                new_line += " "
+            new_line += comment
+
+        if new_line != line:
+            changed = True
+        updated_text_lines.append(new_line)
+
+    if not changed:
+        return None
+
+    if apply:
+        path.write_text("\n".join(updated_text_lines) + "\n", encoding="utf-8")
+
+    return UpdateResult(path=path, trace_hashes=[digest])
+
+def update_trace_hashes(*, apply: bool) -> List[UpdateResult]:
+    updates: List[UpdateResult] = []
+
+    for directory in JSON_DIRECTORIES:
+        if not directory.exists():
+            continue
+        for path in sorted(directory.glob("*.json")):
+            result = _update_json_file(path, apply=apply)
+            if result:
+                updates.append(result)
+
+    for path in JSON_AGGREGATES:
+        if path.exists():
+            result = _update_json_file(path, apply=apply)
+            if result:
+                updates.append(result)
+
+    if YAML_ROOT.exists():
+        for path in sorted(YAML_ROOT.rglob("*.yaml")):
+            result = _update_yaml_file(path, apply=apply)
+            if result:
+                updates.append(result)
+        for path in sorted(YAML_ROOT.rglob("*.yml")):
+            result = _update_yaml_file(path, apply=apply)
+            if result:
+                updates.append(result)
+
+    return updates
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Calcola gli hash senza modificare i file",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.dry_run:
+        updates = update_trace_hashes(apply=False)
+        if updates:
+            print("Sono stati rilevati hash da aggiornare:")
+            for update in updates:
+                hashes = ", ".join(update.trace_hashes)
+                print(f" - {update.path}: {hashes}")
+            print("Rieseguire senza --dry-run per applicare le modifiche.")
+            return 1
+        print("Tutti i trace_hash sono aggiornati.")
+        return 0
+
+    updates = update_trace_hashes(apply=True)
+    for update in updates:
+        hashes = ", ".join(update.trace_hashes)
+        print(f"Aggiornato {update.path} → {hashes}")
+
+    if not updates:
+        print("Nessun trace_hash aggiornato.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a Python utility that normalises Evo Tactics manifests and stamps stable SHA-256 trace hashes across the data, docs and public replicas
- update every receipt.trace_hash in the Evo Tactics pack (YAML sources, catalog JSON and published species files) and document the hashing workflow in the db schema manual
- add a pytest audit that imports the updater configuration and fails if any trace_hash remains set to `to-fill`

## Testing
- python tools/py/update_trace_hashes.py --dry-run
- pytest tests/scripts/test_trace_hashes.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a7624f5083289d07af9847a9a9c1)