### PR TITLE
Ensure Evo pack mirrors use pack-relative paths

### DIFF
--- a/docs/evo-tactics-pack/catalog_data.json
+++ b/docs/evo-tactics-pack/catalog_data.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2025-11-05T18:52:43.280Z",
+  "generated_at": "2025-11-11T23:48:24.660Z",
   "ecosistema": {
     "label": "Evo-Tactics Meta‑Ecosystem Alpha",
     "biomi": [
       {
         "id": "badlands",
-        "path": "../../data/ecosystems/badlands.biome.yaml",
+        "path": "../../packs/evo_tactics_pack/data/ecosystems/badlands.biome.yaml",
         "label": "Brulle Terre Ferrose (Badlands)",
         "network_id": "BADLANDS",
         "biome_profile": "canyons_risonanti",
@@ -13,7 +13,7 @@
       },
       {
         "id": "foresta_temperata",
-        "path": "../../data/ecosystems/foresta_temperata.biome.yaml",
+        "path": "../../packs/evo_tactics_pack/data/ecosystems/foresta_temperata.biome.yaml",
         "label": "Foresta Temperata Demo",
         "network_id": "FORESTA_TEMPERATA",
         "biome_profile": "foresta_miceliale",
@@ -21,7 +21,7 @@
       },
       {
         "id": "deserto_caldo",
-        "path": "../../data/ecosystems/deserto_caldo.biome.yaml",
+        "path": "../../packs/evo_tactics_pack/data/ecosystems/deserto_caldo.biome.yaml",
         "label": "deserto_caldo (scaffold)",
         "network_id": "DESERTO_CALDO",
         "biome_profile": "savana",
@@ -29,7 +29,7 @@
       },
       {
         "id": "cryosteppe",
-        "path": "../../data/ecosystems/cryosteppe.biome.yaml",
+        "path": "../../packs/evo_tactics_pack/data/ecosystems/cryosteppe.biome.yaml",
         "label": "cryosteppe (scaffold)",
         "network_id": "CRYOSTEPPE",
         "biome_profile": "mezzanotte_orbitale",
@@ -82,7 +82,7 @@
   "biomi": [
     {
       "id": "badlands",
-      "path": "../../data/ecosystems/badlands.biome.yaml",
+      "path": "../../packs/evo_tactics_pack/data/ecosystems/badlands.biome.yaml",
       "manifest": {
         "species_counts": {
           "apex": 1,
@@ -104,12 +104,12 @@
           "specie_chiave"
         ],
         "foodweb_links": {
-          "path": "../../data/foodwebs/badlands_foodweb.yaml",
+          "path": "../../packs/evo_tactics_pack/data/foodwebs/badlands_foodweb.yaml",
           "sink_detrito": true
         }
       },
       "foodweb": {
-        "path": "../../data/foodwebs/badlands_foodweb.yaml",
+        "path": "../../packs/evo_tactics_pack/data/foodwebs/badlands_foodweb.yaml",
         "nodes": [
           "arbusti_xerofili",
           "crostoni_criptofite",
@@ -190,7 +190,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/badlands/dune-stalker.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T3",
@@ -272,9 +272,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+            "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "echo-wing",
@@ -290,7 +290,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/badlands/echo-wing.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
           "balance": {
             "rarity": "R2",
             "threat_tier": "T1",
@@ -370,9 +370,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+            "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "evento-tempesta-ferrosa",
@@ -388,7 +388,7 @@
             "threat": false,
             "event": true
           },
-          "path": "../../data/species/badlands/evento-tempesta-ferrosa.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
           "balance": {
             "rarity": "R5",
             "threat_tier": "T4",
@@ -463,9 +463,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+            "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "ferrocolonia-magnetotattica",
@@ -482,7 +482,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/badlands/ferrocolonia-magnetotattica.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T2",
@@ -558,9 +558,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+            "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "nano-rust-bloom",
@@ -576,7 +576,7 @@
             "threat": true,
             "event": false
           },
-          "path": "../../data/species/badlands/nano-rust-bloom.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T3",
@@ -650,9 +650,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+            "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "rust-scavenger",
@@ -668,7 +668,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/badlands/rust-scavenger.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
           "balance": {
             "rarity": "R2",
             "threat_tier": "T1",
@@ -741,9 +741,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+            "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "sand-burrower",
@@ -759,7 +759,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/badlands/sand-burrower.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
           "balance": {
             "rarity": "R1",
             "threat_tier": "T1",
@@ -833,9 +833,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+            "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         }
       ],
       "label": "Brulle Terre Ferrose (Badlands)",
@@ -857,7 +857,7 @@
     },
     {
       "id": "foresta_temperata",
-      "path": "../../data/ecosystems/foresta_temperata.biome.yaml",
+      "path": "../../packs/evo_tactics_pack/data/ecosystems/foresta_temperata.biome.yaml",
       "manifest": {
         "species_counts": {
           "apex": 1,
@@ -868,13 +868,13 @@
         },
         "functional_groups_present": ["patogeno", "pulse_climatico", "specie_chiave"],
         "foodweb_links": {
-          "path": "../../data/foodwebs/foresta_temperata_foodweb.yaml",
+          "path": "../../packs/evo_tactics_pack/data/foodwebs/foresta_temperata_foodweb.yaml",
           "sink_detrito": true
         },
-        "path": "../../data/ecosystems/foresta_temperata.manifest.yaml"
+        "path": "../../packs/evo_tactics_pack/data/ecosystems/foresta_temperata.manifest.yaml"
       },
       "foodweb": {
-        "path": "../../data/foodwebs/foresta_temperata_foodweb.yaml",
+        "path": "../../packs/evo_tactics_pack/data/foodwebs/foresta_temperata_foodweb.yaml",
         "nodes": [
           "produttori_base",
           "HERB_CERVO",
@@ -916,7 +916,7 @@
             "threat": true,
             "event": false
           },
-          "path": "../../data/species/foresta_temperata/blight-micotico.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T3",
@@ -963,9 +963,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+            "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "evento-seme-uragano",
@@ -981,7 +981,7 @@
             "threat": false,
             "event": true
           },
-          "path": "../../data/species/foresta_temperata/evento-seme-uragano.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
           "balance": {
             "rarity": "R5",
             "threat_tier": "T4",
@@ -1023,9 +1023,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+            "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "lupus-temperatus",
@@ -1041,7 +1041,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/foresta_temperata/lupus-temperatus.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
           "balance": {
             "rarity": "R2",
             "threat_tier": "T2",
@@ -1088,9 +1088,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+            "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "sentinella-radice",
@@ -1107,7 +1107,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/foresta_temperata/sentinella-radice.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T1",
@@ -1150,9 +1150,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+            "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         }
       ],
       "label": "Foresta Temperata Demo",
@@ -1168,7 +1168,7 @@
     },
     {
       "id": "deserto_caldo",
-      "path": "../../data/ecosystems/deserto_caldo.biome.yaml",
+      "path": "../../packs/evo_tactics_pack/data/ecosystems/deserto_caldo.biome.yaml",
       "manifest": {
         "species_counts": {
           "apex": 1,
@@ -1188,12 +1188,12 @@
           "specie_chiave"
         ],
         "foodweb_links": {
-          "path": "../../data/foodwebs/deserto_caldo_foodweb.yaml",
+          "path": "../../packs/evo_tactics_pack/data/foodwebs/deserto_caldo_foodweb.yaml",
           "sink_detrito": true
         }
       },
       "foodweb": {
-        "path": "../../data/foodwebs/deserto_caldo_foodweb.yaml",
+        "path": "../../packs/evo_tactics_pack/data/foodwebs/deserto_caldo_foodweb.yaml",
         "nodes": [
           "succulente_xerofile",
           "cianobatteri_dune",
@@ -1272,7 +1272,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/deserto_caldo/cactus-weaver.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
           "balance": {
             "rarity": "R2",
             "threat_tier": "T1",
@@ -1326,9 +1326,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+            "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "evento-ondata-termica",
@@ -1344,7 +1344,7 @@
             "threat": false,
             "event": true
           },
-          "path": "../../data/species/deserto_caldo/evento-ondata-termica.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
           "balance": {
             "rarity": "R5",
             "threat_tier": "T4",
@@ -1395,9 +1395,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+            "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "noctule-termico",
@@ -1413,7 +1413,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/deserto_caldo/noctule-termico.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
           "balance": {
             "rarity": "R2",
             "threat_tier": "T1",
@@ -1464,9 +1464,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+            "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "silica-bloom",
@@ -1482,7 +1482,7 @@
             "threat": true,
             "event": false
           },
-          "path": "../../data/species/deserto_caldo/silica-bloom.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T3",
@@ -1533,9 +1533,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+            "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "thermo-raptor",
@@ -1551,7 +1551,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/deserto_caldo/thermo-raptor.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T3",
@@ -1602,9 +1602,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+            "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         }
       ],
       "label": "deserto_caldo (scaffold)",
@@ -1617,7 +1617,7 @@
     },
     {
       "id": "cryosteppe",
-      "path": "../../data/ecosystems/cryosteppe.biome.yaml",
+      "path": "../../packs/evo_tactics_pack/data/ecosystems/cryosteppe.biome.yaml",
       "manifest": {
         "species_counts": {
           "apex": 1,
@@ -1637,12 +1637,12 @@
           "specie_chiave"
         ],
         "foodweb_links": {
-          "path": "../../data/foodwebs/cryosteppe_foodweb.yaml",
+          "path": "../../packs/evo_tactics_pack/data/foodwebs/cryosteppe_foodweb.yaml",
           "sink_detrito": true
         }
       },
       "foodweb": {
-        "path": "../../data/foodwebs/cryosteppe_foodweb.yaml",
+        "path": "../../packs/evo_tactics_pack/data/foodwebs/cryosteppe_foodweb.yaml",
         "nodes": [
           "tappeti_muschio",
           "arbusti_alpini",
@@ -1715,7 +1715,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/cryosteppe/aurora-gull.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
           "balance": {
             "rarity": "R2",
             "threat_tier": "T1",
@@ -1764,9 +1764,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+            "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "cryo-lynx",
@@ -1782,7 +1782,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/cryosteppe/cryo-lynx.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T3",
@@ -1831,9 +1831,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+            "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "evento-brinastorm",
@@ -1849,7 +1849,7 @@
             "threat": false,
             "event": true
           },
-          "path": "../../data/species/cryosteppe/evento-brinastorm.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
           "balance": {
             "rarity": "R5",
             "threat_tier": "T4",
@@ -1900,9 +1900,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+            "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "steppe-bison-mini",
@@ -1918,7 +1918,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/cryosteppe/steppe-bison-mini.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
           "balance": {
             "rarity": "R2",
             "threat_tier": "T1",
@@ -1967,9 +1967,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+            "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "thaw-rot",
@@ -1985,7 +1985,7 @@
             "threat": true,
             "event": false
           },
-          "path": "../../data/species/cryosteppe/thaw-rot.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T3",
@@ -2034,9 +2034,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+            "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         }
       ],
       "label": "cryosteppe (scaffold)",
@@ -2063,7 +2063,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/badlands/dune-stalker.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T3",
@@ -2140,9 +2140,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+        "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "echo-wing",
@@ -2158,7 +2158,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/badlands/echo-wing.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
       "balance": {
         "rarity": "R2",
         "threat_tier": "T1",
@@ -2224,9 +2224,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+        "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "evento-tempesta-ferrosa",
@@ -2242,7 +2242,7 @@
         "threat": false,
         "event": true
       },
-      "path": "../../data/species/badlands/evento-tempesta-ferrosa.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
       "balance": {
         "rarity": "R5",
         "threat_tier": "T4",
@@ -2312,9 +2312,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+        "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "ferrocolonia-magnetotattica",
@@ -2331,7 +2331,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/badlands/ferrocolonia-magnetotattica.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T2",
@@ -2402,9 +2402,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+        "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "nano-rust-bloom",
@@ -2420,7 +2420,7 @@
         "threat": true,
         "event": false
       },
-      "path": "../../data/species/badlands/nano-rust-bloom.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T3",
@@ -2489,9 +2489,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+        "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "rust-scavenger",
@@ -2507,7 +2507,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/badlands/rust-scavenger.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
       "balance": {
         "rarity": "R2",
         "threat_tier": "T1",
@@ -2571,9 +2571,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+        "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "sand-burrower",
@@ -2589,7 +2589,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/badlands/sand-burrower.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
       "balance": {
         "rarity": "R1",
         "threat_tier": "T1",
@@ -2658,9 +2658,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+        "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "blight-micotico",
@@ -2676,7 +2676,7 @@
         "threat": true,
         "event": false
       },
-      "path": "../../data/species/foresta_temperata/blight-micotico.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T3",
@@ -2723,9 +2723,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+        "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "evento-seme-uragano",
@@ -2741,7 +2741,7 @@
         "threat": false,
         "event": true
       },
-      "path": "../../data/species/foresta_temperata/evento-seme-uragano.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
       "balance": {
         "rarity": "R5",
         "threat_tier": "T4",
@@ -2783,9 +2783,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+        "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "lupus-temperatus",
@@ -2801,7 +2801,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/foresta_temperata/lupus-temperatus.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
       "balance": {
         "rarity": "R2",
         "threat_tier": "T2",
@@ -2844,9 +2844,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+        "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "sentinella-radice",
@@ -2863,7 +2863,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/foresta_temperata/sentinella-radice.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T1",
@@ -2906,9 +2906,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+        "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "cactus-weaver",
@@ -2924,7 +2924,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/deserto_caldo/cactus-weaver.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
       "balance": {
         "rarity": "R2",
         "threat_tier": "T1",
@@ -2975,9 +2975,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+        "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "evento-ondata-termica",
@@ -2993,7 +2993,7 @@
         "threat": false,
         "event": true
       },
-      "path": "../../data/species/deserto_caldo/evento-ondata-termica.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
       "balance": {
         "rarity": "R5",
         "threat_tier": "T4",
@@ -3044,9 +3044,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+        "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "noctule-termico",
@@ -3062,7 +3062,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/deserto_caldo/noctule-termico.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
       "balance": {
         "rarity": "R2",
         "threat_tier": "T1",
@@ -3113,9 +3113,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+        "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "silica-bloom",
@@ -3131,7 +3131,7 @@
         "threat": true,
         "event": false
       },
-      "path": "../../data/species/deserto_caldo/silica-bloom.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T3",
@@ -3182,9 +3182,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+        "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "thermo-raptor",
@@ -3200,7 +3200,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/deserto_caldo/thermo-raptor.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T3",
@@ -3251,9 +3251,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+        "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "aurora-gull",
@@ -3269,7 +3269,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/cryosteppe/aurora-gull.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
       "balance": {
         "rarity": "R2",
         "threat_tier": "T1",
@@ -3318,9 +3318,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+        "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "cryo-lynx",
@@ -3336,7 +3336,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/cryosteppe/cryo-lynx.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T3",
@@ -3385,9 +3385,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+        "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "evento-brinastorm",
@@ -3403,7 +3403,7 @@
         "threat": false,
         "event": true
       },
-      "path": "../../data/species/cryosteppe/evento-brinastorm.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
       "balance": {
         "rarity": "R5",
         "threat_tier": "T4",
@@ -3454,9 +3454,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+        "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "steppe-bison-mini",
@@ -3472,7 +3472,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/cryosteppe/steppe-bison-mini.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
       "balance": {
         "rarity": "R2",
         "threat_tier": "T1",
@@ -3521,9 +3521,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+        "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "thaw-rot",
@@ -3539,7 +3539,7 @@
         "threat": true,
         "event": false
       },
-      "path": "../../data/species/cryosteppe/thaw-rot.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T3",
@@ -3588,9 +3588,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+        "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     }
   ]
 }

--- a/docs/evo-tactics-pack/hazards.json
+++ b/docs/evo-tactics-pack/hazards.json
@@ -2,133 +2,69 @@
   "schema_version": "1.0",
   "hazards": {
     "vento_forte": {
-      "requires_any_of": [
-        "build_cover",
-        "guard_stance"
-      ]
+      "requires_any_of": ["build_cover", "guard_stance"]
     },
     "pioggia_torpida": {
-      "requires_any_of": [
-        "ignore_fog_penalty",
-        "reveal_hidden_radius"
-      ]
+      "requires_any_of": ["ignore_fog_penalty", "reveal_hidden_radius"]
     },
     "pendenze_instabili": {
-      "requires_any_of": [
-        "jump_bonus",
-        "pathing_bonus"
-      ]
+      "requires_any_of": ["jump_bonus", "pathing_bonus"]
     },
     "whiteout": {
-      "requires_any_of": [
-        "ignore_fog_penalty",
-        "reveal_hidden_radius"
-      ]
+      "requires_any_of": ["ignore_fog_penalty", "reveal_hidden_radius"]
     },
     "ghiaccio_sottile": {
-      "requires_any_of": [
-        "landing_on_ice",
-        "jump_bonus"
-      ]
+      "requires_any_of": ["landing_on_ice", "jump_bonus"]
     },
     "tempeste_sabbia": {
-      "requires_any_of": [
-        "eye_protection",
-        "ignore_fog_penalty"
-      ]
+      "requires_any_of": ["eye_protection", "ignore_fog_penalty"]
     },
     "iron_shards": {
-      "requires_any_of": [
-        "dr_impact_cap",
-        "build_cover"
-      ],
+      "requires_any_of": ["dr_impact_cap", "build_cover"],
       "effect": "schegge ferrose: danno su corsa senza protezione"
     },
     "magnetic_patches": {
-      "requires_any_of": [
-        "non_metal_gear",
-        "seal_vents"
-      ],
+      "requires_any_of": ["non_metal_gear", "seal_vents"],
       "effect": "campi magnetici irregolari: penalità a gear metallico"
     },
     "shock_termici": {
-      "requires_any_of": [
-        "thermal_buffering",
-        "res_heat",
-        "res_cold"
-      ],
+      "requires_any_of": ["thermal_buffering", "res_heat", "res_cold"],
       "effect": "sbalzi estremi caldo/freddo che stressano strutture e fluidi"
     },
     "geiser_criogenici": {
-      "requires_any_of": [
-        "pressure_tolerance",
-        "cryogenic_shell",
-        "geothermal_anchor"
-      ],
+      "requires_any_of": ["pressure_tolerance", "cryogenic_shell", "geothermal_anchor"],
       "effect": "getti criogenici pressurizzati che congelano e scagliano in aria"
     },
     "piogge_acide": {
-      "requires_any_of": [
-        "res_acid",
-        "detox_cycle",
-        "corrosion_shell"
-      ],
+      "requires_any_of": ["res_acid", "detox_cycle", "corrosion_shell"],
       "effect": "precipitazioni caustiche che dissolvono carapaci e filtri"
     },
     "aerosol_solfurei": {
-      "requires_any_of": [
-        "respiratory_filters",
-        "detox_cycle",
-        "sealed_respirators"
-      ],
+      "requires_any_of": ["respiratory_filters", "detox_cycle", "sealed_respirators"],
       "effect": "nebbie sulfuree irritanti e corrosive per apparati respiratori"
     },
     "tempeste_salate": {
-      "requires_any_of": [
-        "res_salt",
-        "sealed_membranes",
-        "moisture_harvest"
-      ],
+      "requires_any_of": ["res_salt", "sealed_membranes", "moisture_harvest"],
       "effect": "sabbie saline abrasive che estraggono acqua dai tessuti"
     },
     "miraggi_termici": {
-      "requires_any_of": [
-        "thermal_navigation",
-        "heat_sense",
-        "polarized_vision"
-      ],
+      "requires_any_of": ["thermal_navigation", "heat_sense", "polarized_vision"],
       "effect": "gradienti termici distorcenti che confondono percezione e traiettorie"
     },
     "fulmini_perpetui": {
-      "requires_any_of": [
-        "res_electric",
-        "faraday_carapace",
-        "lightning_sense"
-      ],
+      "requires_any_of": ["res_electric", "faraday_carapace", "lightning_sense"],
       "effect": "scariche costanti e correnti ascendenti che fulminano lenti conduttivi"
     },
     "shearing_winds": {
-      "requires_any_of": [
-        "stability_thrusters",
-        "wind_sense",
-        "anchor_claws"
-      ],
+      "requires_any_of": ["stability_thrusters", "wind_sense", "anchor_claws"],
       "effect": "venti a forbice che destabilizzano volo e arrampicata"
     },
     "sfiati_sulfurei": {
-      "requires_any_of": [
-        "res_acid",
-        "pressure_tolerance",
-        "detox_cycle"
-      ],
+      "requires_any_of": ["res_acid", "pressure_tolerance", "detox_cycle"],
       "effect": "sfiati supercaldi saturi di zolfo e metalli pesanti"
     },
     "frane_abissali": {
-      "requires_any_of": [
-        "anchor_clamps",
-        "seismic_sense",
-        "pressure_tolerance"
-      ],
+      "requires_any_of": ["anchor_clamps", "seismic_sense", "pressure_tolerance"],
       "effect": "crolli sottomarini improvvisi con onde d'urto e detrito"
     }
   }

--- a/docs/evo-tactics-pack/species-index.json
+++ b/docs/evo-tactics-pack/species-index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-11-05T18:52:43.280Z",
+  "generated_at": "2025-11-11T23:48:24.660Z",
   "total_species": 21,
   "species": [
     {
@@ -26,7 +26,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/cryosteppe/aurora-gull.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml"
     },
     {
       "id": "blight-micotico",
@@ -51,7 +51,7 @@
       "jobs_bias": [],
       "hazards_expected": ["alluvioni lampo", "incendi sporadici"],
       "playable_unit": false,
-      "path": "../../data/species/foresta_temperata/blight-micotico.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml"
     },
     {
       "id": "cactus-weaver",
@@ -76,7 +76,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/deserto_caldo/cactus-weaver.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml"
     },
     {
       "id": "cryo-lynx",
@@ -101,7 +101,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/cryosteppe/cryo-lynx.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml"
     },
     {
       "id": "dune-stalker",
@@ -132,7 +132,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/dune-stalker.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml"
     },
     {
       "id": "echo-wing",
@@ -163,7 +163,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": true,
-      "path": "../../data/species/badlands/echo-wing.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml"
     },
     {
       "id": "evento-brinastorm",
@@ -188,7 +188,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/cryosteppe/evento-brinastorm.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml"
     },
     {
       "id": "evento-ondata-termica",
@@ -213,7 +213,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/deserto_caldo/evento-ondata-termica.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml"
     },
     {
       "id": "evento-seme-uragano",
@@ -238,7 +238,7 @@
       "jobs_bias": [],
       "hazards_expected": ["alluvioni lampo", "incendi sporadici"],
       "playable_unit": false,
-      "path": "../../data/species/foresta_temperata/evento-seme-uragano.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml"
     },
     {
       "id": "evento-tempesta-ferrosa",
@@ -269,7 +269,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/evento-tempesta-ferrosa.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml"
     },
     {
       "id": "ferrocolonia-magnetotattica",
@@ -301,7 +301,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": true,
-      "path": "../../data/species/badlands/ferrocolonia-magnetotattica.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml"
     },
     {
       "id": "lupus-temperatus",
@@ -326,7 +326,7 @@
       "jobs_bias": [],
       "hazards_expected": ["alluvioni lampo", "incendi sporadici"],
       "playable_unit": false,
-      "path": "../../data/species/foresta_temperata/lupus-temperatus.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml"
     },
     {
       "id": "nano-rust-bloom",
@@ -357,7 +357,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/nano-rust-bloom.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml"
     },
     {
       "id": "noctule-termico",
@@ -382,7 +382,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/deserto_caldo/noctule-termico.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml"
     },
     {
       "id": "rust-scavenger",
@@ -413,7 +413,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": true,
-      "path": "../../data/species/badlands/rust-scavenger.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml"
     },
     {
       "id": "sand-burrower",
@@ -444,7 +444,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/sand-burrower.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml"
     },
     {
       "id": "sentinella-radice",
@@ -470,7 +470,7 @@
       "jobs_bias": [],
       "hazards_expected": ["alluvioni lampo", "incendi sporadici"],
       "playable_unit": true,
-      "path": "../../data/species/foresta_temperata/sentinella-radice.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml"
     },
     {
       "id": "silica-bloom",
@@ -495,7 +495,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/deserto_caldo/silica-bloom.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml"
     },
     {
       "id": "steppe-bison-mini",
@@ -520,7 +520,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/cryosteppe/steppe-bison-mini.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml"
     },
     {
       "id": "thaw-rot",
@@ -545,7 +545,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/cryosteppe/thaw-rot.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml"
     },
     {
       "id": "thermo-raptor",
@@ -570,7 +570,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/deserto_caldo/thermo-raptor.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml"
     }
   ]
 }

--- a/docs/evo-tactics-pack/species/aurora-gull.json
+++ b/docs/evo-tactics-pack/species/aurora-gull.json
@@ -12,7 +12,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/cryosteppe/aurora-gull.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
   "balance": {
     "rarity": "R2",
     "threat_tier": "T1",
@@ -61,7 +61,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+    "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/blight-micotico.json
+++ b/docs/evo-tactics-pack/species/blight-micotico.json
@@ -12,7 +12,7 @@
     "threat": true,
     "event": false
   },
-  "path": "../../data/species/foresta_temperata/blight-micotico.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T3",
@@ -59,7 +59,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+    "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/cactus-weaver.json
+++ b/docs/evo-tactics-pack/species/cactus-weaver.json
@@ -12,7 +12,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/deserto_caldo/cactus-weaver.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
   "balance": {
     "rarity": "R2",
     "threat_tier": "T1",
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+    "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/cryo-lynx.json
+++ b/docs/evo-tactics-pack/species/cryo-lynx.json
@@ -12,7 +12,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/cryosteppe/cryo-lynx.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T3",
@@ -61,7 +61,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+    "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/dune-stalker.json
+++ b/docs/evo-tactics-pack/species/dune-stalker.json
@@ -12,7 +12,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/badlands/dune-stalker.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T3",
@@ -89,7 +89,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+    "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/echo-wing.json
+++ b/docs/evo-tactics-pack/species/echo-wing.json
@@ -12,7 +12,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/badlands/echo-wing.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
   "balance": {
     "rarity": "R2",
     "threat_tier": "T1",
@@ -78,7 +78,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+    "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/evento-brinastorm.json
+++ b/docs/evo-tactics-pack/species/evento-brinastorm.json
@@ -12,7 +12,7 @@
     "threat": false,
     "event": true
   },
-  "path": "../../data/species/cryosteppe/evento-brinastorm.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
   "balance": {
     "rarity": "R5",
     "threat_tier": "T4",
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+    "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/evento-ondata-termica.json
+++ b/docs/evo-tactics-pack/species/evento-ondata-termica.json
@@ -12,7 +12,7 @@
     "threat": false,
     "event": true
   },
-  "path": "../../data/species/deserto_caldo/evento-ondata-termica.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
   "balance": {
     "rarity": "R5",
     "threat_tier": "T4",
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+    "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/evento-seme-uragano.json
+++ b/docs/evo-tactics-pack/species/evento-seme-uragano.json
@@ -12,7 +12,7 @@
     "threat": false,
     "event": true
   },
-  "path": "../../data/species/foresta_temperata/evento-seme-uragano.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
   "balance": {
     "rarity": "R5",
     "threat_tier": "T4",
@@ -54,7 +54,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+    "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/evento-tempesta-ferrosa.json
+++ b/docs/evo-tactics-pack/species/evento-tempesta-ferrosa.json
@@ -12,7 +12,7 @@
     "threat": false,
     "event": true
   },
-  "path": "../../data/species/badlands/evento-tempesta-ferrosa.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
   "balance": {
     "rarity": "R5",
     "threat_tier": "T4",
@@ -77,7 +77,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+    "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/ferrocolonia-magnetotattica.json
+++ b/docs/evo-tactics-pack/species/ferrocolonia-magnetotattica.json
@@ -13,7 +13,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/badlands/ferrocolonia-magnetotattica.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T2",
@@ -80,7 +80,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+    "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/index.json
+++ b/docs/evo-tactics-pack/species/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-11-05T18:52:43.280Z",
+  "generated_at": "2025-11-11T23:48:24.660Z",
   "total_species": 21,
   "species": [
     {
@@ -26,7 +26,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/cryosteppe/aurora-gull.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml"
     },
     {
       "id": "blight-micotico",
@@ -51,7 +51,7 @@
       "jobs_bias": [],
       "hazards_expected": ["alluvioni lampo", "incendi sporadici"],
       "playable_unit": false,
-      "path": "../../data/species/foresta_temperata/blight-micotico.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml"
     },
     {
       "id": "cactus-weaver",
@@ -76,7 +76,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/deserto_caldo/cactus-weaver.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml"
     },
     {
       "id": "cryo-lynx",
@@ -101,7 +101,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/cryosteppe/cryo-lynx.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml"
     },
     {
       "id": "dune-stalker",
@@ -132,7 +132,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/dune-stalker.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml"
     },
     {
       "id": "echo-wing",
@@ -163,7 +163,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": true,
-      "path": "../../data/species/badlands/echo-wing.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml"
     },
     {
       "id": "evento-brinastorm",
@@ -188,7 +188,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/cryosteppe/evento-brinastorm.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml"
     },
     {
       "id": "evento-ondata-termica",
@@ -213,7 +213,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/deserto_caldo/evento-ondata-termica.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml"
     },
     {
       "id": "evento-seme-uragano",
@@ -238,7 +238,7 @@
       "jobs_bias": [],
       "hazards_expected": ["alluvioni lampo", "incendi sporadici"],
       "playable_unit": false,
-      "path": "../../data/species/foresta_temperata/evento-seme-uragano.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml"
     },
     {
       "id": "evento-tempesta-ferrosa",
@@ -269,7 +269,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/evento-tempesta-ferrosa.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml"
     },
     {
       "id": "ferrocolonia-magnetotattica",
@@ -301,7 +301,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": true,
-      "path": "../../data/species/badlands/ferrocolonia-magnetotattica.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml"
     },
     {
       "id": "lupus-temperatus",
@@ -326,7 +326,7 @@
       "jobs_bias": [],
       "hazards_expected": ["alluvioni lampo", "incendi sporadici"],
       "playable_unit": false,
-      "path": "../../data/species/foresta_temperata/lupus-temperatus.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml"
     },
     {
       "id": "nano-rust-bloom",
@@ -357,7 +357,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/nano-rust-bloom.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml"
     },
     {
       "id": "noctule-termico",
@@ -382,7 +382,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/deserto_caldo/noctule-termico.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml"
     },
     {
       "id": "rust-scavenger",
@@ -413,7 +413,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": true,
-      "path": "../../data/species/badlands/rust-scavenger.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml"
     },
     {
       "id": "sand-burrower",
@@ -444,7 +444,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/sand-burrower.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml"
     },
     {
       "id": "sentinella-radice",
@@ -470,7 +470,7 @@
       "jobs_bias": [],
       "hazards_expected": ["alluvioni lampo", "incendi sporadici"],
       "playable_unit": true,
-      "path": "../../data/species/foresta_temperata/sentinella-radice.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml"
     },
     {
       "id": "silica-bloom",
@@ -495,7 +495,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/deserto_caldo/silica-bloom.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml"
     },
     {
       "id": "steppe-bison-mini",
@@ -520,7 +520,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/cryosteppe/steppe-bison-mini.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml"
     },
     {
       "id": "thaw-rot",
@@ -545,7 +545,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/cryosteppe/thaw-rot.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml"
     },
     {
       "id": "thermo-raptor",
@@ -570,7 +570,7 @@
       "jobs_bias": ["skirmisher", "vanguard", "warden"],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/deserto_caldo/thermo-raptor.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml"
     }
   ]
 }

--- a/docs/evo-tactics-pack/species/lupus-temperatus.json
+++ b/docs/evo-tactics-pack/species/lupus-temperatus.json
@@ -12,7 +12,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/foresta_temperata/lupus-temperatus.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
   "balance": {
     "rarity": "R2",
     "threat_tier": "T2",
@@ -55,7 +55,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+    "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/nano-rust-bloom.json
+++ b/docs/evo-tactics-pack/species/nano-rust-bloom.json
@@ -12,7 +12,7 @@
     "threat": true,
     "event": false
   },
-  "path": "../../data/species/badlands/nano-rust-bloom.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T3",
@@ -81,7 +81,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+    "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/noctule-termico.json
+++ b/docs/evo-tactics-pack/species/noctule-termico.json
@@ -12,7 +12,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/deserto_caldo/noctule-termico.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
   "balance": {
     "rarity": "R2",
     "threat_tier": "T1",
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+    "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/rust-scavenger.json
+++ b/docs/evo-tactics-pack/species/rust-scavenger.json
@@ -12,7 +12,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/badlands/rust-scavenger.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
   "balance": {
     "rarity": "R2",
     "threat_tier": "T1",
@@ -76,7 +76,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+    "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/sand-burrower.json
+++ b/docs/evo-tactics-pack/species/sand-burrower.json
@@ -12,7 +12,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/badlands/sand-burrower.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
   "balance": {
     "rarity": "R1",
     "threat_tier": "T1",
@@ -81,7 +81,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+    "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/sentinella-radice.json
+++ b/docs/evo-tactics-pack/species/sentinella-radice.json
@@ -13,7 +13,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/foresta_temperata/sentinella-radice.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T1",
@@ -56,7 +56,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+    "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/silica-bloom.json
+++ b/docs/evo-tactics-pack/species/silica-bloom.json
@@ -12,7 +12,7 @@
     "threat": true,
     "event": false
   },
-  "path": "../../data/species/deserto_caldo/silica-bloom.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T3",
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+    "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/steppe-bison-mini.json
+++ b/docs/evo-tactics-pack/species/steppe-bison-mini.json
@@ -12,7 +12,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/cryosteppe/steppe-bison-mini.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
   "balance": {
     "rarity": "R2",
     "threat_tier": "T1",
@@ -57,7 +57,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+    "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/thaw-rot.json
+++ b/docs/evo-tactics-pack/species/thaw-rot.json
@@ -12,7 +12,7 @@
     "threat": true,
     "event": false
   },
-  "path": "../../data/species/cryosteppe/thaw-rot.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T3",
@@ -61,7 +61,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+    "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/species/thermo-raptor.json
+++ b/docs/evo-tactics-pack/species/thermo-raptor.json
@@ -12,7 +12,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/deserto_caldo/thermo-raptor.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T3",
@@ -63,7 +63,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+    "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/docs/evo-tactics-pack/traits/difensivo/index.json
+++ b/docs/evo-tactics-pack/traits/difensivo/index.json
@@ -23,10 +23,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -64,10 +61,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -105,10 +99,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -146,10 +137,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -187,10 +175,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -228,10 +213,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -269,10 +251,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -310,10 +289,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -351,10 +327,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -392,10 +365,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -433,10 +403,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -474,10 +441,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -515,10 +479,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -556,10 +517,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
+      "sinergie": ["carapace_fase_variabile", "mimetismo_cromatico_passivo"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,

--- a/docs/evo-tactics-pack/traits/difesa/index.json
+++ b/docs/evo-tactics-pack/traits/difesa/index.json
@@ -2,9 +2,7 @@
   "schema_version": "2.0",
   "traits": {
     "armatura_pietra_planare": {
-      "conflitti": [
-        "frusta_fiammeggiante"
-      ],
+      "conflitti": ["frusta_fiammeggiante"],
       "debolezza": "Pesante: riduce mobilità in ambienti non supportati o a bassa gravità.",
       "famiglia_tipologia": "Difesa/Strutturale",
       "fattore_mantenimento_energetico": "Basso (Risonanza geodetica stabile)",
@@ -13,9 +11,7 @@
       "mutazione_indotta": "Cristallizza il dermascheletro con nodi rune che deviano energia.",
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "deploy_barrier"
-          ],
+          "capacita_richieste": ["deploy_barrier"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -27,9 +23,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile"
-      ],
+      "sinergie": ["carapace_fase_variabile"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -46,9 +40,7 @@
       "uso_funzione": "Offre schermatura massiva e ancoraggio durante le aperture dimensionali."
     },
     "mantello_meteoritico": {
-      "conflitti": [
-        "aura_scudo_radianza"
-      ],
+      "conflitti": ["aura_scudo_radianza"],
       "debolezza": "Vulnerabile a scariche di freddo gravitazionale che irrigidiscono il mantello.",
       "famiglia_tipologia": "Difesa/Termoregolazione",
       "fattore_mantenimento_energetico": "Alto (Rivestimento ablativo rigenerante)",
@@ -57,9 +49,7 @@
       "mutazione_indotta": "Deposita strati sovrapposti di materiale meteorico che vaporizzano l'impatto e rilasciano radianza.",
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "fire_resist"
-          ],
+          "capacita_richieste": ["fire_resist"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -71,10 +61,7 @@
           }
         }
       ],
-      "sinergie": [
-        "frusta_fiammeggiante",
-        "carapace_fase_variabile"
-      ],
+      "sinergie": ["frusta_fiammeggiante", "carapace_fase_variabile"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,

--- a/docs/evo-tactics-pack/traits/escretorio/index.json
+++ b/docs/evo-tactics-pack/traits/escretorio/index.json
@@ -2,9 +2,7 @@
   "schema_version": "2.0",
   "traits": {
     "spore_psichiche_silenziate": {
-      "conflitti": [
-        "respiro_a_scoppio"
-      ],
+      "conflitti": ["respiro_a_scoppio"],
       "debolezza": "Funzionalità ridotta in presenza di vento forte o umidità elevata.",
       "famiglia_tipologia": "Escretorio/Psichico",
       "fattore_mantenimento_energetico": "Alto (Produzione e rilascio)",

--- a/docs/evo-tactics-pack/traits/metabolico/index.json
+++ b/docs/evo-tactics-pack/traits/metabolico/index.json
@@ -23,10 +23,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -64,10 +61,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -105,10 +99,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -146,10 +137,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -187,10 +175,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -207,9 +192,7 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
     },
     "circolazione_bifasica_palude": {
-      "conflitti": [
-        "sangue_piroforico"
-      ],
+      "conflitti": ["sangue_piroforico"],
       "debolezza": "Zone asciutte e calde causano stagnazione del circuito linfatico portando a tossicosi.",
       "famiglia_tipologia": "Metabolico/Resilienza",
       "fattore_mantenimento_energetico": "Medio (Doppio circuito emolinfa/linfa)",
@@ -229,9 +212,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -269,10 +250,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -310,10 +288,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -330,10 +305,7 @@
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
     },
     "criostasi_adattiva": {
-      "conflitti": [
-        "sangue_piroforico",
-        "sacche_galleggianti_ascensoriali"
-      ],
+      "conflitti": ["sangue_piroforico", "sacche_galleggianti_ascensoriali"],
       "debolezza": "Vulnerabilità estrema agli attacchi chimici (veleni) in fase Criostasi.",
       "famiglia_tipologia": "Metabolico/Difensivo",
       "fattore_mantenimento_energetico": "Alto (Fase di risveglio/inizio) / Basso (Fase Criostasi).",
@@ -366,9 +338,7 @@
           }
         }
       ],
-      "sinergie": [
-        "cavita_risonanti_tundra"
-      ],
+      "sinergie": ["cavita_risonanti_tundra"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -393,10 +363,7 @@
       "label": "Cuticole Cerose",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -421,10 +388,7 @@
       "label": "Enzimi Chelanti",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -462,10 +426,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -503,10 +464,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -531,10 +489,7 @@
       "label": "Grassi Termici",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "requisiti_ambientali": [],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -572,10 +527,7 @@
           }
         }
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
+      "sinergie": ["filamenti_digestivi_compattanti", "ventriglio_gastroliti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,

--- a/docs/evo-tactics-pack/traits/nervoso/index.json
+++ b/docs/evo-tactics-pack/traits/nervoso/index.json
@@ -22,10 +22,7 @@
           }
         }
       ],
-      "sinergie": [
-        "artigli_sghiaccio_glaciale",
-        "occhi_infrarosso_composti"
-      ],
+      "sinergie": ["artigli_sghiaccio_glaciale", "occhi_infrarosso_composti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,

--- a/docs/evo-tactics-pack/traits/offensivo/index.json
+++ b/docs/evo-tactics-pack/traits/offensivo/index.json
@@ -23,10 +23,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -64,10 +61,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -105,10 +99,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -146,10 +137,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -187,10 +175,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -228,10 +213,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -269,10 +251,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -310,10 +289,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -351,10 +327,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -392,10 +365,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -412,9 +382,7 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
     },
     "frusta_fiammeggiante": {
-      "conflitti": [
-        "armatura_pietra_planare"
-      ],
+      "conflitti": ["armatura_pietra_planare"],
       "debolezza": "Consumante: richiede costante dissipazione termica per non bruciare la matrice portante.",
       "famiglia_tipologia": "Offensivo/Controllo",
       "fattore_mantenimento_energetico": "Medio (Filamenti di plasma vincolato)",
@@ -423,9 +391,7 @@
       "mutazione_indotta": "Genera appendici tentacolari avvolte da plasma infernale controllato.",
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [
-            "void_stride"
-          ],
+          "capacita_richieste": ["void_stride"],
           "condizioni": {
             "biome_class": "rovine_planari"
           },
@@ -437,10 +403,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "mantello_meteoritico"
-      ],
+      "sinergie": ["focus_frazionato", "mantello_meteoritico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -467,19 +430,12 @@
       "requisiti_ambientali": [],
       "sinergie": [],
       "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "guardia_situazionale"
-        ],
+        "co_occorrenze": ["PE", "guardia_situazionale"],
         "combo_totale": 1,
-        "forme": [
-          "ISTP"
-        ],
+        "forme": ["ISTP"],
         "tabelle_random": []
       },
-      "slot": [
-        "A"
-      ],
+      "slot": ["A"],
       "slot_profile": {
         "complementare": "assalto",
         "core": "offensivo"
@@ -510,10 +466,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -551,10 +504,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -592,10 +542,7 @@
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
+      "sinergie": ["coda_frusta_cinetica", "sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -612,10 +559,7 @@
       "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
     },
     "sangue_piroforico": {
-      "conflitti": [
-        "criostasi_adattiva",
-        "scheletro_idro_regolante"
-      ],
+      "conflitti": ["criostasi_adattiva", "scheletro_idro_regolante"],
       "debolezza": "Rischio di auto-combustione in caso di ferita profonda in atmosfera ricca di ossigeno.",
       "famiglia_tipologia": "Offensivo/Cinetico",
       "fattore_mantenimento_energetico": "Medio (Sintesi dei composti)",

--- a/docs/evo-tactics-pack/traits/respiratorio/index.json
+++ b/docs/evo-tactics-pack/traits/respiratorio/index.json
@@ -2,9 +2,7 @@
   "schema_version": "2.0",
   "traits": {
     "branchie_osmotiche_salmastra": {
-      "conflitti": [
-        "polmoni_cristallini_alta_quota"
-      ],
+      "conflitti": ["polmoni_cristallini_alta_quota"],
       "debolezza": "Richiede accesso costante ad acqua salmastra; ambienti d'acqua dolce provocano stress ionico.",
       "famiglia_tipologia": "Respiratorio/Osmoregolazione",
       "fattore_mantenimento_energetico": "Medio (Pompe ioniche attive)",
@@ -24,10 +22,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "scheletro_idro_regolante"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "scheletro_idro_regolante"],
       "sinergie_pi": {
         "co_occorrenze": [
           "boardgame:Evolution/Symbiosis",
@@ -35,12 +30,8 @@
           "hud:EstuarioPsi"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Amfibio_Oracolare"
-        ],
-        "tabelle_random": [
-          "tabella:osmosi_psionica"
-        ]
+        "forme": ["Forma:Amfibio_Oracolare"],
+        "tabelle_random": ["tabella:osmosi_psionica"]
       },
       "slot": [],
       "slot_profile": {
@@ -52,9 +43,7 @@
       "uso_funzione": "Bilancia sali e tossine sfruttando microvalvole controllate psionicamente."
     },
     "lamelle_termoforetiche": {
-      "conflitti": [
-        "criostasi_adattiva"
-      ],
+      "conflitti": ["criostasi_adattiva"],
       "debolezza": "Rende instabile la fisiologia in ambienti a gelo improvviso, con rischio di microfratture vascolari.",
       "famiglia_tipologia": "Respiratorio/Termoregolazione",
       "fattore_mantenimento_energetico": "Medio (Flusso continuo di fluidi caldi)",
@@ -74,9 +63,7 @@
           }
         }
       ],
-      "sinergie": [
-        "sangue_piroforico"
-      ],
+      "sinergie": ["sangue_piroforico"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -113,10 +100,7 @@
           }
         }
       ],
-      "sinergie": [
-        "piume_solari_fotovoltaiche",
-        "polmoni_cristallini_alta_quota"
-      ],
+      "sinergie": ["piume_solari_fotovoltaiche", "polmoni_cristallini_alta_quota"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -133,9 +117,7 @@
       "uso_funzione": "Filtra l'aria e i flussi luminosi rendendoli sicuri per tessuti delicati."
     },
     "polmoni_cristallini_alta_quota": {
-      "conflitti": [
-        "branchie_osmotiche_salmastra"
-      ],
+      "conflitti": ["branchie_osmotiche_salmastra"],
       "debolezza": "Particolato pesante o sabbia vulcanica graffia i cristalli riducendo l'efficienza respiratoria.",
       "famiglia_tipologia": "Respiratorio/Aerobico",
       "fattore_mantenimento_energetico": "Medio (Pulizia periodica dei cristalli)",
@@ -155,9 +137,7 @@
           }
         }
       ],
-      "sinergie": [
-        "membrane_eliofiltranti"
-      ],
+      "sinergie": ["membrane_eliofiltranti"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -194,10 +174,7 @@
           }
         }
       ],
-      "sinergie": [
-        "sacche_galleggianti_ascensoriali",
-        "squame_rifrangenti_deserto"
-      ],
+      "sinergie": ["sacche_galleggianti_ascensoriali", "squame_rifrangenti_deserto"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,

--- a/docs/evo-tactics-pack/traits/riproduttivo/index.json
+++ b/docs/evo-tactics-pack/traits/riproduttivo/index.json
@@ -2,9 +2,7 @@
   "schema_version": "2.0",
   "traits": {
     "nucleo_ovomotore_rotante": {
-      "conflitti": [
-        "secrezione_rallentante_palmi"
-      ],
+      "conflitti": ["secrezione_rallentante_palmi"],
       "debolezza": "Impossibilità di muoversi su superfici irregolari o in salita ripida.",
       "famiglia_tipologia": "Riproduttivo/Locomotorio",
       "fattore_mantenimento_energetico": "Alto (Rotolamento)",

--- a/docs/evo-tactics-pack/traits/sensoriale/index.json
+++ b/docs/evo-tactics-pack/traits/sensoriale/index.json
@@ -23,10 +23,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -76,13 +73,8 @@
           "bioma:cicloni_psionici"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Tempestarii",
-          "HUD:Fulcro_Tempesta"
-        ],
-        "tabelle_random": [
-          "tabella:fulmini_empatici"
-        ]
+        "forme": ["Forma:Tempestarii", "HUD:Fulcro_Tempesta"],
+        "tabelle_random": ["tabella:fulmini_empatici"]
       },
       "slot": [],
       "slot_profile": {
@@ -115,10 +107,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -156,10 +145,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -197,10 +183,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -238,10 +221,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -291,13 +271,8 @@
           "hud:TundraPulse"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Cantore_Tundra",
-          "HUD:EchoGrid"
-        ],
-        "tabelle_random": [
-          "tabella:canti_ipersonici"
-        ]
+        "forme": ["Forma:Cantore_Tundra", "HUD:EchoGrid"],
+        "tabelle_random": ["tabella:canti_ipersonici"]
       },
       "slot": [],
       "slot_profile": {
@@ -330,10 +305,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -371,10 +343,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -412,10 +381,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -453,10 +419,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -548,10 +511,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -589,10 +549,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -630,10 +587,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -671,10 +625,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -711,9 +662,7 @@
           }
         }
       ],
-      "sinergie": [
-        "olfatto_risonanza_magnetica"
-      ],
+      "sinergie": ["olfatto_risonanza_magnetica"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -751,10 +700,7 @@
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
+      "sinergie": ["focus_frazionato", "sinapsi_coraline_polifoniche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -791,9 +737,7 @@
           }
         }
       ],
-      "sinergie": [
-        "sonno_emisferico_alternato"
-      ],
+      "sinergie": ["sonno_emisferico_alternato"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -843,10 +787,7 @@
           }
         }
       ],
-      "sinergie": [
-        "eco_interno_riflesso",
-        "lingua_tattile_trama"
-      ],
+      "sinergie": ["eco_interno_riflesso", "lingua_tattile_trama"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -883,10 +824,7 @@
           }
         }
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "eco_interno_riflesso"
-      ],
+      "sinergie": ["carapace_fase_variabile", "eco_interno_riflesso"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,

--- a/docs/evo-tactics-pack/traits/simbiotico/index.json
+++ b/docs/evo-tactics-pack/traits/simbiotico/index.json
@@ -23,10 +23,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -64,10 +61,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -105,10 +99,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -157,13 +148,8 @@
           "hud:RootMesh_Psi"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Archivio_Subglaciale",
-          "HUD:Radice_Proxy"
-        ],
-        "tabelle_random": [
-          "tabella:riserva_empatica"
-        ]
+        "forme": ["Forma:Archivio_Subglaciale", "HUD:Radice_Proxy"],
+        "tabelle_random": ["tabella:riserva_empatica"]
       },
       "slot": [],
       "slot_profile": {
@@ -196,10 +182,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -237,10 +220,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -277,10 +257,7 @@
           }
         }
       ],
-      "sinergie": [
-        "bulbi_radici_permafrost",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["bulbi_radici_permafrost", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -318,10 +295,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -359,10 +333,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -400,10 +371,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -441,10 +409,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -482,10 +447,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -523,10 +485,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -564,10 +523,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -605,10 +561,7 @@
           }
         }
       ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
+      "sinergie": ["mucillagine_simbionte_mangrovie", "nodi_micorrizici_oracolari"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -625,9 +578,7 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
     },
     "mucillagine_simbionte_mangrovie": {
-      "conflitti": [
-        "ghiandola_caustica"
-      ],
+      "conflitti": ["ghiandola_caustica"],
       "debolezza": "Acque eccessivamente pure diluiscono la mucillagine riducendo la protezione.",
       "famiglia_tipologia": "Simbiotico/Difensivo",
       "fattore_mantenimento_energetico": "Medio (Coltura simbiotica costante)",
@@ -681,9 +632,7 @@
       "uso_funzione": "Forma una barriera viva che neutralizza veleni e sigilla ferite."
     },
     "nodi_micorrizici_oracolari": {
-      "conflitti": [
-        "spore_psichiche_silenziate"
-      ],
+      "conflitti": ["spore_psichiche_silenziate"],
       "debolezza": "Se la rete micorrizica viene recisa, l'organismo soffre crisi percettive e perdita di orientamento.",
       "famiglia_tipologia": "Simbiotico/Nervoso",
       "fattore_mantenimento_energetico": "Medio (Scambio continuo di segnali con simbionti)",
@@ -737,9 +686,7 @@
       "uso_funzione": "Riceve presagi e segnali tattici dalla rete fungina per coordinare manovre di squadra."
     },
     "sacche_spore_stratosferiche": {
-      "conflitti": [
-        "respiro_a_scoppio"
-      ],
+      "conflitti": ["respiro_a_scoppio"],
       "debolezza": "Correnti ionizzate possono incendiare le sacche rendendo l'organismo instabile.",
       "famiglia_tipologia": "Simbiotico/Supporto",
       "fattore_mantenimento_energetico": "Alto (Coltura continua di spore portanti)",
@@ -759,9 +706,7 @@
           }
         }
       ],
-      "sinergie": [
-        "piume_solari_fotovoltaiche"
-      ],
+      "sinergie": ["piume_solari_fotovoltaiche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -778,9 +723,7 @@
       "uso_funzione": "Distribuisce simbionti di supporto e crea corridoi di movimento per la squadra."
     },
     "sinapsi_coraline_polifoniche": {
-      "conflitti": [
-        "spore_psichiche_silenziate"
-      ],
+      "conflitti": ["spore_psichiche_silenziate"],
       "debolezza": "Vibrazioni sintonizzate male possono generare feedback dolorosi e perdita di coscienza.",
       "famiglia_tipologia": "Simbiotico/Comunicazione",
       "fattore_mantenimento_energetico": "Medio (Scambio continuo di impulsi corallini)",

--- a/docs/evo-tactics-pack/traits/strutturale/index.json
+++ b/docs/evo-tactics-pack/traits/strutturale/index.json
@@ -23,10 +23,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -64,10 +61,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -105,10 +99,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -146,10 +137,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -166,9 +154,7 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
     },
     "carapace_fase_variabile": {
-      "conflitti": [
-        "struttura_elastica_amorfa"
-      ],
+      "conflitti": ["struttura_elastica_amorfa"],
       "debolezza": "Debolezza strutturale durante la transizione tra le fasi di durezza.",
       "famiglia_tipologia": "Strutturale/Difensivo",
       "fattore_mantenimento_energetico": "Alto (Richiede energia per il cambio di fase)",
@@ -228,13 +214,8 @@
           "hud:PhaseShift_Plate"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Guardiano_Cangiante",
-          "HUD:Placca_Sintonica"
-        ],
-        "tabelle_random": [
-          "tabella:assetto_fase"
-        ]
+        "forme": ["Forma:Guardiano_Cangiante", "HUD:Placca_Sintonica"],
+        "tabelle_random": ["tabella:assetto_fase"]
       },
       "slot": [],
       "slot_profile": {
@@ -246,9 +227,7 @@
       "uso_funzione": "Durezza/densità del guscio modificabile rapidamente."
     },
     "carapace_luminiscente_abissale": {
-      "conflitti": [
-        "carapace_fase_variabile"
-      ],
+      "conflitti": ["carapace_fase_variabile"],
       "debolezza": "Luce intensa di superficie sovraccarica i biofotoni rendendo la corazza fragile.",
       "famiglia_tipologia": "Strutturale/Sensoriale",
       "fattore_mantenimento_energetico": "Alto (Bioluminescenza controllata)",
@@ -280,13 +259,8 @@
           "hud:AbyssLight_Array"
         ],
         "combo_totale": 3,
-        "forme": [
-          "Forma:Lanterna_Abissale",
-          "HUD:LuminaNet"
-        ],
-        "tabelle_random": [
-          "tabella:segnali_bioluminosi"
-        ]
+        "forme": ["Forma:Lanterna_Abissale", "HUD:LuminaNet"],
+        "tabelle_random": ["tabella:segnali_bioluminosi"]
       },
       "slot": [],
       "slot_profile": {
@@ -319,10 +293,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -360,10 +331,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -401,10 +369,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -442,10 +407,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -483,10 +445,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -524,10 +483,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -565,10 +521,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -606,10 +559,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -647,10 +597,7 @@
           }
         }
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
+      "sinergie": ["scheletro_idro_regolante", "struttura_elastica_amorfa"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 2,
@@ -667,9 +614,7 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
     },
     "scheletro_idro_regolante": {
-      "conflitti": [
-        "sangue_piroforico"
-      ],
+      "conflitti": ["sangue_piroforico"],
       "debolezza": "Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio.",
       "famiglia_tipologia": "Strutturale/Omeostatico",
       "fattore_mantenimento_energetico": "Medio (Scambio rapido di fluidi)",

--- a/docs/evo-tactics-pack/traits/tegumentario/index.json
+++ b/docs/evo-tactics-pack/traits/tegumentario/index.json
@@ -69,9 +69,7 @@
       "uso_funzione": "Assorbire e replicare il colore dell'ambiente circostante dopo contatto."
     },
     "piume_solari_fotovoltaiche": {
-      "conflitti": [
-        "criostasi_adattiva"
-      ],
+      "conflitti": ["criostasi_adattiva"],
       "debolezza": "Ombre prolungate o polveri dense riducono drasticamente la produzione energetica.",
       "famiglia_tipologia": "Tegumentario/Energetico",
       "fattore_mantenimento_energetico": "Alto (Richiede manutenzione delle lamine fotoreattive)",
@@ -91,10 +89,7 @@
           }
         }
       ],
-      "sinergie": [
-        "membrane_eliofiltranti",
-        "sacche_spore_stratosferiche"
-      ],
+      "sinergie": ["membrane_eliofiltranti", "sacche_spore_stratosferiche"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -111,10 +106,7 @@
       "uso_funzione": "Convertire la radiazione solare in riserve energetiche per abilità a lungo raggio."
     },
     "secrezione_rallentante_palmi": {
-      "conflitti": [
-        "carapace_fase_variabile",
-        "nucleo_ovomotore_rotante"
-      ],
+      "conflitti": ["carapace_fase_variabile", "nucleo_ovomotore_rotante"],
       "debolezza": "Esaurimento rapido delle riserve di liquido con tempo di ricarica prolungato.",
       "famiglia_tipologia": "Tegumentario/Difensivo",
       "fattore_mantenimento_energetico": "Medio (Produzione del liquido)",
@@ -151,9 +143,7 @@
       "uso_funzione": "Neutralizzare o immobilizzare prede/nemici."
     },
     "squame_rifrangenti_deserto": {
-      "conflitti": [
-        "mimetismo_cromatico_passivo"
-      ],
+      "conflitti": ["mimetismo_cromatico_passivo"],
       "debolezza": "Soffre danni da feedback termico se colpito da raggi concentrati o laser.",
       "famiglia_tipologia": "Tegumentario/Difensivo",
       "fattore_mantenimento_energetico": "Medio (Richiede riallineamento delle placche)",
@@ -173,9 +163,7 @@
           }
         }
       ],
-      "sinergie": [
-        "respiro_a_scoppio"
-      ],
+      "sinergie": ["respiro_a_scoppio"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,
@@ -212,9 +200,7 @@
           }
         }
       ],
-      "sinergie": [
-        "bulbi_radici_permafrost"
-      ],
+      "sinergie": ["bulbi_radici_permafrost"],
       "sinergie_pi": {
         "co_occorrenze": [],
         "combo_totale": 0,

--- a/packs/evo_tactics_pack/docs/catalog/catalog_data.json
+++ b/packs/evo_tactics_pack/docs/catalog/catalog_data.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2025-11-05T18:52:43.280Z",
+  "generated_at": "2025-11-11T23:48:24.660Z",
   "ecosistema": {
     "label": "Evo-Tactics Meta‑Ecosystem Alpha",
     "biomi": [
@@ -299,9 +299,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+            "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "echo-wing",
@@ -426,9 +426,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+            "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "evento-tempesta-ferrosa",
@@ -536,9 +536,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+            "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "ferrocolonia-magnetotattica",
@@ -663,9 +663,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+            "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "nano-rust-bloom",
@@ -778,9 +778,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+            "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "rust-scavenger",
@@ -890,9 +890,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+            "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "sand-burrower",
@@ -1006,9 +1006,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+            "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         }
       ],
       "label": "Brulle Terre Ferrose (Badlands)",
@@ -1159,9 +1159,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+            "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "evento-seme-uragano",
@@ -1237,9 +1237,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+            "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "lupus-temperatus",
@@ -1322,9 +1322,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+            "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "sentinella-radice",
@@ -1410,9 +1410,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+            "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         }
       ],
       "label": "Foresta Temperata Demo",
@@ -1614,9 +1614,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+            "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "evento-ondata-termica",
@@ -1702,9 +1702,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+            "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "noctule-termico",
@@ -1791,9 +1791,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+            "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "silica-bloom",
@@ -1880,9 +1880,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+            "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "thermo-raptor",
@@ -1970,9 +1970,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+            "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         }
       ],
       "label": "deserto_caldo (scaffold)",
@@ -2155,9 +2155,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+            "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "cryo-lynx",
@@ -2247,9 +2247,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+            "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "evento-brinastorm",
@@ -2336,9 +2336,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+            "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "steppe-bison-mini",
@@ -2431,9 +2431,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+            "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "thaw-rot",
@@ -2521,9 +2521,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+            "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         }
       ],
       "label": "cryosteppe (scaffold)",
@@ -2659,9 +2659,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+        "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "echo-wing",
@@ -2786,9 +2786,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+        "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "evento-tempesta-ferrosa",
@@ -2896,9 +2896,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+        "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "ferrocolonia-magnetotattica",
@@ -3023,9 +3023,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+        "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "nano-rust-bloom",
@@ -3138,9 +3138,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+        "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "rust-scavenger",
@@ -3250,9 +3250,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+        "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "sand-burrower",
@@ -3366,9 +3366,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+        "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "blight-micotico",
@@ -3450,9 +3450,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+        "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "evento-seme-uragano",
@@ -3528,9 +3528,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+        "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "lupus-temperatus",
@@ -3613,9 +3613,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+        "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "sentinella-radice",
@@ -3701,9 +3701,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+        "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "cactus-weaver",
@@ -3798,9 +3798,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+        "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "evento-ondata-termica",
@@ -3886,9 +3886,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+        "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "noctule-termico",
@@ -3975,9 +3975,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+        "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "silica-bloom",
@@ -4064,9 +4064,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+        "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "thermo-raptor",
@@ -4154,9 +4154,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+        "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "aurora-gull",
@@ -4244,9 +4244,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+        "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "cryo-lynx",
@@ -4336,9 +4336,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+        "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "evento-brinastorm",
@@ -4425,9 +4425,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+        "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "steppe-bison-mini",
@@ -4520,9 +4520,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+        "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "thaw-rot",
@@ -4610,9 +4610,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+        "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     }
   ]
 }

--- a/packs/evo_tactics_pack/docs/catalog/species-index.json
+++ b/packs/evo_tactics_pack/docs/catalog/species-index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-11-05T18:52:43.280Z",
+  "generated_at": "2025-11-11T23:48:24.660Z",
   "total_species": 21,
   "species": [
     {

--- a/packs/evo_tactics_pack/docs/catalog/species/aurora-gull.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/aurora-gull.json
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+    "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/blight-micotico.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/blight-micotico.json
@@ -78,7 +78,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+    "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/cactus-weaver.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/cactus-weaver.json
@@ -91,7 +91,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+    "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/cryo-lynx.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/cryo-lynx.json
@@ -86,7 +86,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+    "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/dune-stalker.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/dune-stalker.json
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+    "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/echo-wing.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/echo-wing.json
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+    "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/evento-brinastorm.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/evento-brinastorm.json
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+    "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/evento-ondata-termica.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/evento-ondata-termica.json
@@ -82,7 +82,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+    "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/evento-seme-uragano.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/evento-seme-uragano.json
@@ -72,7 +72,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+    "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/evento-tempesta-ferrosa.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/evento-tempesta-ferrosa.json
@@ -104,7 +104,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+    "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/ferrocolonia-magnetotattica.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/ferrocolonia-magnetotattica.json
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+    "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/index.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-11-05T18:52:43.280Z",
+  "generated_at": "2025-11-11T23:48:24.660Z",
   "total_species": 21,
   "species": [
     {

--- a/packs/evo_tactics_pack/docs/catalog/species/lupus-temperatus.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/lupus-temperatus.json
@@ -79,7 +79,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+    "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/nano-rust-bloom.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/nano-rust-bloom.json
@@ -109,7 +109,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+    "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/noctule-termico.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/noctule-termico.json
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+    "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/rust-scavenger.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/rust-scavenger.json
@@ -106,7 +106,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+    "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/sand-burrower.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/sand-burrower.json
@@ -110,7 +110,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+    "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/sentinella-radice.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/sentinella-radice.json
@@ -82,7 +82,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+    "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/silica-bloom.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/silica-bloom.json
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+    "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/steppe-bison-mini.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/steppe-bison-mini.json
@@ -89,7 +89,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+    "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/thaw-rot.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/thaw-rot.json
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+    "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/packs/evo_tactics_pack/docs/catalog/species/thermo-raptor.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/thermo-raptor.json
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+    "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/catalog_data.json
+++ b/public/docs/evo-tactics-pack/catalog_data.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2025-11-05T18:52:43.280Z",
+  "generated_at": "2025-11-11T23:48:24.660Z",
   "ecosistema": {
     "label": "Evo-Tactics Meta‑Ecosystem Alpha",
     "biomi": [
       {
         "id": "badlands",
-        "path": "../../data/ecosystems/badlands.biome.yaml",
+        "path": "../../packs/evo_tactics_pack/data/ecosystems/badlands.biome.yaml",
         "label": "Brulle Terre Ferrose (Badlands)",
         "network_id": "BADLANDS",
         "biome_profile": "canyons_risonanti",
@@ -13,7 +13,7 @@
       },
       {
         "id": "foresta_temperata",
-        "path": "../../data/ecosystems/foresta_temperata.biome.yaml",
+        "path": "../../packs/evo_tactics_pack/data/ecosystems/foresta_temperata.biome.yaml",
         "label": "Foresta Temperata Demo",
         "network_id": "FORESTA_TEMPERATA",
         "biome_profile": "foresta_miceliale",
@@ -21,7 +21,7 @@
       },
       {
         "id": "deserto_caldo",
-        "path": "../../data/ecosystems/deserto_caldo.biome.yaml",
+        "path": "../../packs/evo_tactics_pack/data/ecosystems/deserto_caldo.biome.yaml",
         "label": "deserto_caldo (scaffold)",
         "network_id": "DESERTO_CALDO",
         "biome_profile": "savana",
@@ -29,7 +29,7 @@
       },
       {
         "id": "cryosteppe",
-        "path": "../../data/ecosystems/cryosteppe.biome.yaml",
+        "path": "../../packs/evo_tactics_pack/data/ecosystems/cryosteppe.biome.yaml",
         "label": "cryosteppe (scaffold)",
         "network_id": "CRYOSTEPPE",
         "biome_profile": "mezzanotte_orbitale",
@@ -82,7 +82,7 @@
   "biomi": [
     {
       "id": "badlands",
-      "path": "../../data/ecosystems/badlands.biome.yaml",
+      "path": "../../packs/evo_tactics_pack/data/ecosystems/badlands.biome.yaml",
       "manifest": {
         "species_counts": {
           "apex": 1,
@@ -104,12 +104,12 @@
           "specie_chiave"
         ],
         "foodweb_links": {
-          "path": "../../data/foodwebs/badlands_foodweb.yaml",
+          "path": "../../packs/evo_tactics_pack/data/foodwebs/badlands_foodweb.yaml",
           "sink_detrito": true
         }
       },
       "foodweb": {
-        "path": "../../data/foodwebs/badlands_foodweb.yaml",
+        "path": "../../packs/evo_tactics_pack/data/foodwebs/badlands_foodweb.yaml",
         "nodes": [
           "arbusti_xerofili",
           "crostoni_criptofite",
@@ -195,7 +195,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/badlands/dune-stalker.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T3",
@@ -299,9 +299,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+            "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "echo-wing",
@@ -325,7 +325,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/badlands/echo-wing.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
           "balance": {
             "rarity": "R2",
             "threat_tier": "T1",
@@ -426,9 +426,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+            "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "evento-tempesta-ferrosa",
@@ -448,7 +448,7 @@
             "threat": false,
             "event": true
           },
-          "path": "../../data/species/badlands/evento-tempesta-ferrosa.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
           "balance": {
             "rarity": "R5",
             "threat_tier": "T4",
@@ -536,9 +536,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+            "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "ferrocolonia-magnetotattica",
@@ -560,7 +560,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/badlands/ferrocolonia-magnetotattica.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T2",
@@ -663,9 +663,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+            "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "nano-rust-bloom",
@@ -685,7 +685,7 @@
             "threat": true,
             "event": false
           },
-          "path": "../../data/species/badlands/nano-rust-bloom.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T3",
@@ -778,9 +778,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+            "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "rust-scavenger",
@@ -801,7 +801,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/badlands/rust-scavenger.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
           "balance": {
             "rarity": "R2",
             "threat_tier": "T1",
@@ -890,9 +890,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+            "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "sand-burrower",
@@ -913,7 +913,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/badlands/sand-burrower.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
           "balance": {
             "rarity": "R1",
             "threat_tier": "T1",
@@ -1006,9 +1006,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+            "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         }
       ],
       "label": "Brulle Terre Ferrose (Badlands)",
@@ -1030,7 +1030,7 @@
     },
     {
       "id": "foresta_temperata",
-      "path": "../../data/ecosystems/foresta_temperata.biome.yaml",
+      "path": "../../packs/evo_tactics_pack/data/ecosystems/foresta_temperata.biome.yaml",
       "manifest": {
         "species_counts": {
           "apex": 1,
@@ -1045,13 +1045,13 @@
           "specie_chiave"
         ],
         "foodweb_links": {
-          "path": "../../data/foodwebs/foresta_temperata_foodweb.yaml",
+          "path": "../../packs/evo_tactics_pack/data/foodwebs/foresta_temperata_foodweb.yaml",
           "sink_detrito": true
         },
-        "path": "../../data/ecosystems/foresta_temperata.manifest.yaml"
+        "path": "../../packs/evo_tactics_pack/data/ecosystems/foresta_temperata.manifest.yaml"
       },
       "foodweb": {
-        "path": "../../data/foodwebs/foresta_temperata_foodweb.yaml",
+        "path": "../../packs/evo_tactics_pack/data/foodwebs/foresta_temperata_foodweb.yaml",
         "nodes": [
           "produttori_base",
           "HERB_CERVO",
@@ -1097,7 +1097,7 @@
             "threat": true,
             "event": false
           },
-          "path": "../../data/species/foresta_temperata/blight-micotico.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T3",
@@ -1159,9 +1159,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+            "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "evento-seme-uragano",
@@ -1181,7 +1181,7 @@
             "threat": false,
             "event": true
           },
-          "path": "../../data/species/foresta_temperata/evento-seme-uragano.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
           "balance": {
             "rarity": "R5",
             "threat_tier": "T4",
@@ -1237,9 +1237,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+            "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "lupus-temperatus",
@@ -1259,7 +1259,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/foresta_temperata/lupus-temperatus.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
           "balance": {
             "rarity": "R2",
             "threat_tier": "T2",
@@ -1322,9 +1322,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+            "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "sentinella-radice",
@@ -1345,7 +1345,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/foresta_temperata/sentinella-radice.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T1",
@@ -1410,9 +1410,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+            "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         }
       ],
       "label": "Foresta Temperata Demo",
@@ -1431,7 +1431,7 @@
     },
     {
       "id": "deserto_caldo",
-      "path": "../../data/ecosystems/deserto_caldo.biome.yaml",
+      "path": "../../packs/evo_tactics_pack/data/ecosystems/deserto_caldo.biome.yaml",
       "manifest": {
         "species_counts": {
           "apex": 1,
@@ -1451,12 +1451,12 @@
           "specie_chiave"
         ],
         "foodweb_links": {
-          "path": "../../data/foodwebs/deserto_caldo_foodweb.yaml",
+          "path": "../../packs/evo_tactics_pack/data/foodwebs/deserto_caldo_foodweb.yaml",
           "sink_detrito": true
         }
       },
       "foodweb": {
-        "path": "../../data/foodwebs/deserto_caldo_foodweb.yaml",
+        "path": "../../packs/evo_tactics_pack/data/foodwebs/deserto_caldo_foodweb.yaml",
         "nodes": [
           "succulente_xerofile",
           "cianobatteri_dune",
@@ -1541,7 +1541,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/deserto_caldo/cactus-weaver.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
           "balance": {
             "rarity": "R2",
             "threat_tier": "T1",
@@ -1614,9 +1614,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+            "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "evento-ondata-termica",
@@ -1636,7 +1636,7 @@
             "threat": false,
             "event": true
           },
-          "path": "../../data/species/deserto_caldo/evento-ondata-termica.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
           "balance": {
             "rarity": "R5",
             "threat_tier": "T4",
@@ -1702,9 +1702,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+            "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "noctule-termico",
@@ -1725,7 +1725,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/deserto_caldo/noctule-termico.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
           "balance": {
             "rarity": "R2",
             "threat_tier": "T1",
@@ -1791,9 +1791,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+            "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "silica-bloom",
@@ -1813,7 +1813,7 @@
             "threat": true,
             "event": false
           },
-          "path": "../../data/species/deserto_caldo/silica-bloom.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T3",
@@ -1880,9 +1880,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+            "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "thermo-raptor",
@@ -1903,7 +1903,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/deserto_caldo/thermo-raptor.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T3",
@@ -1970,9 +1970,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+            "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         }
       ],
       "label": "deserto_caldo (scaffold)",
@@ -1985,7 +1985,7 @@
     },
     {
       "id": "cryosteppe",
-      "path": "../../data/ecosystems/cryosteppe.biome.yaml",
+      "path": "../../packs/evo_tactics_pack/data/ecosystems/cryosteppe.biome.yaml",
       "manifest": {
         "species_counts": {
           "apex": 1,
@@ -2005,12 +2005,12 @@
           "specie_chiave"
         ],
         "foodweb_links": {
-          "path": "../../data/foodwebs/cryosteppe_foodweb.yaml",
+          "path": "../../packs/evo_tactics_pack/data/foodwebs/cryosteppe_foodweb.yaml",
           "sink_detrito": true
         }
       },
       "foodweb": {
-        "path": "../../data/foodwebs/cryosteppe_foodweb.yaml",
+        "path": "../../packs/evo_tactics_pack/data/foodwebs/cryosteppe_foodweb.yaml",
         "nodes": [
           "tappeti_muschio",
           "arbusti_alpini",
@@ -2088,7 +2088,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/cryosteppe/aurora-gull.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
           "balance": {
             "rarity": "R2",
             "threat_tier": "T1",
@@ -2155,9 +2155,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+            "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "cryo-lynx",
@@ -2178,7 +2178,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/cryosteppe/cryo-lynx.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T3",
@@ -2247,9 +2247,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+            "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "evento-brinastorm",
@@ -2269,7 +2269,7 @@
             "threat": false,
             "event": true
           },
-          "path": "../../data/species/cryosteppe/evento-brinastorm.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
           "balance": {
             "rarity": "R5",
             "threat_tier": "T4",
@@ -2336,9 +2336,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+            "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "steppe-bison-mini",
@@ -2360,7 +2360,7 @@
             "threat": false,
             "event": false
           },
-          "path": "../../data/species/cryosteppe/steppe-bison-mini.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
           "balance": {
             "rarity": "R2",
             "threat_tier": "T1",
@@ -2431,9 +2431,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+            "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         },
         {
           "id": "thaw-rot",
@@ -2453,7 +2453,7 @@
             "threat": true,
             "event": false
           },
-          "path": "../../data/species/cryosteppe/thaw-rot.yaml",
+          "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
           "balance": {
             "rarity": "R3",
             "threat_tier": "T3",
@@ -2521,9 +2521,9 @@
             "source": "PTPF.v1.0",
             "author": "designer",
             "date": "2025-10-25",
-            "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+            "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
           },
-          "last_synced_at": "2025-11-05T18:52:43.280Z"
+          "last_synced_at": "2025-11-11T23:48:24.660Z"
         }
       ],
       "label": "cryosteppe (scaffold)",
@@ -2555,7 +2555,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/badlands/dune-stalker.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T3",
@@ -2659,9 +2659,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+        "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "echo-wing",
@@ -2685,7 +2685,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/badlands/echo-wing.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
       "balance": {
         "rarity": "R2",
         "threat_tier": "T1",
@@ -2786,9 +2786,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+        "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "evento-tempesta-ferrosa",
@@ -2808,7 +2808,7 @@
         "threat": false,
         "event": true
       },
-      "path": "../../data/species/badlands/evento-tempesta-ferrosa.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
       "balance": {
         "rarity": "R5",
         "threat_tier": "T4",
@@ -2896,9 +2896,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+        "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "ferrocolonia-magnetotattica",
@@ -2920,7 +2920,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/badlands/ferrocolonia-magnetotattica.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T2",
@@ -3023,9 +3023,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+        "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "nano-rust-bloom",
@@ -3045,7 +3045,7 @@
         "threat": true,
         "event": false
       },
-      "path": "../../data/species/badlands/nano-rust-bloom.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T3",
@@ -3138,9 +3138,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+        "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "rust-scavenger",
@@ -3161,7 +3161,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/badlands/rust-scavenger.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
       "balance": {
         "rarity": "R2",
         "threat_tier": "T1",
@@ -3250,9 +3250,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+        "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "sand-burrower",
@@ -3273,7 +3273,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/badlands/sand-burrower.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
       "balance": {
         "rarity": "R1",
         "threat_tier": "T1",
@@ -3366,9 +3366,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+        "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "blight-micotico",
@@ -3388,7 +3388,7 @@
         "threat": true,
         "event": false
       },
-      "path": "../../data/species/foresta_temperata/blight-micotico.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T3",
@@ -3450,9 +3450,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+        "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "evento-seme-uragano",
@@ -3472,7 +3472,7 @@
         "threat": false,
         "event": true
       },
-      "path": "../../data/species/foresta_temperata/evento-seme-uragano.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
       "balance": {
         "rarity": "R5",
         "threat_tier": "T4",
@@ -3528,9 +3528,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+        "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "lupus-temperatus",
@@ -3550,7 +3550,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/foresta_temperata/lupus-temperatus.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
       "balance": {
         "rarity": "R2",
         "threat_tier": "T2",
@@ -3613,9 +3613,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+        "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "sentinella-radice",
@@ -3636,7 +3636,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/foresta_temperata/sentinella-radice.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T1",
@@ -3701,9 +3701,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+        "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "cactus-weaver",
@@ -3725,7 +3725,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/deserto_caldo/cactus-weaver.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
       "balance": {
         "rarity": "R2",
         "threat_tier": "T1",
@@ -3798,9 +3798,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+        "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "evento-ondata-termica",
@@ -3820,7 +3820,7 @@
         "threat": false,
         "event": true
       },
-      "path": "../../data/species/deserto_caldo/evento-ondata-termica.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
       "balance": {
         "rarity": "R5",
         "threat_tier": "T4",
@@ -3886,9 +3886,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+        "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "noctule-termico",
@@ -3909,7 +3909,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/deserto_caldo/noctule-termico.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
       "balance": {
         "rarity": "R2",
         "threat_tier": "T1",
@@ -3975,9 +3975,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+        "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "silica-bloom",
@@ -3997,7 +3997,7 @@
         "threat": true,
         "event": false
       },
-      "path": "../../data/species/deserto_caldo/silica-bloom.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T3",
@@ -4064,9 +4064,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+        "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "thermo-raptor",
@@ -4087,7 +4087,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/deserto_caldo/thermo-raptor.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T3",
@@ -4154,9 +4154,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+        "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "aurora-gull",
@@ -4177,7 +4177,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/cryosteppe/aurora-gull.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
       "balance": {
         "rarity": "R2",
         "threat_tier": "T1",
@@ -4244,9 +4244,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+        "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "cryo-lynx",
@@ -4267,7 +4267,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/cryosteppe/cryo-lynx.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T3",
@@ -4336,9 +4336,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+        "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "evento-brinastorm",
@@ -4358,7 +4358,7 @@
         "threat": false,
         "event": true
       },
-      "path": "../../data/species/cryosteppe/evento-brinastorm.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
       "balance": {
         "rarity": "R5",
         "threat_tier": "T4",
@@ -4425,9 +4425,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+        "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "steppe-bison-mini",
@@ -4449,7 +4449,7 @@
         "threat": false,
         "event": false
       },
-      "path": "../../data/species/cryosteppe/steppe-bison-mini.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
       "balance": {
         "rarity": "R2",
         "threat_tier": "T1",
@@ -4520,9 +4520,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+        "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     },
     {
       "id": "thaw-rot",
@@ -4542,7 +4542,7 @@
         "threat": true,
         "event": false
       },
-      "path": "../../data/species/cryosteppe/thaw-rot.yaml",
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
       "balance": {
         "rarity": "R3",
         "threat_tier": "T3",
@@ -4610,9 +4610,9 @@
         "source": "PTPF.v1.0",
         "author": "designer",
         "date": "2025-10-25",
-        "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+        "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
       },
-      "last_synced_at": "2025-11-05T18:52:43.280Z"
+      "last_synced_at": "2025-11-11T23:48:24.660Z"
     }
   ]
 }

--- a/public/docs/evo-tactics-pack/species-index.json
+++ b/public/docs/evo-tactics-pack/species-index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-11-05T18:52:43.280Z",
+  "generated_at": "2025-11-11T23:48:24.660Z",
   "total_species": 21,
   "species": [
     {
@@ -35,7 +35,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/cryosteppe/aurora-gull.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml"
     },
     {
       "id": "blight-micotico",
@@ -67,7 +67,7 @@
         "incendi sporadici"
       ],
       "playable_unit": false,
-      "path": "../../data/species/foresta_temperata/blight-micotico.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml"
     },
     {
       "id": "cactus-weaver",
@@ -102,7 +102,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/deserto_caldo/cactus-weaver.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml"
     },
     {
       "id": "cryo-lynx",
@@ -136,7 +136,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/cryosteppe/cryo-lynx.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml"
     },
     {
       "id": "dune-stalker",
@@ -175,7 +175,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/dune-stalker.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml"
     },
     {
       "id": "echo-wing",
@@ -218,7 +218,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": true,
-      "path": "../../data/species/badlands/echo-wing.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml"
     },
     {
       "id": "evento-brinastorm",
@@ -251,7 +251,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/cryosteppe/evento-brinastorm.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml"
     },
     {
       "id": "evento-ondata-termica",
@@ -284,7 +284,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/deserto_caldo/evento-ondata-termica.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml"
     },
     {
       "id": "evento-seme-uragano",
@@ -316,7 +316,7 @@
         "incendi sporadici"
       ],
       "playable_unit": false,
-      "path": "../../data/species/foresta_temperata/evento-seme-uragano.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml"
     },
     {
       "id": "evento-tempesta-ferrosa",
@@ -354,7 +354,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/evento-tempesta-ferrosa.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml"
     },
     {
       "id": "ferrocolonia-magnetotattica",
@@ -394,7 +394,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": true,
-      "path": "../../data/species/badlands/ferrocolonia-magnetotattica.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml"
     },
     {
       "id": "lupus-temperatus",
@@ -426,7 +426,7 @@
         "incendi sporadici"
       ],
       "playable_unit": false,
-      "path": "../../data/species/foresta_temperata/lupus-temperatus.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml"
     },
     {
       "id": "nano-rust-bloom",
@@ -464,7 +464,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/nano-rust-bloom.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml"
     },
     {
       "id": "noctule-termico",
@@ -498,7 +498,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/deserto_caldo/noctule-termico.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml"
     },
     {
       "id": "rust-scavenger",
@@ -534,7 +534,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": true,
-      "path": "../../data/species/badlands/rust-scavenger.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml"
     },
     {
       "id": "sand-burrower",
@@ -573,7 +573,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/sand-burrower.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml"
     },
     {
       "id": "sentinella-radice",
@@ -606,7 +606,7 @@
         "incendi sporadici"
       ],
       "playable_unit": true,
-      "path": "../../data/species/foresta_temperata/sentinella-radice.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml"
     },
     {
       "id": "silica-bloom",
@@ -639,7 +639,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/deserto_caldo/silica-bloom.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml"
     },
     {
       "id": "steppe-bison-mini",
@@ -674,7 +674,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/cryosteppe/steppe-bison-mini.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml"
     },
     {
       "id": "thaw-rot",
@@ -707,7 +707,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/cryosteppe/thaw-rot.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml"
     },
     {
       "id": "thermo-raptor",
@@ -741,7 +741,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/deserto_caldo/thermo-raptor.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml"
     }
   ]
 }

--- a/public/docs/evo-tactics-pack/species/aurora-gull.json
+++ b/public/docs/evo-tactics-pack/species/aurora-gull.json
@@ -17,7 +17,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/cryosteppe/aurora-gull.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
   "balance": {
     "rarity": "R2",
     "threat_tier": "T1",
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "7d527fc1cfc2c304e5a29fca9c9dbfc49ff818222b1a89c3c3884f81ab1a4a2f"
+    "trace_hash": "7266df45d2fc0f71cbe30c8a0d99ac516dc3c058b213cf9ec4f3db6013b1edde"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/blight-micotico.json
+++ b/public/docs/evo-tactics-pack/species/blight-micotico.json
@@ -16,7 +16,7 @@
     "threat": true,
     "event": false
   },
-  "path": "../../data/species/foresta_temperata/blight-micotico.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T3",
@@ -78,7 +78,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "62327422fd83c959841ffb677ade2b743479cb508282a6bd9c6377a02bbfeef6"
+    "trace_hash": "1ceb65cf419ec898f6cd2868ad123128cf252296253c16f87382e1cbe8fb866b"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/cactus-weaver.json
+++ b/public/docs/evo-tactics-pack/species/cactus-weaver.json
@@ -18,7 +18,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/deserto_caldo/cactus-weaver.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
   "balance": {
     "rarity": "R2",
     "threat_tier": "T1",
@@ -91,7 +91,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "292922284a3d239d348896ceb846f71f8f6cf694e7c31a08991acc55682ff05f"
+    "trace_hash": "1dd6bbfb1052ac0238f0f2508335a3a22e4ba4c2c99ddc84041355320f09091b"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/cryo-lynx.json
+++ b/public/docs/evo-tactics-pack/species/cryo-lynx.json
@@ -17,7 +17,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/cryosteppe/cryo-lynx.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T3",
@@ -86,7 +86,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "dc74dcf3832844d2629724580aa06ab6b1bf49627b9dbcb1162c4c89e368446f"
+    "trace_hash": "75e8602243ab87487aac6306c51e95bb2764dd76dec2c56c9158e55817a133dc"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/dune-stalker.json
+++ b/public/docs/evo-tactics-pack/species/dune-stalker.json
@@ -17,7 +17,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/badlands/dune-stalker.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T3",
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "64b8dbb2f6eb938004dbe5e0df3e5876d97328cf3efeb8b8b7b4ae57ac2e5a47"
+    "trace_hash": "f3253a3525d42e0521b89bf176ef80e18210c60c56097718402461033e07b6cb"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/echo-wing.json
+++ b/public/docs/evo-tactics-pack/species/echo-wing.json
@@ -20,7 +20,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/badlands/echo-wing.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
   "balance": {
     "rarity": "R2",
     "threat_tier": "T1",
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8a9d00488b255a945dca4d9190d62463f9d67320b7b58e38d53e0ec227589687"
+    "trace_hash": "bfa87faea1e2446a9785596011608bff528cdfc088ca421166df88d0ae99fdb8"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/evento-brinastorm.json
+++ b/public/docs/evo-tactics-pack/species/evento-brinastorm.json
@@ -16,7 +16,7 @@
     "threat": false,
     "event": true
   },
-  "path": "../../data/species/cryosteppe/evento-brinastorm.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml",
   "balance": {
     "rarity": "R5",
     "threat_tier": "T4",
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "52af93ee70b530c95143acf8219da38232ec9131a7e2506a53520aa74a7218e7"
+    "trace_hash": "1d813e5cea26a284eb2155ea1720eadb9d5bc5ba65b497dd3410ada35a1713bb"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/evento-ondata-termica.json
+++ b/public/docs/evo-tactics-pack/species/evento-ondata-termica.json
@@ -16,7 +16,7 @@
     "threat": false,
     "event": true
   },
-  "path": "../../data/species/deserto_caldo/evento-ondata-termica.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml",
   "balance": {
     "rarity": "R5",
     "threat_tier": "T4",
@@ -82,7 +82,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "f26de2ba83e5ea0bc7e2076412fb0491e14e7600d06d76d46157f4802d7f3913"
+    "trace_hash": "804c9a52ace9c67910468236a3f99aea24ba4c40bc380c6efdfd5b0dfd2671b7"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/evento-seme-uragano.json
+++ b/public/docs/evo-tactics-pack/species/evento-seme-uragano.json
@@ -16,7 +16,7 @@
     "threat": false,
     "event": true
   },
-  "path": "../../data/species/foresta_temperata/evento-seme-uragano.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml",
   "balance": {
     "rarity": "R5",
     "threat_tier": "T4",
@@ -72,7 +72,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8bbcb9d51158f40612acd6a6fb8299a3c66b67ebea3b9bfc94490cbfb59311be"
+    "trace_hash": "6378bb4d48ab1daee32ac3ae18c156cfcfe562ad7529baa67d050b0046846a6e"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/evento-tempesta-ferrosa.json
+++ b/public/docs/evo-tactics-pack/species/evento-tempesta-ferrosa.json
@@ -16,7 +16,7 @@
     "threat": false,
     "event": true
   },
-  "path": "../../data/species/badlands/evento-tempesta-ferrosa.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml",
   "balance": {
     "rarity": "R5",
     "threat_tier": "T4",
@@ -104,7 +104,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "566b53a7564477c3f86b197a095af87f0c5a70a1a1e541fa996d2cb0a49365a6"
+    "trace_hash": "6e07bbd8680e292def732ca859aa8712aef4807bea820bfa7c4773dfa644cfc1"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/ferrocolonia-magnetotattica.json
+++ b/public/docs/evo-tactics-pack/species/ferrocolonia-magnetotattica.json
@@ -18,7 +18,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/badlands/ferrocolonia-magnetotattica.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T2",
@@ -121,7 +121,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "19e4eb8e1657b8d18d05b16c7208a7e0b44926d1c45eee883797217e507b1c70"
+    "trace_hash": "1cebf5c3c8a932aa2cc8338d9d7776c1bd31b269e493ffef8d1f2283e0215497"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/index.json
+++ b/public/docs/evo-tactics-pack/species/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-11-05T18:52:43.280Z",
+  "generated_at": "2025-11-11T23:48:24.660Z",
   "total_species": 21,
   "species": [
     {
@@ -35,7 +35,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/cryosteppe/aurora-gull.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml"
     },
     {
       "id": "blight-micotico",
@@ -67,7 +67,7 @@
         "incendi sporadici"
       ],
       "playable_unit": false,
-      "path": "../../data/species/foresta_temperata/blight-micotico.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml"
     },
     {
       "id": "cactus-weaver",
@@ -102,7 +102,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/deserto_caldo/cactus-weaver.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml"
     },
     {
       "id": "cryo-lynx",
@@ -136,7 +136,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/cryosteppe/cryo-lynx.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml"
     },
     {
       "id": "dune-stalker",
@@ -175,7 +175,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/dune-stalker.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml"
     },
     {
       "id": "echo-wing",
@@ -218,7 +218,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": true,
-      "path": "../../data/species/badlands/echo-wing.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml"
     },
     {
       "id": "evento-brinastorm",
@@ -251,7 +251,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/cryosteppe/evento-brinastorm.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml"
     },
     {
       "id": "evento-ondata-termica",
@@ -284,7 +284,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/deserto_caldo/evento-ondata-termica.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml"
     },
     {
       "id": "evento-seme-uragano",
@@ -316,7 +316,7 @@
         "incendi sporadici"
       ],
       "playable_unit": false,
-      "path": "../../data/species/foresta_temperata/evento-seme-uragano.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml"
     },
     {
       "id": "evento-tempesta-ferrosa",
@@ -354,7 +354,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/evento-tempesta-ferrosa.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml"
     },
     {
       "id": "ferrocolonia-magnetotattica",
@@ -394,7 +394,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": true,
-      "path": "../../data/species/badlands/ferrocolonia-magnetotattica.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml"
     },
     {
       "id": "lupus-temperatus",
@@ -426,7 +426,7 @@
         "incendi sporadici"
       ],
       "playable_unit": false,
-      "path": "../../data/species/foresta_temperata/lupus-temperatus.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml"
     },
     {
       "id": "nano-rust-bloom",
@@ -464,7 +464,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/nano-rust-bloom.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml"
     },
     {
       "id": "noctule-termico",
@@ -498,7 +498,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/deserto_caldo/noctule-termico.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml"
     },
     {
       "id": "rust-scavenger",
@@ -534,7 +534,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": true,
-      "path": "../../data/species/badlands/rust-scavenger.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml"
     },
     {
       "id": "sand-burrower",
@@ -573,7 +573,7 @@
         "tempeste_sabbia"
       ],
       "playable_unit": false,
-      "path": "../../data/species/badlands/sand-burrower.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml"
     },
     {
       "id": "sentinella-radice",
@@ -606,7 +606,7 @@
         "incendi sporadici"
       ],
       "playable_unit": true,
-      "path": "../../data/species/foresta_temperata/sentinella-radice.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml"
     },
     {
       "id": "silica-bloom",
@@ -639,7 +639,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/deserto_caldo/silica-bloom.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml"
     },
     {
       "id": "steppe-bison-mini",
@@ -674,7 +674,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": true,
-      "path": "../../data/species/cryosteppe/steppe-bison-mini.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml"
     },
     {
       "id": "thaw-rot",
@@ -707,7 +707,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/cryosteppe/thaw-rot.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml"
     },
     {
       "id": "thermo-raptor",
@@ -741,7 +741,7 @@
       ],
       "hazards_expected": [],
       "playable_unit": false,
-      "path": "../../data/species/deserto_caldo/thermo-raptor.yaml"
+      "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml"
     }
   ]
 }

--- a/public/docs/evo-tactics-pack/species/lupus-temperatus.json
+++ b/public/docs/evo-tactics-pack/species/lupus-temperatus.json
@@ -16,7 +16,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/foresta_temperata/lupus-temperatus.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
   "balance": {
     "rarity": "R2",
     "threat_tier": "T2",
@@ -79,7 +79,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "7e93aff34970f504d266ff51b38aba2c2baf271bb5cf279cb218170d77fa34cf"
+    "trace_hash": "fb98c402302a4e6ca41af7cb0034d4efd40bcd55eb312f2fa333442878b790b2"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/nano-rust-bloom.json
+++ b/public/docs/evo-tactics-pack/species/nano-rust-bloom.json
@@ -16,7 +16,7 @@
     "threat": true,
     "event": false
   },
-  "path": "../../data/species/badlands/nano-rust-bloom.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T3",
@@ -109,7 +109,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "d75c052df6e0b49251fff8dbad92e2a351385066ecfd7990ff20fd739f8f094e"
+    "trace_hash": "6207fcce34051682f68ae62aba1b1bd6ddc7dfe5b6855fb923868376bcedd1ec"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/noctule-termico.json
+++ b/public/docs/evo-tactics-pack/species/noctule-termico.json
@@ -17,7 +17,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/deserto_caldo/noctule-termico.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
   "balance": {
     "rarity": "R2",
     "threat_tier": "T1",
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "48d60d5c49d62ce46685c587b8827bf8542828c7c929cb7f5bc99b55be70e398"
+    "trace_hash": "2b98448ee2537bfedd47824861fb2a6c8577ec6a1f63d720d704aa23a00ef0d5"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/rust-scavenger.json
+++ b/public/docs/evo-tactics-pack/species/rust-scavenger.json
@@ -17,7 +17,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/badlands/rust-scavenger.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
   "balance": {
     "rarity": "R2",
     "threat_tier": "T1",
@@ -106,7 +106,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "8f43383027bdce3e6e92a380eb2184e229e46186ace905774edbf59019cf1c90"
+    "trace_hash": "ad1ca1a5777c3438f1e819d3446f9640d8bd42666a9f60b9df19adbb95e44654"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/sand-burrower.json
+++ b/public/docs/evo-tactics-pack/species/sand-burrower.json
@@ -17,7 +17,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/badlands/sand-burrower.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
   "balance": {
     "rarity": "R1",
     "threat_tier": "T1",
@@ -110,7 +110,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "2af231da1b73ee7efecd62799d60aa1b03690a87a1f3ecd87c4b7fabf4a9f9d3"
+    "trace_hash": "e6dd1545f31674af6dcd47220be84e05e4c7eb26bfdc37b7d02f2e33c39ee356"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/sentinella-radice.json
+++ b/public/docs/evo-tactics-pack/species/sentinella-radice.json
@@ -17,7 +17,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/foresta_temperata/sentinella-radice.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T1",
@@ -82,7 +82,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "4ce0a383a8ef4ec8323f74b8ae9d878fdcb1f6d862a946e743014268a860d044"
+    "trace_hash": "3fd2c271e53fc2f1d709884390b4ad18bbc9b4111351abb7312c054d6e3760ce"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/silica-bloom.json
+++ b/public/docs/evo-tactics-pack/species/silica-bloom.json
@@ -16,7 +16,7 @@
     "threat": true,
     "event": false
   },
-  "path": "../../data/species/deserto_caldo/silica-bloom.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T3",
@@ -83,7 +83,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "89f1eeede87d4609e66d9d3339bf18fcfe8e497c20f48bd1325f269b3cd25af1"
+    "trace_hash": "a03646e3372cf21213177616f691ed47a8e1cdb5b29f484e84582fda4b2bf3cc"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/steppe-bison-mini.json
+++ b/public/docs/evo-tactics-pack/species/steppe-bison-mini.json
@@ -18,7 +18,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/cryosteppe/steppe-bison-mini.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
   "balance": {
     "rarity": "R2",
     "threat_tier": "T1",
@@ -89,7 +89,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "d98a20765971c71ed73a8c4ce73c45d6dac31ab437f3397867cde1a9e3dab252"
+    "trace_hash": "a961ea3d37fb106680a3326d34925a73a3b0bd498d9563a464a54be39641705e"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/thaw-rot.json
+++ b/public/docs/evo-tactics-pack/species/thaw-rot.json
@@ -16,7 +16,7 @@
     "threat": true,
     "event": false
   },
-  "path": "../../data/species/cryosteppe/thaw-rot.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T3",
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "9026bad1f961d6db5a451a41526404be5318b66a243e29953727e4447817e09b"
+    "trace_hash": "18f213e4c7b49b4795fd786490dcb62cebefadc67f42dd91b287cedc3a8e427f"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/public/docs/evo-tactics-pack/species/thermo-raptor.json
+++ b/public/docs/evo-tactics-pack/species/thermo-raptor.json
@@ -17,7 +17,7 @@
     "threat": false,
     "event": false
   },
-  "path": "../../data/species/deserto_caldo/thermo-raptor.yaml",
+  "path": "../../packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
   "balance": {
     "rarity": "R3",
     "threat_tier": "T3",
@@ -84,7 +84,7 @@
     "source": "PTPF.v1.0",
     "author": "designer",
     "date": "2025-10-25",
-    "trace_hash": "c583cb65f9015a2b78b298da22d0eb7a0284b13be4ca088d874a8046d8779c18"
+    "trace_hash": "06b34eedd8c3605b422c436bed32cf441196aabe1843562f300ce504bd5f3257"
   },
-  "last_synced_at": "2025-11-05T18:52:43.280Z"
+  "last_synced_at": "2025-11-11T23:48:24.660Z"
 }

--- a/scripts/sync_evo_pack_assets.js
+++ b/scripts/sync_evo_pack_assets.js
@@ -13,30 +13,87 @@ const PACK_DOCS_DIR = path.join(REPO_ROOT, 'packs', 'evo_tactics_pack', 'docs', 
 const DOCS_TARGET = path.join(REPO_ROOT, 'docs', 'evo-tactics-pack');
 const PUBLIC_TARGET = path.join(REPO_ROOT, 'public', 'docs', 'evo-tactics-pack');
 
+const PATH_PREFIX_SOURCE = '../../data/';
+const PATH_PREFIX_TARGET = '../../packs/evo_tactics_pack/data/';
+
 const ASSET_MAP = [
-  { source: 'catalog_data.json', targets: ['catalog_data.json'] },
+  { source: 'catalog_data.json', targets: ['catalog_data.json'], rewritePaths: true },
   { source: 'env_traits.json', targets: ['env-traits.json'] },
   { source: 'trait_reference.json', targets: ['trait-reference.json'] },
   { source: 'trait_glossary.json', targets: ['trait-glossary.json'] },
   { source: 'hazards.json', targets: ['hazards.json'] },
-  { source: 'species-index.json', targets: ['species-index.json'] },
+  { source: 'species-index.json', targets: ['species-index.json'], rewritePaths: true },
 ];
 
-function copyFile(sourcePath, targetPath) {
+function ensureDir(targetPath) {
   fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+}
+
+function copyFile(sourcePath, targetPath) {
+  ensureDir(targetPath);
   fs.copyFileSync(sourcePath, targetPath);
 }
 
+function rewritePathPrefix(value) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  if (value.startsWith(PATH_PREFIX_TARGET)) {
+    return value;
+  }
+  if (value.startsWith(PATH_PREFIX_SOURCE)) {
+    return PATH_PREFIX_TARGET + value.slice(PATH_PREFIX_SOURCE.length);
+  }
+  return value;
+}
+
+function updatePathFields(value) {
+  if (Array.isArray(value)) {
+    value.forEach((entry) => updatePathFields(entry));
+    return value;
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  Object.keys(value).forEach((key) => {
+    if (key === 'path' && typeof value[key] === 'string') {
+      value[key] = rewritePathPrefix(value[key]);
+    } else {
+      updatePathFields(value[key]);
+    }
+  });
+  return value;
+}
+
+function rewriteJsonPreservingOrder(sourcePath, targetPath, mutator) {
+  const raw = fs.readFileSync(sourcePath, 'utf8');
+  const data = JSON.parse(raw);
+  mutator(data);
+  const serialised = `${JSON.stringify(data, null, 2)}\n`;
+  ensureDir(targetPath);
+  fs.writeFileSync(targetPath, serialised, 'utf8');
+}
+
+function syncMirrorFile(sourcePath, targetPath, rewritePaths) {
+  if (rewritePaths && path.extname(sourcePath) === '.json') {
+    rewriteJsonPreservingOrder(sourcePath, targetPath, updatePathFields);
+    return;
+  }
+  copyFile(sourcePath, targetPath);
+}
+
 function syncAssets() {
-  ASSET_MAP.forEach(({ source, targets }) => {
+  ASSET_MAP.forEach(({ source, targets, rewritePaths }) => {
     const sourcePath = path.join(PACK_DOCS_DIR, source);
     if (!fs.existsSync(sourcePath)) {
       console.warn(`Asset mancante: ${sourcePath}`);
       return;
     }
     targets.forEach((targetName) => {
-      copyFile(sourcePath, path.join(DOCS_TARGET, targetName));
-      copyFile(sourcePath, path.join(PUBLIC_TARGET, targetName));
+      const docsTarget = path.join(DOCS_TARGET, targetName);
+      const publicTarget = path.join(PUBLIC_TARGET, targetName);
+      syncMirrorFile(sourcePath, docsTarget, rewritePaths);
+      syncMirrorFile(sourcePath, publicTarget, rewritePaths);
     });
   });
 
@@ -62,8 +119,10 @@ function syncAssets() {
     entries.forEach((entry) => {
       if (!entry.isFile()) return;
       const sourcePath = path.join(speciesDir, entry.name);
-      copyFile(sourcePath, path.join(DOCS_TARGET, 'species', entry.name));
-      copyFile(sourcePath, path.join(PUBLIC_TARGET, 'species', entry.name));
+      const docsTarget = path.join(DOCS_TARGET, 'species', entry.name);
+      const publicTarget = path.join(PUBLIC_TARGET, 'species', entry.name);
+      syncMirrorFile(sourcePath, docsTarget, true);
+      syncMirrorFile(sourcePath, publicTarget, true);
     });
   }
 }


### PR DESCRIPTION
## Summary
- update the Evo asset sync to rewrite mirror JSON `path` fields with pack-relative prefixes while preserving key order
- regenerate the Evo Tactics catalog mirrors so docs and public bundles carry pack-relative references
- extend the data health audit to flag mirror JSON entries that do not use the pack-relative prefix

## Testing
- node scripts/update_evo_pack_catalog.js
- node scripts/sync_evo_pack_assets.js
- python tools/audit/data_health.py *(fails: Missing file packs/evo_tactics_pack/data/core/species.yaml)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913caf6b62c83289e19b4f213d3140c)