### PR TITLE
Extend trace hash updater to ecosystem manifests

### DIFF
--- a/data/ecosystems/badlands.ecosystem.yaml
+++ b/data/ecosystems/badlands.ecosystem.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 3e7ac828bdf9e6a97629ad5238c96162ea4486398ca6b6054e09af90bf3c3e56
 ecosistema:
   id: BADLANDS
   label: Brulle Terre Ferrose

--- a/data/ecosystems/cryosteppe.ecosystem.yaml
+++ b/data/ecosystems/cryosteppe.ecosystem.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 39b77ef0cc8a514b372dee5cb30a5d92bf45b5120dbb9865845288be9838c1ad
 ecosistema:
   id: CRYOSTEPPE
   label: Cryosteppe Magnetica

--- a/data/ecosystems/deserto_caldo.ecosystem.yaml
+++ b/data/ecosystems/deserto_caldo.ecosystem.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: f9378c27e41f40a03e5fb01feb0beee52e23176a066b9e366dc134ea7b26b4c6
 ecosistema:
   id: DESERTO_CALDO
   label: Deserto Caldo Vetrificato

--- a/data/ecosystems/foresta_temperata.ecosystem.yaml
+++ b/data/ecosystems/foresta_temperata.ecosystem.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: to-fill
+  trace_hash: 855c6f966ea766edac4ac36d55828f04081acfbcad998b4a0634173c7f875914
 ecosistema:
   id: FORESTA_TEMPERATA
   label: Foresta Temperata Demo

--- a/docs/evo-tactics-pack/db-schema.md
+++ b/docs/evo-tactics-pack/db-schema.md
@@ -151,7 +151,9 @@ verificare la coerenza tra le copie pubblicate (cataloghi locali e repliche in
    esadecimale.
 3. Il valore ottenuto viene scritto nel campo `receipt.trace_hash` del manifest
    sorgente, delle copie documentali (`docs/evo-tactics-pack/species`) e delle
-   repliche aggregate (`catalog_data.json`).
+   repliche aggregate (`catalog_data.json`). Lo stesso processo viene applicato
+   alle YAML degli ecosistemi (`data/ecosystems/*.ecosystem.yaml`) per
+   garantire la tracciabilità completa del pacchetto.
 
 Lo stesso script è utilizzato nella pipeline di audit (`tests/scripts`)
 per garantire che nessun `trace_hash` resti valorizzato a `to-fill`.

--- a/tests/scripts/test_trace_hashes.py
+++ b/tests/scripts/test_trace_hashes.py
@@ -18,7 +18,13 @@ _SPEC.loader.exec_module(_MODULE)
 
 JSON_DIRECTORIES = _MODULE.JSON_DIRECTORIES
 JSON_AGGREGATES = _MODULE.JSON_AGGREGATES
-YAML_ROOT = _MODULE.YAML_ROOT
+_fallback_yaml_root = getattr(_MODULE, "YAML_ROOT", None)
+if _fallback_yaml_root is not None:
+    _default_yaml_roots = (_fallback_yaml_root,)
+else:
+    _default_yaml_roots = ()
+
+YAML_ROOTS = tuple(getattr(_MODULE, "YAML_ROOTS", _default_yaml_roots))
 
 
 def _iter_manifest_files() -> Iterator[Path]:
@@ -28,9 +34,10 @@ def _iter_manifest_files() -> Iterator[Path]:
     for aggregate in JSON_AGGREGATES:
         if aggregate.exists():
             yield aggregate
-    if YAML_ROOT.exists():
-        yield from sorted(YAML_ROOT.rglob("*.yaml"))
-        yield from sorted(YAML_ROOT.rglob("*.yml"))
+    for root in YAML_ROOTS:
+        if root.exists():
+            yield from sorted(root.rglob("*.yaml"))
+            yield from sorted(root.rglob("*.yml"))
 
 
 def _iter_trace_hashes(payload) -> Iterable[Tuple[Tuple[str, ...], str]]:

--- a/tools/py/update_trace_hashes.py
+++ b/tools/py/update_trace_hashes.py
@@ -34,7 +34,10 @@ JSON_AGGREGATES: Sequence[Path] = (
     REPO_ROOT / "public" / "docs" / "evo-tactics-pack" / "catalog_data.json",
 )
 
-YAML_ROOT = REPO_ROOT / "packs" / "evo_tactics_pack" / "data"
+YAML_ROOTS: Sequence[Path] = (
+    REPO_ROOT / "packs" / "evo_tactics_pack" / "data",
+    REPO_ROOT / "data" / "ecosystems",
+)
 
 
 @dataclass
@@ -175,12 +178,14 @@ def update_trace_hashes(*, apply: bool) -> List[UpdateResult]:
             if result:
                 updates.append(result)
 
-    if YAML_ROOT.exists():
-        for path in sorted(YAML_ROOT.rglob("*.yaml")):
+    for yaml_root in YAML_ROOTS:
+        if not yaml_root.exists():
+            continue
+        for path in sorted(yaml_root.rglob("*.yaml")):
             result = _update_yaml_file(path, apply=apply)
             if result:
                 updates.append(result)
-        for path in sorted(YAML_ROOT.rglob("*.yml")):
+        for path in sorted(yaml_root.rglob("*.yml")):
             result = _update_yaml_file(path, apply=apply)
             if result:
                 updates.append(result)


### PR DESCRIPTION
## Summary
- extend the trace-hash updater to also scan the canonical ecosystem YAML manifests
- refresh the pending ecosystem trace hashes and document the broader coverage in the schema notes
- update the audit test harness so it follows every configured manifest root

## Testing
- pytest tests/scripts/test_trace_hashes.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a56f69a88328b4d895b01633da90)