### PR TITLE
Fix Evo pack asset path rewrites

### DIFF
--- a/docs/evo-tactics-pack/catalog.html
+++ b/docs/evo-tactics-pack/catalog.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="it">
   <head>
     <meta charset="utf-8" />

--- a/docs/evo-tactics-pack/catalog.js
+++ b/docs/evo-tactics-pack/catalog.js
@@ -1,13 +1,9 @@
-import {
-  loadPackCatalog,
-  manualLoadCatalog,
-  getPackRootCandidates,
-} from "./pack-data.js";
+import { loadPackCatalog, manualLoadCatalog, getPackRootCandidates } from './pack-data.js';
 
 const elements = {
-  summary: document.getElementById("ecosystem-summary"),
-  connections: document.getElementById("ecosystem-connections"),
-  biomeCards: document.getElementById("biome-cards"),
+  summary: document.getElementById('ecosystem-summary'),
+  connections: document.getElementById('ecosystem-connections'),
+  biomeCards: document.getElementById('biome-cards'),
 };
 
 let packContext = null;
@@ -36,63 +32,71 @@ function resolvePackHref(relativePath) {
     try {
       return packContext.resolveDocHref(relativePath);
     } catch (error) {
-      console.warn("Impossibile risolvere il percorso tramite resolveDocHref", relativePath, error);
+      console.warn('Impossibile risolvere il percorso tramite resolveDocHref', relativePath, error);
     }
   }
   if (packDocsBase) {
     try {
       return new URL(relativePath, packDocsBase).toString();
     } catch (error) {
-      console.warn("Impossibile risolvere il percorso tramite packDocsBase", relativePath, error);
+      console.warn('Impossibile risolvere il percorso tramite packDocsBase', relativePath, error);
     }
   }
   if (packContext?.resolvePackHref) {
     try {
       return packContext.resolvePackHref(relativePath);
     } catch (error) {
-      console.warn("Impossibile risolvere il percorso tramite resolvePackHref", relativePath, error);
+      console.warn(
+        'Impossibile risolvere il percorso tramite resolvePackHref',
+        relativePath,
+        error,
+      );
     }
   }
   if (resolvedPackRoot) {
     try {
       return new URL(relativePath, resolvedPackRoot).toString();
     } catch (error) {
-      console.warn("Impossibile risolvere il percorso tramite resolvedPackRoot", relativePath, error);
+      console.warn(
+        'Impossibile risolvere il percorso tramite resolvedPackRoot',
+        relativePath,
+        error,
+      );
     }
   }
   return relativePath;
 }
 
 function formatConnectionType(type) {
-  return type.replace(/_/g, " ");
+  return type.replace(/_/g, ' ');
 }
 
 function renderConnections(data) {
   if (!elements.connections) return;
-  elements.connections.innerHTML = "";
+  elements.connections.innerHTML = '';
 
   if (!data.connessioni?.length) {
-    const placeholder = document.createElement("p");
-    placeholder.className = "placeholder";
-    placeholder.textContent = "Nessuna connessione registrata.";
+    const placeholder = document.createElement('p');
+    placeholder.className = 'placeholder';
+    placeholder.textContent = 'Nessuna connessione registrata.';
     elements.connections.appendChild(placeholder);
     return;
   }
 
   data.connessioni.forEach((conn) => {
-    const card = document.createElement("article");
-    card.className = "card";
+    const card = document.createElement('article');
+    card.className = 'card';
 
-    const title = document.createElement("h3");
+    const title = document.createElement('h3');
     title.textContent = `${conn.from} → ${conn.to}`;
 
-    const meta = document.createElement("p");
+    const meta = document.createElement('p');
     meta.innerHTML = `<strong>${formatConnectionType(conn.type)}</strong> · resistenza ${
-      conn.resistance ?? "—"
-    } · ${conn.seasonality || "stagionalità n/d"}`;
+      conn.resistance ?? '—'
+    } · ${conn.seasonality || 'stagionalità n/d'}`;
 
-    const notes = document.createElement("p");
-    notes.textContent = conn.notes || "";
+    const notes = document.createElement('p');
+    notes.textContent = conn.notes || '';
 
     card.append(title, meta, notes);
 
@@ -101,27 +105,27 @@ function renderConnections(data) {
 }
 
 function createBadge(label, value) {
-  const badge = document.createElement("span");
-  badge.className = "chip";
+  const badge = document.createElement('span');
+  badge.className = 'chip';
   badge.textContent = `${label}: ${value}`;
   return badge;
 }
 
 function renderManifest(manifest) {
-  const wrapper = document.createElement("div");
-  wrapper.className = "manifest-block";
+  const wrapper = document.createElement('div');
+  wrapper.className = 'manifest-block';
 
-  const badgeRow = document.createElement("div");
-  badgeRow.className = "chip-list chip-list--compact";
+  const badgeRow = document.createElement('div');
+  badgeRow.className = 'chip-list chip-list--compact';
   Object.entries(manifest?.species_counts ?? {}).forEach(([key, value]) => {
     badgeRow.appendChild(createBadge(key, value));
   });
   wrapper.appendChild(badgeRow);
 
   if (manifest?.functional_groups_present?.length) {
-    const groups = document.createElement("p");
-    groups.className = "form__hint";
-    groups.textContent = `Functional groups: ${manifest.functional_groups_present.join(", ")}`;
+    const groups = document.createElement('p');
+    groups.className = 'form__hint';
+    groups.textContent = `Functional groups: ${manifest.functional_groups_present.join(', ')}`;
     wrapper.appendChild(groups);
   }
 
@@ -132,13 +136,13 @@ function formatFlags(flags) {
   return Object.entries(flags || {})
     .filter(([, value]) => Boolean(value))
     .map(([key]) => key)
-    .join(", ");
+    .join(', ');
 }
 
 function renderSpeciesTable(speciesList) {
-  const table = document.createElement("table");
-  table.className = "table";
-  const header = document.createElement("thead");
+  const table = document.createElement('table');
+  table.className = 'table';
+  const header = document.createElement('thead');
   header.innerHTML = `
     <tr>
       <th>Nome</th>
@@ -150,15 +154,15 @@ function renderSpeciesTable(speciesList) {
     </tr>`;
   table.appendChild(header);
 
-  const body = document.createElement("tbody");
+  const body = document.createElement('tbody');
   speciesList.forEach((sp) => {
-    const row = document.createElement("tr");
+    const row = document.createElement('tr');
     const yamlHref = resolvePackHref(sp.path);
     row.innerHTML = `
       <td>${sp.display_name}</td>
       <td>${sp.id}</td>
-      <td>${sp.role_trofico || "—"}</td>
-      <td>${(sp.functional_tags || []).join(", ")}</td>
+      <td>${sp.role_trofico || '—'}</td>
+      <td>${(sp.functional_tags || []).join(', ')}</td>
       <td>${formatFlags(sp.flags)}</td>
       <td><a href="${yamlHref}" target="_blank" rel="noreferrer">Apri</a></td>`;
     body.appendChild(row);
@@ -168,15 +172,15 @@ function renderSpeciesTable(speciesList) {
 }
 
 function renderBiomeCard(biome) {
-  const card = document.createElement("article");
-  card.className = "card";
+  const card = document.createElement('article');
+  card.className = 'card';
   card.id = `bioma-${biome.id}`;
 
-  const title = document.createElement("h3");
+  const title = document.createElement('h3');
   title.textContent = `Bioma — ${biome.id}`;
 
-  const linkRow = document.createElement("p");
-  linkRow.className = "form__hint";
+  const linkRow = document.createElement('p');
+  linkRow.className = 'form__hint';
   const biomeYaml = resolvePackHref(biome.path);
   const manifestYaml = biome.manifest?.path ? resolvePackHref(biome.manifest.path) : null;
   const foodwebYaml = biome.foodweb?.path ? resolvePackHref(biome.foodweb.path) : null;
@@ -192,10 +196,8 @@ function renderBiomeCard(biome) {
     links.push(`<a href="${foodwebPng}" target="_blank" rel="noreferrer">Foodweb PNG</a>`);
   }
   links.push(`<a href="${webReport}">Report web</a>`);
-  links.push(
-    `<a href="${legacyReport}" target="_blank" rel="noreferrer">Report originale</a>`
-  );
-  linkRow.innerHTML = links.join(" · ");
+  links.push(`<a href="${legacyReport}" target="_blank" rel="noreferrer">Report originale</a>`);
+  linkRow.innerHTML = links.join(' · ');
 
   const manifestBlock = renderManifest(biome.manifest);
   const speciesTable = renderSpeciesTable(biome.species || []);
@@ -205,7 +207,7 @@ function renderBiomeCard(biome) {
 }
 
 async function loadCatalog() {
-  setSummary("Caricamento del catalogo in corso…");
+  setSummary('Caricamento del catalogo in corso…');
   try {
     const { data, context } = await loadPackCatalog();
     applyCatalogContext(context);
@@ -213,19 +215,19 @@ async function loadCatalog() {
     const biomeCount = data.biomi?.length ?? 0;
     const connectionsCount = data.ecosistema?.connessioni?.length ?? 0;
     setSummary(
-      `${data.ecosistema?.label ?? "Meta-ecosistema"} con ${biomeCount} biomi collegati e ${connectionsCount} connessioni.`
+      `${data.ecosistema?.label ?? 'Meta-ecosistema'} con ${biomeCount} biomi collegati e ${connectionsCount} connessioni.`,
     );
     renderConnections(data.ecosistema ?? {});
 
     if (elements.biomeCards) {
-      elements.biomeCards.innerHTML = "";
+      elements.biomeCards.innerHTML = '';
       data.biomi.forEach((biome) => {
         elements.biomeCards.appendChild(renderBiomeCard(biome));
       });
     }
     return;
   } catch (error) {
-    console.warn("Caricamento catalogo tramite loader condiviso fallito", error);
+    console.warn('Caricamento catalogo tramite loader condiviso fallito', error);
   }
 
   try {
@@ -235,25 +237,25 @@ async function loadCatalog() {
     const biomeCount = data.biomi?.length ?? 0;
     const connectionsCount = data.ecosistema?.connessioni?.length ?? 0;
     setSummary(
-      `${data.ecosistema?.label ?? "Meta-ecosistema"} con ${biomeCount} biomi collegati e ${connectionsCount} connessioni (fallback).`
+      `${data.ecosistema?.label ?? 'Meta-ecosistema'} con ${biomeCount} biomi collegati e ${connectionsCount} connessioni (fallback).`,
     );
     renderConnections(data.ecosistema ?? {});
 
     if (elements.biomeCards) {
-      elements.biomeCards.innerHTML = "";
+      elements.biomeCards.innerHTML = '';
       data.biomi.forEach((biome) => {
         elements.biomeCards.appendChild(renderBiomeCard(biome));
       });
     }
   } catch (error) {
-    console.error("Impossibile caricare il catalogo del pack", error);
-    setSummary("Errore durante il caricamento del catalogo. Controlla la console per i dettagli.");
+    console.error('Impossibile caricare il catalogo del pack', error);
+    setSummary('Errore durante il caricamento del catalogo. Controlla la console per i dettagli.');
   }
 }
 
 loadCatalog();
 
-if (typeof window !== "undefined") {
+if (typeof window !== 'undefined') {
   window.EvoPack = window.EvoPack || {};
   window.EvoPack.packRootCandidates = PACK_ROOT_CANDIDATES;
   window.EvoPack.catalog = {

--- a/docs/evo-tactics-pack/ennea-themes.md
+++ b/docs/evo-tactics-pack/ennea-themes.md
@@ -7,6 +7,7 @@ condivisi nel repository e alimentano sia i generatori Ennea sia i report
 telemetrici TV.
 
 ## Stats & Eventi engine (v0.3)
+
 - **Statistiche supportate**: `ac`, `aura_radius`, `bond_aura`, `burst_damage`,
   `charisma_checks`, `counter_chance`, `damage_taken`, `duel_bonus`,
   `evasion`, `hp_max`, `initiative`, `initiative_adv`, `melee_damage`, `pe`,
@@ -28,6 +29,7 @@ telemetrici TV.
   `add_flat_initiative` 4.
 
 ## Biome Coherence (Tipo 1)
+
 - **Dataset & Hooks**: `themes.yaml` → `reformer_1`, `personality_module.v1.json` → `mechanics_registry.hooks["theme.reformer_1"].links`, `dataset.themes[reformer_1]`.
 - **Scopo**: mantenere coerenza tra biomi, affissi e mutazioni per ridurre
   l'entropia ambientale degli encounter. I riferimenti principali sono
@@ -41,6 +43,7 @@ telemetrici TV.
   coerenza dati-bioma.
 
 ## Coordinatore (Tipo 2)
+
 - **Dataset & Hooks**: `themes.yaml` → `helper_2`, registry hook `theme.helper_2` con sinergie `triad.core_emotion.vergogna`, `hornevian.obbediente`, `harmonic.ottimisti`.
 - **Scopo**: esaltare il supporto continuo e la gestione scudi nelle squadre ad
   alta coesione (telemetria `cohesion>0.70`).【F:data/core/telemetry.yaml†L14-L29】
@@ -52,6 +55,7 @@ telemetrici TV.
   adattamenti `cohesion_high` che aggiungono controllo al campo.【F:data/core/biomes.yaml†L6-L10】
 
 ## Conquistatore (Tipo 3)
+
 - **Dataset & Hooks**: `themes.yaml` → `achiever_3`, hook `theme.achiever_3` e links su `dataset.themes[achiever_3]`.
 - **Scopo**: premiare squadre aggressive che mantengono pressione elevata.
 - **Trigger**: telemetria `aggro>0.65` con `risk>0.55`, coerente con il tema
@@ -62,6 +66,7 @@ telemetrici TV.
   di tilt durante i playtest.
 
 ## Sintonizzatore (Tipo 4)
+
 - **Dataset & Hooks**: `themes.yaml` → `individual_4`, `theme.individual_4` + sinergie Hornevian/Harmonic nel blocco `links`.
 - **Scopo**: orchestrare pattern estetici e tattici, alternando rigore e
   improvvisazione regolata.
@@ -73,6 +78,7 @@ telemetrici TV.
   varianti visive dei biomi sintetici.
 
 ## Architetto (Tipo 5)
+
 - **Dataset & Hooks**: `themes.yaml` → `investigator_5`, `mechanics_registry.hooks["theme.investigator_5"]` e `triad.core_emotion.paura`.
 - **Scopo**: valorizzare pianificazione pre-battaglia e controllo di trappole.
 - **Trigger**: `setup>0.70` e uso intenso di overwatch/trappole.
@@ -82,6 +88,7 @@ telemetrici TV.
   difensivi.
 
 ## Telemetry Sync (Tipo 6)
+
 - **Dataset & Hooks**: `themes.yaml` → `loyalist_6`, hook `theme.loyalist_6` collegato alle metriche EMA tramite `links.telemetry_metrics`.
 - **Scopo**: garantire la sincronizzazione dell'infrastruttura di telemetria,
   verificando parametri `ema_alpha`, `debounce_ms` e `idle_threshold_s` descritti
@@ -94,6 +101,7 @@ telemetrici TV.
   log `logs/playtests/*/session-metrics.yaml`.
 
 ## Esploratore (Tipo 7)
+
 - **Dataset & Hooks**: `themes.yaml` → `enthusiast_7`, hook `theme.enthusiast_7` e sinergia `triad.core_emotion.paura`.
 - **Scopo**: incentivare rotte opzionali e scoperta di nuovi tile.
 - **Trigger**: `explore>0.70` e azioni `optional_discovery`/`new_biome_entry`
@@ -103,6 +111,7 @@ telemetrici TV.
 - **Note operative**: raccoglie log per bilanciare affissi esplorativi nei biomi.
 
 ## Baluardo (Tipo 8)
+
 - **Dataset & Hooks**: `themes.yaml` → `challenger_8`, `theme.challenger_8` + `harmonic.reattivi` nel blocco `links`.
 - **Scopo**: trasformare il rischio controllato in dominanza difensiva.
 - **Trigger**: valori `risk` elevati con `damage_taken_window` sotto soglia e
@@ -113,6 +122,7 @@ telemetrici TV.
   guardia per evitare instabilità.
 
 ## Stoico (Tipo 9)
+
 - **Dataset & Hooks**: `themes.yaml` → `peacemaker_9`, `theme.peacemaker_9` e sinergie `triad.core_emotion.rabbia`/`harmonic.ottimisti`.
 - **Scopo**: mitigare tilt e mantenere equilibrio mentale della squadra.
 - **Trigger**: `tilt>0.65` come definito in telemetria e gestione delle finestre
@@ -123,6 +133,7 @@ telemetrici TV.
   durante sessioni lunghe.
 
 ## Modulo e dataset Enneagramma
+
 - **Modulo**: `packs/evo_tactics_pack/tools/py/modules/personality/enneagram/personality_module.v1.json` collega gli hook `theme.reformer_1`→`theme.peacemaker_9` ai temi definiti nel file `themes.yaml` e alle soglie telemetriche aggiornate.
 - **Dataset personaggi**: `packs/evo_tactics_pack/tools/py/modules/personality/enneagram/enneagramma_dataset.json` fornisce nove profili operativi (ruoli, motivazioni, azioni firma) allineati alle metriche VC e ai requisiti di mating.
 - **Compatibilità**: `packs/evo_tactics_pack/tools/py/modules/personality/enneagram/compat_map.json` documenta sinergie/antagonismi tra temi e statistiche (`ac`, `pp`, `sg` ecc.) per gli script di generazione e bilanciamento.

--- a/docs/evo-tactics-pack/generator-benchmarks.md
+++ b/docs/evo-tactics-pack/generator-benchmarks.md
@@ -2,30 +2,34 @@
 
 ## Benchmark visivi e funzionali
 
-| Benchmark | Tipo | Evidenza chiave | Implicazioni per il generatore |
-| --- | --- | --- | --- |
-| Compilazione seed su *Aurora Playkit* | Funzionale | Roll completo in 5 click medi, export JSON immediato | Targetare pari o migliore efficienza con preset e profili salvataggio | 
-| Dashboard riepilogo *Gaea Suite* | Visivo | Layout a schede con stati, storico e CTA in vista unica | Convergere su vista flow map + riepilogo per minimizzare il contesto perso |
-| Cronologia snapshot *ArcForge* | Funzionale | Timeline filtrabile, export csv in < 2s | Allineare pipeline export e filtro tag timeline |
+| Benchmark                             | Tipo       | Evidenza chiave                                         | Implicazioni per il generatore                                             |
+| ------------------------------------- | ---------- | ------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Compilazione seed su _Aurora Playkit_ | Funzionale | Roll completo in 5 click medi, export JSON immediato    | Targetare pari o migliore efficienza con preset e profili salvataggio      |
+| Dashboard riepilogo _Gaea Suite_      | Visivo     | Layout a schede con stati, storico e CTA in vista unica | Convergere su vista flow map + riepilogo per minimizzare il contesto perso |
+| Cronologia snapshot _ArcForge_        | Funzionale | Timeline filtrabile, export csv in < 2s                 | Allineare pipeline export e filtro tag timeline                            |
 
 ## Metriche di qualità e criteri di verifica
 
 ### Click per roll completo
+
 - **Definizione**: numero di interazioni necessarie per generare biomi, specie e seed partendo da una scheda vuota.
 - **Target**: ≤ 4 click medi, con deviazione standard ≤ 1.
 - **Verifica**: sessione di 10 roll monitorata con log strumenti (registro attività + osservazione). Flag rosso se > 5 click medi.
 
 ### Tempo medio roll
+
 - **Definizione**: intervallo medio tra avvio generazione e ultimo seed disponibile.
 - **Target**: ≤ 3.5 s con catalogo locale, ≤ 5 s con fetch remoto.
 - **Verifica**: cronometro automatico (metriche `avg-roll`) confrontato con tempi osservati manualmente. Deviazione ammessa ±0.5 s.
 
 ### Leggibilità riepilogo
+
 - **Definizione**: facilità di interpretazione di summary, narrative hook e cronologia.
 - **Target**: punteggio ≥ 4/5 in sondaggio rapido con team design (scala Likert) e 0 errori critici di comprensione.
 - **Verifica**: walkthrough guidato + checklist linguaggio chiaro, accompagnato da test contrasto (WCAG AA).
 
 ### Riutilizzo profili filtro
+
 - **Definizione**: numero di applicazioni dei profili salvati tramite pannello Parametri durante una sessione.
 - **Target**: ≥ 2 riusi medi a sessione, con metrica tracciata nei KPI (`profile-reuse`).
 - **Verifica**: controllo rapido del contatore in dashboard e correlazione con evento `profile-load` nel registro attività.

--- a/docs/evo-tactics-pack/index.html
+++ b/docs/evo-tactics-pack/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="it">
   <head>
     <meta charset="utf-8" />
@@ -22,8 +22,8 @@
         <p class="section__kicker">Evo-Tactics · Ecosystem Pack</p>
         <h1>Strumenti e Catalogo</h1>
         <p>
-          Risorse pronte all'uso per esplorare il pacchetto di ecosistemi sperimentali:
-          generatori procedurali, cataloghi e collegamenti diretti ai dataset YAML.
+          Risorse pronte all'uso per esplorare il pacchetto di ecosistemi sperimentali: generatori
+          procedurali, cataloghi e collegamenti diretti ai dataset YAML.
         </p>
       </div>
       <nav class="chip-list" aria-label="Navigazione secondaria">

--- a/scripts/sync_evo_pack_assets.js
+++ b/scripts/sync_evo_pack_assets.js
@@ -50,26 +50,20 @@ function rewritePathPrefix(value) {
 }
 
 function updatePathFields(value) {
+  if (typeof value === 'string') {
+    return rewritePathPrefix(value);
+  }
   if (Array.isArray(value)) {
-    value.forEach((entry) => updatePathFields(entry));
+    value.forEach((entry, index) => {
+      value[index] = updatePathFields(entry);
+    });
     return value;
   }
   if (!value || typeof value !== 'object') {
     return value;
   }
   Object.keys(value).forEach((key) => {
-    if (key === 'path' && typeof value[key] === 'string') {
-      value[key] = rewritePathPrefix(value[key]);
-      return;
-    }
-    if (key === 'manifest' && value[key] && typeof value[key] === 'object') {
-      if (typeof value[key].path === 'string') {
-        value[key].path = rewritePathPrefix(value[key].path);
-      }
-      updatePathFields(value[key]);
-      return;
-    }
-    updatePathFields(value[key]);
+    value[key] = updatePathFields(value[key]);
   });
   return value;
 }


### PR DESCRIPTION
## Summary
- update the Evo pack sync script to rewrite any string references from ../../data/ to ../../packs/evo_tactics_pack/data/ when mirroring assets
- regenerate Evo Tactics pack mirror assets so the docs and public bundles reference the packaged data paths

## Testing
- node scripts/sync_evo_pack_assets.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fc29567688328ad8fdc614c3d8634)