### PR TITLE
Add species rollout matrix support to nebula tooling

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -405,6 +405,14 @@ function createApp(options = {}) {
     nebulaOptions.mockAtlasPath || path.join(mockDataRoot, 'nebula', 'atlas.json');
   const mockTelemetryPath =
     nebulaOptions.mockTelemetryPath || path.join(mockDataRoot, 'nebula', 'telemetry.json');
+  const defaultSpeciesMatrixPath = path.resolve(
+    __dirname,
+    '..',
+    'reports',
+    'evo',
+    'rollout',
+    'species_ecosystem_matrix.csv',
+  );
 
   async function loadMockAtlasBundle() {
     return readJsonFile(mockAtlasBundlePath, null);
@@ -500,6 +508,11 @@ function createApp(options = {}) {
       res.status(500).json({ error: error?.message || 'Errore caricamento telemetria mock' });
     }
   }
+  const speciesMatrixPath =
+    nebulaOptions.speciesMatrixPath === undefined
+      ? defaultSpeciesMatrixPath
+      : nebulaOptions.speciesMatrixPath;
+
   const nebulaAggregator =
     nebulaOptions.aggregator ||
     createNebulaTelemetryAggregator({
@@ -509,6 +522,7 @@ function createApp(options = {}) {
       telemetry: nebulaOptions.telemetry,
       orchestrator: nebulaOptions.orchestrator,
       staticDataset: nebulaOptions.staticDataset,
+      speciesMatrixPath,
     });
 
   const nebulaRouter = createNebulaRouter({
@@ -517,6 +531,7 @@ function createApp(options = {}) {
     configPath: nebulaOptions.configPath,
     config: nebulaOptions.config,
     aggregator: nebulaAggregator,
+    speciesMatrixPath,
     schemaValidator,
     telemetrySchemaId,
     speciesSchemaId,
@@ -528,6 +543,7 @@ function createApp(options = {}) {
     configPath: nebulaOptions.configPath,
     config: nebulaOptions.config,
     aggregator: nebulaAggregator,
+    speciesMatrixPath,
     schemaValidator,
     telemetrySchemaId,
     speciesSchemaId,

--- a/tests/scripts/generate-demo-data.spec.js
+++ b/tests/scripts/generate-demo-data.spec.js
@@ -1,0 +1,65 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { mkdtemp, writeFile, rm } = require('node:fs/promises');
+const path = require('node:path');
+const { tmpdir } = require('node:os');
+
+const { generateAtlasBundle } = require('../../scripts/mock/generate-demo-data.js');
+
+async function createTempDir(prefix) {
+  return mkdtemp(path.join(tmpdir(), prefix));
+}
+
+test('generate-demo-data aggregator enriches species from rollout matrix', async (t) => {
+  const tempDir = await createTempDir('demo-data-');
+  t.after(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  const telemetryPath = path.join(tempDir, 'telemetry.json');
+  const generatorPath = path.join(tempDir, 'generator.json');
+  const matrixPath = path.join(tempDir, 'matrix.csv');
+
+  await writeFile(
+    telemetryPath,
+    JSON.stringify([
+      {
+        id: 'evt-02',
+        event_timestamp: '2024-05-18T09:30:00Z',
+        priority: 'medium',
+        status: 'acknowledged',
+      },
+    ]),
+    'utf8',
+  );
+  await writeFile(
+    generatorPath,
+    JSON.stringify({ status: 'success', metrics: { generationTimeMs: 200, speciesTotal: 6 } }),
+    'utf8',
+  );
+  await writeFile(
+    matrixPath,
+    [
+      'species_slug,legacy_default_slot_count,terraforming_max_slots,sentience_index,terraforming_band_slots',
+      'nebula-alpha,4,5,T2,0;1;2',
+    ].join('\n'),
+    'utf8',
+  );
+
+  const atlas = await generateAtlasBundle({
+    telemetryPath,
+    generatorTelemetryPath: generatorPath,
+    speciesMatrixPath: matrixPath,
+    writeTargets: false,
+  });
+
+  const nebulaAlpha = (atlas.dataset?.species || []).find((entry) => entry.id === 'nebula-alpha');
+  assert.ok(nebulaAlpha, 'Expected nebula-alpha species present');
+  assert.equal(nebulaAlpha.sentienceIndex, 'T2');
+  assert.equal(nebulaAlpha.legacy?.defaultSlotCount, 4);
+  assert.equal(nebulaAlpha.legacy?.fallbackSlotCount, 5);
+  assert.deepEqual(nebulaAlpha.legacy?.bandSlots, [0, 1, 2]);
+  const distribution = atlas.telemetry?.incidents?.sentienceIndexDistribution || {};
+  assert.equal(distribution.T2, 1);
+  assert.ok(distribution.Unknown >= 1, 'Expected fallback bucket for species without rollout data');
+});

--- a/tests/tools/generate-status-report.spec.js
+++ b/tests/tools/generate-status-report.spec.js
@@ -1,0 +1,101 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { mkdtemp, writeFile, mkdir, rm, readFile } = require('node:fs/promises');
+const path = require('node:path');
+const { tmpdir } = require('node:os');
+
+const { runWithOptions } = require('../../tools/deploy/generateStatusReport.js');
+
+async function createTempDir(prefix) {
+  return mkdtemp(path.join(tmpdir(), prefix));
+}
+
+test('generateStatusReport applies species rollout matrix to nebula dataset', async (t) => {
+  const tempDir = await createTempDir('status-report-');
+  t.after(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  const statusPath = path.join(tempDir, 'status.json');
+  const snapshotPath = path.join(tempDir, 'snapshot.json');
+  const telemetryPath = path.join(tempDir, 'telemetry.json');
+  const generatorPath = path.join(tempDir, 'generator.json');
+  const traitBaselinePath = path.join(tempDir, 'trait-baseline.json');
+  const orchestratorDir = path.join(tempDir, 'orchestrator');
+  const matrixPath = path.join(tempDir, 'matrix.csv');
+
+  await writeFile(
+    snapshotPath,
+    JSON.stringify({
+      biomeSummary: { validated: 1, pending: 0 },
+      encounterSummary: { variants: 1, warnings: 0, seeds: 1 },
+      qualityRelease: { checks: { traits: { passed: 1, total: 1, conflicts: 0 } } },
+    }),
+    'utf8',
+  );
+  await writeFile(
+    telemetryPath,
+    JSON.stringify([
+      {
+        id: 'evt-01',
+        event_timestamp: '2024-05-18T09:00:00Z',
+        priority: 'high',
+        status: 'open',
+      },
+    ]),
+    'utf8',
+  );
+  await writeFile(
+    generatorPath,
+    JSON.stringify({ status: 'success', metrics: { generationTimeMs: 120, speciesTotal: 6 } }),
+    'utf8',
+  );
+  await mkdir(orchestratorDir, { recursive: true });
+  await writeFile(
+    path.join(orchestratorDir, 'events.jsonl'),
+    `${JSON.stringify({ timestamp: '2024-05-18T09:05:00Z', level: 'info', message: 'ready' })}\n`,
+    'utf8',
+  );
+  await writeFile(
+    traitBaselinePath,
+    JSON.stringify({
+      summary: {
+        total_traits: 2,
+        glossary_ok: 2,
+        with_conflicts: 0,
+        matrix_mismatch: 0,
+        glossary_missing: 0,
+      },
+      generated_at: '2024-05-18T10:00:00Z',
+    }),
+    'utf8',
+  );
+  await writeFile(
+    matrixPath,
+    [
+      'species_slug,legacy_default_slot_count,terraforming_max_slots,sentience_index,terraforming_band_slots',
+      'nebula-alpha,2,3,T1,0;1',
+    ].join('\n'),
+    'utf8',
+  );
+
+  const result = await runWithOptions({
+    status: statusPath,
+    snapshot: snapshotPath,
+    telemetry: telemetryPath,
+    generatorTelemetry: generatorPath,
+    traitBaseline: traitBaselinePath,
+    orchestratorLogDir: orchestratorDir,
+    speciesMatrix: matrixPath,
+  });
+
+  assert.ok(result);
+  const persisted = JSON.parse(await readFile(statusPath, 'utf8'));
+  const atlas = persisted?.telemetry?.nebula?.atlas;
+  assert.ok(atlas, 'Nebula atlas payload is available');
+  const nebulaAlpha = (atlas.dataset?.species || []).find((entry) => entry.id === 'nebula-alpha');
+  assert.ok(nebulaAlpha, 'Expected species nebula-alpha in dataset');
+  assert.equal(nebulaAlpha.sentienceIndex, 'T1');
+  assert.equal(nebulaAlpha.legacy?.defaultSlotCount, 2);
+  assert.equal(nebulaAlpha.legacy?.fallbackSlotCount, 3);
+});


### PR DESCRIPTION
## Summary
- inject the species rollout matrix into the server-side nebula aggregator by default and when provided via options
- extend the status report and demo data CLI scripts to accept a species matrix path and reuse shared helpers for testing
- add regression tests ensuring sentience index and fallback slots are applied in generated payloads

## Testing
- node --test tests/tools/generate-status-report.spec.js tests/scripts/generate-demo-data.spec.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69150fecf95883289168994add4541c2)