### PR TITLE
Add pathfinder dataset modular crystal eyes trait

### DIFF
--- a/data/traits/index.csv
+++ b/data/traits/index.csv
@@ -117,6 +117,7 @@ lamine_scudo_silice,i18n:traits.lamine_scudo_silice.label,Sensoriale/Analitico,A
 lingua_tattile_trama,i18n:traits.lingua_tattile_trama.label,Sensoriale/Alimentare,Alimentare,data/traits/sensoriale/lingua_tattile_trama.json,,controllo_psionico,caverna_risonante,scout;sustain,true,false
 midollo_antivibrazione,i18n:traits.midollo_antivibrazione.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/midollo_antivibrazione.json,,coverage_q4_2025,caverna_risonante,scout;support,true,false
 occhi_infrarosso_composti,i18n:traits.occhi_infrarosso_composti.label,Sensoriale/Visivo,Visivo,data/traits/sensoriale/occhi_infrarosso_composti.json,,controllo_psionico,caverna_risonante,scout,true,false
+occhi_cristallo_modulare,Occhi di Cristallo Modulare,Sensoriale/Visivo,Visivo,data/traits/sensoriale/occhi_cristallo_modulare.json,,pathfinder_dataset,,,false,false
 olfatto_risonanza_magnetica,i18n:traits.olfatto_risonanza_magnetica.label,Sensoriale/Nervoso,Nervoso,data/traits/sensoriale/olfatto_risonanza_magnetica.json,,controllo_psionico,falde_magnetiche_psioniche;orbita_psionica_inversa,controller;scout,true,false
 sensori_geomagnetici,i18n:traits.sensori_geomagnetici.label,Sensoriale/Navigazione,Navigazione,data/traits/sensoriale/sensori_geomagnetici.json,,controllo_psionico,pianure_magnetiche,scout,true,false
 antenne_reagenti,i18n:traits.antenne_reagenti.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/antenne_reagenti.json,,coverage_q4_2025,foresta_acida,support,true,false

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -9901,6 +9901,27 @@
       ],
       "uso_funzione": "Vista specializzata che percepisce il calore corporeo."
     },
+    "occhi_cristallo_modulare": {
+      "completion_flags": {
+        "has_biome": false,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": false
+      },
+      "conflitti": [],
+      "data_origin": "pathfinder_dataset",
+      "famiglia_tipologia": "Sensoriale/Visivo",
+      "fattore_mantenimento_energetico": "Moderato (Attivo)",
+      "id": "occhi_cristallo_modulare",
+      "label": "Occhi di Cristallo Modulare",
+      "mutazione_indotta": "L'organo visivo si fraziona in lenti di cristallo sostituibili che modulano spettro e messa a fuoco in tempo reale.",
+      "sinergie": [],
+      "slot": [],
+      "spinta_selettiva": "Garantire riconoscimento rapido di minacce e risorse in scenari multibioma mantenendo resilienza a bagliori o accecamenti mirati.",
+      "tier": "T2",
+      "usage_tags": [],
+      "uso_funzione": "Amplifica la raccolta dati a lunga distanza e consente di passare rapidamente da zoom tattici a panoramiche ambientali senza perdita di dettaglio."
+    },
     "olfatto_risonanza_magnetica": {
       "completion_flags": {
         "has_biome": true,

--- a/data/traits/sensoriale/occhi_cristallo_modulare.json
+++ b/data/traits/sensoriale/occhi_cristallo_modulare.json
@@ -1,0 +1,14 @@
+{
+  "id": "occhi_cristallo_modulare",
+  "label": "Occhi di Cristallo Modulare",
+  "famiglia_tipologia": "Sensoriale/Visivo",
+  "fattore_mantenimento_energetico": "Moderato (Attivo)",
+  "tier": "T2",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "data_origin": "pathfinder_dataset",
+  "mutazione_indotta": "L'organo visivo si fraziona in lenti di cristallo sostituibili che modulano spettro e messa a fuoco in tempo reale.",
+  "uso_funzione": "Amplifica la raccolta dati a lunga distanza e consente di passare rapidamente da zoom tattici a panoramiche ambientali senza perdita di dettaglio.",
+  "spinta_selettiva": "Garantire riconoscimento rapido di minacce e risorse in scenari multibioma mantenendo resilienza a bagliori o accecamenti mirati."
+}


### PR DESCRIPTION
## Summary
- add the Occhi di Cristallo Modulare trait for the Sensoriale/Visivo category based on the template
- register the new trait in the trait indexes with the pathfinder_dataset data origin

## Testing
- python tools/py/trait_template_validator.py --summary

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a900a8fc8328a0aac3a4758e3c90)