### PR TITLE
Migrate backend storage to Prisma

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Variabili ambiente per lo stack locale/CI
+DATABASE_URL=postgresql://game:game@localhost:5432/game?schema=public
+PRISMA_BOOTSTRAP_FILE=.docker-prisma-bootstrapped
+POSTGRES_USER=game
+POSTGRES_PASSWORD=game
+POSTGRES_DB=game

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ reports/trait_style/
 logs/monthly_trait_maintenance/trait_style_*.json
 logs/monthly_trait_maintenance/trait_style_*.md
 .local/
+.docker-prisma-bootstrapped

--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -242,8 +242,7 @@ function shouldRefreshStatusFlag(value) {
 
 function createApp(options = {}) {
   const dataRoot = options.dataRoot || path.resolve(ROOT_DIR, 'data');
-  const databasePath = options.databasePath || path.resolve(dataRoot, 'idea_engine.db');
-  const repo = options.repo || new IdeaRepository(databasePath);
+  const repo = options.repo || new IdeaRepository(options.repoOptions || {});
   const runtimeValidator =
     options.runtimeValidator || createRuntimeValidator(options.runtimeValidatorOptions || {});
   const catalogService =

--- a/apps/backend/db/prisma.js
+++ b/apps/backend/db/prisma.js
@@ -1,0 +1,15 @@
+const { PrismaClient } = require('@prisma/client');
+
+const globalForPrisma = globalThis;
+
+const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({
+    log: process.env.PRISMA_LOG_QUERIES ? ['query', 'info', 'warn', 'error'] : ['warn', 'error'],
+  });
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}
+
+module.exports = { prisma };

--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -7,14 +7,14 @@ const port = Number.parseInt(process.env.PORT || '3333', 10);
 const host = process.env.HOST || '0.0.0.0';
 const ROOT_DIR = path.resolve(__dirname, '..', '..');
 const dataRoot = path.resolve(ROOT_DIR, 'data');
-const databasePath = process.env.IDEA_ENGINE_DB || path.join(dataRoot, 'idea_engine.db');
+const databaseUrl = process.env.DATABASE_URL || '';
 
-const { app } = createApp({ databasePath, dataRoot });
+const { app } = createApp({ dataRoot });
 
 const server = http.createServer(app);
 server.listen(port, host, () => {
   console.log(`[idea-engine] API online su http://${host}:${port}`);
-  console.log(`[idea-engine] Database: ${databasePath}`);
+  console.log(`[idea-engine] Database URL: ${databaseUrl ? '[set]' : '[missing]'}`);
 });
 
 process.on('SIGTERM', () => {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -4,9 +4,12 @@
   "private": true,
   "type": "commonjs",
   "main": "index.js",
+  "prisma": {
+    "seed": "node prisma/seed.js"
+  },
   "scripts": {
     "dev": "node index.js",
-    "dev:setup": "if [ -f prisma/schema.prisma ]; then npx prisma generate --schema prisma/schema.prisma; else echo 'Prisma schema mancante, skip setup'; fi",
+    "dev:setup": "if [ -f prisma/schema.prisma ]; then npx prisma generate --schema prisma/schema.prisma && npx prisma migrate deploy --schema prisma/schema.prisma && npx prisma db seed --schema prisma/schema.prisma; else echo 'Prisma schema mancante, skip setup'; fi",
     "start": "node index.js"
   },
   "dependencies": {
@@ -17,7 +20,6 @@
     "express": "^4.19.2",
     "js-yaml": "^4.1.0",
     "mongodb": "^6.9.0",
-    "nedb-promises": "^6.2.3",
     "prisma": "^6.2.1",
     "prom-client": "^15.1.3"
   }

--- a/apps/backend/prisma/migrations/0001_init/migration.sql
+++ b/apps/backend/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,34 @@
+-- CreateTable
+CREATE TABLE "ideas" (
+    "id" SERIAL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "summary" TEXT NOT NULL DEFAULT '',
+    "category" TEXT NOT NULL,
+    "tags" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "biomes" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "ecosystems" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "species" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "traits" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "game_functions" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "priority" TEXT NOT NULL DEFAULT 'P2',
+    "actions_next" TEXT NOT NULL DEFAULT '',
+    "link_drive" TEXT NOT NULL DEFAULT '',
+    "github" TEXT NOT NULL DEFAULT '',
+    "note" TEXT NOT NULL DEFAULT '',
+    "allow_slug_override" BOOLEAN NOT NULL DEFAULT FALSE,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "idea_feedback" (
+    "id" SERIAL PRIMARY KEY,
+    "message" TEXT NOT NULL,
+    "contact" TEXT NOT NULL DEFAULT '',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "idea_id" INTEGER NOT NULL,
+    CONSTRAINT "idea_feedback_idea_id_fkey" FOREIGN KEY ("idea_id") REFERENCES "ideas" ("id") ON DELETE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "idea_feedback_idea_id_idx" ON "idea_feedback"("idea_id");

--- a/apps/backend/prisma/migrations/migration_lock.toml
+++ b/apps/backend/prisma/migrations/migration_lock.toml
@@ -1,0 +1,2 @@
+# Prisma migration provider lockfile
+provider = "postgresql"

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1,0 +1,46 @@
+// Prisma schema for idea engine
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Idea {
+  id                Int        @id @default(autoincrement())
+  title             String
+  summary           String     @default("")
+  category          String
+  tags              String[]   @default([])
+  biomes            String[]   @default([])
+  ecosystems        String[]   @default([])
+  species           String[]   @default([])
+  traits            String[]   @default([])
+  gameFunctions     String[]   @default([]) @map("game_functions")
+  priority          String     @default("P2")
+  actionsNext       String     @default("") @map("actions_next")
+  linkDrive         String     @default("") @map("link_drive")
+  github            String     @default("")
+  note              String     @default("")
+  allowSlugOverride Boolean    @default(false) @map("allow_slug_override")
+  createdAt         DateTime   @default(now()) @map("created_at")
+  updatedAt         DateTime   @updatedAt @map("updated_at")
+  feedback          Feedback[]
+
+  @@map("ideas")
+}
+
+model Feedback {
+  id        Int      @id @default(autoincrement())
+  message   String
+  contact   String   @default("")
+  createdAt DateTime @default(now()) @map("created_at")
+  ideaId    Int      @map("idea_id")
+  idea      Idea     @relation(fields: [ideaId], references: [id], onDelete: Cascade)
+
+  @@index([ideaId])
+  @@map("idea_feedback")
+}

--- a/apps/backend/prisma/seed.js
+++ b/apps/backend/prisma/seed.js
@@ -1,0 +1,44 @@
+const { PrismaClient } = require('@prisma/client');
+
+const prisma = new PrismaClient();
+
+async function seedIdeas() {
+  const existing = await prisma.idea.count();
+  if (existing > 0) {
+    return { created: 0, skipped: existing };
+  }
+  const idea = await prisma.idea.create({
+    data: {
+      title: 'Idea Engine bootstrap',
+      summary: 'Seed idea creata automaticamente per verificare il datastore Prisma.',
+      category: 'Altro',
+      priority: 'P2',
+      tags: [],
+      biomes: [],
+      ecosystems: [],
+      species: [],
+      traits: [],
+      gameFunctions: [],
+      actionsNext: '',
+      linkDrive: '',
+      github: '',
+      note: '',
+      allowSlugOverride: false,
+    },
+  });
+  return { created: 1, skipped: 0, id: idea.id };
+}
+
+async function main() {
+  const result = await seedIdeas();
+  console.log(`Prisma seed completato (idee create: ${result.created}, skip: ${result.skipped})`);
+}
+
+main()
+  .catch((error) => {
+    console.error('Errore durante il seed Prisma', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.9'
+
+services:
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-game}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-game}
+      POSTGRES_DB: ${POSTGRES_DB:-game}
+    ports:
+      - '5432:5432'
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  backend:
+    image: node:20
+    depends_on:
+      - db
+    working_dir: /workspace/app
+    command: >
+      bash -lc "cd /workspace/app && \
+      if [ ! -f ${PRISMA_BOOTSTRAP_FILE:-.docker-prisma-bootstrapped} ]; then \
+        npm install --ignore-scripts && \
+        npm run dev:setup --workspace apps/backend && \
+        touch ${PRISMA_BOOTSTRAP_FILE:-.docker-prisma-bootstrapped}; \
+      else \
+        echo 'Prisma schema già applicato'; \
+      fi && \
+      npm run dev --workspace apps/backend"
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://game:game@db:5432/game?schema=public}
+      PRISMA_BOOTSTRAP_FILE: ${PRISMA_BOOTSTRAP_FILE:-.docker-prisma-bootstrapped}
+      HOST: 0.0.0.0
+      PORT: 3333
+    ports:
+      - '3333:3333'
+    volumes:
+      - .:/workspace/app
+
+volumes:
+  pgdata:

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "express": "^4.19.2",
         "js-yaml": "^4.1.0",
         "mongodb": "^6.9.0",
-        "nedb-promises": "^6.2.3",
         "prisma": "^6.2.1",
         "prom-client": "^15.1.3"
       }
@@ -1237,22 +1236,6 @@
         "win32"
       ]
     },
-    "node_modules/@seald-io/binary-search-tree": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@seald-io/binary-search-tree/-/binary-search-tree-1.0.3.tgz",
-      "integrity": "sha512-qv3jnwoakeax2razYaMsGI/luWdliBLHTdC6jU55hQt1hcFqzauH/HsBollQ7IR4ySTtYhT+xyHoijpA16C+tA=="
-    },
-    "node_modules/@seald-io/nedb": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@seald-io/nedb/-/nedb-4.1.2.tgz",
-      "integrity": "sha512-bDr6TqjBVS2rDyYM9CPxAnotj5FuNL9NF8o7h7YyFXM7yruqT4ddr+PkSb2mJvvw991bqdftazkEo38gykvaww==",
-      "license": "MIT",
-      "dependencies": {
-        "@seald-io/binary-search-tree": "^1.0.3",
-        "localforage": "^1.10.0",
-        "util": "^0.12.5"
-      }
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -1664,21 +1647,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/axios": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.1.tgz",
@@ -1894,24 +1862,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -2310,23 +2260,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -2949,21 +2882,6 @@
         }
       }
     },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.4",
       "dev": true,
@@ -3027,15 +2945,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/generator-function": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
-      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-caller-file": {
@@ -3183,18 +3092,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "license": "MIT",
@@ -3207,6 +3104,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3359,12 +3257,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "license": "MIT"
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3403,40 +3295,12 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-docker": {
       "version": "2.2.1",
@@ -3464,64 +3328,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-generator-function": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
-      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.4",
-        "generator-function": "^2.0.0",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
@@ -3646,30 +3458,12 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
-    "node_modules/lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
-      "license": "MIT",
-      "dependencies": {
-        "immediate": "~3.0.5"
-      }
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/localforage": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
-      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lie": "3.1.1"
-      }
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -3989,15 +3783,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/nedb-promises": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/nedb-promises/-/nedb-promises-6.2.3.tgz",
-      "integrity": "sha512-enq0IjNyBz9Qy9W/QPCcLGh/QORGBjXbIeZeWvIjO3OMLyAvlKT3hiJubP2BKEiFniUlR3L01o18ktqgn5jxqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@seald-io/nedb": "^4.0.2"
       }
     },
     "node_modules/negotiator": {
@@ -4464,15 +4249,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -5059,23 +4835,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
@@ -5157,23 +4916,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {
@@ -5698,19 +5440,6 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
-      }
-    },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/utils-merge": {
@@ -6468,27 +6197,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/why-is-node-running": {


### PR DESCRIPTION
## Summary
- add Prisma schema, migration, and seed for the idea engine models and generateable client
- refactor backend storage/controllers to rely on Prisma Client and adjust setup scripts
- add Docker Compose and environment defaults for Postgres with idempotent Prisma bootstrap marker

## Testing
- Not run (Prisma engine downloads require network access in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691facd188888328ad9632ca03266115)