### PR TITLE
Automate Evo rollout status updates

### DIFF
--- a/.github/workflows/evo-rollout-status.yml
+++ b/.github/workflows/evo-rollout-status.yml
@@ -1,0 +1,38 @@
+name: Evo rollout status sync
+
+on:
+  schedule:
+    - cron: '0 6 * * MON'
+  workflow_dispatch:
+
+jobs:
+  rollout-status:
+    name: Generate rollout status snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run Evo rollout status updater
+        run: |
+          python tools/roadmap/update_status.py --weekly-date $(date -u +%Y%m%d)
+
+      - name: Show resulting diff
+        run: git diff
+
+      - name: Upload Kanban export
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: evo-rollout-status
+          path: |
+            reports/evo/rollout/status_export.json
+            docs/roadmap/status/evo-weekly-*.md

--- a/docs/roadmap/evo-rollout-status.md
+++ b/docs/roadmap/evo-rollout-status.md
@@ -1,50 +1,44 @@
 ---
 title: Evo-Tactics rollout status
-updated: 2025-12-21
+updated: 2025-10-29
+generated_by: tools/roadmap/update_status.py
 ---
 
 # Evo-Tactics rollout status
 
+<!-- Generated automatically; edit via tools/roadmap/update_status.py -->
+
 ## Snapshot settimanale
 
-- **Data riferimento:** 2025-12-21
+- **Data riferimento:** 2025-10-29
 - **Owner aggiornamento:** Gameplay Ops · Evo rollout crew
-- **Status generale:** on-track
-- **Ultimo report:** `reports/evo/rollout/species_ecosystem_gap.md`
+- **Status generale:** at-risk
+- **Ultimo report trait gap:** `data/derived/analysis/trait_gap_report.json`
+- **Copertura trait ETL:** 29/170 (17.1%)
+- **Gap trait principali:** 51 missing_in_index, 174 missing_in_external
+- **Playbook da archiviare:** 3
+- **Ecotipi con mismatch legacy:** 20 su 20
 
 ## Avanzamento epiche ROL-\*
 
-| Epic   | Stato    | Progress (%) | Note/Blocker                                                                                                                                                             |
-| ------ | -------- | -----------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| ROL-01 | on-track |          100 | Frontmatter archivio aggiornato con `scripts/evo_tactics_metadata_diff.py --mode=backfill` (output verificato su `incoming/archive/2025-12-19_inventory_cleanup/`).      |
-| ROL-02 | on-track |          100 | Mappa ancore generata in `docs/evo-tactics/anchors-map.csv` e notifiche inviate a DevRel per l'aggiornamento wiki.                                                       |
-| ROL-03 | at-risk  |           30 | Snapshot playbook ancora da redigere; dipende dalla riconciliazione cambi doc legacy.                                                                                    |
-| ROL-04 | on-track |           60 | Script `tools/traits/sync_missing_index.py` integrato nel workflow `.github/workflows/traits-sync.yml`; restano verifiche QA su descrizioni multilingua.                 |
-| ROL-05 | on-track |           45 | Export partner `reports/evo/rollout/traits_external_sync.csv` pubblicato automaticamente su S3 (bucket partners) in attesa di approvazione Partner Success.              |
-| ROL-06 | on-track |           55 | Telemetria arricchita con `sentience_index` e fallback slot applicato in `server/services/nebulaTelemetryAggregator.js`; restano fixture Atlas/telemetria da aggiornare. |
+| Epic   | Stato       | Progress (%) | Gap aperti                     | Campione                                                                                                                        |
+| ------ | ----------- | ------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| ROL-03 | in-progress | 99           | Playbook da archiviare: 3      | docs/evo-tactics/guides/security-ops.md, docs/evo-tactics/guides/template-ptpf.md, docs/evo-tactics/guides/visione-struttura.md |
+| ROL-04 | in-progress | 77           | Trait missing_in_index: 51     | ali_fono_risonanti, articolazioni_a_leva_idraulica, articolazioni_multiassiali, artigli_ipo_termici, artiglio_cinetico_a_urto   |
+| ROL-05 | at-risk     | 23           | Trait missing_in_external: 174 | ali_fulminee, ali_ioniche, ali_membrana_sonica, antenne_dustsense, antenne_eco_turbina                                          |
+| ROL-06 | at-risk     | 0            | Ecotipi con mismatch: 20       | Anguis magnetica, Chemnotela toxica, Elastovaranus hydrus, Gulogluteus scutiger, Perfusuas pedes                                |
 
-## Deliverable imminenti
+## Focus operativi
 
-- [ ] 2026-01-05 – Snapshot playbook security/PMO – Owner Security PMO – Artefatti `incoming/archive/2025-12-19_inventory_cleanup/playbook_*.md`
-- [ ] 2026-01-12 – QA generatori trait Evo – Owner Gameplay Data – Artefatto `reports/evo/qa/trait-generators.log`
-- [ ] 2026-01-19 – Demo telemetria specie (ROL-06) – Owner Gameplay Ops – Artefatti `reports/evo/rollout/species_ecosystem_gap.md`, log QA Atlas
+- **Documentazione legacy da snapshot (ROL-03):** docs/evo-tactics/guides/security-ops.md, docs/evo-tactics/guides/template-ptpf.md, docs/evo-tactics/guides/visione-struttura.md
+- **Trait da indicizzare (ROL-04):** ali_fono_risonanti, articolazioni_a_leva_idraulica, articolazioni_multiassiali, artigli_ipo_termici, artiglio_cinetico_a_urto
+- **Trait da fornire ai consumer esterni (ROL-05):** ali_fulminee, ali_ioniche, ali_membrana_sonica, antenne_dustsense, antenne_eco_turbina
+- **Specie/ecotipi con mismatch (ROL-06):** Anguis magnetica, Chemnotela toxica, Elastovaranus hydrus, Gulogluteus scutiger, Perfusuas pedes
 
-## Rischi e mitigazioni
+## Fonti principali
 
-1. **Rischio:** Descrizioni inglesi mancanti per i trait sincronizzati automaticamente.
-   - **Impatto:** Medio (export partner potrebbe richiedere revisione manuale).
-   - **Mitigazione:** DevRel compilerà le traduzioni entro il QA del 12 gennaio; issue aperta in board ROL-04.
-2. **Rischio:** Mock telemetria Atlas non ancora aggiornati ai nuovi campi `sentience_index` e fallback slot.
-   - **Impatto:** Medio (possibili failure nei test end-to-end).
-   - **Mitigazione:** task `ROL-06` prevede aggiornamento fixture e rerun `npm run test:telemetry` entro la prossima sprint.
-
-## Decisioni e azioni
-
-- **Decisione:** Automatizzare la sincronizzazione trait con il workflow `traits-sync` e pubblicare gli export su S3 condiviso.
-  - **Data:** 2025-12-28
-  - **Partecipanti:** Gameplay Ops, DevRel, Partner Success
-  - **Riferimenti:** `.github/workflows/traits-sync.yml`, `docs/tooling/evo.md`, `reports/evo/rollout/documentation_gap.md`
-- **Azione:** Aggiornare le fixture Atlas con payload `sentience_index` e fallback slot.
-  - **Owner:** Gameplay Ops
-  - **Scadenza:** 2026-01-10
-  - **Link task:** ROL-06
+- `reports/evo/rollout/documentation_gap.md`
+- `reports/evo/rollout/documentation_diff.json`
+- `reports/evo/rollout/traits_gap.csv`
+- `reports/evo/rollout/species_ecosystem_gap.md`
+- `data/derived/analysis/trait_gap_report.json`

--- a/docs/roadmap/status/evo-weekly-20251029.md
+++ b/docs/roadmap/status/evo-weekly-20251029.md
@@ -1,0 +1,37 @@
+---
+title: Evo rollout weekly status
+generated: 2025-10-29T14:20:44+00:00
+reference_date: 2025-10-29
+workflow_run: —
+---
+
+# Evo Rollout – Weekly status (2025-10-29)
+
+> Generato automaticamente da `tools/roadmap/update_status.py`.
+
+## Snapshot indicatori
+
+| Indicatore                | Valore |
+| ------------------------- | ------ |
+| Playbook da archiviare    | 3      |
+| Trait missing_in_index    | 51     |
+| Trait missing_in_external | 174    |
+| Ecotipi con mismatch      | 20     |
+
+## Workflow & integrazioni
+
+- Ultima run workflow: —
+- Export Kanban: `reports/evo/rollout/status_export.json`
+
+## Link ai report
+
+- `reports/evo/rollout/documentation_gap.md`
+- `reports/evo/rollout/traits_gap.csv`
+- `reports/evo/rollout/species_ecosystem_gap.md`
+- `data/derived/analysis/trait_gap_report.json`
+
+## Note rapide
+
+- [ ] Aggiornare board roadmap con lo stato corrente.
+- [ ] Validare azioni di follow-up per consumer esterni.
+- [ ] Pianificare remediation specie/ecotipi aperti.

--- a/incoming/lavoro_da_classificare/tasks.yml
+++ b/incoming/lavoro_da_classificare/tasks.yml
@@ -2,7 +2,7 @@
 
 meta:
   version: 1
-  last_update: 2025-11-11
+  last_update: 2025-10-29
   notes: 'Aggiornare status e assegnatari quando i task vengono presi in carico. Directory di destinazione già disponibili: docs/evo-tactics, docs/security, data/external/evo, reports/evo, incoming/archive/documents, tools/automation, docs/wireframes/evo. Utilizzare tools/automation/evo_batch_runner.py per automatizzare i comandi batch (dry-run di default).'
 
 tasks:
@@ -321,7 +321,7 @@ tasks:
     batch: rollout
     title: Snapshot playbook Evo mancanti
     description: 'Produrre versioni archivio per i playbook senza controparte legacy.'
-    status: todo
+    status: in-progress
     owner: security-pmo
     depends_on:
       - ROL-01
@@ -330,6 +330,18 @@ tasks:
       - incoming/archive/2025-12-19_inventory_cleanup/playbook_template_ptpf.md
       - incoming/archive/2025-12-19_inventory_cleanup/playbook_visione_struttura.md
     notes: 'Estrarre le copie consolidate dei playbook security/PMO e versionarle nell’archivio storico con changelog.'
+
+    telemetry:
+      last_sync: 2025-10-29T14:20:44+00:00
+      progress: 99
+      metric:
+        label: Playbook da archiviare
+        open_items: 3
+        total_items: 218
+      samples:
+        - docs/evo-tactics/guides/security-ops.md
+        - docs/evo-tactics/guides/template-ptpf.md
+        - docs/evo-tactics/guides/visione-struttura.md
 
   - id: ROL-04
     batch: rollout
@@ -346,11 +358,25 @@ tasks:
       - python tools/traits/sync_missing_index.py --source reports/evo/rollout/traits_gap.csv --dest data/core/traits/glossary.json
     notes: 'Garantisce corrispondenza tra slug Evo e catalogo legacy per trait in stato `missing_in_index`.'
 
+    telemetry:
+      last_sync: 2025-10-29T14:20:44+00:00
+      progress: 77
+      metric:
+        label: Trait missing_in_index
+        open_items: 51
+        total_items: 225
+      samples:
+        - ali_fono_risonanti
+        - articolazioni_a_leva_idraulica
+        - articolazioni_multiassiali
+        - artigli_ipo_termici
+        - artiglio_cinetico_a_urto
+
   - id: ROL-05
     batch: rollout
     title: Esportazione dataset trait consumer esterni
     description: 'Preparare il pacchetto CSV/JSON per i consumer esterni che non ricevono i nuovi trait.'
-    status: in-progress
+    status: at-risk
     owner: partner-success
     depends_on:
       - ROL-04
@@ -359,11 +385,25 @@ tasks:
       - reports/evo/rollout/traits_gap.csv
     notes: 'Deriva dall’analisi `missing_in_external` e fornisce export normalizzato per partner tooling.'
 
+    telemetry:
+      last_sync: 2025-10-29T14:20:44+00:00
+      progress: 23
+      metric:
+        label: Trait missing_in_external
+        open_items: 174
+        total_items: 225
+      samples:
+        - ali_fulminee
+        - ali_ioniche
+        - ali_membrana_sonica
+        - antenne_dustsense
+        - antenne_eco_turbina
+
   - id: ROL-06
     batch: rollout
     title: Piano rollout specie/ecotipi
     description: 'Sequenziare le milestone di attivazione specie e aggiornare i consumer telemetria.'
-    status: in-progress
+    status: at-risk
     owner: gameplay-ops
     depends_on:
       - SPEC-03
@@ -372,3 +412,17 @@ tasks:
       - server/services/nebulaTelemetryAggregator.js
       - server/controllers/atlasController.js
     notes: 'Integra fallback slot legacy, arricchisce payload timeline con sentience_index e allinea mock telemetry.'
+
+    telemetry:
+      last_sync: 2025-10-29T14:20:44+00:00
+      progress: 0
+      metric:
+        label: Ecotipi con mismatch
+        open_items: 20
+        total_items: 20
+      samples:
+        - Anguis magnetica
+        - Chemnotela toxica
+        - Elastovaranus hydrus
+        - Gulogluteus scutiger
+        - Perfusuas pedes

--- a/reports/evo/rollout/status_export.json
+++ b/reports/evo/rollout/status_export.json
@@ -1,0 +1,65 @@
+{
+  "generated_at": "2025-10-29T14:20:44+00:00",
+  "overall_status": "at-risk",
+  "workflow_run": null,
+  "epics": [
+    {
+      "id": "ROL-03",
+      "status": "in-progress",
+      "progress": 99,
+      "metric_label": "Playbook da archiviare",
+      "open_items": 3,
+      "total_items": 218,
+      "samples": [
+        "docs/evo-tactics/guides/security-ops.md",
+        "docs/evo-tactics/guides/template-ptpf.md",
+        "docs/evo-tactics/guides/visione-struttura.md"
+      ]
+    },
+    {
+      "id": "ROL-04",
+      "status": "in-progress",
+      "progress": 77,
+      "metric_label": "Trait missing_in_index",
+      "open_items": 51,
+      "total_items": 225,
+      "samples": [
+        "ali_fono_risonanti",
+        "articolazioni_a_leva_idraulica",
+        "articolazioni_multiassiali",
+        "artigli_ipo_termici",
+        "artiglio_cinetico_a_urto"
+      ]
+    },
+    {
+      "id": "ROL-05",
+      "status": "at-risk",
+      "progress": 23,
+      "metric_label": "Trait missing_in_external",
+      "open_items": 174,
+      "total_items": 225,
+      "samples": [
+        "ali_fulminee",
+        "ali_ioniche",
+        "ali_membrana_sonica",
+        "antenne_dustsense",
+        "antenne_eco_turbina"
+      ]
+    },
+    {
+      "id": "ROL-06",
+      "status": "at-risk",
+      "progress": 0,
+      "metric_label": "Ecotipi con mismatch",
+      "open_items": 20,
+      "total_items": 20,
+      "samples": [
+        "Anguis magnetica",
+        "Chemnotela toxica",
+        "Elastovaranus hydrus",
+        "Gulogluteus scutiger",
+        "Perfusuas pedes"
+      ]
+    }
+  ]
+}

--- a/tools/roadmap/update_status.py
+++ b/tools/roadmap/update_status.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env python3
+"""Utility per aggiornare lo stato rollout Evo.
+
+Lo script consolida i report di gap (documentazione, trait, specie/ecosistemi)
+per aggiornare in modo coerente:
+
+* ``docs/roadmap/evo-rollout-status.md`` – snapshot roadmap.
+* ``incoming/lavoro_da_classificare/tasks.yml`` – stato epiche ROL-*.
+* ``docs/roadmap/status/evo-weekly-YYYYMMDD.md`` – template stato settimanale.
+* ``reports/evo/rollout/status_export.json`` – export per board Kanban/Linear.
+
+Il tool è pensato per essere eseguito sia in locale sia in CI/GitHub Actions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from textwrap import dedent
+from typing import Dict, Iterable, List, Optional
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_STATUS_MD = REPO_ROOT / "docs/roadmap/evo-rollout-status.md"
+DEFAULT_TASKS_YAML = REPO_ROOT / "incoming/lavoro_da_classificare/tasks.yml"
+DEFAULT_WEEKLY_DIR = REPO_ROOT / "docs/roadmap/status"
+DEFAULT_KANBAN_EXPORT = REPO_ROOT / "reports/evo/rollout/status_export.json"
+
+TRAIT_GAP_REPORT = REPO_ROOT / "data/derived/analysis/trait_gap_report.json"
+TRAITS_GAP_CSV = REPO_ROOT / "reports/evo/rollout/traits_gap.csv"
+DOCUMENTATION_DIFF_JSON = REPO_ROOT / "reports/evo/rollout/documentation_diff.json"
+SPECIES_GAP_MD = REPO_ROOT / "reports/evo/rollout/species_ecosystem_gap.md"
+
+
+@dataclass
+class TraitsGapMetrics:
+    missing_in_index: int
+    missing_in_external: int
+    total_rows: int
+    samples_missing_in_index: List[str]
+    samples_missing_in_external: List[str]
+
+
+@dataclass
+class DocumentationMetrics:
+    unmatched: int
+    total_imports: int
+    samples_unmatched: List[str]
+
+
+@dataclass
+class SpeciesGapMetrics:
+    mismatched_rows: int
+    total_rows: int
+    species_count: int
+    samples_species: List[str]
+
+
+@dataclass
+class EpicStatus:
+    id: str
+    status: str
+    progress: int
+    metric_label: str
+    open_items: int
+    total_items: int
+    samples: List[str]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "progress": self.progress,
+            "metric_label": self.metric_label,
+            "open_items": self.open_items,
+            "total_items": self.total_items,
+            "samples": self.samples,
+        }
+
+
+class StatusComputationError(RuntimeError):
+    """Errore sollevato quando i report richiesti non sono disponibili."""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Aggiorna lo stato rollout Evo")
+    parser.add_argument(
+        "--status-md",
+        type=Path,
+        default=DEFAULT_STATUS_MD,
+        help="File Markdown con lo snapshot roadmap da aggiornare.",
+    )
+    parser.add_argument(
+        "--tasks-yaml",
+        type=Path,
+        default=DEFAULT_TASKS_YAML,
+        help="Registro dei task/epiche da aggiornare.",
+    )
+    parser.add_argument(
+        "--weekly-dir",
+        type=Path,
+        default=DEFAULT_WEEKLY_DIR,
+        help="Directory dove salvare il template di stato settimanale.",
+    )
+    parser.add_argument(
+        "--weekly-date",
+        type=str,
+        default=None,
+        help="Data (YYYYMMDD) da usare per il template settimanale. Default: data report.",
+    )
+    parser.add_argument(
+        "--kanban-export",
+        type=Path,
+        default=DEFAULT_KANBAN_EXPORT,
+        help="Percorso dell'export JSON per sincronizzazione board Kanban.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Stampa i risultati senza scrivere i file di output.",
+    )
+    return parser.parse_args()
+
+
+def read_json(path: Path) -> Dict[str, object]:
+    if not path.exists():
+        raise StatusComputationError(f"File JSON mancante: {path}")
+    return json.loads(path.read_text())
+
+
+def load_trait_gap_summary(path: Path = TRAIT_GAP_REPORT) -> Dict[str, object]:
+    data = read_json(path)
+    summary = data.get("summary") or {}
+    generated_at = data.get("generated_at")
+    if generated_at:
+        try:
+            generated_dt = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise StatusComputationError(
+                f"Formato data non valido in {path}: {generated_at}"
+            ) from exc
+    else:
+        generated_dt = datetime.now(timezone.utc)
+    return {
+        "generated_at": generated_dt,
+        "summary": summary,
+        "sources": data.get("sources", {}),
+    }
+
+
+def load_traits_gap_metrics(path: Path = TRAITS_GAP_CSV) -> TraitsGapMetrics:
+    if not path.exists():
+        raise StatusComputationError(f"File CSV mancante: {path}")
+    counts = Counter()
+    samples: Dict[str, List[str]] = defaultdict(list)
+    total_rows = 0
+    with path.open(newline="") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            total_rows += 1
+            status = row.get("status", "unknown")
+            slug = row.get("slug", "")
+            counts[status] += 1
+            if slug and len(samples[status]) < 5:
+                samples[status].append(slug)
+    return TraitsGapMetrics(
+        missing_in_index=counts.get("missing_in_index", 0),
+        missing_in_external=counts.get("missing_in_external", 0),
+        total_rows=total_rows,
+        samples_missing_in_index=samples.get("missing_in_index", []),
+        samples_missing_in_external=samples.get("missing_in_external", []),
+    )
+
+
+def load_documentation_metrics(path: Path = DOCUMENTATION_DIFF_JSON) -> DocumentationMetrics:
+    data = read_json(path)
+    unmatched = data.get("unmatched", [])
+    imports = data.get("imports", [])
+    samples = [str(item) for item in unmatched[:5]]
+    return DocumentationMetrics(
+        unmatched=len(unmatched),
+        total_imports=len(imports),
+        samples_unmatched=samples,
+    )
+
+
+def load_species_gap_metrics(path: Path = SPECIES_GAP_MD) -> SpeciesGapMetrics:
+    if not path.exists():
+        raise StatusComputationError(f"File Markdown mancante: {path}")
+    text = path.read_text()
+    def extract_int(pattern: str, default: int = 0) -> int:
+        match = re.search(pattern, text)
+        if match:
+            return int(match.group(1))
+        return default
+
+    species = extract_int(r"Specie analizzate:\s*(\d+)")
+    total_rows = extract_int(r"Righe ecotipo:\s*(\d+)")
+    mismatched_rows = extract_int(r"Righe con mismatch trait ↔ legacy:\s*(\d+)")
+    samples = []
+    detail_section = re.search(r"## Dettaglio specie\n\n(.*)", text, re.S)
+    if detail_section:
+        lines = detail_section.group(1).splitlines()
+        for line in lines:
+            if line.startswith("| ") and not line.startswith("| ---"):
+                parts = [part.strip() for part in line.strip("|").split("|")]
+                if parts and parts[0].lower() != "specie":
+                    species_name = parts[0]
+                    if species_name and len(samples) < 5:
+                        samples.append(species_name)
+    return SpeciesGapMetrics(
+        mismatched_rows=mismatched_rows,
+        total_rows=total_rows,
+        species_count=species,
+        samples_species=samples,
+    )
+
+
+def compute_progress(open_items: int, total_items: int) -> int:
+    if total_items <= 0:
+        return 0 if open_items else 100
+    ratio = max(0.0, 1.0 - (open_items / total_items))
+    return int(round(ratio * 100))
+
+
+def derive_epic_statuses(
+    traits_metrics: TraitsGapMetrics,
+    documentation_metrics: DocumentationMetrics,
+    species_metrics: SpeciesGapMetrics,
+) -> List[EpicStatus]:
+    epic_data = [
+        {
+            "id": "ROL-03",
+            "metric_label": "Playbook da archiviare",
+            "open_items": documentation_metrics.unmatched,
+            "total": max(documentation_metrics.total_imports, documentation_metrics.unmatched),
+            "samples": documentation_metrics.samples_unmatched,
+            "threshold": 5,
+        },
+        {
+            "id": "ROL-04",
+            "metric_label": "Trait missing_in_index",
+            "open_items": traits_metrics.missing_in_index,
+            "total": traits_metrics.total_rows,
+            "samples": traits_metrics.samples_missing_in_index,
+            "threshold": 75,
+        },
+        {
+            "id": "ROL-05",
+            "metric_label": "Trait missing_in_external",
+            "open_items": traits_metrics.missing_in_external,
+            "total": traits_metrics.total_rows,
+            "samples": traits_metrics.samples_missing_in_external,
+            "threshold": 75,
+        },
+        {
+            "id": "ROL-06",
+            "metric_label": "Ecotipi con mismatch",
+            "open_items": species_metrics.mismatched_rows,
+            "total": max(species_metrics.total_rows, species_metrics.mismatched_rows),
+            "samples": species_metrics.samples_species,
+            "threshold": 10,
+        },
+    ]
+    statuses: List[EpicStatus] = []
+    for item in epic_data:
+        progress = compute_progress(item["open_items"], item["total"])
+        if item["open_items"] == 0:
+            status = "done"
+        elif item["open_items"] <= item["threshold"]:
+            status = "in-progress"
+        else:
+            status = "at-risk"
+        statuses.append(
+            EpicStatus(
+                id=item["id"],
+                status=status,
+                progress=progress,
+                metric_label=item["metric_label"],
+                open_items=item["open_items"],
+                total_items=item["total"],
+                samples=item["samples"],
+            )
+        )
+    return statuses
+
+
+def derive_overall_status(epics: Iterable[EpicStatus]) -> str:
+    statuses = {epic.status for epic in epics}
+    if statuses == {"done"}:
+        return "on-track"
+    if "at-risk" in statuses:
+        return "at-risk"
+    return "in-progress"
+
+
+def ensure_weekly_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def format_samples(samples: List[str]) -> str:
+    if not samples:
+        return "—"
+    return ", ".join(samples)
+
+
+def write_status_markdown(
+    path: Path,
+    generated_at: datetime,
+    trait_summary: Dict[str, object],
+    traits_metrics: TraitsGapMetrics,
+    doc_metrics: DocumentationMetrics,
+    species_metrics: SpeciesGapMetrics,
+    epics: List[EpicStatus],
+    overall_status: str,
+) -> str:
+    date_str = generated_at.date().isoformat()
+    coverage = trait_summary.get("traits_missing_in_etl")
+    reference_total = trait_summary.get("reference_traits_total")
+    etl_total = trait_summary.get("etl_traits_total")
+
+    coverage_line = "—"
+    if reference_total and etl_total is not None:
+        coverage_pct = (etl_total / reference_total) * 100 if reference_total else 0
+        coverage_line = f"{etl_total}/{reference_total} ({coverage_pct:.1f}%)"
+    traits_missing_line = f"{traits_metrics.missing_in_index} missing_in_index, {traits_metrics.missing_in_external} missing_in_external"
+
+    content = dedent(
+        f"""\
+        ---
+        title: Evo-Tactics rollout status
+        updated: {date_str}
+        generated_by: tools/roadmap/update_status.py
+        ---
+
+        # Evo-Tactics rollout status
+
+        <!-- Generated automatically; edit via tools/roadmap/update_status.py -->
+
+        ## Snapshot settimanale
+
+        - **Data riferimento:** {date_str}
+        - **Owner aggiornamento:** Gameplay Ops · Evo rollout crew
+        - **Status generale:** {overall_status}
+        - **Ultimo report trait gap:** `data/derived/analysis/trait_gap_report.json`
+        - **Copertura trait ETL:** {coverage_line}
+        - **Gap trait principali:** {traits_missing_line}
+        - **Playbook da archiviare:** {doc_metrics.unmatched}
+        - **Ecotipi con mismatch legacy:** {species_metrics.mismatched_rows} su {max(species_metrics.total_rows, species_metrics.mismatched_rows)}
+
+        ## Avanzamento epiche ROL-*
+
+        | Epic | Stato | Progress (%) | Gap aperti | Campione |
+        | ---- | ----- | ------------ | ---------- | -------- |
+        """
+    )
+    for epic in epics:
+        sample_text = format_samples(epic.samples)
+        content += f"| {epic.id} | {epic.status} | {epic.progress} | {epic.metric_label}: {epic.open_items} | {sample_text} |\n"
+
+    content += "\n"
+    content += dedent(
+        """\
+        ## Focus operativi
+
+        - **Documentazione legacy da snapshot (ROL-03):** {doc_samples}
+        - **Trait da indicizzare (ROL-04):** {index_samples}
+        - **Trait da fornire ai consumer esterni (ROL-05):** {external_samples}
+        - **Specie/ecotipi con mismatch (ROL-06):** {species_samples}
+
+        ## Fonti principali
+
+        - `reports/evo/rollout/documentation_gap.md`
+        - `reports/evo/rollout/documentation_diff.json`
+        - `reports/evo/rollout/traits_gap.csv`
+        - `reports/evo/rollout/species_ecosystem_gap.md`
+        - `data/derived/analysis/trait_gap_report.json`
+        """.format(
+            doc_samples=format_samples(doc_metrics.samples_unmatched),
+            index_samples=format_samples(traits_metrics.samples_missing_in_index),
+            external_samples=format_samples(traits_metrics.samples_missing_in_external),
+            species_samples=format_samples(species_metrics.samples_species),
+        )
+    )
+    path.write_text(content)
+    return content
+
+
+def update_tasks_yaml(path: Path, epics: List[EpicStatus], generated_at: datetime) -> str:
+    text = path.read_text()
+    sync_date = generated_at.date().isoformat()
+
+    def _last_update_repl(match: re.Match[str]) -> str:
+        return f"{match.group(1)}{sync_date}"
+
+    text, _ = re.subn(
+        r"^(  last_update:\s*)(\S+)",
+        _last_update_repl,
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+
+    lines = text.splitlines()
+
+    try:
+        last_update_idx = next(
+            i for i, line in enumerate(lines) if line.strip().startswith("last_update:")
+        )
+        lines[last_update_idx] = "  last_update: " + sync_date
+    except StopIteration:
+        try:
+            version_idx = next(
+                i for i, line in enumerate(lines) if line.strip().startswith("version:")
+            )
+        except StopIteration:
+            version_idx = 3
+        insert_pos = version_idx + 1
+        lines.insert(insert_pos, "  last_update: " + sync_date)
+
+    for epic in epics:
+        target = f"  - id: {epic.id}"
+        try:
+            start_idx = next(i for i, line in enumerate(lines) if line.startswith(target))
+        except StopIteration:
+            continue
+        end_idx = start_idx + 1
+        while end_idx < len(lines) and not lines[end_idx].startswith("  - id: "):
+            end_idx += 1
+
+        # Aggiorna lo status.
+        for i in range(start_idx, end_idx):
+            stripped = lines[i].lstrip()
+            if stripped.startswith("status:"):
+                lines[i] = "    status: " + epic.status
+                break
+
+        # Rimuove blocco telemetry esistente.
+        telemetry_start = None
+        for i in range(start_idx, end_idx):
+            if lines[i].strip().startswith("telemetry:"):
+                telemetry_start = i
+                break
+        if telemetry_start is not None:
+            telemetry_end = telemetry_start + 1
+            while telemetry_end < end_idx and (
+                lines[telemetry_end].startswith("      ") or lines[telemetry_end].strip() == ""
+            ):
+                telemetry_end += 1
+            del lines[telemetry_start:telemetry_end]
+            end_idx = telemetry_start
+
+        telemetry_lines = [
+            "    telemetry:",
+            f"      last_sync: {generated_at.isoformat()}",
+            f"      progress: {epic.progress}",
+            "      metric:",
+            f"        label: {epic.metric_label}",
+            f"        open_items: {epic.open_items}",
+            f"        total_items: {epic.total_items}",
+            "      samples:",
+        ]
+        if epic.samples:
+            telemetry_lines.extend([f"        - {sample}" for sample in epic.samples])
+        else:
+            telemetry_lines.append("        - Nessun elemento")
+        telemetry_lines.append("")
+        insertion_pos = end_idx
+        lines[insertion_pos:insertion_pos] = telemetry_lines
+
+    updated_text = "\n".join(lines) + "\n"
+    path.write_text(updated_text)
+    return updated_text
+
+
+def write_weekly_template(
+    directory: Path,
+    generated_at: datetime,
+    traits_metrics: TraitsGapMetrics,
+    doc_metrics: DocumentationMetrics,
+    species_metrics: SpeciesGapMetrics,
+    workflow_url: Optional[str],
+    date_override: Optional[str] = None,
+) -> Path:
+    ensure_weekly_dir(directory)
+    date_ref = (
+        datetime.strptime(date_override, "%Y%m%d").date()
+        if date_override
+        else generated_at.date()
+    )
+    filename = f"evo-weekly-{date_ref.strftime('%Y%m%d')}.md"
+    path = directory / filename
+    workflow_line = workflow_url or "—"
+    content = dedent(
+        """\
+        ---
+        title: Evo rollout weekly status
+        generated: {timestamp}
+        reference_date: {date_ref}
+        workflow_run: {workflow_line}
+        ---
+
+        # Evo Rollout – Weekly status ({date_ref})
+
+        > Generato automaticamente da `tools/roadmap/update_status.py`.
+
+        ## Snapshot indicatori
+
+        | Indicatore | Valore |
+        | ---------- | ------ |
+        | Playbook da archiviare | {doc_open} |
+        | Trait missing_in_index | {index_open} |
+        | Trait missing_in_external | {external_open} |
+        | Ecotipi con mismatch | {species_open} |
+
+        ## Workflow & integrazioni
+
+        - Ultima run workflow: {workflow_line}
+        - Export Kanban: `reports/evo/rollout/status_export.json`
+
+        ## Link ai report
+
+        - `reports/evo/rollout/documentation_gap.md`
+        - `reports/evo/rollout/traits_gap.csv`
+        - `reports/evo/rollout/species_ecosystem_gap.md`
+        - `data/derived/analysis/trait_gap_report.json`
+
+        ## Note rapide
+
+        - [ ] Aggiornare board roadmap con lo stato corrente.
+        - [ ] Validare azioni di follow-up per consumer esterni.
+        - [ ] Pianificare remediation specie/ecotipi aperti.
+        """
+    ).format(
+        timestamp=generated_at.isoformat(),
+        date_ref=date_ref.isoformat(),
+        workflow_line=workflow_line,
+        doc_open=doc_metrics.unmatched,
+        index_open=traits_metrics.missing_in_index,
+        external_open=traits_metrics.missing_in_external,
+        species_open=species_metrics.mismatched_rows,
+    )
+    path.write_text(content)
+    return path
+
+
+def write_kanban_export(
+    path: Path,
+    generated_at: datetime,
+    overall_status: str,
+    epics: List[EpicStatus],
+    workflow_url: Optional[str],
+) -> None:
+    payload = {
+        "generated_at": generated_at.isoformat(),
+        "overall_status": overall_status,
+        "workflow_run": workflow_url,
+        "epics": [epic.to_dict() for epic in epics],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+
+
+def detect_workflow_run_url() -> Optional[str]:
+    server = os.environ.get("GITHUB_SERVER_URL")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    if server and repo and run_id:
+        return f"{server}/{repo}/actions/runs/{run_id}"
+    return None
+
+
+def main() -> None:
+    args = parse_args()
+
+    trait_summary_data = load_trait_gap_summary()
+    traits_metrics = load_traits_gap_metrics()
+    doc_metrics = load_documentation_metrics()
+    species_metrics = load_species_gap_metrics()
+
+    generated_at: datetime = trait_summary_data["generated_at"]
+    trait_summary = trait_summary_data["summary"]
+
+    epics = derive_epic_statuses(traits_metrics, doc_metrics, species_metrics)
+    overall_status = derive_overall_status(epics)
+    workflow_url = detect_workflow_run_url()
+
+    if args.dry_run:
+        print("=== Snapshot ===")
+        print(json.dumps(
+            {
+                "generated_at": generated_at.isoformat(),
+                "overall_status": overall_status,
+                "epics": [epic.to_dict() for epic in epics],
+            },
+            indent=2,
+            ensure_ascii=False,
+        ))
+        weekly_path = args.weekly_dir / "evo-weekly-placeholder.md"
+    else:
+        write_status_markdown(
+            args.status_md,
+            generated_at,
+            trait_summary,
+            traits_metrics,
+            doc_metrics,
+            species_metrics,
+            epics,
+            overall_status,
+        )
+        update_tasks_yaml(args.tasks_yaml, epics, generated_at)
+        weekly_path = write_weekly_template(
+            args.weekly_dir,
+            generated_at,
+            traits_metrics,
+            doc_metrics,
+            species_metrics,
+            workflow_url,
+            args.weekly_date,
+        )
+        write_kanban_export(
+            args.kanban_export,
+            generated_at,
+            overall_status,
+            epics,
+            workflow_url,
+        )
+
+    if args.dry_run:
+        print("Weekly template (anteprima):", weekly_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a roadmap updater utility that ingests Evo gap reports and refreshes the rollout status markdown, tasks registry telemetry, weekly template, and Kanban JSON export
- generate the latest Evo rollout status snapshot and weekly template using the new tool
- schedule a weekly GitHub Actions workflow to run the updater and publish the Kanban export artifact

## Testing
- python tools/roadmap/update_status.py
- npx prettier --write docs/roadmap/evo-rollout-status.md docs/roadmap/status/evo-weekly-20251029.md incoming/lavoro_da_classificare/tasks.yml

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691480ccab6083289bc654098ca44ba2)