### PR TITLE
Align Nebula atlas rollout with feature flag

### DIFF
--- a/config/featureFlags.json
+++ b/config/featureFlags.json
@@ -1,217 +1,240 @@
 {
-    "featureFlags": {
+  "featureFlags": {
+    "rollout": {
+      "qaMetricsMonitoring": {
+        "description": "Abilita il monitoraggio automatizzato delle metriche di rollout Mission Control.",
+        "default": false,
         "rollout": {
-            "qaMetricsMonitoring": {
-                "description": "Abilita il monitoraggio automatizzato delle metriche di rollout Mission Control.",
-                "default": false,
-                "rollout": {
-                    "phase": "canary",
-                    "stageGate": "qa-approval",
-                    "start": "2025-11-20",
-                    "target": "2025-12-05",
-                    "cohorts": [
-                        "qa-bravo",
-                        "qa-delta",
-                        "ops-foxtrot"
-                    ],
-                    "pipeline": {
-                        "jobId": "qa-rollout-metrics",
-                        "config": "config/jobs/monitoring.yaml"
-                    }
-                },
-                "owner": {
-                    "team": "qa-insights",
-                    "contact": "qa-insights@gamestudio.local"
-                },
-                "playbook": "docs/qa/rollout_checklist.md",
-                "metrics": [
-                    {
-                        "name": "mission_control_uptime",
-                        "threshold": ">=99.5%",
-                        "window": "24h",
-                        "alertChannel": "ops-oncall"
-                    },
-                    {
-                        "name": "hud_action_latency_p95",
-                        "threshold": "<=3800ms",
-                        "window": "6h",
-                        "alertChannel": "qa-rollout"
-                    },
-                    {
-                        "name": "playtest_squad_engagement",
-                        "threshold": ">=0.62",
-                        "window": "7d",
-                        "alertChannel": "analytics-duty"
-                    }
-                ]
-            },
-            "ideaEngineFeedback": {
-                "description": "Attiva il modulo feedback Idea Engine con canale Slack #feedback-enhancements.",
-                "default": true,
-                "rollout": {
-                    "phase": "general_availability",
-                    "cohorts": [
-                        "idea-engine",
-                        "qa-support",
-                        "webapp"
-                    ],
-                    "start": "2025-12-02",
-                    "target": "2025-12-09"
-                },
-                "owner": {
-                    "team": "support-qa",
-                    "contact": "support-qa@gamestudio.local",
-                    "slack": "#feedback-enhancements"
-                },
-                "playbook": "docs/tutorials/idea-engine-feedback.md",
-                "metrics": [
-                    {
-                        "name": "feedback_response_time_hours",
-                        "threshold": "<=24",
-                        "window": "7d",
-                        "alertChannel": "#feedback-enhancements"
-                    },
-                    {
-                        "name": "tutorial_views_weekly",
-                        "threshold": ">=12",
-                        "window": "7d",
-                        "alertChannel": "analytics-duty"
-                    }
-                ]
-            },
-            "eventiLiveOrchestration": {
-                "description": "Abilita il sistema di regia eventi live con sincronizzazione cross-shard.",
-                "default": false,
-                "rollout": {
-                    "phase": "canary",
-                    "stageGate": "eventi-go",
-                    "start": "2026-01-05",
-                    "target": "2026-01-19",
-                    "cohorts": [
-                        "eventi-internal",
-                        "eventi-beta"
-                    ],
-                    "pipeline": {
-                        "jobId": "eventi-rollout-health",
-                        "config": "config/jobs/eventi-rollout.yaml"
-                    }
-                },
-                "owner": {
-                    "team": "live-ops",
-                    "contact": "live-ops@gamestudio.local",
-                    "slack": "#eventi-control-room"
-                },
-                "playbook": "docs/qa/playbooks/eventi.md",
-                "metrics": [
-                    {
-                        "name": "eventi_active_instances",
-                        "threshold": ">=95%",
-                        "window": "1h",
-                        "alertChannel": "#eventi-control-room"
-                    },
-                    {
-                        "name": "eventi_sync_drift_ms",
-                        "threshold": "<=250",
-                        "window": "30m",
-                        "alertChannel": "ops-oncall"
-                    },
-                    {
-                        "name": "eventi_player_drop_rate",
-                        "threshold": "<=3%",
-                        "window": "2h",
-                        "alertChannel": "analytics-duty"
-                    }
-                ]
-            },
-            "loadoutDynamicTemplates": {
-                "description": "Rende disponibili i loadout dinamici con template stagionali e progressione QA.",
-                "default": false,
-                "rollout": {
-                    "phase": "limited_availability",
-                    "stageGate": "loadout-qa",
-                    "start": "2026-02-10",
-                    "target": "2026-02-24",
-                    "cohorts": [
-                        "qa-delta",
-                        "squad-alpha",
-                        "creators-program"
-                    ],
-                    "pipeline": {
-                        "jobId": "loadout-rollout-health",
-                        "config": "config/jobs/loadout-rollout.yaml"
-                    }
-                },
-                "owner": {
-                    "team": "progression-design",
-                    "contact": "progression-design@gamestudio.local",
-                    "slack": "#loadout-updates"
-                },
-                "playbook": "docs/qa/playbooks/loadout.md",
-                "metrics": [
-                    {
-                        "name": "loadout_publish_success_rate",
-                        "threshold": ">=98%",
-                        "window": "4h",
-                        "alertChannel": "#loadout-updates"
-                    },
-                    {
-                        "name": "loadout_build_time_p95",
-                        "threshold": "<=4200ms",
-                        "window": "2h",
-                        "alertChannel": "ops-oncall"
-                    },
-                    {
-                        "name": "loadout_rollbacks",
-                        "threshold": "<=1",
-                        "window": "24h",
-                        "alertChannel": "progression-oncall"
-                    }
-                ]
-            },
-            "moderazioneAssistedOps": {
-                "description": "Attiva il pannello di moderazione assistita con suggerimenti ML in tempo reale.",
-                "default": true,
-                "rollout": {
-                    "phase": "canary",
-                    "stageGate": "moderation-ops",
-                    "start": "2026-01-22",
-                    "target": "2026-02-05",
-                    "cohorts": [
-                        "moderation-core",
-                        "moderation-emea"
-                    ],
-                    "pipeline": {
-                        "jobId": "moderation-rollout-health",
-                        "config": "config/jobs/moderation-rollout.yaml"
-                    }
-                },
-                "owner": {
-                    "team": "moderation-ops",
-                    "contact": "moderation-ops@gamestudio.local",
-                    "slack": "#moderation-ops"
-                },
-                "playbook": "docs/qa/playbooks/moderazione.md",
-                "metrics": [
-                    {
-                        "name": "moderation_assist_accept_rate",
-                        "threshold": ">=0.65",
-                        "window": "6h",
-                        "alertChannel": "#moderation-ops"
-                    },
-                    {
-                        "name": "moderation_triage_latency_p95",
-                        "threshold": "<=900s",
-                        "window": "3h",
-                        "alertChannel": "ops-oncall"
-                    },
-                    {
-                        "name": "moderation_manual_escalations",
-                        "threshold": "<=12",
-                        "window": "24h",
-                        "alertChannel": "moderation-oncall"
-                    }
-                ]
-            }
-        }
+          "phase": "canary",
+          "stageGate": "qa-approval",
+          "start": "2025-11-20",
+          "target": "2025-12-05",
+          "cohorts": ["qa-bravo", "qa-delta", "ops-foxtrot"],
+          "pipeline": {
+            "jobId": "qa-rollout-metrics",
+            "config": "config/jobs/monitoring.yaml"
+          }
+        },
+        "owner": {
+          "team": "qa-insights",
+          "contact": "qa-insights@gamestudio.local"
+        },
+        "playbook": "docs/qa/rollout_checklist.md",
+        "metrics": [
+          {
+            "name": "mission_control_uptime",
+            "threshold": ">=99.5%",
+            "window": "24h",
+            "alertChannel": "ops-oncall"
+          },
+          {
+            "name": "hud_action_latency_p95",
+            "threshold": "<=3800ms",
+            "window": "6h",
+            "alertChannel": "qa-rollout"
+          },
+          {
+            "name": "playtest_squad_engagement",
+            "threshold": ">=0.62",
+            "window": "7d",
+            "alertChannel": "analytics-duty"
+          }
+        ]
+      },
+      "ideaEngineFeedback": {
+        "description": "Attiva il modulo feedback Idea Engine con canale Slack #feedback-enhancements.",
+        "default": true,
+        "rollout": {
+          "phase": "general_availability",
+          "cohorts": ["idea-engine", "qa-support", "webapp"],
+          "start": "2025-12-02",
+          "target": "2025-12-09"
+        },
+        "owner": {
+          "team": "support-qa",
+          "contact": "support-qa@gamestudio.local",
+          "slack": "#feedback-enhancements"
+        },
+        "playbook": "docs/tutorials/idea-engine-feedback.md",
+        "metrics": [
+          {
+            "name": "feedback_response_time_hours",
+            "threshold": "<=24",
+            "window": "7d",
+            "alertChannel": "#feedback-enhancements"
+          },
+          {
+            "name": "tutorial_views_weekly",
+            "threshold": ">=12",
+            "window": "7d",
+            "alertChannel": "analytics-duty"
+          }
+        ]
+      },
+      "eventiLiveOrchestration": {
+        "description": "Abilita il sistema di regia eventi live con sincronizzazione cross-shard.",
+        "default": false,
+        "rollout": {
+          "phase": "canary",
+          "stageGate": "eventi-go",
+          "start": "2026-01-05",
+          "target": "2026-01-19",
+          "cohorts": ["eventi-internal", "eventi-beta"],
+          "pipeline": {
+            "jobId": "eventi-rollout-health",
+            "config": "config/jobs/eventi-rollout.yaml"
+          }
+        },
+        "owner": {
+          "team": "live-ops",
+          "contact": "live-ops@gamestudio.local",
+          "slack": "#eventi-control-room"
+        },
+        "playbook": "docs/qa/playbooks/eventi.md",
+        "metrics": [
+          {
+            "name": "eventi_active_instances",
+            "threshold": ">=95%",
+            "window": "1h",
+            "alertChannel": "#eventi-control-room"
+          },
+          {
+            "name": "eventi_sync_drift_ms",
+            "threshold": "<=250",
+            "window": "30m",
+            "alertChannel": "ops-oncall"
+          },
+          {
+            "name": "eventi_player_drop_rate",
+            "threshold": "<=3%",
+            "window": "2h",
+            "alertChannel": "analytics-duty"
+          }
+        ]
+      },
+      "loadoutDynamicTemplates": {
+        "description": "Rende disponibili i loadout dinamici con template stagionali e progressione QA.",
+        "default": false,
+        "rollout": {
+          "phase": "limited_availability",
+          "stageGate": "loadout-qa",
+          "start": "2026-02-10",
+          "target": "2026-02-24",
+          "cohorts": ["qa-delta", "squad-alpha", "creators-program"],
+          "pipeline": {
+            "jobId": "loadout-rollout-health",
+            "config": "config/jobs/loadout-rollout.yaml"
+          }
+        },
+        "owner": {
+          "team": "progression-design",
+          "contact": "progression-design@gamestudio.local",
+          "slack": "#loadout-updates"
+        },
+        "playbook": "docs/qa/playbooks/loadout.md",
+        "metrics": [
+          {
+            "name": "loadout_publish_success_rate",
+            "threshold": ">=98%",
+            "window": "4h",
+            "alertChannel": "#loadout-updates"
+          },
+          {
+            "name": "loadout_build_time_p95",
+            "threshold": "<=4200ms",
+            "window": "2h",
+            "alertChannel": "ops-oncall"
+          },
+          {
+            "name": "loadout_rollbacks",
+            "threshold": "<=1",
+            "window": "24h",
+            "alertChannel": "progression-oncall"
+          }
+        ]
+      },
+      "moderazioneAssistedOps": {
+        "description": "Attiva il pannello di moderazione assistita con suggerimenti ML in tempo reale.",
+        "default": true,
+        "rollout": {
+          "phase": "canary",
+          "stageGate": "moderation-ops",
+          "start": "2026-01-22",
+          "target": "2026-02-05",
+          "cohorts": ["moderation-core", "moderation-emea"],
+          "pipeline": {
+            "jobId": "moderation-rollout-health",
+            "config": "config/jobs/moderation-rollout.yaml"
+          }
+        },
+        "owner": {
+          "team": "moderation-ops",
+          "contact": "moderation-ops@gamestudio.local",
+          "slack": "#moderation-ops"
+        },
+        "playbook": "docs/qa/playbooks/moderazione.md",
+        "metrics": [
+          {
+            "name": "moderation_assist_accept_rate",
+            "threshold": ">=0.65",
+            "window": "6h",
+            "alertChannel": "#moderation-ops"
+          },
+          {
+            "name": "moderation_triage_latency_p95",
+            "threshold": "<=900s",
+            "window": "3h",
+            "alertChannel": "ops-oncall"
+          },
+          {
+            "name": "moderation_manual_escalations",
+            "threshold": "<=12",
+            "window": "24h",
+            "alertChannel": "moderation-oncall"
+          }
+        ]
+      },
+      "nebulaAtlasAggregator": {
+        "description": "Abilita l'aggregatore telemetria Nebula Atlas con controllo canary.",
+        "default": false,
+        "rollout": {
+          "phase": "canary",
+          "stageGate": "nebula-pilot-go",
+          "start": "2026-03-02",
+          "target": "2026-03-23",
+          "cohorts": ["nebula-alpha", "nebula-beta", "qa-delta"],
+          "pipeline": {
+            "jobId": "nebula-atlas-rollout",
+            "config": "config/jobs/nebula-atlas-rollout.yaml"
+          }
+        },
+        "owner": {
+          "team": "nebula-ops",
+          "contact": "nebula-ops@gamestudio.local",
+          "slack": "#nebula-ops"
+        },
+        "playbook": "docs/ops/nebula-rollout.md",
+        "metrics": [
+          {
+            "name": "nebula_atlas_aggregator_success_rate",
+            "threshold": ">=0.99",
+            "window": "1h",
+            "alertChannel": "ops-oncall"
+          },
+          {
+            "name": "nebula_atlas_fallback_ratio",
+            "threshold": "<=0.05",
+            "window": "1h",
+            "alertChannel": "#nebula-rollout"
+          },
+          {
+            "name": "nebula_atlas_latency_p95_ms",
+            "threshold": "<=4500",
+            "window": "30m",
+            "alertChannel": "observability"
+          }
+        ]
+      }
     }
+  }
 }

--- a/docs/ops/nebula-rollout.md
+++ b/docs/ops/nebula-rollout.md
@@ -1,0 +1,66 @@
+# Nebula Atlas Aggregator Rollout Runbook
+
+## Contesto
+
+Il rollout dell'aggregatore Nebula Atlas è controllato dal flag `featureFlags.rollout.nebulaAtlasAggregator` definito in `config/featureFlags.json`. Il flag è in fase _canary_, richiede lo stage gate `nebula-pilot-go` e abilita i soli cohort `nebula-alpha`, `nebula-beta` e `qa-delta`. Il rollout porta in produzione il controller `atlasController` con l'aggregatore `nebulaTelemetryAggregator`, introducendo:
+
+- Header di risposta `x-nebula-rollout-*` per tracciare lo stato (enabled/disabled, motivo, stage gate, cohort).
+- Logging dedicato (`[atlas-controller]` e `[nebula-aggregator]`) per validare fallback e fonti mancanti.
+- Metriche operative per verificare successo, fallback e latenza (vedi sezione [Metriche](#metriche-da-monitorare)).
+
+## Prerequisiti
+
+1. Stage gate `nebula-pilot-go` approvato e comunicato alle squadre coinvolte.
+2. Telemetria QA aggiornata (`data/derived/exports/qa-telemetry-export.json`) e profilo generatore (`logs/tooling/generator_run_profile.json`).
+3. Cartella log orchestrator con file `*.jsonl` accessibile (configurazione in `nebulaTelemetryAggregator`).
+4. Pipeline `nebula-atlas-rollout` pronta (config: `config/jobs/nebula-atlas-rollout.yaml`).
+5. Squadre `nebula-ops` e `qa-insights` reperibili su Slack (`#nebula-ops`, `#nebula-rollout`).
+
+## Procedura di Rollout
+
+1. **Baseline**
+   - Eseguire `curl` (o Postman) su `/nebula/atlas?cohort=nebula-alpha&stageGate=nebula-pilot-go` dall'ambiente canary.
+   - Verificare header `x-nebula-rollout-state: enabled` e motivo `cohort_enabled`.
+   - Controllare i log applicativi per assicurarsi che non compaiano warning `[nebula-aggregator] ... fallback`.
+2. **Monitoraggio iniziale (15 minuti)**
+   - Tracciare le metriche (success rate ≥99%, fallback ratio ≤5%, latency p95 ≤4500 ms).
+   - Validare che la metrica `nebula_atlas_fallback_ratio` resti sotto soglia; in caso contrario analizzare i log di fallback.
+3. **Estensione cohort**
+   - Abilitare progressivamente `nebula-beta` e poi `qa-delta` coordinando i client: assicurarsi che gli endpoint includano `stageGate=nebula-pilot-go` e il cohort appropriato.
+   - Dopo ogni estensione ripetere il punto 2 per almeno un ciclo di raccolta dati.
+4. **Stabilizzazione**
+   - Quando tutte le metriche sono stabili per ≥24h, pianificare l'eventuale passaggio a GA impostando `default: true` nel flag (previa approvazione).
+
+## Metriche da monitorare
+
+| Metrica                                | Soglia | Finestra | Canale allerta    |
+| -------------------------------------- | ------ | -------- | ----------------- |
+| `nebula_atlas_aggregator_success_rate` | ≥ 0.99 | 1h       | `ops-oncall`      |
+| `nebula_atlas_fallback_ratio`          | ≤ 0.05 | 1h       | `#nebula-rollout` |
+| `nebula_atlas_latency_p95_ms`          | ≤ 4500 | 30m      | `observability`   |
+
+## Verifiche manuali
+
+- **Header**: ogni risposta deve riportare `x-nebula-rollout-state` e `x-nebula-rollout-reason`. In caso di fallback atteso si osserva `stage_gate_required` o `cohort_not_authorized`.
+- **Logging**:
+  - `[atlas-controller] rollout Nebula disabilitato (...)` indica fallback deciso dal flag.
+  - `[nebula-aggregator] telemetria/orchestrator ... uso valori di fallback` segnala sorgenti mancanti.
+- **API**: quando il flag è disabilitato, `/nebula/atlas/orchestrator` restituisce `404 Telemetria orchestrator non disponibile per rollout Nebula`.
+
+## Piano di Fallback
+
+1. Rimuovere lo stage gate dalle chiamate client o impostare un cohort non autorizzato per forzare subito il ritorno al dataset statico.
+2. Se necessario, impostare temporaneamente `default: false` o rimuovere i cohort dal flag in `config/featureFlags.json` e ridistribuire.
+3. Monitorare che i log `[atlas-controller]` confermino lo stato `disabled` e che il traffico ritorni alle sorgenti statiche (assenza di log `[nebula-aggregator]` con errori gravi).
+4. Segnalare l'esito su `#nebula-ops` e aggiornare la checklist QA.
+
+## Ripartenza dopo fallback
+
+- Ripulire eventuali cache chiamando `invalidateCache()` sull'aggregatore (se esposto) o riavviando l'istanza.
+- Ripristinare i cohort nel flag e ripetere la procedura a partire dal punto 1 (Baseline).
+
+## Contatti
+
+- **Owner**: team `nebula-ops` (`nebula-ops@gamestudio.local`)
+- **Supporto QA**: `qa-insights@gamestudio.local`
+- **Canali Slack**: `#nebula-ops`, `#nebula-rollout`

--- a/ops/release/nebula.yaml
+++ b/ops/release/nebula.yaml
@@ -1,0 +1,61 @@
+rollout:
+  name: Nebula Atlas Aggregator
+  featureFlag: featureFlags.rollout.nebulaAtlasAggregator
+  stageGate: nebula-pilot-go
+  cohorts:
+    - nebula-alpha
+    - nebula-beta
+    - qa-delta
+  playbook: docs/ops/nebula-rollout.md
+  pipeline:
+    job: nebula-atlas-rollout
+    config: config/jobs/nebula-atlas-rollout.yaml
+  contacts:
+    owner: nebula-ops@gamestudio.local
+    slack:
+      - '#nebula-ops'
+      - '#nebula-rollout'
+  steps:
+    - name: Pre-rollout baseline
+      checklist:
+        - 'Eseguire richiesta canary con stageGate e cohort autorizzati'
+        - 'Verificare header x-nebula-rollout-state=enabled'
+        - 'Controllare assenza di log di fallback nel namespace [nebula-aggregator]'
+    - name: Canary rollout
+      checklist:
+        - "Abilitare l'accesso per il cohort nebula-alpha"
+        - 'Monitorare metriche per 15 minuti'
+    - name: Estensione cohort
+      checklist:
+        - 'Abilitare nebula-beta e qa-delta in sequenza'
+        - "Confermare con QA l'accesso end-to-end"
+    - name: Stabilizzazione
+      checklist:
+        - 'Monitorare le metriche per 24h'
+        - 'Pianificare il passaggio a default=true se approvato'
+  verification:
+    metrics:
+      - name: nebula_atlas_aggregator_success_rate
+        target: '>=0.99'
+        window: 1h
+        alertChannel: ops-oncall
+      - name: nebula_atlas_fallback_ratio
+        target: '<=0.05'
+        window: 1h
+        alertChannel: '#nebula-rollout'
+      - name: nebula_atlas_latency_p95_ms
+        target: '<=4500'
+        window: 30m
+        alertChannel: observability
+    manualChecks:
+      - 'Header x-nebula-rollout-state e reason coerenti con lo stato atteso'
+      - 'Endpoint /nebula/atlas/orchestrator risponde 404 quando il flag è disabilitato'
+      - "Log [atlas-controller] riportano l'eventuale fallback con reason"
+  fallback:
+    actions:
+      - 'Rimuovere stageGate dalle richieste client o usare cohort non autorizzati per tornare al dataset statico'
+      - 'Aggiornare config/featureFlags.json impostando default=false se necessario'
+      - 'Notificare #nebula-ops e #nebula-rollout, allegando le metriche raccolte'
+    validation:
+      - 'Verificare header x-nebula-rollout-state=disabled'
+      - 'Controllare log [nebula-aggregator] per garantire che non emergano errori'


### PR DESCRIPTION
## Summary
- gate Nebula atlas controller endpoints behind the `nebulaAtlasAggregator` feature flag and expose rollout headers
- add fallback logging to the Nebula telemetry aggregator and align the shared feature flag configuration
- document the Nebula rollout plan and release steps while extending router tests for enabled/disabled flows

## Testing
- node --test tests/server/nebula-route.spec.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69147d760da8832896f5da9acd0adebe)