### PR TITLE
Add internal evaluation artifacts to traits sync workflow

### DIFF
--- a/.github/workflows/traits-sync.yml
+++ b/.github/workflows/traits-sync.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: '0 6 * * MON'
   workflow_dispatch:
+    inputs:
+      publish_external:
+        description: "Carica l'export partner su S3 (richiede segreti configurati)"
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   sync-traits:
@@ -11,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       EXPORT_PATH: reports/evo/rollout/traits_external_sync.csv
+      INTERNAL_EVAL_OUTPUT: reports/evo/internal/traits_evaluation/${{ github.run_id }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,6 +40,22 @@ jobs:
             --update-glossary \
             --export "${EXPORT_PATH}"
 
+      - name: Run internal evaluation
+        run: |
+          python tools/traits/evaluate_internal.py \
+            --gap-report reports/evo/rollout/traits_gap.csv \
+            --glossary data/core/traits/glossary.json \
+            --output "${INTERNAL_EVAL_OUTPUT}"
+
+      - name: Upload internal evaluation artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: traits-internal-evaluation-${{ github.run_id }}
+          path: |
+            ${{ env.INTERNAL_EVAL_OUTPUT }}.json
+            ${{ env.INTERNAL_EVAL_OUTPUT }}.csv
+          retention-days: 21
+
       - name: Upload export artifact
         uses: actions/upload-artifact@v4
         with:
@@ -52,8 +75,26 @@ jobs:
             echo "configured=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Determine external publication
+        id: publish-external
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PUBLISH_EXTERNAL: ${{ inputs.publish_external }}
+          PARTNERS_CONFIGURED: ${{ steps.partners-secrets.outputs.configured }}
+        run: |
+          if [ "$PARTNERS_CONFIGURED" != "true" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$INPUT_PUBLISH_EXTERNAL" != "true" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Configure AWS credentials
-        if: ${{ steps.partners-secrets.outputs.configured == 'true' }}
+        if: ${{ steps.publish-external.outputs.enabled == 'true' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.PARTNERS_AWS_ACCESS_KEY_ID }}
@@ -61,7 +102,7 @@ jobs:
           aws-region: ${{ vars.PARTNERS_AWS_REGION || 'eu-west-1' }}
 
       - name: Publish export to shared storage
-        if: ${{ steps.partners-secrets.outputs.configured == 'true' }}
+        if: ${{ steps.publish-external.outputs.enabled == 'true' }}
         env:
           EXPORT_FILE: ${{ env.EXPORT_PATH }}
           S3_BUCKET: ${{ vars.PARTNERS_S3_BUCKET }}

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -1,0 +1,60 @@
+# Processo interno — Valutazione trait Evo
+
+Questa pagina riassume il flusso interno per verificare il glossario trait senza
+attivare la pubblicazione esterna verso i partner. La pipeline GitHub e gli
+script locali condividono gli stessi parametri così da produrre report coerenti
+fra loro.
+
+## Workflow GitHub `traits-sync`
+
+Il workflow pianificato/avviabile manualmente esegue i passaggi nell'ordine
+seguente:
+
+1. Aggiorna il glossario legacy con `tools/traits/sync_missing_index.py` e
+   rigenera l'export partner (`reports/evo/rollout/traits_external_sync.csv`).
+2. Avvia la valutazione interna con `tools/traits/evaluate_internal.py` e
+   produce due report archiviati in `reports/evo/internal/traits_evaluation/`:
+   - `<run_id>.json` – dettaglio punteggi, verdetti e motivazioni aggregati.
+   - `<run_id>.csv` – versione tabellare con motivazioni concatenate.
+3. Carica gli output come artifact GitHub:
+   - `traits-external-sync-<run_id>` (export partner).
+   - `traits-internal-evaluation-<run_id>` (report JSON/CSV interni).
+4. Opzionalmente pubblica l'export su S3 se l'input `publish_external` è attivo
+   e i segreti AWS sono configurati.
+
+Per eseguire soltanto la valutazione interna, avvia il workflow manualmente da
+GitHub Actions impostando `publish_external` su `false`.
+
+## Esecuzione manuale
+
+Replica l'intera pipeline locale tramite:
+
+```bash
+python tools/traits/publish_partner_export.py \
+  --source reports/evo/rollout/traits_gap.csv \
+  --dest data/core/traits/glossary.json \
+  --export reports/evo/rollout/traits_external_sync.csv \
+  --evaluation-output reports/evo/internal/traits_evaluation/manual_$(date -u +%Y%m%dT%H%M%SZ) \
+  --no-upload
+```
+
+Lo script:
+
+- Sincronizza il glossario e genera l'export partner locale.
+- Produce i report interni JSON/CSV nel percorso indicato (crea la cartella se
+  assente).
+- Stampa i comandi equivalenti usati nella pipeline GitHub, utili per audit e
+  runbook.
+
+Per rieseguire soltanto l'analisi, dopo aver sincronizzato i dati lancia
+esplicitamente il validatore:
+
+```bash
+python tools/traits/evaluate_internal.py \
+  --gap-report reports/evo/rollout/traits_gap.csv \
+  --glossary data/core/traits/glossary.json \
+  --output reports/evo/internal/traits_evaluation/manual_<timestamp>
+```
+
+Aggiungi `--incoming-matrix <percorso.csv>` (ripetibile) se vuoi includere
+segnali di moderazione aggiuntivi nelle valutazioni.


### PR DESCRIPTION
## Summary
- run the internal evaluation script inside the traits-sync workflow and upload its reports as artifacts
- gate the S3 upload on an explicit `publish_external` flag and reuse the same logic in the manual helper
- extend the partner export helper to generate evaluation reports and print the equivalent commands, documenting the new flow in the internal README

## Testing
- python -m compileall tools/traits/publish_partner_export.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914ed20904483288bffae7c52adc5fd)