### PR TITLE
Update documentation for CLI subcommands and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ evo-tactics/
   python3 game_cli.py validate-ecosystem-pack \
     --json-out ../../packs/evo_tactics_pack/out/validation/last_report.json \
     --html-out ../../packs/evo_tactics_pack/out/validation/last_report.html
+  python3 game_cli.py investigate ../../incoming --recursive --json --html --destination latest
   ```
 - Wrapper legacy ancora disponibili (`roll_pack.py`, `generate_encounter.py`) reindirizzano al parser condiviso.
+- Tutti i comandi accettano l'opzione globale `--profile <nome>` per caricare le variabili definite in `config/cli/<nome>.yaml`.
 
 #### Quick start — Python
 
@@ -132,6 +134,7 @@ python3 game_cli.py validate-datasets
 python3 game_cli.py validate-ecosystem-pack \
   --json-out ../../packs/evo_tactics_pack/out/validation/last_report.json \
   --html-out ../../packs/evo_tactics_pack/out/validation/last_report.html
+python3 game_cli.py investigate ../../incoming --recursive --json --html --destination latest
 
 # Wrapper legacy (reindirizzati al parser condiviso)
 python3 roll_pack.py ENTP invoker

--- a/docs/adr/ADR-XXX-refactor-cli.md
+++ b/docs/adr/ADR-XXX-refactor-cli.md
@@ -27,7 +27,7 @@ Adottare l'opzione **C**. Il refactor CLI rimane modulare, ma tutti i comandi de
 
 ### Sottocomandi disponibili (2025-11)
 
-L'entrypoint `python tools/py/game_cli.py` espone i comandi `roll-pack`, `generate-encounter`, `validate-datasets`, `validate-ecosystem-pack` (alias legacy `validate-ecosystem`) e `investigate`. Ogni nuovo flusso deve essere aggiunto qui e coperto dai test di parità.
+L'entrypoint `python tools/py/game_cli.py [--profile <nome>] <comando>` espone i comandi `roll-pack [FORM MBTI] [ARCHETIPO] [data_path] [--seed <valore>]`, `generate-encounter [biome] [data_path] [--party-power <int>] [--seed <valore>]`, `validate-datasets`, `validate-ecosystem-pack [--json-out <percorso>] [--html-out <percorso>]` (alias legacy `validate-ecosystem`) e `investigate <file|dir> [...] [--recursive] [--json] [--html] [--destination NAME|-] [--max-preview <int>]`. Ogni nuovo flusso deve essere aggiunto qui e coperto dai test di parità.
 
 ## Impatti sugli strumenti
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,15 +14,15 @@ Aggiornato al ciclo VC-2025-11. Nuove domande vengono raccolte dopo ogni retro s
 
 ### Comandi disponibili della CLI Python
 
-L'entrypoint documentato in `tools/py/game_cli.py` espone i seguenti sottocomandi (`python tools/py/game_cli.py <comando>`):
+L'entrypoint documentato in `tools/py/game_cli.py` accetta un flag globale `--profile <nome>` e espone i seguenti sottocomandi (`python tools/py/game_cli.py [--profile <nome>] <comando>`):
 
-- `roll-pack [FORM MBTI] [ARCHETIPO] [--seed <valore>]`
+- `roll-pack [FORM MBTI] [ARCHETIPO] [data_path] [--seed <valore>]`
 - `generate-encounter [biome] [data_path] [--party-power <int>] [--seed <valore>]`
 - `validate-datasets`
-- `validate-ecosystem-pack [--json-out <path>] [--html-out <path>]`
-- `investigate <file|dir> [...] [--recursive] [--json] [--html] [--destination NAME]`
+- `validate-ecosystem-pack [--json-out <percorso>] [--html-out <percorso>]`
+- `investigate <file|dir> [...] [--recursive] [--json] [--html] [--destination NAME|-] [--max-preview <int>]`
 
-L'alias storico `validate-ecosystem` viene normalizzato in `validate-ecosystem-pack` dal wrapper stesso.
+L'alias storico `validate-ecosystem` viene normalizzato in `validate-ecosystem-pack` dal wrapper stesso. Impostare `--destination -` con `investigate` evita la creazione dei report su disco e restituisce l'output JSON sullo standard output.
 
 ## QA
 

--- a/docs/support/bug-template.md
+++ b/docs/support/bug-template.md
@@ -15,6 +15,6 @@
 - **Owner escalation**: Support Lead / QA Lead / Tools Dev
 - **Link log**: URL/Drive al log principale (obbligatorio)
 - **Link screenshot/video**: evidenza visiva (PNG/MP4) oppure `N/A` se non applicabile
-- **Riferimento comandi CLI**: `python tools/py/game_cli.py <comando>` con sottocomandi `roll-pack`, `generate-encounter`, `validate-datasets`, `validate-ecosystem-pack`, `investigate`
+- **Riferimento comandi CLI**: `python tools/py/game_cli.py [--profile <nome>] <comando>` con sottocomandi `roll-pack [FORM MBTI] [ARCHETIPO] [data_path] [--seed <valore>]`, `generate-encounter [biome] [data_path] [--party-power <int>] [--seed <valore>]`, `validate-datasets`, `validate-ecosystem-pack [--json-out <percorso>] [--html-out <percorso>]`, `investigate <file|dir> [...] [--recursive] [--json] [--html] [--destination NAME|-] [--max-preview <int>]`
 
 _Compila il template in Drive e collega il ticket `#vc-ops` relativo._

--- a/docs/tutorials/feedback-form.md
+++ b/docs/tutorials/feedback-form.md
@@ -58,12 +58,12 @@ Questa guida illustra come accedere, compilare e monitorare il nuovo form di fee
 
 ### Appendice · Comandi CLI disponibili
 
-Per operazioni correlate alla convalida dati e alle indagini dei pacchetti usa `python tools/py/game_cli.py <comando>`, che espone i sottocomandi aggiornati:
+Per operazioni correlate alla convalida dati e alle indagini dei pacchetti usa `python tools/py/game_cli.py [--profile <nome>] <comando>`, che espone i sottocomandi aggiornati:
 
-- `roll-pack [FORM MBTI] [ARCHETIPO] [--seed <valore>]`
+- `roll-pack [FORM MBTI] [ARCHETIPO] [data_path] [--seed <valore>]`
 - `generate-encounter [biome] [data_path] [--party-power <int>] [--seed <valore>]`
 - `validate-datasets`
-- `validate-ecosystem-pack [--json-out <path>] [--html-out <path>]`
-- `investigate <file|dir> [...] [--recursive] [--json] [--html] [--destination NAME]`
+- `validate-ecosystem-pack [--json-out <percorso>] [--html-out <percorso>]`
+- `investigate <file|dir> [...] [--recursive] [--json] [--html] [--destination NAME|-] [--max-preview <int>]`
 
-> Se occorre un nuovo sottocomando `feedback`, aprire una richiesta dedicata nel backlog Tools indicando gli automatismi necessari.
+> Se occorre un nuovo sottocomando `feedback`, aprire una richiesta dedicata nel backlog Tools indicando gli automatismi necessari. Per evitare la creazione di report su disco durante l'indagine, passa `--destination -` assieme a `--json`.

--- a/incoming/README.md
+++ b/incoming/README.md
@@ -23,6 +23,15 @@ python tools/py/game_cli.py validate-ecosystem-pack
 (il secondo solo quando il pack ecosistema è disponibile) e salva i log corrispondenti in `reports/incoming/validation/` assieme a un file `summary.txt` con gli esiti. Al termine, l'area temporanea viene ripulita automaticamente.
 
 Per evitare la creazione di file e ottenere solo l'output JSON su `stdout`, puoi lanciare:
+
 ```bash
 ./scripts/report_incoming.sh --destination -
 ```
+
+Puoi anche eseguire direttamente il comando principale per le indagini:
+
+```bash
+python tools/py/game_cli.py investigate incoming --recursive --json --html --destination latest --max-preview 400
+```
+
+Il flag `--destination` accetta anche `-` per disabilitare la generazione di file sul disco, mentre `--max-preview` controlla la lunghezza delle anteprime testuali nel report.


### PR DESCRIPTION
## Summary
- align CLI documentation in the FAQ, support template, tutorial, and ADR with the current subcommands and flags, including the global profile option
- extend the main README and incoming guide with up-to-date `investigate` usage examples and notes on JSON/HTML outputs

## Testing
- n/a

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69151806ab2c8328a45894be277e8d66)