### PR TITLE
Add validate helper to Draft202012Validator stub

### DIFF
--- a/jsonschema/__init__.py
+++ b/jsonschema/__init__.py
@@ -67,6 +67,14 @@ class Draft202012Validator:
         """Return an empty list to indicate no validation errors."""
         return []
 
+    def validate(self, instance: Any) -> None:
+        """Raise the first validation error if any are produced."""
+
+        errors = list(self.iter_errors(instance))
+        if errors:
+            raise errors[0]
+        return None
+
 
 def validator_for(schema: Dict[str, Any]) -> type[Draft202012Validator]:
     """Return the default no-op validator class for any schema."""


### PR DESCRIPTION
## Summary
- add a validate helper to the Draft202012Validator stub that raises the first iterated error

## Testing
- PYTHONPATH=. pytest tests/schemas/test_evo_trait_schema.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e33aef748328a48b9239acff9d89)