### PR TITLE
Enable offline MongoDB migrations for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ reports/trait_balance/*.png
 reports/trait_style/
 logs/monthly_trait_maintenance/trait_style_*.json
 logs/monthly_trait_maintenance/trait_style_*.md
+.local/

--- a/config/mongodb.mock.json
+++ b/config/mongodb.mock.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "./schemas/mongodb-config.schema.json",
+  "description": "Configurazione MongoDB fittizia basata su Mongomock con persistenza su file.",
+  "mongoUrl": "mongomock://.local/mongomock/mock_dump.json",
+  "database": "evo_tactics_mock",
+  "options": {
+    "tz_aware": true
+  }
+}

--- a/migrations/evo_tactics_pack/202411050001_initialize_evo_schema.py
+++ b/migrations/evo_tactics_pack/202411050001_initialize_evo_schema.py
@@ -11,7 +11,13 @@ DESCRIPTION = "Initialize core collections and indexes for Evo Tactics Pack"
 def _ensure_collection(db: Database, name: str) -> None:
     if name in db.list_collection_names():
         return
-    db.create_collection(name)
+    try:
+        db.create_collection(name)
+    except Exception:
+        # Alcuni backend mock (es. Mongita) non implementano create_collection ma
+        # creano la collection on-demand accedendo al relativo handler.
+        db[name].insert_one({"__bootstrap__": True})
+        db[name].delete_many({"__bootstrap__": True})
 
 
 def upgrade(db: Database) -> None:

--- a/ops/mongodb/apply.sh
+++ b/ops/mongodb/apply.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 CONFIG_DIR="$ROOT_DIR/config"
 MIGRATION_SCRIPT="$ROOT_DIR/scripts/db/run_migrations.py"
 SEED_SCRIPT="$ROOT_DIR/scripts/db/seed_evo_generator.py"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,8 @@
 pyyaml
 numpy
 pymongo
+mongomock
+mongita
 jsonschema>=4.22.0
 
 boto3


### PR DESCRIPTION
## Summary
- add mock-friendly client handling to the migration runner, including persistence when using mongomock URLs
- provide a reusable mongomock-backed MongoDB config and make the first migration tolerant of mock backends
- update tooling dependencies, ignore local state directories, and fix the ops helper script root detection

## Testing
- python scripts/db/run_migrations.py status --config config/mongodb.mock.json
- python scripts/db/run_migrations.py up --config config/mongodb.mock.json
- python scripts/db/run_migrations.py status --config config/mongodb.mock.json
- bash ops/mongodb/apply.sh config/mongodb.mock.json --skip-seed


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177396e3548328979f5dee44ab007f)