### PR TITLE
Align Evo doc metadata workflow outputs

### DIFF
--- a/.github/workflows/evo-doc-backfill.yml
+++ b/.github/workflows/evo-doc-backfill.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           python ops/notifier.py \
             --diff-json reports/evo/rollout/documentation_diff.json \
+            --slack-channel "#devrel-docs" \
             --issue-output ops/notifier_issue.json
           python - <<'PY'
           import json

--- a/reports/evo/rollout/evo_tactics_metadata_diff.json
+++ b/reports/evo/rollout/evo_tactics_metadata_diff.json
@@ -1107,13 +1107,13 @@
       "frontmatter_missing_in_archive": [],
       "frontmatter_missing_in_consolidated": [],
       "frontmatter_mismatched": {
-        "title": {
-          "consolidated": "Evo-Tactics · Guida ai Tratti (Parte 1)",
-          "archive": "Evo-Tactics · Guida ai Tratti (Parte 2)"
-        },
         "description": {
           "consolidated": "Sommario operativo del pacchetto Evo-Tactics Pack v2 con standard specie e tratti, workflow di migrazione e QA.",
           "archive": "Approfondimento su governance dei tratti, migrazione v2.1 e controllo qualità del pacchetto Evo-Tactics."
+        },
+        "title": {
+          "consolidated": "Evo-Tactics · Guida ai Tratti (Parte 1)",
+          "archive": "Evo-Tactics · Guida ai Tratti (Parte 2)"
         }
       },
       "anchors_added": [


### PR DESCRIPTION
## Summary
- capture the latest Evo-Tactics metadata diff in version-controlled reports
- route evo-doc-backfill workflow notifications to the DevRel/Docs Slack channel
- allow ops notifier to override the Slack destination channel when dispatching alerts

## Testing
- python -m compileall ops/notifier.py
- npx prettier --write incoming/archive/2025-12-19_inventory_cleanup/lavoro_da_classificare/INTEGRAZIONE_GUIDE.md incoming/archive/2025-12-19_inventory_cleanup/lavoro_da_classificare/README.md incoming/archive/2025-12-19_inventory_cleanup/lavoro_da_classificare/docs/QA_TRAITS_V2.md incoming/archive/2025-12-19_inventory_cleanup/lavoro_da_classificare/evo_tactics_game_database_guide.md incoming/archive/2025-12-19_inventory_cleanup/lavoro_da_classificare/evo_tactics_guide.md

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69148970dcd483288a585866f542abae)