### PR TITLE
Add Evo documentation archive sync workflow

### DIFF
--- a/.github/workflows/evo-doc-backfill.yml
+++ b/.github/workflows/evo-doc-backfill.yml
@@ -1,0 +1,128 @@
+name: Evo documentation archive sync
+
+on:
+  schedule:
+    - cron: '30 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  evo-doc-backfill:
+    name: Sync Evo docs metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Generate documentation diff
+        run: |
+          python scripts/evo_tactics_metadata_diff.py \
+            --output reports/evo/rollout/documentation_diff.json \
+            --consolidated-root docs/evo-tactics \
+            --archive-root incoming/archive/2025-12-19_inventory_cleanup
+
+      - name: Backfill archive frontmatter
+        run: |
+          python scripts/evo_tactics_metadata_diff.py \
+            --mode backfill \
+            --consolidated-root docs/evo-tactics \
+            --archive-root incoming/archive/2025-12-19_inventory_cleanup \
+            --target incoming/archive/2025-12-19_inventory_cleanup
+
+      - name: Generate anchors map
+        run: |
+          python scripts/evo_tactics_metadata_diff.py \
+            --mode anchors \
+            --consolidated-root docs/evo-tactics \
+            --archive-root incoming/archive/2025-12-19_inventory_cleanup \
+            --output docs/evo-tactics/anchors-map.csv
+
+      - name: Evaluate diff and notify
+        id: notifier
+        run: |
+          python ops/notifier.py \
+            --diff-json reports/evo/rollout/documentation_diff.json \
+            --issue-output ops/notifier_issue.json
+          python - <<'PY'
+          import json
+          import os
+
+          with open('ops/notifier_issue.json', 'r', encoding='utf-8') as handle:
+              payload = json.load(handle)
+
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as output:
+              output.write(f"has_blocking={'true' if payload['has_blocking'] else 'false'}\n")
+              output.write('issue_title<<EOF\n')
+              output.write(payload['issue_title'] + '\n')
+              output.write('EOF\n')
+              output.write('issue_body<<EOF\n')
+              output.write(payload['issue_body'] + '\n')
+              output.write('EOF\n')
+              output.write('summary<<EOF\n')
+              output.write(payload['summary'] + '\n')
+              output.write('EOF\n')
+          PY
+        env:
+          EVO_NOTIFIER_SLACK_WEBHOOK: ${{ secrets.EVO_DEVREL_SLACK_WEBHOOK }}
+          EVO_NOTIFIER_TEAMS_WEBHOOK: ${{ secrets.EVO_DEVREL_TEAMS_WEBHOOK }}
+
+      - name: Create issue for blocking diffs
+        if: steps.notifier.outputs.has_blocking == 'true'
+        uses: actions/github-script@v7
+        env:
+          ISSUE_TITLE: ${{ steps.notifier.outputs.issue_title }}
+          ISSUE_BODY: ${{ steps.notifier.outputs.issue_body }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { ISSUE_TITLE, ISSUE_BODY } = process.env;
+            const { owner, repo } = context.repo;
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const existing = issues.find(issue => issue.title === ISSUE_TITLE);
+            if (existing) {
+              core.info(`Issue already exists: #${existing.number}`);
+            } else {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title: ISSUE_TITLE,
+                body: ISSUE_BODY,
+              });
+              core.info('Blocking diff issue created');
+            }
+
+      - name: Upload anchors map artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: evo-anchors-map
+          path: docs/evo-tactics/anchors-map.csv
+
+      - name: Upload documentation gap report
+        uses: actions/upload-artifact@v4
+        with:
+          name: evo-documentation-gap
+          path: reports/evo/rollout/documentation_gap.md
+
+      - name: Upload diff payload
+        uses: actions/upload-artifact@v4
+        with:
+          name: evo-documentation-diff
+          path: reports/evo/rollout/documentation_diff.json

--- a/ops/notifier.py
+++ b/ops/notifier.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Notifier utilities for Ops workflows.
+
+This module parses the documentation diff produced by
+`scripts/evo_tactics_metadata_diff.py` and notifies downstream channels
+(Slack, Teams) when blocking differences are detected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+from urllib.error import URLError, HTTPError
+from urllib.request import Request, urlopen
+
+
+@dataclass
+class BlockingDiff:
+    document: str
+    reasons: List[str]
+
+    def to_markdown(self) -> str:
+        bullets = "\n".join(f"  - {reason}" for reason in self.reasons)
+        return f"- **{self.document}**\n{bullets}"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Send notifications for Evo documentation drifts.")
+    parser.add_argument("--diff-json", type=Path, required=True, help="Path to documentation_diff.json produced by the diff script.")
+    parser.add_argument(
+        "--issue-output",
+        type=Path,
+        help="Optional path where an issue payload (JSON) will be written.",
+    )
+    parser.add_argument(
+        "--slack-webhook",
+        default=os.getenv("EVO_NOTIFIER_SLACK_WEBHOOK"),
+        help="Slack webhook URL. Falls back to EVO_NOTIFIER_SLACK_WEBHOOK env variable.",
+    )
+    parser.add_argument(
+        "--teams-webhook",
+        default=os.getenv("EVO_NOTIFIER_TEAMS_WEBHOOK"),
+        help="Microsoft Teams webhook URL. Falls back to EVO_NOTIFIER_TEAMS_WEBHOOK env variable.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="If set, do not send network requests and simply print the summary to stdout.",
+    )
+    return parser.parse_args()
+
+
+def load_diff(path: Path) -> Dict[str, object]:
+    if not path.exists():
+        raise SystemExit(f"Diff JSON non trovato: {path}")
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def detect_blocking(diffs: Iterable[Dict[str, object]]) -> List[BlockingDiff]:
+    blocking: List[BlockingDiff] = []
+    for diff in diffs:
+        document = diff.get("consolidated") or "<unknown>"
+        reasons: List[str] = []
+
+        fm_missing_archive = diff.get("frontmatter_missing_in_archive") or []
+        fm_missing_consolidated = diff.get("frontmatter_missing_in_consolidated") or []
+        fm_mismatched = diff.get("frontmatter_mismatched") or {}
+        anchors_added = diff.get("anchors_added") or []
+        anchors_removed = diff.get("anchors_removed") or []
+
+        if fm_missing_archive or fm_missing_consolidated or fm_mismatched:
+            details = []
+            if fm_missing_archive:
+                details.append(f"mancano in archivio: {', '.join(fm_missing_archive)}")
+            if fm_missing_consolidated:
+                details.append(f"mancano in consolidato: {', '.join(fm_missing_consolidated)}")
+            if fm_mismatched:
+                keys = ", ".join(sorted(fm_mismatched.keys()))
+                details.append(f"valori divergenti: {keys}")
+            reasons.append("Frontmatter divergente (" + "; ".join(details) + ")")
+
+        if anchors_removed:
+            reasons.append(f"Ancore rimosse nel consolidato: {', '.join(anchors_removed[:10])}" + ("…" if len(anchors_removed) > 10 else ""))
+        if anchors_added:
+            reasons.append(f"Ancore mancanti nell'archivio: {', '.join(anchors_added[:10])}" + ("…" if len(anchors_added) > 10 else ""))
+
+        if reasons:
+            blocking.append(BlockingDiff(document=document, reasons=reasons))
+
+    return blocking
+
+
+def build_issue_payload(blocking: List[BlockingDiff]) -> Dict[str, str]:
+    today = datetime.utcnow().strftime("%Y-%m-%d")
+    title = f"Evo docs blocking diffs detected on {today}"
+    if not blocking:
+        summary = "Nessuna differenza bloccante rilevata."
+        body = "Tutti i documenti analizzati sono allineati."
+        return {"title": title, "body": body, "summary": summary}
+
+    lines = [
+        "Sono state rilevate differenze bloccanti tra documentazione consolidata e archivio.",
+        "",
+        "Dettaglio file:",
+    ]
+    for diff in blocking:
+        lines.append(diff.to_markdown())
+
+    lines.extend(
+        [
+            "",
+            "Azioni consigliate:",
+            "- Eseguire il backfill dei frontmatter per i file indicati.",
+            "- Aggiornare o aggiungere le ancore mancanti nei documenti legacy.",
+        ]
+    )
+
+    body = "\n".join(lines)
+    summary = f"{len(blocking)} documenti con frontmatter/ancore da verificare."
+    return {"title": title, "body": body, "summary": summary}
+
+
+def send_webhook(url: Optional[str], payload: Dict[str, object], dry_run: bool = False) -> None:
+    if not url:
+        return
+    if dry_run:
+        print(f"[dry-run] Skip webhook: {url}")
+        return
+
+    data = json.dumps(payload).encode("utf-8")
+    request = Request(url, data=data, headers={"Content-Type": "application/json"})
+    try:
+        with urlopen(request) as response:  # nosec B310
+            response.read()
+    except (HTTPError, URLError) as exc:
+        print(f"Impossibile inviare la notifica ({url}): {exc}", file=sys.stderr)
+
+
+def build_slack_payload(summary: str, blocking: List[BlockingDiff]) -> Dict[str, object]:
+    blocks: List[Dict[str, object]] = [
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*:rotating_light: Evo docs alert*\n{summary}"},
+        }
+    ]
+    if blocking:
+        details = "\n".join(diff.to_markdown() for diff in blocking)
+        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": details}})
+    return {"text": summary, "blocks": blocks}
+
+
+def build_teams_payload(summary: str, blocking: List[BlockingDiff]) -> Dict[str, object]:
+    facts = [
+        {"name": "Documenti coinvolti", "value": str(len(blocking))},
+    ]
+    if blocking:
+        details = "\n".join(diff.to_markdown() for diff in blocking)
+        facts.append({"name": "Dettaglio", "value": details})
+
+    return {
+        "@type": "MessageCard",
+        "@context": "http://schema.org/extensions",
+        "summary": summary,
+        "themeColor": "F04F47",
+        "title": "Evo documentation gap",
+        "sections": [
+            {
+                "activityTitle": "DevRel alert",
+                "activitySubtitle": summary,
+                "facts": facts,
+            }
+        ],
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    payload = load_diff(args.diff_json)
+
+    diffs = payload.get("diffs") or []
+    blocking = detect_blocking(diffs) if isinstance(diffs, list) else []
+
+    issue_payload = build_issue_payload(blocking)
+
+    print(issue_payload["summary"])
+    for diff in blocking:
+        print(f"- {diff.document}: {', '.join(diff.reasons)}")
+
+    if args.issue_output:
+        args.issue_output.parent.mkdir(parents=True, exist_ok=True)
+        with args.issue_output.open("w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "has_blocking": bool(blocking),
+                    "issue_title": issue_payload["title"],
+                    "issue_body": issue_payload["body"],
+                    "summary": issue_payload["summary"],
+                },
+                handle,
+                ensure_ascii=False,
+                indent=2,
+            )
+            handle.write("\n")
+
+    slack_payload = build_slack_payload(issue_payload["summary"], blocking)
+    teams_payload = build_teams_payload(issue_payload["summary"], blocking)
+
+    send_webhook(args.slack_webhook, slack_payload, dry_run=args.dry_run)
+    send_webhook(args.teams_webhook, teams_payload, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add evo-doc-backfill workflow to diff, backfill and export Evo documentation metadata
- upload Evo documentation reports as artifacts and open issues for blocking drifts automatically
- introduce ops/notifier.py to summarize diffs and send Slack/Teams alerts for frontmatter or anchor gaps

## Testing
- python -m compileall ops/notifier.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69147ae4a8148328ab94b3aaa72731c1)