### PR TITLE
Add Prisma-backed species-biome relations and dashboard wiring

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -13,6 +13,7 @@ const { createGenerationSnapshotStore } = require('./services/generationSnapshot
 const { createNebulaRouter, createAtlasV1Router } = require('./routes/nebula');
 const { createMonitoringRouter } = require('./routes/monitoring');
 const { createGenerationRouter, createGenerationRoutes } = require('./routes/generation');
+const { createSpeciesBiomesRouter } = require('./routes/speciesBiomes');
 const { createTraitRouter } = require('./routes/traits');
 const { createQualityRouter } = require('./routes/quality');
 const { createValidatorsRouter } = require('./routes/validators');
@@ -750,6 +751,13 @@ function createApp(options = {}) {
       }
     }
   });
+
+  app.use(
+    '/api',
+    createSpeciesBiomesRouter({
+      prisma: repo.prisma,
+    }),
+  );
 
   const validatorsRouter = createValidatorsRouter({ runtimeValidator });
   app.use('/api/v1/validators', validatorsRouter);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1,4 +1,4 @@
-// Prisma schema for idea engine
+// Prisma schema for idea engine and taxonomy relationships
 
 generator client {
   provider = "prisma-client-js"
@@ -43,4 +43,43 @@ model Feedback {
 
   @@index([ideaId])
   @@map("idea_feedback")
+}
+
+model Species {
+  id             String          @id
+  name           String
+  classification String?
+  tags           String[]        @default([])
+  createdAt      DateTime        @default(now()) @map("created_at")
+  updatedAt      DateTime        @updatedAt @map("updated_at")
+  biomes         SpeciesBiome[]
+
+  @@map("species")
+}
+
+model Biome {
+  id        String          @id
+  name      String
+  climate   String?
+  region    String?
+  createdAt DateTime        @default(now()) @map("created_at")
+  updatedAt DateTime        @updatedAt @map("updated_at")
+  species   SpeciesBiome[]
+
+  @@map("biomes")
+}
+
+model SpeciesBiome {
+  id        Int      @id @default(autoincrement())
+  speciesId String   @map("species_id")
+  biomeId   String   @map("biome_id")
+  strength  String?
+  note      String?
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+  species   Species  @relation(fields: [speciesId], references: [id], onDelete: Cascade)
+  biome     Biome    @relation(fields: [biomeId], references: [id], onDelete: Cascade)
+
+  @@unique([speciesId, biomeId])
+  @@map("species_biomes")
 }

--- a/apps/backend/prisma/seed.js
+++ b/apps/backend/prisma/seed.js
@@ -29,9 +29,77 @@ async function seedIdeas() {
   return { created: 1, skipped: 0, id: idea.id };
 }
 
+async function seedTaxonomy() {
+  const speciesCatalog = [
+    {
+      id: 'gryphon-strider',
+      name: 'Gryphon Strider',
+      classification: 'Aerial Vanguard',
+      tags: ['skirmisher', 'recon'],
+    },
+    {
+      id: 'tidal-warden',
+      name: 'Tidal Warden',
+      classification: 'Littoral Guardian',
+      tags: ['support', 'amphibious'],
+    },
+    {
+      id: 'emberclaw',
+      name: 'Emberclaw',
+      classification: 'Volcanic Stalker',
+      tags: ['assault'],
+    },
+  ];
+
+  const biomeCatalog = [
+    { id: 'badlands', name: 'Badlands Expanse', climate: 'arid', region: 'Frontier' },
+    { id: 'tidal-reef', name: 'Tidal Reef', climate: 'humid', region: 'Pelagic Corridor' },
+    { id: 'volcanic-rim', name: 'Volcanic Rim', climate: 'hot', region: 'Anomaly Belt' },
+  ];
+
+  const relations = [
+    { speciesId: 'gryphon-strider', biomeId: 'badlands', strength: 'primary' },
+    { speciesId: 'tidal-warden', biomeId: 'tidal-reef', strength: 'primary' },
+    { speciesId: 'emberclaw', biomeId: 'volcanic-rim', strength: 'primary' },
+    { speciesId: 'tidal-warden', biomeId: 'badlands', strength: 'secondary' },
+  ];
+
+  for (const entry of speciesCatalog) {
+    await prisma.species.upsert({
+      where: { id: entry.id },
+      update: { ...entry },
+      create: entry,
+    });
+  }
+
+  for (const entry of biomeCatalog) {
+    await prisma.biome.upsert({
+      where: { id: entry.id },
+      update: { ...entry },
+      create: entry,
+    });
+  }
+
+  let created = 0;
+  for (const relation of relations) {
+    await prisma.speciesBiome.upsert({
+      where: { speciesId_biomeId: { speciesId: relation.speciesId, biomeId: relation.biomeId } },
+      update: { strength: relation.strength },
+      create: relation,
+    });
+    created += 1;
+  }
+
+  return { species: speciesCatalog.length, biomes: biomeCatalog.length, relations: created };
+}
+
 async function main() {
-  const result = await seedIdeas();
-  console.log(`Prisma seed completato (idee create: ${result.created}, skip: ${result.skipped})`);
+  const ideaResult = await seedIdeas();
+  const taxonomyResult = await seedTaxonomy();
+  console.log(
+    `Prisma seed completato (idee create: ${ideaResult.created}, skip: ${ideaResult.skipped}, ` +
+      `specie: ${taxonomyResult.species}, biomi: ${taxonomyResult.biomes}, relazioni: ${taxonomyResult.relations})`,
+  );
 }
 
 main()

--- a/apps/backend/routes/speciesBiomes.js
+++ b/apps/backend/routes/speciesBiomes.js
@@ -1,0 +1,105 @@
+const express = require('express');
+
+function mapSpecies(entry) {
+  if (!entry) return null;
+  return {
+    id: entry.id,
+    name: entry.name,
+    classification: entry.classification || null,
+    tags: Array.isArray(entry.tags) ? entry.tags : [],
+    createdAt: entry.createdAt ? entry.createdAt.toISOString() : null,
+    updatedAt: entry.updatedAt ? entry.updatedAt.toISOString() : null,
+  };
+}
+
+function mapBiome(entry) {
+  if (!entry) return null;
+  return {
+    id: entry.id,
+    name: entry.name,
+    climate: entry.climate || null,
+    region: entry.region || null,
+    createdAt: entry.createdAt ? entry.createdAt.toISOString() : null,
+    updatedAt: entry.updatedAt ? entry.updatedAt.toISOString() : null,
+  };
+}
+
+function mapRelation(entry) {
+  if (!entry) return null;
+  return {
+    id: entry.id,
+    speciesId: entry.speciesId,
+    biomeId: entry.biomeId,
+    strength: entry.strength || null,
+    note: entry.note || null,
+    createdAt: entry.createdAt ? entry.createdAt.toISOString() : null,
+    updatedAt: entry.updatedAt ? entry.updatedAt.toISOString() : null,
+    species: mapSpecies(entry.species),
+    biome: mapBiome(entry.biome),
+  };
+}
+
+function createSpeciesBiomesRouter({ prisma }) {
+  if (!prisma) {
+    throw new Error('prisma client richiesto per il router specie-biomi');
+  }
+
+  const router = express.Router();
+
+  router.get('/species', async (req, res) => {
+    try {
+      const species = await prisma.species.findMany({
+        include: { biomes: { include: { biome: true } } },
+        orderBy: [{ name: 'asc' }, { id: 'asc' }],
+      });
+      res.json({
+        species: species.map((entry) => ({
+          ...mapSpecies(entry),
+          biomes: Array.isArray(entry.biomes) ? entry.biomes.map((link) => mapRelation(link)) : [],
+        })),
+        requestedBy: req.get('x-user') || null,
+      });
+    } catch (error) {
+      res.status(500).json({ error: 'Errore caricamento specie' });
+    }
+  });
+
+  router.get('/biomes', async (req, res) => {
+    try {
+      const biomes = await prisma.biome.findMany({
+        include: { species: { include: { species: true } } },
+        orderBy: [{ name: 'asc' }, { id: 'asc' }],
+      });
+      res.json({
+        biomes: biomes.map((entry) => ({
+          ...mapBiome(entry),
+          species: Array.isArray(entry.species)
+            ? entry.species.map((link) => mapRelation(link))
+            : [],
+        })),
+        requestedBy: req.get('x-user') || null,
+      });
+    } catch (error) {
+      res.status(500).json({ error: 'Errore caricamento biomi' });
+    }
+  });
+
+  router.get('/species-biomes', async (req, res) => {
+    try {
+      const links = await prisma.speciesBiome.findMany({
+        include: { species: true, biome: true },
+        orderBy: [{ speciesId: 'asc' }, { biomeId: 'asc' }],
+      });
+      res.json({
+        links: links.map((entry) => mapRelation(entry)),
+        requestedBy: req.get('x-user') || null,
+      });
+    } catch (error) {
+      res.status(500).json({ error: 'Errore caricamento relazioni specie-biomi' });
+    }
+  });
+
+  return router;
+}
+
+module.exports = { createSpeciesBiomesRouter };

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -12,6 +12,7 @@
     "qa": "node ./scripts/print-qa-checklist.mjs"
   },
   "dependencies": {
+    "@game/contracts": "file:../../packages/contracts",
     "@game/ui": "file:../../packages/ui",
     "angular": "file:../../packages/angular",
     "angular-animate": "file:../../packages/angular-animate",

--- a/apps/dashboard/src/data/sample-data.ts
+++ b/apps/dashboard/src/data/sample-data.ts
@@ -4,6 +4,9 @@ import type {
   EventLog,
   Mission,
   NebulaMilestone,
+  SpeciesBiomeLink,
+  TaxonomyBiome,
+  TaxonomySpecies,
   Trait,
 } from '../types';
 
@@ -318,5 +321,67 @@ export const dashboardMetrics: DashboardMetric[] = [
     value: '14m',
     trend: 'up',
     change: 'Improved by 2m with new orbital relays',
+  },
+];
+
+export const taxonomyBiomes: TaxonomyBiome[] = [
+  { id: 'badlands', name: 'Badlands Expanse', climate: 'arid', region: 'Frontier' },
+  { id: 'tidal-reef', name: 'Tidal Reef', climate: 'humid', region: 'Pelagic Corridor' },
+  { id: 'volcanic-rim', name: 'Volcanic Rim', climate: 'hot', region: 'Anomaly Belt' },
+];
+
+export const taxonomySpecies: TaxonomySpecies[] = [
+  {
+    id: 'gryphon-strider',
+    name: 'Gryphon Strider',
+    classification: 'Aerial Vanguard',
+    tags: ['skirmisher', 'recon'],
+  },
+  {
+    id: 'tidal-warden',
+    name: 'Tidal Warden',
+    classification: 'Littoral Guardian',
+    tags: ['support', 'amphibious'],
+  },
+  {
+    id: 'emberclaw',
+    name: 'Emberclaw',
+    classification: 'Volcanic Stalker',
+    tags: ['assault'],
+  },
+];
+
+export const speciesBiomeLinks: SpeciesBiomeLink[] = [
+  {
+    id: 1,
+    speciesId: 'gryphon-strider',
+    biomeId: 'badlands',
+    strength: 'primary',
+    species: taxonomySpecies[0],
+    biome: taxonomyBiomes[0],
+  },
+  {
+    id: 2,
+    speciesId: 'tidal-warden',
+    biomeId: 'tidal-reef',
+    strength: 'primary',
+    species: taxonomySpecies[1],
+    biome: taxonomyBiomes[1],
+  },
+  {
+    id: 3,
+    speciesId: 'emberclaw',
+    biomeId: 'volcanic-rim',
+    strength: 'primary',
+    species: taxonomySpecies[2],
+    biome: taxonomyBiomes[2],
+  },
+  {
+    id: 4,
+    speciesId: 'tidal-warden',
+    biomeId: 'badlands',
+    strength: 'secondary',
+    species: taxonomySpecies[1],
+    biome: taxonomyBiomes[0],
   },
 ];

--- a/apps/dashboard/src/pages/dashboard/dashboard.page.ts
+++ b/apps/dashboard/src/pages/dashboard/dashboard.page.ts
@@ -1,4 +1,4 @@
-import type { DashboardMetric, EventLog, Mission } from '../../types';
+import type { DashboardMetric, EventLog, Mission, SpeciesBiomeLink } from '../../types';
 import { formatDate } from '../../utils/format-date';
 import { DataStoreService } from '../../services/data-store.service';
 
@@ -9,6 +9,9 @@ class DashboardController {
   public metrics: DashboardMetric[] = [];
   public events: EventLog[] = [];
   public statusSummary: Record<string, number> = {};
+  public speciesBiomes: SpeciesBiomeLink[] = [];
+  public speciesBiomeLoading = false;
+  public speciesBiomeError: string | null = null;
 
   static $inject = ['DataStoreService'];
 
@@ -19,6 +22,7 @@ class DashboardController {
     this.metrics = this.dataStore.getDashboardMetrics();
     this.events = this.dataStore.getEventLog(4);
     this.statusSummary = this.dataStore.getMissionStatusSummary();
+    this.loadSpeciesBiomes();
   }
 
   missionBadgeClass(status: MissionBadge): string {
@@ -50,6 +54,24 @@ class DashboardController {
 
   formatTimestamp(value: string): string {
     return formatDate(value);
+  }
+
+  private loadSpeciesBiomes(): void {
+    this.speciesBiomeLoading = true;
+    this.dataStore
+      .getSpeciesBiomeLinks()
+      .then((links) => {
+        this.speciesBiomes = links;
+        this.speciesBiomeError = null;
+      })
+      .catch((error: unknown) => {
+        console.warn('Errore caricamento relazioni specie/biomi', error);
+        this.speciesBiomes = [];
+        this.speciesBiomeError = 'Impossibile caricare le relazioni specie/biomi';
+      })
+      .finally(() => {
+        this.speciesBiomeLoading = false;
+      });
   }
 }
 
@@ -155,6 +177,43 @@ export const registerDashboardPage = (module: any): void => {
                 </span>
               </li>
             </ul>
+          </article>
+
+          <article class="panel panel--relations">
+            <h2 class="panel__title">Specie ↔ Biomi (Prisma)</h2>
+            <p class="panel__subtitle">
+              Preferenza per backend live via VITE_API_BASE_URL; fallback automatico su dataset mock.
+            </p>
+            <div class="panel__placeholder" ng-if="$ctrl.speciesBiomeLoading">
+              Caricamento relazioni specie/biomi…
+            </div>
+            <div class="panel__placeholder" ng-if="!$ctrl.speciesBiomeLoading && !$ctrl.speciesBiomes.length">
+              Nessuna relazione disponibile al momento.
+            </div>
+            <ul class="mission-list mission-list--compact" ng-if="!$ctrl.speciesBiomeLoading && $ctrl.speciesBiomes.length">
+              <li class="mission-card" ng-repeat="link in $ctrl.speciesBiomes | limitTo:4">
+                <div class="mission-card__header">
+                  <span class="mission-card__codename">{{ link.species?.name || link.speciesId }}</span>
+                  <span class="mission-card__status mission-card__status--planned">
+                    {{ link.strength || 'associazione' }}
+                  </span>
+                </div>
+                <p class="mission-card__summary">
+                  Habitat prioritario: {{ link.biome?.name || link.biomeId }}
+                </p>
+                <dl class="mission-card__meta">
+                  <div>
+                    <dt>Biome ID</dt>
+                    <dd>{{ link.biome?.id || link.biomeId }}</dd>
+                  </div>
+                  <div>
+                    <dt>Specie ID</dt>
+                    <dd>{{ link.species?.id || link.speciesId }}</dd>
+                  </div>
+                </dl>
+              </li>
+            </ul>
+            <p class="panel__subtitle" ng-if="$ctrl.speciesBiomeError">{{ $ctrl.speciesBiomeError }}</p>
           </article>
         </section>
       </section>

--- a/apps/dashboard/src/services/data-store.service.ts
+++ b/apps/dashboard/src/services/data-store.service.ts
@@ -4,6 +4,9 @@ import {
   eventLog,
   missions,
   nebulaMilestones,
+  speciesBiomeLinks,
+  taxonomyBiomes,
+  taxonomySpecies,
   traits,
 } from '../data/sample-data';
 import type {
@@ -12,10 +15,30 @@ import type {
   EventLog,
   Mission,
   NebulaMilestone,
+  SpeciesBiomeLink,
   Trait,
 } from '../types';
 
 export class DataStoreService {
+  private readonly apiBaseUrl: string | null;
+  private readonly apiUser: string | null;
+  private readonly useMockApi: boolean;
+
+  constructor() {
+    const apiBaseCandidate =
+      (import.meta.env.VITE_API_BASE_URL as string | undefined) ||
+      (import.meta.env.VITE_API_BASE as string | undefined) ||
+      '';
+    const trimmedBase = apiBaseCandidate.trim().replace(/\/$/, '');
+    this.apiBaseUrl = trimmedBase || null;
+    this.apiUser =
+      typeof import.meta.env.VITE_API_USER === 'string'
+        ? import.meta.env.VITE_API_USER.trim() || null
+        : null;
+    const apiMode = ((import.meta.env.VITE_API_MODE as string | undefined) || '').toLowerCase();
+    this.useMockApi = apiMode === 'mock' || !this.apiBaseUrl;
+  }
+
   getMissions(): Mission[] {
     return missions.map((mission) => ({ ...mission }));
   }
@@ -60,6 +83,69 @@ export class DataStoreService {
       acc[mission.status] = count + 1;
       return acc;
     }, {});
+  }
+
+  async getSpeciesBiomeLinks(): Promise<SpeciesBiomeLink[]> {
+    const fallback = (): SpeciesBiomeLink[] =>
+      speciesBiomeLinks.map((entry) => ({
+        ...entry,
+        species:
+          entry.species ||
+          taxonomySpecies.find((species) => species.id === entry.speciesId) ||
+          null,
+        biome: entry.biome || taxonomyBiomes.find((biome) => biome.id === entry.biomeId) || null,
+      }));
+
+    if (!this.shouldUseApi()) {
+      return fallback();
+    }
+
+    try {
+      const response = await this.fetchFromApi('/api/species-biomes');
+      if (!response.ok) {
+        throw new Error(`API species-biomes risponde ${response.status}`);
+      }
+      const payload = await response.json();
+      const links = Array.isArray(payload?.links) ? payload.links : [];
+      if (!links.length) {
+        return fallback();
+      }
+      return links.map((entry: SpeciesBiomeLink) => ({
+        ...entry,
+        species: entry.species || null,
+        biome: entry.biome || null,
+      }));
+    } catch (error) {
+      console.warn(
+        'Impossibile caricare relazioni specie-biomi dal backend, uso dataset locale',
+        error,
+      );
+      return fallback();
+    }
+  }
+
+  private shouldUseApi(): boolean {
+    return Boolean(this.apiBaseUrl) && !this.useMockApi;
+  }
+
+  private buildApiUrl(path: string): string {
+    if (!this.apiBaseUrl) {
+      throw new Error('API base URL non configurata');
+    }
+    const suffix = path.startsWith('/') ? path : `/${path}`;
+    return `${this.apiBaseUrl}${suffix}`;
+  }
+
+  private async fetchFromApi(path: string, init?: RequestInit): Promise<Response> {
+    const headers: Record<string, string> = { ...(init?.headers as Record<string, string>) };
+    if (this.apiUser) {
+      headers['X-User'] = this.apiUser;
+    }
+    const target = this.buildApiUrl(path);
+    return fetch(target, {
+      ...init,
+      headers,
+    });
   }
 }
 

--- a/apps/dashboard/src/types/index.ts
+++ b/apps/dashboard/src/types/index.ts
@@ -1,3 +1,5 @@
+export type { TaxonomySpecies, TaxonomyBiome, SpeciesBiomeLink } from '@game/contracts';
+
 export type MissionStatus = 'planned' | 'in-progress' | 'completed' | 'at-risk';
 
 export interface Mission {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
     "apps/dashboard": {
       "name": "@game/dashboard",
       "dependencies": {
+        "@game/contracts": "file:../../packages/contracts",
         "@game/ui": "file:../../packages/ui",
         "ajv": "^8.17.1",
         "angular": "file:../../packages/angular",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:web": "npm run test:web --workspace tools/ts",
     "test:e2e": "./node_modules/.bin/playwright test --config=apps/dashboard/tests/playwright/playwright.config.mjs",
     "test:backend": "npm run test:api",
-    "test:stack": "npm run test:backend && npm run test --workspace apps/dashboard",
+    "test:stack": "bash scripts/test-stack.sh",
     "lint:stack": "node scripts/lint-stack.mjs",
     "lint:lighthouse": "lhci autorun --config=./config/lighthouse/evo.lighthouserc.json",
     "schema:lint": "python tools/automation/evo_schema_lint.py schemas/evo",

--- a/packages/contracts/index.d.ts
+++ b/packages/contracts/index.d.ts
@@ -202,6 +202,47 @@ export interface AtlasTelemetry {
   [key: string]: unknown;
 }
 
+export interface TaxonomyBiome {
+  id: string;
+  name: string;
+  climate?: string | null;
+  region?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  [key: string]: unknown;
+}
+
+export interface TaxonomySpecies {
+  id: string;
+  name: string;
+  classification?: string | null;
+  tags?: string[];
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  biomes?: SpeciesBiomeLink[];
+  [key: string]: unknown;
+}
+
+export interface SpeciesBiomeLink {
+  id: number;
+  speciesId: string;
+  biomeId: string;
+  strength?: string | null;
+  note?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  species?: TaxonomySpecies | null;
+  biome?: TaxonomyBiome | null;
+  [key: string]: unknown;
+}
+
+export interface SpeciesBiomeLinkList {
+  links: SpeciesBiomeLink[];
+  requestedBy?: string | null;
+  [key: string]: unknown;
+}
+
 export declare const generationSnapshotSchema: Record<string, unknown>;
 export declare const speciesSchema: Record<string, unknown>;
 export declare const telemetrySchema: Record<string, unknown>;
+export declare const speciesBiomesSchema: Record<string, unknown>;

--- a/packages/contracts/index.js
+++ b/packages/contracts/index.js
@@ -3,9 +3,11 @@
 const generationSnapshotSchema = require('./schemas/generationSnapshot.schema.json');
 const speciesSchema = require('./schemas/species.schema.json');
 const telemetrySchema = require('./schemas/telemetry.schema.json');
+const speciesBiomesSchema = require('./schemas/speciesBiomes.schema.json');
 
 module.exports = {
   generationSnapshotSchema,
   speciesSchema,
   telemetrySchema,
+  speciesBiomesSchema,
 };

--- a/packages/contracts/schemas/speciesBiomes.schema.json
+++ b/packages/contracts/schemas/speciesBiomes.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.game.local/species-biomes.schema.json",
+  "title": "SpeciesBiomeLinks",
+  "type": "object",
+  "required": ["links"],
+  "properties": {
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "speciesId", "biomeId"],
+        "properties": {
+          "id": { "type": "integer" },
+          "speciesId": { "type": "string" },
+          "biomeId": { "type": "string" },
+          "strength": { "type": ["string", "null"] },
+          "note": { "type": ["string", "null"] },
+          "createdAt": { "type": ["string", "null"], "format": "date-time" },
+          "updatedAt": { "type": ["string", "null"], "format": "date-time" },
+          "species": { "$ref": "./species.schema.json" },
+          "biome": {
+            "type": "object",
+            "required": ["id", "name"],
+            "properties": {
+              "id": { "type": "string" },
+              "name": { "type": "string" },
+              "climate": { "type": ["string", "null"] },
+              "region": { "type": ["string", "null"] },
+              "createdAt": { "type": ["string", "null"], "format": "date-time" },
+              "updatedAt": { "type": ["string", "null"], "format": "date-time" }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "requestedBy": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/scripts/dev-stack.sh
+++ b/scripts/dev-stack.sh
@@ -31,6 +31,10 @@ on_signal() {
 trap on_exit EXIT
 trap on_signal INT TERM
 
+export VITE_API_BASE_URL="${VITE_API_BASE_URL:-http://localhost:3333}"
+export VITE_API_USER="${VITE_API_USER:-devstack}"
+export VITE_API_MODE="${VITE_API_MODE:-live}"
+
 npm run dev:setup --workspace apps/backend
 npm run dev --workspace apps/backend &
 API_PID=$!

--- a/scripts/test-stack.sh
+++ b/scripts/test-stack.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export VITE_API_MODE="${VITE_API_MODE:-mock}"
+export VITE_API_BASE_URL="${VITE_API_BASE_URL:-http://localhost:3333}"
+export VITE_API_USER="${VITE_API_USER:-test-runner}"
+
+npm run test:backend
+npm run test --workspace apps/dashboard


### PR DESCRIPTION
## Summary
- extend the Prisma schema/seed and expose `/api/species`, `/api/biomes`, and `/api/species-biomes` endpoints that honour the X-User header
- add shared contract types/schemas plus dashboard data store and view updates to consume live species-biome links with mock fallbacks
- wire stack scripts to set VITE_API_BASE_URL/VITE_API_USER defaults and provide a combined frontend/backend test runner

## Testing
- npm test --workspace apps/dashboard *(fails: missing ../../src/config/dataSources.ts and existing analytics expectations)*
- PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate --schema apps/backend/prisma/schema.prisma *(fails: Prisma engine download blocked by 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fb07a0df88328a55aec7d5b4463a6)