### PR TITLE
Add Evo trait schema validation and rollout report checks

### DIFF
--- a/reports/evo/rollout/traits_gap.svg
+++ b/reports/evo/rollout/traits_gap.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2025-11-12T02:08:58.076107</dc:date>
+    <dc:date>2025-11-12T19:02:45.328233</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 217.189874 288.095888
 L 217.189874 227.036609 
 L 67.688864 227.036609 
 z
-" clip-path="url(#pfe7e552ea9)" style="fill: #005f73"/>
+" clip-path="url(#pd47d2ce846)" style="fill: #005f73"/>
    </g>
    <g id="patch_4">
     <path d="M 254.565126 288.095888 
@@ -51,18 +51,18 @@ L 404.066136 288.095888
 L 404.066136 79.775995 
 L 254.565126 79.775995 
 z
-" clip-path="url(#pfe7e552ea9)" style="fill: #005f73"/>
+" clip-path="url(#pd47d2ce846)" style="fill: #005f73"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m70dad0beee" d="M 0 0 
+       <path id="mf4d38f0fcf" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m70dad0beee" x="142.439369" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4d38f0fcf" x="142.439369" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -292,7 +292,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m70dad0beee" x="329.315631" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4d38f0fcf" x="329.315631" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -405,12 +405,12 @@ z
     <g id="ytick_1">
      <g id="line2d_3">
       <defs>
-       <path id="m415d767ef2" d="M 0 0 
+       <path id="mf82c41a237" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m415d767ef2" x="50.87" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf82c41a237" x="50.87" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -446,7 +446,7 @@ z
     <g id="ytick_2">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m415d767ef2" x="50.87" y="258.164868" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf82c41a237" x="50.87" y="258.164868" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -511,7 +511,7 @@ z
     <g id="ytick_3">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m415d767ef2" x="50.87" y="228.233849" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf82c41a237" x="50.87" y="228.233849" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -525,7 +525,7 @@ z
     <g id="ytick_4">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m415d767ef2" x="50.87" y="198.30283" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf82c41a237" x="50.87" y="198.30283" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -551,7 +551,7 @@ z
     <g id="ytick_5">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m415d767ef2" x="50.87" y="168.371811" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf82c41a237" x="50.87" y="168.371811" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -582,7 +582,7 @@ z
     <g id="ytick_6">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m415d767ef2" x="50.87" y="138.440792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf82c41a237" x="50.87" y="138.440792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -597,7 +597,7 @@ z
     <g id="ytick_7">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m415d767ef2" x="50.87" y="108.509773" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf82c41a237" x="50.87" y="108.509773" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -612,7 +612,7 @@ z
     <g id="ytick_8">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m415d767ef2" x="50.87" y="78.578754" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf82c41a237" x="50.87" y="78.578754" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -838,7 +838,7 @@ L 556.066742 178.727944
 L 556.066742 178.727944 
 L 500.003864 178.727944 
 z
-" clip-path="url(#p97d041a714)" style="fill: #ee9b00"/>
+" clip-path="url(#pbee2b3dc11)" style="fill: #ee9b00"/>
    </g>
    <g id="patch_11">
     <path d="M 570.082462 178.727944 
@@ -846,7 +846,7 @@ L 626.145341 178.727944
 L 626.145341 178.727944 
 L 570.082462 178.727944 
 z
-" clip-path="url(#p97d041a714)" style="fill: #ee9b00"/>
+" clip-path="url(#pbee2b3dc11)" style="fill: #ee9b00"/>
    </g>
    <g id="patch_12">
     <path d="M 640.161061 178.727944 
@@ -854,7 +854,7 @@ L 696.223939 178.727944
 L 696.223939 178.727944 
 L 640.161061 178.727944 
 z
-" clip-path="url(#p97d041a714)" style="fill: #ee9b00"/>
+" clip-path="url(#pbee2b3dc11)" style="fill: #ee9b00"/>
    </g>
    <g id="patch_13">
     <path d="M 710.239659 178.727944 
@@ -862,7 +862,7 @@ L 766.302538 178.727944
 L 766.302538 178.727944 
 L 710.239659 178.727944 
 z
-" clip-path="url(#p97d041a714)" style="fill: #ee9b00"/>
+" clip-path="url(#pbee2b3dc11)" style="fill: #ee9b00"/>
    </g>
    <g id="patch_14">
     <path d="M 780.318258 178.727944 
@@ -870,13 +870,13 @@ L 836.381136 178.727944
 L 836.381136 178.727944 
 L 780.318258 178.727944 
 z
-" clip-path="url(#p97d041a714)" style="fill: #ee9b00"/>
+" clip-path="url(#pbee2b3dc11)" style="fill: #ee9b00"/>
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_3">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m70dad0beee" x="528.035303" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4d38f0fcf" x="528.035303" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -924,7 +924,7 @@ z
     <g id="xtick_4">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m70dad0beee" x="598.113902" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4d38f0fcf" x="598.113902" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -951,7 +951,7 @@ z
     <g id="xtick_5">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m70dad0beee" x="668.1925" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4d38f0fcf" x="668.1925" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1000,7 +1000,7 @@ z
     <g id="xtick_6">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m70dad0beee" x="738.271098" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4d38f0fcf" x="738.271098" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1038,7 +1038,7 @@ z
     <g id="xtick_7">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m70dad0beee" x="808.349697" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf4d38f0fcf" x="808.349697" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1076,7 +1076,7 @@ z
     <g id="ytick_9">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m415d767ef2" x="483.185" y="258.268267" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf82c41a237" x="483.185" y="258.268267" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1128,7 +1128,7 @@ z
     <g id="ytick_10">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m415d767ef2" x="483.185" y="218.498105" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf82c41a237" x="483.185" y="218.498105" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1145,7 +1145,7 @@ z
     <g id="ytick_11">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m415d767ef2" x="483.185" y="178.727944" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf82c41a237" x="483.185" y="178.727944" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1161,7 +1161,7 @@ z
     <g id="ytick_12">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m415d767ef2" x="483.185" y="138.957782" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf82c41a237" x="483.185" y="138.957782" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
@@ -1177,7 +1177,7 @@ z
     <g id="ytick_13">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m415d767ef2" x="483.185" y="99.187621" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf82c41a237" x="483.185" y="99.187621" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
@@ -1423,10 +1423,10 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pfe7e552ea9">
+  <clipPath id="pd47d2ce846">
    <rect x="50.87" y="69.36" width="370.015" height="218.735888"/>
   </clipPath>
-  <clipPath id="p97d041a714">
+  <clipPath id="pbee2b3dc11">
    <rect x="483.185" y="69.36" width="370.015" height="218.735888"/>
   </clipPath>
  </defs>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@ pyyaml
 numpy
 pymongo
 jsonschema>=4.22.0
-referencing
 
 boto3
 matplotlib

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ pyyaml
 numpy
 pymongo
 jsonschema>=4.22.0
+referencing
 
 boto3
 matplotlib

--- a/schemas/evo/trait.schema.json
+++ b/schemas/evo/trait.schema.json
@@ -4,12 +4,7 @@
   "title": "Evo Tactics Trait",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "trait_code",
-    "label",
-    "tier",
-    "metrics"
-  ],
+  "required": ["trait_code", "label", "tier", "metrics"],
   "properties": {
     "trait_code": {
       "type": "string",
@@ -32,28 +27,68 @@
       "type": "array",
       "items": {
         "type": "string",
-        "minLength": 1
-      }
+        "pattern": "^[A-Z]$"
+      },
+      "uniqueItems": true
     },
     "sinergie": {
       "type": "array",
       "items": {
         "type": "string",
         "pattern": "^TR-\\d{4}$"
-      }
+      },
+      "uniqueItems": true
     },
     "conflitti": {
       "type": "array",
       "items": {
         "type": "string",
         "pattern": "^TR-\\d{4}$"
-      }
+      },
+      "uniqueItems": true
     },
     "requisiti_ambientali": {
       "type": "array",
       "items": {
-        "type": "string",
-        "minLength": 1
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["condizioni", "fonte", "meta"],
+        "properties": {
+          "capacita_richieste": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "condizioni": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["biome_class"],
+            "properties": {
+              "biome_class": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "fonte": {
+            "type": "string",
+            "minLength": 1
+          },
+          "meta": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "tier": {
+                "$ref": "enums.json#/$defs/sentience_tier"
+              },
+              "notes": {
+                "type": "string"
+              }
+            }
+          }
+        }
       }
     },
     "mutazione_indotta": {
@@ -70,39 +105,100 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "name",
-          "value",
-          "unit"
-        ],
+        "required": ["name", "value", "unit"],
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "value": {
             "type": "number"
           },
           "unit": {
             "$ref": "enums.json#/$defs/metric_unit"
+          },
+          "conditions": {
+            "type": "string"
           }
         }
       },
       "minItems": 1
     },
     "cost_profile": {
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rest": {
+          "type": "string"
+        },
+        "burst": {
+          "type": "string"
+        },
+        "sustained": {
+          "type": "string"
+        }
+      }
     },
     "testability": {
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "observable": {
+          "type": "string"
+        },
+        "scene_prompt": {
+          "type": "string"
+        }
+      }
     },
     "applicability": {
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "clades": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "envo_terms": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^http://purl\\.obolibrary\\.org/obo/ENVO_\\d+$"
+          }
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
     },
     "version": {
-      "type": "string"
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z-.]+)?(?:\\+[0-9A-Za-z-.]+)?$"
     },
     "versioning": {
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["created", "updated", "author"],
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date"
+        },
+        "author": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/tests/reports/test_traits_rollout_reports.py
+++ b/tests/reports/test_traits_rollout_reports.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROLL_OUT_DIR = REPO_ROOT / "reports" / "evo" / "rollout"
+
+
+def _read_header(path: Path) -> list[str]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.reader(handle)
+        return next(reader)
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        (
+            "traits_gap.csv",
+            [
+                "slug",
+                "status",
+                "name_mismatch",
+                "tier_mismatch",
+                "synergy_mismatch",
+                "env_mismatch",
+                "legacy_flag_mismatch",
+                "external_code",
+                "external_label",
+                "external_tier",
+                "external_synergies",
+                "external_envs",
+                "legacy_label",
+                "legacy_tier",
+                "legacy_synergies",
+                "legacy_envs",
+                "duplicate_flag",
+                "merge_conflict_flag",
+            ],
+        ),
+        (
+            "traits_external_sync.csv",
+            ["slug", "label_it", "label_en", "tier", "external_code", "status"],
+        ),
+        (
+            "traits_normalized.csv",
+            [
+                "source",
+                "slug",
+                "trait_code",
+                "label",
+                "tier",
+                "legacy_flag",
+                "data_origin",
+                "sinergie",
+                "env_biomes",
+            ],
+        ),
+    ],
+)
+def test_rollout_csv_headers(filename: str, expected: list[str]) -> None:
+    header = _read_header(ROLL_OUT_DIR / filename)
+    assert header == expected
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "traits_gap.csv",
+        "traits_external_sync.csv",
+        "traits_normalized.csv",
+    ],
+)
+def test_rollout_reports_have_rows(filename: str) -> None:
+    with (ROLL_OUT_DIR / filename).open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.reader(handle)
+        header = next(reader, None)
+        first_row = next(reader, None)
+    assert header is not None
+    assert first_row is not None
+

--- a/tests/schemas/test_evo_trait_schema.py
+++ b/tests/schemas/test_evo_trait_schema.py
@@ -4,8 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
-from jsonschema import Draft202012Validator
-from referencing import Registry, Resource
+from jsonschema import Draft202012Validator, RefResolver
 
 SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schemas" / "evo" / "trait.schema.json"
 TRAIT_DIR = Path(__file__).resolve().parents[2] / "data" / "external" / "evo" / "traits"
@@ -17,12 +16,15 @@ enums_path = SCHEMA_PATH.parent / "enums.json"
 with enums_path.open("r", encoding="utf-8") as handle:
     enums_schema = json.load(handle)
 
-registry = Registry().with_resource(
-    "https://game.example.com/schemas/evo/enums.json",
-    Resource.from_contents(enums_schema),
+resolver = RefResolver.from_schema(
+    TRAIT_SCHEMA,
+    store={
+        "https://game.example.com/schemas/evo/enums.json": enums_schema,
+        "enums.json": enums_schema,
+    },
 )
 
-VALIDATOR = Draft202012Validator(TRAIT_SCHEMA, registry=registry)
+VALIDATOR = Draft202012Validator(TRAIT_SCHEMA, resolver=resolver)
 
 TRAIT_FILES = sorted(path for path in TRAIT_DIR.glob("TR-*.json"))
 

--- a/tests/schemas/test_evo_trait_schema.py
+++ b/tests/schemas/test_evo_trait_schema.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schemas" / "evo" / "trait.schema.json"
+TRAIT_DIR = Path(__file__).resolve().parents[2] / "data" / "external" / "evo" / "traits"
+
+with SCHEMA_PATH.open("r", encoding="utf-8") as handle:
+    TRAIT_SCHEMA = json.load(handle)
+
+enums_path = SCHEMA_PATH.parent / "enums.json"
+with enums_path.open("r", encoding="utf-8") as handle:
+    enums_schema = json.load(handle)
+
+registry = Registry().with_resource(
+    "https://game.example.com/schemas/evo/enums.json",
+    Resource.from_contents(enums_schema),
+)
+
+VALIDATOR = Draft202012Validator(TRAIT_SCHEMA, registry=registry)
+
+TRAIT_FILES = sorted(path for path in TRAIT_DIR.glob("TR-*.json"))
+
+
+@pytest.mark.parametrize("path", TRAIT_FILES, ids=lambda path: path.stem)
+def test_evo_trait_files_match_schema(path: Path) -> None:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    VALIDATOR.validate(payload)


### PR DESCRIPTION
## Summary
- expand the Evo trait JSON schema to cover structured requirement, cost, applicability, and versioning fields
- add automated tests that validate external Evo trait files against the schema and ensure rollout CSV reports keep the expected headers
- regenerate the rollout gap visualization to capture the refreshed comparison output

## Testing
- pytest tests/schemas/test_evo_trait_schema.py tests/reports/test_traits_rollout_reports.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d95b27ec8328867ed4f4125ef4bf)