### PR TITLE
Propagate Nebula species rollout matrix to telemetry tools

### DIFF
--- a/scripts/mock/generate-demo-data.js
+++ b/scripts/mock/generate-demo-data.js
@@ -11,7 +11,9 @@ const {
   speciesSchema,
 } = require('../../packages/contracts');
 const { atlasDataset } = require('../../data/nebula/atlasDataset.js');
-const { createNebulaTelemetryAggregator } = require('../../server/services/nebulaTelemetryAggregator');
+const {
+  createNebulaTelemetryAggregator,
+} = require('../../server/services/nebulaTelemetryAggregator');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const SNAPSHOT_SOURCE = path.resolve(ROOT, 'data', 'flow-shell', 'atlas-snapshot.json');
@@ -26,12 +28,65 @@ const SNAPSHOT_TARGET = path.resolve(
 );
 const ATLAS_TARGET = path.resolve(ROOT, 'webapp', 'public', 'data', 'nebula', 'atlas.json');
 const TELEMETRY_TARGET = path.resolve(ROOT, 'webapp', 'public', 'data', 'nebula', 'telemetry.json');
+const DEFAULT_TELEMETRY_SOURCE = path.resolve(
+  ROOT,
+  'data',
+  'derived',
+  'exports',
+  'qa-telemetry-export.json',
+);
+const DEFAULT_GENERATOR_SOURCE = path.resolve(
+  ROOT,
+  'logs',
+  'tooling',
+  'generator_run_profile.json',
+);
+const DEFAULT_SPECIES_MATRIX_PATH = path.resolve(
+  ROOT,
+  'reports',
+  'evo',
+  'rollout',
+  'species_ecosystem_matrix.csv',
+);
 
 const ajv = new Ajv({ allErrors: true, strict: false });
 ajv.addFormat('date-time', true);
 const validateSnapshot = ajv.compile(generationSnapshotSchema);
 const validateTelemetry = ajv.compile(telemetrySchema);
 const validateSpecies = ajv.compile(speciesSchema);
+
+function parseArgs(argv = []) {
+  const options = {
+    telemetryOnly: false,
+    snapshotOnly: false,
+    speciesMatrix: DEFAULT_SPECIES_MATRIX_PATH,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--telemetry-only') {
+      options.telemetryOnly = true;
+      continue;
+    }
+    if (token === '--snapshot-only') {
+      options.snapshotOnly = true;
+      continue;
+    }
+    if ((token === '--species-matrix' || token === '--species-matrix-path') && argv[index + 1]) {
+      options.speciesMatrix = path.resolve(ROOT, argv[index + 1]);
+      index += 1;
+      continue;
+    }
+    if (token.startsWith('--species-matrix=')) {
+      options.speciesMatrix = path.resolve(ROOT, token.slice('--species-matrix='.length));
+      continue;
+    }
+    if (token.startsWith('--species-matrix-path=')) {
+      options.speciesMatrix = path.resolve(ROOT, token.slice('--species-matrix-path='.length));
+      continue;
+    }
+  }
+  return options;
+}
 
 function formatErrors(validator) {
   if (!validator || !validator.errors || !validator.errors.length) {
@@ -73,37 +128,48 @@ async function validateSpeciesList(list) {
   }
 }
 
-async function generateAtlasBundle() {
+async function generateAtlasBundle(options = {}) {
+  const dataset = options.dataset || atlasDataset;
+  const telemetryPath = options.telemetryPath || DEFAULT_TELEMETRY_SOURCE;
+  const generatorTelemetryPath = options.generatorTelemetryPath || DEFAULT_GENERATOR_SOURCE;
+  const speciesMatrixPath =
+    options.speciesMatrixPath || options.speciesMatrix || DEFAULT_SPECIES_MATRIX_PATH;
+  const atlasTarget = options.atlasTarget || ATLAS_TARGET;
+  const telemetryTarget = options.telemetryTarget || TELEMETRY_TARGET;
+
   const aggregator = createNebulaTelemetryAggregator({
-    staticDataset: atlasDataset,
-    telemetryPath: path.resolve(ROOT, 'data', 'derived', 'exports', 'qa-telemetry-export.json'),
-    generatorTelemetryPath: path.resolve(ROOT, 'logs', 'tooling', 'generator_run_profile.json'),
+    staticDataset: dataset,
+    telemetryPath,
+    generatorTelemetryPath,
+    speciesMatrixPath,
   });
   const atlas = await aggregator.getAtlas({});
   if (atlas?.dataset?.species) {
     await validateSpeciesList(atlas.dataset.species);
   }
   if (atlas?.telemetry && !validateTelemetry(atlas.telemetry)) {
-    throw new Error(`Telemetria Nebula non conforme allo schema: ${formatErrors(validateTelemetry)}`);
+    throw new Error(
+      `Telemetria Nebula non conforme allo schema: ${formatErrors(validateTelemetry)}`,
+    );
   }
-  await writeJson(ATLAS_TARGET, atlas);
+  await writeJson(atlasTarget, atlas);
   if (atlas?.telemetry) {
-    await writeJson(TELEMETRY_TARGET, atlas.telemetry);
+    await writeJson(telemetryTarget, atlas.telemetry);
   }
   return atlas;
 }
 
-async function main() {
-  const args = new Set(process.argv.slice(2));
-  const skipSnapshot = args.has('--telemetry-only');
-  const skipAtlas = args.has('--snapshot-only');
+async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const skipSnapshot = options.telemetryOnly;
+  const skipAtlas = options.snapshotOnly;
 
   const results = {};
   if (!skipSnapshot) {
     results.snapshot = await generateSnapshot();
   }
   if (!skipAtlas) {
-    results.atlas = await generateAtlasBundle();
+    results.atlas = await generateAtlasBundle({ speciesMatrixPath: options.speciesMatrix });
   }
 
   console.log('[mock] Snapshot demo aggiornato:', skipSnapshot ? 'skip' : SNAPSHOT_TARGET);
@@ -114,7 +180,20 @@ async function main() {
   return results;
 }
 
-main().catch((error) => {
-  console.error('[mock] Errore generazione demo', error);
-  process.exitCode = 1;
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[mock] Errore generazione demo', error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  parseArgs,
+  generateSnapshot,
+  generateAtlasBundle,
+  DEFAULT_SPECIES_MATRIX_PATH,
+  SNAPSHOT_SOURCE,
+  SNAPSHOT_TARGET,
+  ATLAS_TARGET,
+  TELEMETRY_TARGET,
+};

--- a/server/app.js
+++ b/server/app.js
@@ -405,6 +405,10 @@ function createApp(options = {}) {
     nebulaOptions.mockAtlasPath || path.join(mockDataRoot, 'nebula', 'atlas.json');
   const mockTelemetryPath =
     nebulaOptions.mockTelemetryPath || path.join(mockDataRoot, 'nebula', 'telemetry.json');
+  const defaultSpeciesMatrixPath =
+    nebulaOptions.speciesMatrixPath ||
+    nebulaOptions.speciesRolloutMatrixPath ||
+    path.resolve(__dirname, '..', 'reports', 'evo', 'rollout', 'species_ecosystem_matrix.csv');
 
   async function loadMockAtlasBundle() {
     return readJsonFile(mockAtlasBundlePath, null);
@@ -509,6 +513,7 @@ function createApp(options = {}) {
       telemetry: nebulaOptions.telemetry,
       orchestrator: nebulaOptions.orchestrator,
       staticDataset: nebulaOptions.staticDataset,
+      speciesMatrixPath: defaultSpeciesMatrixPath,
     });
 
   const nebulaRouter = createNebulaRouter({

--- a/tests/tools/generate-demo-data.spec.js
+++ b/tests/tools/generate-demo-data.spec.js
@@ -1,0 +1,61 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { mkdtemp, writeFile, rm } = require('node:fs/promises');
+const path = require('node:path');
+const { tmpdir } = require('node:os');
+
+const { generateAtlasBundle } = require('../../scripts/mock/generate-demo-data.js');
+
+test('generateAtlasBundle applica il rollout Nebula su specie demo', async (t) => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'demo-atlas-'));
+  t.after(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  const telemetryPath = path.join(tempDir, 'telemetry.json');
+  await writeFile(telemetryPath, '[]\n', 'utf8');
+  const generatorPath = path.join(tempDir, 'generator.json');
+  await writeFile(generatorPath, '{}\n', 'utf8');
+  const speciesMatrixPath = path.join(tempDir, 'species_matrix.csv');
+  const matrixRows = [
+    'species_slug,legacy_default_slot_count,terraforming_max_slots,sentience_index,terraforming_band_slots',
+    'wolf-01,0,3,T1,0;1;2',
+    'wolf-02,1,2,T0,0;1',
+  ];
+  await writeFile(speciesMatrixPath, `${matrixRows.join('\n')}\n`, 'utf8');
+
+  const atlasTarget = path.join(tempDir, 'atlas.json');
+  const telemetryTarget = path.join(tempDir, 'atlas-telemetry.json');
+
+  const dataset = {
+    id: 'nebula-demo',
+    title: 'Nebula Demo Dataset',
+    species: [
+      { id: 'wolf-01', name: 'Lupo Alfa' },
+      { id: 'wolf-02', name: 'Lupo Beta' },
+    ],
+  };
+
+  const atlas = await generateAtlasBundle({
+    dataset,
+    telemetryPath,
+    generatorTelemetryPath: generatorPath,
+    speciesMatrixPath,
+    atlasTarget,
+    telemetryTarget,
+  });
+
+  const first = atlas.dataset?.species?.find((entry) => entry.id === 'wolf-01');
+  const second = atlas.dataset?.species?.find((entry) => entry.id === 'wolf-02');
+
+  assert.ok(first, 'la specie wolf-01 deve essere presente nel bundle');
+  assert.equal(first.sentienceIndex, 'T1');
+  assert.ok(first.legacy, 'la specie wolf-01 deve includere dati legacy');
+  assert.equal(first.legacy.defaultSlotCount, 3);
+  assert.equal(first.legacy.fallbackSlotCount, 3);
+
+  assert.ok(second, 'la specie wolf-02 deve essere presente nel bundle');
+  assert.equal(second.sentienceIndex, 'T0');
+  assert.ok(second.legacy, 'la specie wolf-02 deve includere dati legacy');
+  assert.equal(second.legacy.fallbackSlotCount, 2);
+});

--- a/tools/deploy/generateStatusReport.js
+++ b/tools/deploy/generateStatusReport.js
@@ -27,6 +27,13 @@ const DEFAULT_GENERATOR_TELEMETRY_PATH = path.join(
 );
 const DEFAULT_TRAIT_BASELINE_PATH = path.join(ROOT_DIR, 'reports', 'trait_baseline.json');
 const DEFAULT_ORCHESTRATOR_LOG_DIR = path.join(ROOT_DIR, 'logs', 'orchestrator');
+const DEFAULT_SPECIES_MATRIX_PATH = path.join(
+  ROOT_DIR,
+  'reports',
+  'evo',
+  'rollout',
+  'species_ecosystem_matrix.csv',
+);
 
 function parseArgs(argv) {
   const options = {
@@ -36,6 +43,7 @@ function parseArgs(argv) {
     generatorTelemetry: DEFAULT_GENERATOR_TELEMETRY_PATH,
     traitBaseline: DEFAULT_TRAIT_BASELINE_PATH,
     orchestratorLogDir: DEFAULT_ORCHESTRATOR_LOG_DIR,
+    speciesMatrix: DEFAULT_SPECIES_MATRIX_PATH,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -98,6 +106,19 @@ function parseArgs(argv) {
         ROOT_DIR,
         token.slice('--orchestrator-log-dir='.length),
       );
+      continue;
+    }
+    if ((token === '--species-matrix' || token === '--species-matrix-path') && argv[index + 1]) {
+      options.speciesMatrix = path.resolve(ROOT_DIR, argv[index + 1]);
+      index += 1;
+      continue;
+    }
+    if (token.startsWith('--species-matrix=')) {
+      options.speciesMatrix = path.resolve(ROOT_DIR, token.slice('--species-matrix='.length));
+      continue;
+    }
+    if (token.startsWith('--species-matrix-path=')) {
+      options.speciesMatrix = path.resolve(ROOT_DIR, token.slice('--species-matrix-path='.length));
       continue;
     }
   }
@@ -190,6 +211,7 @@ async function main() {
     orchestrator: {
       logDir: options.orchestratorLogDir,
     },
+    speciesMatrixPath: options.speciesMatrix,
   });
 
   const reporter = createReleaseReporter({
@@ -209,7 +231,16 @@ async function main() {
   console.log(`[status] report aggiornato in ${options.status}`);
 }
 
-main().catch((error) => {
-  console.error('[status] errore generazione status report:', error);
-  process.exitCode = 1;
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[status] errore generazione status report:', error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  DEFAULT_SPECIES_MATRIX_PATH,
+  parseArgs,
+  createStaticTraitDiagnostics,
+  main,
+};


### PR DESCRIPTION
## Summary
- default the Nebula server aggregator to load the species rollout matrix and forward the path to consumers
- extend the status report and demo data generators with CLI support for custom species matrices and reuse the aggregator path
- add a regression test covering the demo generator to ensure sentience and fallback slots are applied from the rollout matrix

## Testing
- node --test tests/tools/generate-demo-data.spec.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914fde771d88328a8ab09ee92761be0)