### PR TITLE
Add ali_solari_fotoni to trait glossary

### DIFF
--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -29,6 +29,12 @@
       "description_it": "Piastre vibranti che dissipano energia e attenuano impatti corrosivi.",
       "description_en": "Vibrating plates that dissipate energy and blunt corrosive impacts."
     },
+    "ali_solari_fotoni": {
+      "label_it": "Ali Solari Fotoniche",
+      "label_en": "Photonic Solar Wings",
+      "description_it": "Piume fotovoltaiche che trasformano luce in spinta e schermature di radianza.",
+      "description_en": "Photovoltaic plumage converting light into thrust and radiant shielding."
+    },
     "antenne_dustsense": {
       "label_it": "Antenne Dustsense",
       "label_en": "Dustsense Antennae",


### PR DESCRIPTION
## Summary
- add Italian and English labels and descriptions for the ali_solari_fotoni trait in the core glossary
- validate JSON structure with json.tool formatting

## Testing
- python -m json.tool --indent 2 --no-ensure-ascii data/core/traits/glossary.json > /tmp/trait_glossary.json && mv /tmp/trait_glossary.json data/core/traits/glossary.json


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a72964708328b764cbf52afa83fb)