### PR TITLE
Ensure Evo Tactics trace hashes propagate canonical digest

### DIFF
--- a/docs/evo-tactics-pack/catalog_data.json
+++ b/docs/evo-tactics-pack/catalog_data.json
@@ -272,7 +272,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+            "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -370,7 +370,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+            "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -463,7 +463,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+            "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -558,7 +558,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+            "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -650,7 +650,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+            "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -741,7 +741,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+            "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -833,7 +833,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+            "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -963,7 +963,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+            "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1023,7 +1023,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+            "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1088,7 +1088,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+            "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1150,7 +1150,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+            "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -1326,7 +1326,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+            "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1395,7 +1395,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+            "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1464,7 +1464,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+            "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1533,7 +1533,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+            "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1602,7 +1602,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+            "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -1764,7 +1764,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+            "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1831,7 +1831,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+            "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1900,7 +1900,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+            "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1967,7 +1967,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+            "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2034,7 +2034,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+            "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -2140,7 +2140,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+        "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2224,7 +2224,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+        "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2312,7 +2312,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+        "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2402,7 +2402,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+        "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2489,7 +2489,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+        "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2571,7 +2571,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+        "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2658,7 +2658,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+        "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2723,7 +2723,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+        "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2783,7 +2783,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+        "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2844,7 +2844,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+        "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2906,7 +2906,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+        "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2975,7 +2975,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+        "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3044,7 +3044,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+        "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3113,7 +3113,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+        "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3182,7 +3182,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+        "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3251,7 +3251,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+        "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3318,7 +3318,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+        "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3385,7 +3385,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+        "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3454,7 +3454,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+        "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3521,7 +3521,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+        "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3588,7 +3588,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+        "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     }

--- a/docs/evo-tactics-pack/species/aurora-gull.json
+++ b/docs/evo-tactics-pack/species/aurora-gull.json
@@ -61,7 +61,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+    "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/blight-micotico.json
+++ b/docs/evo-tactics-pack/species/blight-micotico.json
@@ -59,7 +59,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+    "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/cactus-weaver.json
+++ b/docs/evo-tactics-pack/species/cactus-weaver.json
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+    "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/cryo-lynx.json
+++ b/docs/evo-tactics-pack/species/cryo-lynx.json
@@ -61,7 +61,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+    "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/dune-stalker.json
+++ b/docs/evo-tactics-pack/species/dune-stalker.json
@@ -89,7 +89,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+    "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/echo-wing.json
+++ b/docs/evo-tactics-pack/species/echo-wing.json
@@ -78,7 +78,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+    "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/evento-brinastorm.json
+++ b/docs/evo-tactics-pack/species/evento-brinastorm.json
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+    "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/evento-ondata-termica.json
+++ b/docs/evo-tactics-pack/species/evento-ondata-termica.json
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+    "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/evento-seme-uragano.json
+++ b/docs/evo-tactics-pack/species/evento-seme-uragano.json
@@ -54,7 +54,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+    "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/evento-tempesta-ferrosa.json
+++ b/docs/evo-tactics-pack/species/evento-tempesta-ferrosa.json
@@ -77,7 +77,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+    "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/ferrocolonia-magnetotattica.json
+++ b/docs/evo-tactics-pack/species/ferrocolonia-magnetotattica.json
@@ -80,7 +80,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+    "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/lupus-temperatus.json
+++ b/docs/evo-tactics-pack/species/lupus-temperatus.json
@@ -55,7 +55,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+    "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/nano-rust-bloom.json
+++ b/docs/evo-tactics-pack/species/nano-rust-bloom.json
@@ -81,7 +81,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+    "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/noctule-termico.json
+++ b/docs/evo-tactics-pack/species/noctule-termico.json
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+    "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/rust-scavenger.json
+++ b/docs/evo-tactics-pack/species/rust-scavenger.json
@@ -76,7 +76,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+    "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/sand-burrower.json
+++ b/docs/evo-tactics-pack/species/sand-burrower.json
@@ -81,7 +81,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+    "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/sentinella-radice.json
+++ b/docs/evo-tactics-pack/species/sentinella-radice.json
@@ -56,7 +56,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+    "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/silica-bloom.json
+++ b/docs/evo-tactics-pack/species/silica-bloom.json
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+    "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/steppe-bison-mini.json
+++ b/docs/evo-tactics-pack/species/steppe-bison-mini.json
@@ -57,7 +57,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+    "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/thaw-rot.json
+++ b/docs/evo-tactics-pack/species/thaw-rot.json
@@ -61,7 +61,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+    "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/docs/evo-tactics-pack/species/thermo-raptor.json
+++ b/docs/evo-tactics-pack/species/thermo-raptor.json
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+    "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/catalog_data.json
+++ b/packs/evo_tactics_pack/docs/catalog/catalog_data.json
@@ -299,7 +299,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+            "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -426,7 +426,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+            "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -536,7 +536,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+            "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -663,7 +663,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+            "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -778,7 +778,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+            "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -890,7 +890,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+            "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1006,7 +1006,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+            "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -1159,7 +1159,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+            "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1237,7 +1237,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+            "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1322,7 +1322,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+            "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1410,7 +1410,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+            "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -1614,7 +1614,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+            "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1702,7 +1702,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+            "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1791,7 +1791,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+            "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1880,7 +1880,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+            "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1970,7 +1970,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+            "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -2155,7 +2155,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+            "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2247,7 +2247,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+            "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2336,7 +2336,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+            "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2431,7 +2431,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+            "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2521,7 +2521,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+            "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -2659,7 +2659,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+        "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2786,7 +2786,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+        "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2896,7 +2896,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+        "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3023,7 +3023,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+        "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3138,7 +3138,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+        "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3250,7 +3250,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+        "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3366,7 +3366,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+        "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3450,7 +3450,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+        "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3528,7 +3528,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+        "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3613,7 +3613,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+        "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3701,7 +3701,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+        "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3798,7 +3798,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+        "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3886,7 +3886,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+        "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3975,7 +3975,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+        "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4064,7 +4064,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+        "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4154,7 +4154,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+        "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4244,7 +4244,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+        "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4336,7 +4336,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+        "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4425,7 +4425,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+        "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4520,7 +4520,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+        "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4610,7 +4610,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+        "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     }

--- a/packs/evo_tactics_pack/docs/catalog/species/aurora-gull.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/aurora-gull.json
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+    "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/blight-micotico.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/blight-micotico.json
@@ -78,7 +78,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+    "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/cactus-weaver.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/cactus-weaver.json
@@ -91,7 +91,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+    "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/cryo-lynx.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/cryo-lynx.json
@@ -86,7 +86,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+    "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/dune-stalker.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/dune-stalker.json
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+    "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/echo-wing.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/echo-wing.json
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+    "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/evento-brinastorm.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/evento-brinastorm.json
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+    "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/evento-ondata-termica.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/evento-ondata-termica.json
@@ -82,7 +82,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+    "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/evento-seme-uragano.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/evento-seme-uragano.json
@@ -72,7 +72,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+    "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/evento-tempesta-ferrosa.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/evento-tempesta-ferrosa.json
@@ -104,7 +104,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+    "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/ferrocolonia-magnetotattica.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/ferrocolonia-magnetotattica.json
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+    "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/lupus-temperatus.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/lupus-temperatus.json
@@ -79,7 +79,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+    "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/nano-rust-bloom.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/nano-rust-bloom.json
@@ -109,7 +109,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+    "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/noctule-termico.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/noctule-termico.json
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+    "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/rust-scavenger.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/rust-scavenger.json
@@ -106,7 +106,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+    "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/sand-burrower.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/sand-burrower.json
@@ -110,7 +110,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+    "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/sentinella-radice.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/sentinella-radice.json
@@ -82,7 +82,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+    "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/silica-bloom.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/silica-bloom.json
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+    "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/steppe-bison-mini.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/steppe-bison-mini.json
@@ -89,7 +89,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+    "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/thaw-rot.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/thaw-rot.json
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+    "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/thermo-raptor.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/thermo-raptor.json
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+    "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/catalog_data.json
+++ b/public/docs/evo-tactics-pack/catalog_data.json
@@ -299,7 +299,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+            "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -426,7 +426,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+            "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -536,7 +536,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+            "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -663,7 +663,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+            "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -778,7 +778,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+            "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -890,7 +890,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+            "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1006,7 +1006,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+            "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -1159,7 +1159,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+            "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1237,7 +1237,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+            "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1322,7 +1322,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+            "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1410,7 +1410,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+            "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -1614,7 +1614,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+            "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1702,7 +1702,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+            "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1791,7 +1791,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+            "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1880,7 +1880,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+            "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -1970,7 +1970,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+            "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -2155,7 +2155,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+            "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2247,7 +2247,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+            "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2336,7 +2336,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+            "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2431,7 +2431,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+            "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         },
@@ -2521,7 +2521,7 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+            "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
           },
           "last_synced_at": "2025-11-05T18:52:43.280Z"
         }
@@ -2659,7 +2659,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+        "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2786,7 +2786,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+        "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -2896,7 +2896,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+        "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3023,7 +3023,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+        "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3138,7 +3138,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+        "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3250,7 +3250,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+        "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3366,7 +3366,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+        "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3450,7 +3450,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+        "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3528,7 +3528,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+        "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3613,7 +3613,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+        "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3701,7 +3701,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+        "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3798,7 +3798,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+        "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3886,7 +3886,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+        "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -3975,7 +3975,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+        "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4064,7 +4064,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+        "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4154,7 +4154,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+        "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4244,7 +4244,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+        "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4336,7 +4336,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+        "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4425,7 +4425,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+        "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4520,7 +4520,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+        "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     },
@@ -4610,7 +4610,7 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+        "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
       },
       "last_synced_at": "2025-11-05T18:52:43.280Z"
     }

--- a/public/docs/evo-tactics-pack/species/aurora-gull.json
+++ b/public/docs/evo-tactics-pack/species/aurora-gull.json
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+    "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/blight-micotico.json
+++ b/public/docs/evo-tactics-pack/species/blight-micotico.json
@@ -78,7 +78,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+    "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/cactus-weaver.json
+++ b/public/docs/evo-tactics-pack/species/cactus-weaver.json
@@ -91,7 +91,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+    "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/cryo-lynx.json
+++ b/public/docs/evo-tactics-pack/species/cryo-lynx.json
@@ -86,7 +86,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+    "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/dune-stalker.json
+++ b/public/docs/evo-tactics-pack/species/dune-stalker.json
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+    "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/echo-wing.json
+++ b/public/docs/evo-tactics-pack/species/echo-wing.json
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+    "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/evento-brinastorm.json
+++ b/public/docs/evo-tactics-pack/species/evento-brinastorm.json
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+    "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/evento-ondata-termica.json
+++ b/public/docs/evo-tactics-pack/species/evento-ondata-termica.json
@@ -82,7 +82,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+    "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/evento-seme-uragano.json
+++ b/public/docs/evo-tactics-pack/species/evento-seme-uragano.json
@@ -72,7 +72,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+    "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/evento-tempesta-ferrosa.json
+++ b/public/docs/evo-tactics-pack/species/evento-tempesta-ferrosa.json
@@ -104,7 +104,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+    "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/ferrocolonia-magnetotattica.json
+++ b/public/docs/evo-tactics-pack/species/ferrocolonia-magnetotattica.json
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+    "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/lupus-temperatus.json
+++ b/public/docs/evo-tactics-pack/species/lupus-temperatus.json
@@ -79,7 +79,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+    "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/nano-rust-bloom.json
+++ b/public/docs/evo-tactics-pack/species/nano-rust-bloom.json
@@ -109,7 +109,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+    "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/noctule-termico.json
+++ b/public/docs/evo-tactics-pack/species/noctule-termico.json
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+    "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/rust-scavenger.json
+++ b/public/docs/evo-tactics-pack/species/rust-scavenger.json
@@ -106,7 +106,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+    "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/sand-burrower.json
+++ b/public/docs/evo-tactics-pack/species/sand-burrower.json
@@ -110,7 +110,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+    "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/sentinella-radice.json
+++ b/public/docs/evo-tactics-pack/species/sentinella-radice.json
@@ -82,7 +82,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+    "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/silica-bloom.json
+++ b/public/docs/evo-tactics-pack/species/silica-bloom.json
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+    "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/steppe-bison-mini.json
+++ b/public/docs/evo-tactics-pack/species/steppe-bison-mini.json
@@ -89,7 +89,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+    "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/thaw-rot.json
+++ b/public/docs/evo-tactics-pack/species/thaw-rot.json
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+    "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }

--- a/public/docs/evo-tactics-pack/species/thermo-raptor.json
+++ b/public/docs/evo-tactics-pack/species/thermo-raptor.json
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+    "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
   },
   "last_synced_at": "2025-11-05T18:52:43.280Z"
 }


### PR DESCRIPTION
## Summary
- compute canonical trace hash digests from the Evo Tactics YAML sources and reuse them while updating JSON replicas
- restamp the Evo Tactics catalog, docs and public JSON receipts so their trace hashes now mirror the YAML source digests

## Testing
- python tools/py/update_trace_hashes.py --dry-run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6913bfd21960832aa1281ba182565b90)