### PR TITLE
Aggiorna documentazione CLI con comandi supportati

### DIFF
--- a/docs/adr/ADR-XXX-refactor-cli.md
+++ b/docs/adr/ADR-XXX-refactor-cli.md
@@ -6,33 +6,45 @@
 - **Stakeholder**: Team Platform, HUD/UX, Support, QA
 
 ## Contesto
+
 Durante il ciclo VC-2025-10 il refactor della CLI (`game-cli`) ha introdotto entrypoint modulare e profili di esecuzione condivisi. Il team lead ha richiesto una decisione formale che preservi: (1) determinismo sugli output, (2) parità tra implementazioni TypeScript e Python e (3) continuità della pipeline HUD che consuma gli eventi CLI.
 
 ## Motivazioni raccolte dal team lead
+
 1. **Determinismo riproducibile** — ogni comando deve accettare `--seed` e loggare gli input in modo da poter riprodurre un encounter o un pacchetto partendo dagli stessi dati.
 2. **Allineamento TS/Python** — `roll_pack` e gli altri tool devono condividere lo stesso set di sorgenti YAML e la stessa logica di calcolo per evitare regressioni quando i team cambiano linguaggio di riferimento.
 3. **Pipeline HUD** — gli aggiornamenti `hud_alerts.ts` devono ricevere stream coerenti dagli script CLI, evitando divergenze sui formati telemetry (`ema.update`) e mantenendo i tag missione configurabili.
 
 ## Opzioni valutate
+
 - **A. Mantenere doppia CLI separata (status quo pre-refactor)**: lasciare gli script Python e TypeScript indipendenti con logiche duplicate.
 - **B. Centralizzare tutto in TypeScript**: spostare la generazione dei pacchetti e encounter in TS e deprecare i wrapper Python.
 - **C. Stabilire un contratto di reference implementation**: definire moduli condivisi (schema YAML, seed handling, normalizzazione log) e test cross-language obbligatori.
 
 ## Decisione
+
 Adottare l'opzione **C**. Il refactor CLI rimane modulare, ma tutti i comandi devono validare seed e schema dati contro la reference TypeScript, con test di parità che girano sia in `tools/ts` sia in `tools/py` ad ogni modifica.
 
+### Sottocomandi disponibili (2025-11)
+
+L'entrypoint `python tools/py/game_cli.py` espone i comandi `roll-pack`, `generate-encounter`, `validate-datasets`, `validate-ecosystem-pack` (alias legacy `validate-ecosystem`) e `investigate`. Ogni nuovo flusso deve essere aggiunto qui e coperto dai test di parità.
+
 ## Impatti sugli strumenti
+
 - **`tools/py/roll_pack.py`**: mantiene supporto come wrapper di compatibilità. I test di parità con `tools/ts/dist/roll_pack.js` devono essere schedulati nelle pipeline e documentati nei log giornalieri.
-- **`tools/ts/hud_alerts.ts`**: riceve gli output normalizzati del comando `game-cli telemetry stream`. Il refactor impone mapping esplicito dei campi `missionId`, `risk.indices.weighted_index` e `risk.indices.time_low_hp_turns`, oltre a controlli sui tag missione forniti dal CLI profile.
+- **`tools/ts/hud_alerts.ts`**: consuma gli eventi prodotti da `server/services/nebulaTelemetryAggregator` (lanciato da `tools/deploy/generateStatusReport.js`). In assenza di un sottocomando `telemetry stream`, il monitoraggio real time deve appoggiarsi a questo aggregatore o prevedere un nuovo task Tools per introdurre un wrapper dedicato.
 - **Pipeline HUD**: la CLI diventa la fonte autorevole per gli eventi `ema.update`; gli adapter HUD devono ascoltare il bus CLI e rispettare il formato JSON deciso qui.
 
 ## Conseguenze
+
 - Gli script Python vengono trattati come implementazione di riferimento secondaria ma con parità garantita tramite test comparativi.
 - La documentazione operativa deve descrivere come usare i seed condivisi e dove reperire i log (`logs/cli/<data>.log`).
 - HUD/UX può anticipare regressioni monitorando i tag missione e gli alert generati dal nuovo flusso CLI.
 
 ## Azioni di follow-up
+
 - [x] Aggiornare i test di parità CLI TS/Python (`npm test` in `tools/ts`, `pytest tests/test_tools_modules.py`).
 - [ ] Automatizzare l'esecuzione giornaliera dei test di parità nella pipeline CI (`scripts/cli_smoke.sh`).
 - [ ] Estendere la documentazione HUD con esempi di alert generati dalla CLI (`docs/tools/hud.md`).
 - [ ] Verificare con Support/QA la disponibilità dei log CLI nel drive condiviso.
+- [ ] Valutare la necessità di un nuovo sottocomando `telemetry` basato sull'aggregatore, aprendo task dedicato se richiesto dalle squadre HUD/Telemetria.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,41 +4,56 @@ Aggiornato al ciclo VC-2025-11. Nuove domande vengono raccolte dopo ogni retro s
 
 ## Support
 
-| Domanda | Risposta rapida | Owner | Stato |
-| ------- | ---------------- | ----- | ----- |
-| Come abilitiamo i log CLI giornalieri nel profilo `support`? | Usare `game-cli support init --logs daily` e verificare upload su bucket Drive Sync entro le 18:00 CET. | Support Lead | In corso (test 2025-11-07).
-| Qual è la procedura di escalation se `game-cli deploy` fallisce in produzione? | Aprire ticket `#vc-ops`, allegare log `logs/cli/<data>.log`, eseguire rollback con profilo `support`. | Support Lead | Attivo.
-| Quando ruotare i token API condivisi? | Ogni lunedì 08:00 CET seguendo `docs/support/token-rotation.md` e aggiornando `config/cli/support.yaml`. | Security Liaison | Attivo (ultima rotazione 2025-11-10).
-| Come confermiamo la versione CLI usata in playtest e supporto? | Eseguire `game-cli version --json`, copiare l'hash in `docs/chatgpt_sync_status.md` e linkare il log di giornata. | Support Lead | Nuovo (verifica giornaliera).
-| Dove archiviare le registrazioni demo per l'onboarding? | Cartella Drive `Presentations/Onboarding-2025-11-18` + riferimento in `docs/presentations/2025-11-18-onboarding.md`. | Narrative Ops | Pianificato (upload 2025-11-16).
+| Domanda                                                                 | Risposta rapida                                                                                                                                                                               | Owner            | Stato                                 |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------------------------------- |
+| Come abilitiamo i log CLI giornalieri nel profilo `support`?            | Pianificare `scripts/cli_smoke.sh --profile support` (cron o azione manuale), verificare che generi `logs/cli/support-pack.json` e caricare il file sul bucket Drive Sync entro le 18:00 CET. | Support Lead     | In corso (test 2025-11-07).           |
+| Qual è la procedura di escalation se i controlli pre-deploy falliscono? | Aprire ticket `#vc-ops`, allegare output di `scripts/run_deploy_checks.sh`, raccogliere i log in `logs/tooling/` e coordinare il rollback con il profilo `support`.                           | Support Lead     | Attivo.                               |
+| Quando ruotare i token API condivisi?                                   | Ogni lunedì 08:00 CET seguendo `docs/support/token-rotation.md` e aggiornando `config/cli/support.yaml`.                                                                                      | Security Liaison | Attivo (ultima rotazione 2025-11-10). |
+| Come confermiamo la revisione CLI usata in playtest e supporto?         | Registrare `git rev-parse HEAD` (o `git describe --tags --always`) nel log giornaliero, allegare gli artefatti di `scripts/cli_smoke.sh` e aggiornare `docs/chatgpt_sync_status.md`.          | Support Lead     | Nuovo (verifica giornaliera).         |
+| Dove archiviare le registrazioni demo per l'onboarding?                 | Cartella Drive `Presentations/Onboarding-2025-11-18` + riferimento in `docs/presentations/2025-11-18-onboarding.md`.                                                                          | Narrative Ops    | Pianificato (upload 2025-11-16).      |
+
+### Comandi disponibili della CLI Python
+
+L'entrypoint documentato in `tools/py/game_cli.py` espone i seguenti sottocomandi (`python tools/py/game_cli.py <comando>`):
+
+- `roll-pack [FORM MBTI] [ARCHETIPO] [--seed <valore>]`
+- `generate-encounter [biome] [data_path] [--party-power <int>] [--seed <valore>]`
+- `validate-datasets`
+- `validate-ecosystem-pack [--json-out <path>] [--html-out <path>]`
+- `investigate <file|dir> [...] [--recursive] [--json] [--html] [--destination NAME]`
+
+L'alias storico `validate-ecosystem` viene normalizzato in `validate-ecosystem-pack` dal wrapper stesso.
 
 ## QA
 
-| Domanda | Risposta rapida | Owner | Stato |
-| ------- | ---------------- | ----- | ----- |
-| Come eseguiamo gli smoke test CLI? | Run `scripts/cli_smoke.sh` (default) o filtra con `--profile support`; archivia output in `logs/cli/qa/`. | QA Lead | Attivo (copre playtest/telemetry/support).
-| Dove registriamo gli esiti dei playtest VC? | Nel tracker `docs/checklist/playtest-status.md` + allegato `logs/playtests/<data>-vc/summary.yaml`. | QA Analyst | Continuo.
-| Chi conferma la copertura telemetria dopo ogni build? | QA Lead coordina con Telemetria usando il report `docs/chatgpt_changes/sync-<data>.md`. | Telemetria POC | In corso.
-| Come prepariamo il test bed per l'onboarding del 18/11? | Clonare branch demo `feature/onboarding-cli-demo`, lanciare `scripts/cli_smoke.sh --profile playtest` e validare export Drive. | QA Support | Pianificato (setup 2025-11-15).
-| Quando aggiornare i template di bug legati alla CLI? | Dopo ogni retro Support/QA del martedì, sincronizzare i campi in `docs/support/bug-template.md`. | QA Lead | Nuovo (post-onboarding).
+| Domanda                                                 | Risposta rapida                                                                                                                | Owner          | Stato                                      |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------- | ------------------------------------------ |
+| Come eseguiamo gli smoke test CLI?                      | Run `scripts/cli_smoke.sh` (default) o filtra con `--profile support`; archivia output in `logs/cli/qa/`.                      | QA Lead        | Attivo (copre playtest/telemetry/support). |
+| Dove registriamo gli esiti dei playtest VC?             | Nel tracker `docs/checklist/playtest-status.md` + allegato `logs/playtests/<data>-vc/summary.yaml`.                            | QA Analyst     | Continuo.                                  |
+| Chi conferma la copertura telemetria dopo ogni build?   | QA Lead coordina con Telemetria usando il report `docs/chatgpt_changes/sync-<data>.md`.                                        | Telemetria POC | In corso.                                  |
+| Come prepariamo il test bed per l'onboarding del 18/11? | Clonare branch demo `feature/onboarding-cli-demo`, lanciare `scripts/cli_smoke.sh --profile playtest` e validare export Drive. | QA Support     | Pianificato (setup 2025-11-15).            |
+| Quando aggiornare i template di bug legati alla CLI?    | Dopo ogni retro Support/QA del martedì, sincronizzare i campi in `docs/support/bug-template.md`.                               | QA Lead        | Nuovo (post-onboarding).                   |
 
 ## Post-onboarding 2025 Q4
 
-| Domanda | Risposta rapida | Owner | Stato |
-| ------- | ---------------- | ----- | ----- |
-| Dove trovo le registrazioni onboarding? | In `docs/presentations/2025-11-onboarding-recordings.md` con link Drive e note di follow-up. | HR Ops | Aggiornato. |
+| Domanda                                                        | Risposta rapida                                                                                                                                                                                                | Owner            | Stato                |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------------------- |
+| Dove trovo le registrazioni onboarding?                        | In `docs/presentations/2025-11-onboarding-recordings.md` con link Drive e note di follow-up.                                                                                                                   | HR Ops           | Aggiornato.          |
 | Come verifico che il workflow `daily-pr-summary` abbia girato? | Controlla GitHub Actions (`daily-pr-summary`), poi apri `docs/chatgpt_changes/daily-pr-<data>.md`; se assente esegui manualmente `python tools/py/daily_pr_report.py --repo <owner/repo> --date <YYYY-MM-DD>`. | Technical Writer | Attivo giornalmente. |
-| Qual è la checklist post-onboarding per Support/QA? | Seguire `docs/piani/roadmap.md` > Procedura post-ottobre 2025 (punti 1-6) e spuntare `docs/checklist/project-setup-todo.md` sezione Knowledge sharing. | Support Lead | In corso. |
+| Qual è la checklist post-onboarding per Support/QA?            | Seguire `docs/piani/roadmap.md` > Procedura post-ottobre 2025 (punti 1-6) e spuntare `docs/checklist/project-setup-todo.md` sezione Knowledge sharing.                                                         | Support Lead     | In corso.            |
 
 ### Sessioni registrate
+
 - Batch Q4 (2025-11-18, 10:00-12:00 CET) — Setup repo, workflow PR giornaliero, telemetria VC.【F:docs/presentations/2025-11-onboarding-recordings.md†L1-L7】
 - Support handoff (2025-11-19, 16:00 CET) — Escalation CLI, gestione ticket post-sync.【F:docs/presentations/2025-11-onboarding-recordings.md†L1-L7】
 - Companion relazioni (2025-11-20, 14:30 CET) — Modulo Relazioni, rituali Nido, log `relations-log.yaml`.【F:docs/presentations/2025-11-onboarding-recordings.md†L1-L7】
 
 ## Da raccogliere
+
 - Verificare disponibilità di template escalation nel drive Support entro 2025-11-12.
 
 ## Troubleshooting CLI (Nov 2025)
-- `game-cli deploy` restituisce `Missing token for profile support`: verificare rotazione in `config/cli/support.yaml`, rigenerare token via `docs/support/token-rotation.md` e rilanciare il comando con `--refresh-credentials`.
-- Log mancanti dopo smoke test QA: controllare che il comando sia stato eseguito con `--store-log` e che la cartella `logs/cli/qa/<data>/` sia sincronizzata con Drive.
-- Differenze di hash tra `game-cli version` e config: aggiornare il branch locale con `git pull --rebase` e rilanciare `scripts/cli_smoke.sh` per generare i log corretti.
+
+- `python tools/py/game_cli.py validate-ecosystem-pack` restituisce `Validator del pack non trovato`: assicurarsi che gli asset siano sincronizzati (vedi `scripts/run_deploy_checks.sh`) e che `tools/py/roll_pack.py` sia aggiornato.
+- Log mancanti dopo smoke test QA: controllare che sia stato eseguito `scripts/cli_smoke.sh --profile <profilo>` e che la cartella `logs/cli/qa/<data>/` sia sincronizzata con Drive.
+- Differenze tra commit registrato e ambiente locale: eseguire `git pull --rebase`, rilanciare `scripts/cli_smoke.sh` e aggiornare `docs/chatgpt_sync_status.md` con il nuovo hash.

--- a/docs/support/bug-template.md
+++ b/docs/support/bug-template.md
@@ -2,9 +2,9 @@
 
 - **Titolo**: `[CLI][<profile>] <descrizione>`
 - **Data**: `<AAAA-MM-GG>`
-- **Build CLI**: output di `game-cli version --json`
+- **Build CLI**: output di `git rev-parse HEAD` (eventualmente `git describe --tags --always`)
 - **Profilo**: `playtest` | `telemetry` | `support`
-- **Comando eseguito**: es. `game-cli deploy --profile support`
+- **Comando eseguito**: es. `python tools/py/game_cli.py validate-ecosystem-pack --profile support`
 - **Log allegati**: `logs/cli/<data>.log`, estratto `docs/chatgpt_changes/sync-<data>.md`
 - **Esito smoke test**: link a `logs/cli/qa/<data>/`
 - **Impatto**: `blocking` | `degraded` | `info`
@@ -15,5 +15,6 @@
 - **Owner escalation**: Support Lead / QA Lead / Tools Dev
 - **Link log**: URL/Drive al log principale (obbligatorio)
 - **Link screenshot/video**: evidenza visiva (PNG/MP4) oppure `N/A` se non applicabile
+- **Riferimento comandi CLI**: `python tools/py/game_cli.py <comando>` con sottocomandi `roll-pack`, `generate-encounter`, `validate-datasets`, `validate-ecosystem-pack`, `investigate`
 
 _Compila il template in Drive e collega il ticket `#vc-ops` relativo._

--- a/docs/tutorials/feedback-form.md
+++ b/docs/tutorials/feedback-form.md
@@ -3,13 +3,15 @@
 Questa guida illustra come accedere, compilare e monitorare il nuovo form di feedback introdotto con la pipeline descritta in `docs/process/feedback_collection_pipeline.md`.
 
 ## 1. Accesso al form
+
 - **Dashboard documentazione**: link rapido nel menu "Supporto" → "Invia feedback".
 - **Webapp di playtest**: pulsante `Invia feedback` in basso a destra, sincronizzato con questa configurazione.
-- **CLI**: eseguire `python tools/py/game_cli.py feedback --open-form` per aprire l'URL precompilato.
+- **Automazione da terminale**: il sottocomando `feedback` non è più disponibile. Recupera l'URL dal portale o dai metadati in `tools/feedback/form_config.yaml` e, se serve un launcher dedicato, apri un task Tools per reintrodurlo.
 
-> Il form è ospitato nell'app Notion condivisa del team. Copia sempre l'URL generato dal comando CLI per includere l'ID build.
+> Il form è ospitato nell'app Notion condivisa del team. Conserva l'URL generato dal portale per includere l'ID build.
 
 ## 2. Compilazione step-by-step
+
 1. **Contesto build**
    - `build_version`: seleziona dal menu la build in test (es. `v0.8.3-nightly`).
    - `platform`: indica il device principale (`pc`, `steamdeck`, `cloud`).
@@ -31,21 +33,37 @@ Questa guida illustra come accedere, compilare e monitorare il nuovo form di fee
    - `contact`: email o handle Discord/Slack.
 
 ## 3. Linee guida qualitative
+
 - Preferisci **descrizioni osservabili** alle interpretazioni (es. "la mutazione non attiva il bonus" invece di "non funziona").
 - Se il problema è critico (`severity >= 3`), fornisci sempre **passi di riproduzione** e, se possibile, un log estratto.
 - Seleziona `sandbox` solo per sessioni esplorative; per regressioni indica sempre la build di riferimento.
 
 ## 4. Dopo l'invio
+
 - Riceverai una conferma via email con l'ID feedback (es. `FDB-2024-051`).
 - Quando il feedback entra nel backlog, l'owner aggiorna lo stato in `tools/feedback/collection_pipeline.yaml`.
 - Puoi monitorare i progressi nel report settimanale pubblicato in `docs/playtest/INSIGHTS-2025-11.md`.
 
 ## 5. Risoluzione dei problemi
+
 - **Il form non carica?** Verifica la VPN aziendale; il dominio Notion è accessibile solo da IP autorizzati.
 - **Non trovi la build in elenco?** Apri un ticket in `#feedback-enhancements` con l'ID commit e l'ambiente.
 - **Serve supporto audio/video?** Allegare file superiori a 50MB direttamente su Drive e incollare il link con permessi `comment`.
 
 ## 6. Link utili
+
 - Configurazione del form: [`tools/feedback/form_config.yaml`](../../tools/feedback/form_config.yaml)
 - Pipeline di raccolta: [`docs/process/feedback_collection_pipeline.md`](../process/feedback_collection_pipeline.md)
 - Changelog delle revisioni: [`docs/changelog.md`](../changelog.md)
+
+### Appendice · Comandi CLI disponibili
+
+Per operazioni correlate alla convalida dati e alle indagini dei pacchetti usa `python tools/py/game_cli.py <comando>`, che espone i sottocomandi aggiornati:
+
+- `roll-pack [FORM MBTI] [ARCHETIPO] [--seed <valore>]`
+- `generate-encounter [biome] [data_path] [--party-power <int>] [--seed <valore>]`
+- `validate-datasets`
+- `validate-ecosystem-pack [--json-out <path>] [--html-out <path>]`
+- `investigate <file|dir> [...] [--recursive] [--json] [--html] [--destination NAME]`
+
+> Se occorre un nuovo sottocomando `feedback`, aprire una richiesta dedicata nel backlog Tools indicando gli automatismi necessari.


### PR DESCRIPTION
## Summary
- aggiorna le sezioni Support/QA e troubleshooting della FAQ sostituendo i comandi CLI rimossi con gli script attivi e aggiungendo l'elenco dei sottocomandi disponibili
- allinea il template di escalation bug e il tutorial del form feedback alle nuove modalità d'uso della CLI, indicando alternative e il set aggiornato di comandi
- integra l'ADR sul refactor della CLI con la lista dei sottocomandi attuali e la strategia alternativa per lo streaming di telemetria

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913e2c490bc83288f6e00c5252edb64)