### PR TITLE
Preserve biome pool metadata for offline generation

### DIFF
--- a/services/generation/biomeSynthesizer.js
+++ b/services/generation/biomeSynthesizer.js
@@ -78,10 +78,16 @@ function injectPoolMetadata(payload) {
     return { pools: [] };
   }
 
-  const hasSchemaVersion = Object.prototype.hasOwnProperty.call(payload, 'schema_version');
-  const hasUpdatedAt = Object.prototype.hasOwnProperty.call(payload, 'updated_at');
-  const schemaVersion = hasSchemaVersion ? payload.schema_version : null;
-  const updatedAt = hasUpdatedAt ? payload.updated_at : null;
+  const manifestMetadata =
+    payload.metadata && typeof payload.metadata === 'object' ? payload.metadata : {};
+  const schemaVersion =
+    manifestMetadata.schema_version ??
+    (Object.prototype.hasOwnProperty.call(payload, 'schema_version')
+      ? payload.schema_version
+      : null);
+  const updatedAt =
+    manifestMetadata.updated_at ??
+    (Object.prototype.hasOwnProperty.call(payload, 'updated_at') ? payload.updated_at : null);
 
   const pools = Array.isArray(payload.pools) ? payload.pools : [];
   const poolsWithMetadata = pools.map((pool) => {
@@ -89,10 +95,10 @@ function injectPoolMetadata(payload) {
       return pool;
     }
     const metadata = { ...(pool.metadata || {}) };
-    if (hasSchemaVersion) {
+    if (schemaVersion && !metadata.schema_version) {
       metadata.schema_version = schemaVersion;
     }
-    if (hasUpdatedAt) {
+    if (updatedAt && !metadata.updated_at) {
       metadata.updated_at = updatedAt;
     }
     return {


### PR DESCRIPTION
## Summary
- pull schema_version and updated_at from manifest metadata or fallback fields when injecting biome pool metadata
- ensure offline-generated biome pools retain canonical metadata defaults

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fc34eccd88328a57b734d17685cd7)