### PR TITLE
Add modular crystal eyes trait localization

### DIFF
--- a/data/traits/_drafts/balance_reflex.json
+++ b/data/traits/_drafts/balance_reflex.json
@@ -12,8 +12,8 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.balance_reflex.mutazione_indotta",
-  "uso_funzione": "Tier Pre‑Sociale (T2). Milestone: Senses mid; AB 01 Endurance.",
-  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+  "uso_funzione": "i18n:traits.balance_reflex.uso_funzione",
+  "spinta_selettiva": "i18n:traits.balance_reflex.spinta_selettiva",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/craft_loop.json
+++ b/data/traits/_drafts/craft_loop.json
@@ -12,8 +12,8 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.craft_loop.mutazione_indotta",
-  "uso_funzione": "Tier Avanzato (T5). Milestone: Memorie echoic/iconic multiple; AB 11 pain.",
-  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+  "uso_funzione": "i18n:traits.craft_loop.uso_funzione",
+  "spinta_selettiva": "i18n:traits.craft_loop.spinta_selettiva",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/echoic_trace.json
+++ b/data/traits/_drafts/echoic_trace.json
@@ -12,8 +12,8 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.echoic_trace.mutazione_indotta",
-  "uso_funzione": "Tier Emergente (T3). Milestone: Senses mid+; AB 02–03 movement/carry.",
-  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+  "uso_funzione": "i18n:traits.echoic_trace.uso_funzione",
+  "spinta_selettiva": "i18n:traits.echoic_trace.spinta_selettiva",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/executive_loop.json
+++ b/data/traits/_drafts/executive_loop.json
@@ -12,8 +12,8 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.executive_loop.mutazione_indotta",
-  "uso_funzione": "Tier Sapiente (T6). Milestone: Senses 37/37; Ambulation 26/26.",
-  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+  "uso_funzione": "i18n:traits.executive_loop.uso_funzione",
+  "spinta_selettiva": "i18n:traits.executive_loop.spinta_selettiva",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/group_form.json
+++ b/data/traits/_drafts/group_form.json
@@ -12,8 +12,8 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.group_form.mutazione_indotta",
-  "uso_funzione": "Tier Civico (T4). Milestone: Sound Awareness/Chemotopy full; AB 05–09 climb/carry.",
-  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+  "uso_funzione": "i18n:traits.group_form.uso_funzione",
+  "spinta_selettiva": "i18n:traits.group_form.spinta_selettiva",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/interoception_seed.json
+++ b/data/traits/_drafts/interoception_seed.json
@@ -12,8 +12,8 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.interoception_seed.mutazione_indotta",
-  "uso_funzione": "Tier Proto‑Sentiente (T1). Milestone: Senses (core).",
-  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+  "uso_funzione": "i18n:traits.interoception_seed.uso_funzione",
+  "spinta_selettiva": "i18n:traits.interoception_seed.spinta_selettiva",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/mimicry_basic.json
+++ b/data/traits/_drafts/mimicry_basic.json
@@ -12,8 +12,8 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.mimicry_basic.mutazione_indotta",
-  "uso_funzione": "Tier Pre‑Sociale (T2). Milestone: Senses mid; AB 01 Endurance.",
-  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+  "uso_funzione": "i18n:traits.mimicry_basic.uso_funzione",
+  "spinta_selettiva": "i18n:traits.mimicry_basic.spinta_selettiva",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/postural_endurance.json
+++ b/data/traits/_drafts/postural_endurance.json
@@ -12,8 +12,8 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.postural_endurance.mutazione_indotta",
-  "uso_funzione": "Tier Sapiente (T6). Milestone: Senses 37/37; Ambulation 26/26.",
-  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+  "uso_funzione": "i18n:traits.postural_endurance.uso_funzione",
+  "spinta_selettiva": "i18n:traits.postural_endurance.spinta_selettiva",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/sheltering.json
+++ b/data/traits/_drafts/sheltering.json
@@ -12,8 +12,8 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.sheltering.mutazione_indotta",
-  "uso_funzione": "Tier Avanzato (T5). Milestone: Memorie echoic/iconic multiple; AB 11 pain.",
-  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+  "uso_funzione": "i18n:traits.sheltering.uso_funzione",
+  "spinta_selettiva": "i18n:traits.sheltering.spinta_selettiva",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/startle_reflex.json
+++ b/data/traits/_drafts/startle_reflex.json
@@ -12,8 +12,8 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.startle_reflex.mutazione_indotta",
-  "uso_funzione": "Tier Proto‑Sentiente (T1). Milestone: Senses (core).",
-  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+  "uso_funzione": "i18n:traits.startle_reflex.uso_funzione",
+  "spinta_selettiva": "i18n:traits.startle_reflex.spinta_selettiva",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/teach_action.json
+++ b/data/traits/_drafts/teach_action.json
@@ -12,8 +12,8 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.teach_action.mutazione_indotta",
-  "uso_funzione": "Tier Civico (T4). Milestone: Sound Awareness/Chemotopy full; AB 05–09 climb/carry.",
-  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+  "uso_funzione": "i18n:traits.teach_action.uso_funzione",
+  "spinta_selettiva": "i18n:traits.teach_action.spinta_selettiva",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/_drafts/toolseed.json
+++ b/data/traits/_drafts/toolseed.json
@@ -12,8 +12,8 @@
   "sinergie": [],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.toolseed.mutazione_indotta",
-  "uso_funzione": "Tier Emergente (T3). Milestone: Senses mid+; AB 02–03 movement/carry.",
-  "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
+  "uso_funzione": "i18n:traits.toolseed.uso_funzione",
+  "spinta_selettiva": "i18n:traits.toolseed.spinta_selettiva",
   "completion_flags": {
     "external_source": true
   },

--- a/data/traits/sensoriale/occhi_cristallo_modulare.json
+++ b/data/traits/sensoriale/occhi_cristallo_modulare.json
@@ -1,14 +1,14 @@
 {
   "id": "occhi_cristallo_modulare",
-  "label": "Occhi di Cristallo Modulare",
+  "label": "i18n:traits.occhi_cristallo_modulare.label",
   "famiglia_tipologia": "Sensoriale/Visivo",
-  "fattore_mantenimento_energetico": "Moderato (Attivo)",
+  "fattore_mantenimento_energetico": "i18n:traits.occhi_cristallo_modulare.fattore_mantenimento_energetico",
   "tier": "T2",
   "slot": [],
   "sinergie": [],
   "conflitti": [],
   "data_origin": "pathfinder_dataset",
-  "mutazione_indotta": "L'organo visivo si fraziona in lenti di cristallo sostituibili che modulano spettro e messa a fuoco in tempo reale.",
-  "uso_funzione": "Amplifica la raccolta dati a lunga distanza e consente di passare rapidamente da zoom tattici a panoramiche ambientali senza perdita di dettaglio.",
-  "spinta_selettiva": "Garantire riconoscimento rapido di minacce e risorse in scenari multibioma mantenendo resilienza a bagliori o accecamenti mirati."
+  "mutazione_indotta": "i18n:traits.occhi_cristallo_modulare.mutazione_indotta",
+  "uso_funzione": "i18n:traits.occhi_cristallo_modulare.uso_funzione",
+  "spinta_selettiva": "i18n:traits.occhi_cristallo_modulare.spinta_selettiva"
 }

--- a/locales/it/traits.json
+++ b/locales/it/traits.json
@@ -5,6 +5,7 @@
   "entries": {
     "ali_fulminee": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "description": "Ali Fulminee permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di stratosfera tempestosa.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ali Fulminee",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
@@ -13,33 +14,34 @@
     },
     "ali_ioniche": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "description": "Membrane propulsive che rilasciano micro-scariche per scatti controllati.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ali Ioniche",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali.",
-      "description": "Membrane propulsive che rilasciano micro-scariche per scatti controllati."
+      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
     },
     "ali_membrana_sonica": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "description": "Piastre vibranti che dissipano energia e attenuano impatti corrosivi.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ali a Membrana Sonica",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali.",
-      "description": "Piastre vibranti che dissipano energia e attenuano impatti corrosivi."
+      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
     },
     "antenne_dustsense": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "description": "Ricettori stratificati che stabilizzano l’assorbimento multi-fonte in deserti ionici.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Dustsense",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate.",
-      "description": "Ricettori stratificati che stabilizzano l’assorbimento multi-fonte in deserti ionici."
+      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
     },
     "antenne_eco_turbina": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "description": "Antenne Eco Turbina permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Eco Turbina",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
@@ -48,6 +50,7 @@
     },
     "antenne_flusso_mareale": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "description": "Antenne Flusso Mareale permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di laguna bioreattiva.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Flusso Mareale",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
@@ -56,6 +59,7 @@
     },
     "antenne_microonde_cavernose": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "description": "Antenne Microonde Cavernose permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caverna risonante.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Microonde Cavernose",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
@@ -64,15 +68,16 @@
     },
     "antenne_plasmatiche_tempesta": {
       "debolezza": "Scariche elettriche massicce possono bruciare i recettori e compromettere la coordinazione.",
+      "description": "Convoglia fulmini atmosferici in attacchi mirati o scudi ionici.",
       "fattore_mantenimento_energetico": "Alto (Canalizzazione costante di plasma atmosferico)",
       "label": "Antenne Plasmatiche di Tempesta",
       "mutazione_indotta": "Flagelli coronati da nodi plasma-sensibili che captano e deviano fulmini.",
       "spinta_selettiva": "Comandare fulmini e navigare in cieli turbolenti durante campagne aeree.",
-      "uso_funzione": "Canalizza scariche atmosferiche in attacchi direzionati o scudi ionici.",
-      "description": "Convoglia fulmini atmosferici in attacchi mirati o scudi ionici."
+      "uso_funzione": "Canalizza scariche atmosferiche in attacchi direzionati o scudi ionici."
     },
     "antenne_reagenti": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "description": "Antenne Reagenti permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di foresta acida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Reagenti",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
@@ -81,6 +86,7 @@
     },
     "antenne_tesla": {
       "debolezza": "Risonanze errate possono generare microfratture.",
+      "description": "Antenne Tesla permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di canopia ionica.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Tesla",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
@@ -89,6 +95,7 @@
     },
     "antenne_waveguide": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "description": "Antenne Waveguide permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di reef luminescente.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Waveguide",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
@@ -97,6 +104,7 @@
     },
     "antenne_wideband": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "description": "Antenne Wideband permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di steppe algoritmiche.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Wideband",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
@@ -105,6 +113,7 @@
     },
     "appendici_risonanti_marea": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "description": "Appendici Risonanti Marea permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di laguna bioreattiva.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Appendici Risonanti Marea",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
@@ -113,6 +122,7 @@
     },
     "appendici_thermotattiche": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "description": "Appendici Thermotattiche permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di abisso vulcanico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Appendici Thermotattiche",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -121,6 +131,7 @@
     },
     "armatura_pietra_planare": {
       "debolezza": "Pesante: riduce mobilità in ambienti non supportati o a bassa gravità.",
+      "description": "Corazza risonante scolpita da roccia extradimensionale che smorza onde d'urto.",
       "fattore_mantenimento_energetico": "Basso (Risonanza geodetica stabile)",
       "label": "Armatura di Pietra Planare",
       "mutazione_indotta": "Cristallizza il dermascheletro con nodi rune che deviano energia.",
@@ -136,6 +147,7 @@
     },
     "artigli_acidofagi": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "description": "Artigli Acidofagi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Artigli Acidofagi",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
@@ -144,6 +156,7 @@
     },
     "artigli_induzione": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "description": "Artigli Induzione permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di canopia ionica.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Artigli Induzione",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
@@ -152,6 +165,7 @@
     },
     "artigli_radice": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "description": "Artigli Radice permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di mangrovieto cinetico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Artigli Radice",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
@@ -160,6 +174,7 @@
     },
     "artigli_scivolo_silente": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "description": "Artigli Scivolo Silente permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di caverna risonante.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Artigli Scivolo Silente",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
@@ -168,6 +183,7 @@
     },
     "artigli_sette_vie": {
       "debolezza": "Angoli di presa limitati se la superficie è perfettamente liscia.",
+      "description": "Artigli multipli che assicurano presa stabile su superfici irregolari.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Artigli a Sette Vie",
       "mutazione_indotta": "Dita lunghe e segmentate con punte a uncino multiplo.",
@@ -176,6 +192,7 @@
     },
     "artigli_sghiaccio_glaciale": {
       "debolezza": "In ambienti temperati i tessuti subiscono microfratture e richiedono continue riparazioni.",
+      "description": "Falangi criogeniche che congelano e fissano il bersaglio al contatto.",
       "fattore_mantenimento_energetico": "Medio (Raffreddamento endogeno controllato)",
       "label": "Artigli Sghiaccio Glaciale",
       "mutazione_indotta": "Falangi rivestite da ghiaccio strutturale che si espande creando lame traslucide.",
@@ -184,6 +201,7 @@
     },
     "artigli_vetrificati": {
       "debolezza": "Risonanze errate possono generare microfratture.",
+      "description": "Artigli Vetrificati permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caldera glaciale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Artigli Vetrificati",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
@@ -192,6 +210,7 @@
     },
     "aura_scudo_radianza": {
       "debolezza": "Soffre saturazione se esposta a ombre gravitazionali o zone di antimagia.",
+      "description": "Campo fotoplasmatico che devia danni planari e sincronizza i battiti della squadra.",
       "fattore_mantenimento_energetico": "Alto (Canalizzazione fotonica continua)",
       "label": "Aura Scudo di Radianza",
       "mutazione_indotta": "Innesta organi fotoplasmatici che diffondono uno scudo radiante sugli alleati vicini.",
@@ -200,6 +219,7 @@
     },
     "baffi_mareomotori": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "description": "Baffi Mareomotori permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di mangrovieto cinetico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Baffi Mareomotori",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
@@ -215,6 +235,7 @@
     },
     "barbigli_sensori_plasma": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "description": "Barbigli Sensori Plasma permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di stratosfera tempestosa.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Barbigli Sensori Plasma",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
@@ -223,6 +244,7 @@
     },
     "barriere_miasma_glaciale": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "description": "Barriere Miasma Glaciale permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di caldera glaciale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Barriere Miasma Glaciale",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
@@ -231,6 +253,7 @@
     },
     "batteri_endosimbionti_chemio": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "description": "Batteri Endosimbionti Chemio permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di abisso vulcanico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Batteri Endosimbionti Chemio",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -239,6 +262,7 @@
     },
     "batteri_termofili_endosimbiosi": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "description": "Batteri Termofili Endosimbiosi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Batteri Termofili Endosimbiosi",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
@@ -247,6 +271,7 @@
     },
     "biochip_memoria": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "description": "Biochip Memoria permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di steppe algoritmiche.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Biochip Memoria",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
@@ -255,6 +280,7 @@
     },
     "biofilm_glow": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "description": "Biofilm Glow permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di reef luminescente.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Biofilm Glow",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
@@ -263,6 +289,7 @@
     },
     "biofilm_iperarido": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "description": "Biofilm Iperarido permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di pianura salina iperarida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Biofilm Iperarido",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
@@ -271,6 +298,7 @@
     },
     "branchie_dual_mode": {
       "debolezza": "Risonanze errate possono generare microfratture.",
+      "description": "Branchie Dual Mode permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di laguna bioreattiva.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Branchie Dual Mode",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
@@ -279,6 +307,7 @@
     },
     "branchie_eoliche": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "description": "Branchie Eoliche permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di stratosfera tempestosa.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Branchie Eoliche",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
@@ -287,6 +316,7 @@
     },
     "branchie_metalloidi": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "description": "Branchie Metalloidi permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di abisso vulcanico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Branchie Metalloidi",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
@@ -295,6 +325,7 @@
     },
     "branchie_microfiltri": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "description": "Branchie Microfiltri permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di reef luminescente.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Branchie Microfiltri",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
@@ -303,6 +334,7 @@
     },
     "branchie_osmotiche_salmastra": {
       "debolezza": "Richiede accesso costante ad acqua salmastra; ambienti d'acqua dolce provocano stress ionico.",
+      "description": "Branchie psioniche che filtrano sali e tossine in acque variabili.",
       "fattore_mantenimento_energetico": "Medio (Pompe ioniche attive)",
       "label": "Branchie Osmotiche Salmastre",
       "mutazione_indotta": "Lamelle branchiali multilivello con valvole che separano sali e tossine.",
@@ -311,6 +343,7 @@
     },
     "branchie_solfatiche": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "description": "Branchie Solfatiche permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di caldera glaciale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Branchie Solfatiche",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -319,6 +352,7 @@
     },
     "branchie_turbina": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "description": "Branchie Turbina permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Branchie Turbina",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
@@ -327,6 +361,7 @@
     },
     "bulbi_radici_permafrost": {
       "debolezza": "Disgeli improvvisi trasformano i bulbi in masse gelatinose che rallentano i movimenti.",
+      "description": "Bulbi radice che rilasciano calore e nutrimento alle unità connesse.",
       "fattore_mantenimento_energetico": "Medio (Accumulo e rilascio lento di nutrienti)",
       "label": "Bulbi Radici del Permafrost",
       "mutazione_indotta": "Bulbi radicali multipli che immagazzinano energia nelle stagioni fredde per rilasciarla durante le missioni.",
@@ -335,6 +370,7 @@
     },
     "camere_anticorrosione": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "description": "Camere Anticorrosione permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di foresta acida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Camere Anticorrosione",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
@@ -343,6 +379,7 @@
     },
     "camere_mirage": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "description": "Camere Mirage permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Camere Mirage",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
@@ -351,6 +388,7 @@
     },
     "camere_nutrienti_vent": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "description": "Camere Nutrienti Vent permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di dorsale termale tropicale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Camere Nutrienti Vent",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
@@ -359,6 +397,7 @@
     },
     "capillari_criogenici": {
       "debolezza": "Risonanze errate possono generare microfratture.",
+      "description": "Capillari Criogenici permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caldera glaciale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Capillari Criogenici",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
@@ -367,6 +406,7 @@
     },
     "capillari_fluoridici": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "description": "Capillari Fluoridici permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di foresta acida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Capillari Fluoridici",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
@@ -375,6 +415,7 @@
     },
     "capillari_fotovoltaici": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "description": "Capillari Fotovoltaici permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di canopia ionica.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Capillari Fotovoltaici",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
@@ -383,6 +424,7 @@
     },
     "capsule_paracadute": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "description": "Capsule Paracadute permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di stratosfera tempestosa.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Capsule Paracadute",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
@@ -391,6 +433,7 @@
     },
     "carapace_fase_variabile": {
       "debolezza": "Debolezza strutturale durante la transizione tra le fasi di durezza.",
+      "description": "Corazza che varia densità per bilanciare difesa e mobilità.",
       "fattore_mantenimento_energetico": "Alto (Richiede energia per il cambio di fase)",
       "label": "Carapace a Variazione di Fase",
       "mutazione_indotta": "Strutture minerali a legame reversibile o micro-strutture a rigidità controllata.",
@@ -399,6 +442,7 @@
     },
     "carapace_luminiscente_abissale": {
       "debolezza": "Luce intensa di superficie sovraccarica i biofotoni rendendo la corazza fragile.",
+      "description": "Guscio bioluminescente che confonde i predatori nelle profondità.",
       "fattore_mantenimento_energetico": "Alto (Bioluminescenza controllata)",
       "label": "Carapace Luminiscente Abissale",
       "mutazione_indotta": "Placche chitino-minerali con microrganismi luminescenti che comunicano in pattern.",
@@ -407,6 +451,7 @@
     },
     "carapace_segmenti_logici": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "description": "Carapace Segmenti Logici permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di steppe algoritmiche.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Carapace Segmenti Logici",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -415,6 +460,7 @@
     },
     "carapaci_ferruginosi": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "description": "Carapaci Ferruginosi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di abisso vulcanico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Carapaci Ferruginosi",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
@@ -423,6 +469,7 @@
     },
     "cartilagine_flessotermica_venti": {
       "debolezza": "Temperature stabili riducono la reattività della cartilagine rendendo l'organismo lento.",
+      "description": "Cartilagine termoreattiva che ottimizza virate e planate aeree.",
       "fattore_mantenimento_energetico": "Medio (Richiede frequenti riallineamenti fibrosi)",
       "label": "Cartilagine Flessotermica dei Venti",
       "mutazione_indotta": "Giunzioni cartilaginee che cambiano rigidità in risposta a gradienti termici e eolici.",
@@ -431,6 +478,7 @@
     },
     "cartilagini_biofibre": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "description": "Cartilagini Biofibre permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di reef luminescente.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cartilagini Biofibre",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
@@ -439,6 +487,7 @@
     },
     "cartilagini_desertiche": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "description": "Cartilagini Desertiche permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cartilagini Desertiche",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
@@ -447,6 +496,7 @@
     },
     "cartilagini_flessoacustiche": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "description": "Cartilagini Flessoacustiche permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di caverna risonante.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cartilagini Flessoacustiche",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
@@ -455,6 +505,7 @@
     },
     "cartilagini_pseudometalliche": {
       "debolezza": "Risonanze errate possono generare microfratture.",
+      "description": "Cartilagini Pseudometalliche permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cartilagini Pseudometalliche",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
@@ -463,6 +514,7 @@
     },
     "cavita_risonanti_tundra": {
       "debolezza": "In ambienti temperati l'eco interna produce rumori udibili che rivelano la posizione.",
+      "description": "Camere toraciche che proiettano richiami a lunga distanza nel gelo.",
       "fattore_mantenimento_energetico": "Basso (Camere di risonanza statiche)",
       "label": "Cavità Risonanti della Tundra",
       "mutazione_indotta": "Camere toraciche espanse che amplificano vibrazioni subsoniche nel permafrost.",
@@ -471,6 +523,7 @@
     },
     "cervelletto_equilibrio_statico": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "description": "Cervelletto Equilibrio Statico permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di canopia ionica.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cervelletto Equilibrio Statico",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
@@ -479,6 +532,7 @@
     },
     "chemiorecettori_bromuro": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "description": "Chemiorecettori Bromuro permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di pianura salina iperarida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Chemiorecettori Bromuro",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
@@ -487,6 +541,7 @@
     },
     "chioma_parassita_canopica": {
       "debolezza": "Se la pianta ospite muore la chioma psionica collassa causando shock sistemico.",
+      "description": "Filamenti parassiti che creano corsie energetiche nella canopia.",
       "fattore_mantenimento_energetico": "Medio (Nutrimento condiviso con l'ospite arboreo)",
       "label": "Chioma Parassita Canopica",
       "mutazione_indotta": "Filamenti vegetali che si intrecciano con la canopia ospite fornendo punti d'ancoraggio e energia.",
@@ -495,6 +550,7 @@
     },
     "circolazione_bifasica": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "description": "Circolazione Bifasica permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di caldera glaciale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Circolazione Bifasica",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
@@ -503,15 +559,16 @@
     },
     "circolazione_bifasica_palude": {
       "debolezza": "Zone asciutte e calde causano stagnazione del circuito linfatico portando a tossicosi.",
+      "description": "Doppio circuito sanguigno che separa ossigeno e agenti tossici in ambienti stagnanti.",
       "fattore_mantenimento_energetico": "Medio (Doppio circuito emolinfa/linfa)",
       "label": "Circolazione Bifasica di Palude",
       "mutazione_indotta": "Cuori gemelli che pompano separatamente emolinfa ossigenata e linfa detossificante.",
       "spinta_selettiva": "Resistere a tossine e anossia tipiche delle paludi psioniche.",
-      "uso_funzione": "Gestisce due circuiti circolatori per filtrare veleni e mantenere prestazioni elevate.",
-      "description": "Doppio circuito sanguigno che separa ossigeno e agenti tossici in ambienti stagnanti."
+      "uso_funzione": "Gestisce due circuiti circolatori per filtrare veleni e mantenere prestazioni elevate."
     },
     "circolazione_cooling_loop": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "description": "Circolazione Cooling Loop permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di steppe algoritmiche.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Circolazione Cooling Loop",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -520,6 +577,7 @@
     },
     "circolazione_doppia": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "description": "Circolazione Doppia permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Circolazione Doppia",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
@@ -528,6 +586,7 @@
     },
     "circolazione_supercritica": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "description": "Circolazione Supercritica permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di abisso vulcanico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Circolazione Supercritica",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
@@ -536,6 +595,7 @@
     },
     "ciste_riduttive": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "description": "Ciste Riduttive permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di laguna bioreattiva.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ciste Riduttive",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
@@ -544,6 +604,7 @@
     },
     "ciste_salmastre": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "description": "Ciste Salmastre permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di pianura salina iperarida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ciste Salmastre",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
@@ -552,6 +613,7 @@
     },
     "cisti_iperbariche": {
       "debolezza": "Risonanze errate possono generare microfratture.",
+      "description": "Cisti Iperbariche permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cisti Iperbariche",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
@@ -567,6 +629,7 @@
     },
     "coda_balanciere": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "description": "Coda Balanciere permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Coda Balanciere",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
@@ -575,6 +638,7 @@
     },
     "coda_contrappeso": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "description": "Coda Contrappeso permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di mangrovieto cinetico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Coda Contrappeso",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
@@ -583,6 +647,7 @@
     },
     "coda_coppia_retroattiva": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "description": "Coda Coppia Retroattiva permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di steppe algoritmiche.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Coda Coppia Retroattiva",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
@@ -591,6 +656,7 @@
     },
     "coda_frusta_cinetica": {
       "debolezza": "Richiede un periodo di inattività o movimento preparatorio per massimizzare il danno.",
+      "description": "Coda elastica che accumula slancio per un colpo cinetico devastante.",
       "fattore_mantenimento_energetico": "Medio (Mantenimento dell'energia accumulata)",
       "label": "Coda a Frusta Cinetica",
       "mutazione_indotta": "Muscolatura della coda densa con tendini e fibre che agiscono come molle.",
@@ -599,6 +665,7 @@
     },
     "coda_stabilizzatrice_filo": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "description": "Coda Stabilizzatrice Filo permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di canopia ionica.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Coda Stabilizzatrice Filo",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -607,6 +674,7 @@
     },
     "coda_stabilizzatrice_geiser": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "description": "Coda Stabilizzatrice Geiser permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Coda Stabilizzatrice Geiser",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
@@ -615,6 +683,7 @@
     },
     "coda_stabilizzatrice_vortex": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "description": "Coda Stabilizzatrice Vortex permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di stratosfera tempestosa.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Coda Stabilizzatrice Vortex",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
@@ -623,6 +692,7 @@
     },
     "colonne_vibromagnetiche": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "description": "Colonne Vibromagnetiche permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caverna risonante.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Colonne Vibromagnetiche",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
@@ -631,6 +701,7 @@
     },
     "coralli_partner": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "description": "Coralli Partner permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di reef luminescente.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Coralli Partner",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
@@ -653,6 +724,7 @@
     },
     "criostasi_adattiva": {
       "debolezza": "Vulnerabilità estrema agli attacchi chimici (veleni) in fase Criostasi.",
+      "description": "Metabolismo sospeso che sopravvive a stagioni estreme prolungate.",
       "fattore_mantenimento_energetico": "Alto (Fase di risveglio/inizio) / Basso (Fase Criostasi).",
       "label": "Criostasi",
       "mutazione_indotta": "Sviluppo di enzimi crioprotettivi e tessuto adiposo isolante.",
@@ -661,6 +733,7 @@
     },
     "cromofori_alert_acido": {
       "debolezza": "Risonanze errate possono generare microfratture.",
+      "description": "Cromofori Alert Acido permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di foresta acida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cromofori Alert Acido",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
@@ -669,6 +742,7 @@
     },
     "cuore_multicamera_bassa_pressione": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "description": "Cuore Multicamera Bassa Pressione permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di stratosfera tempestosa.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cuore Multicamera Bassa Pressione",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
@@ -677,6 +751,7 @@
     },
     "cuscinetti_elettrostatici": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "description": "Cuscinetti Elettrostatici permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di pianura salina iperarida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cuscinetti Elettrostatici",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
@@ -685,6 +760,7 @@
     },
     "cute_resistente_sali": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "description": "Cute Resistente Sali permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di badlands.",
       "fattore_mantenimento_energetico": "Medio (Attivazione situazionale)",
       "label": "Cute Resistente Sali",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
@@ -693,6 +769,7 @@
     },
     "cuticole_cerose": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "description": "Cuticole Cerose permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cuticole Cerose",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -701,6 +778,7 @@
     },
     "cuticole_neutralizzanti": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "description": "Cuticole Neutralizzanti permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cuticole Neutralizzanti",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
@@ -709,6 +787,7 @@
     },
     "denti_chelatanti": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "description": "Denti Chelatanti permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di foresta acida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Denti Chelatanti",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
@@ -717,6 +796,7 @@
     },
     "denti_ossidoferro": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "description": "Denti Ossidoferro permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di abisso vulcanico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Denti Ossidoferro",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
@@ -725,6 +805,7 @@
     },
     "denti_silice_termici": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "description": "Denti Silice Termici permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di dorsale termale tropicale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Denti Silice Termici",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
@@ -733,6 +814,7 @@
     },
     "denti_tuning_fork": {
       "debolezza": "Risonanze errate possono generare microfratture.",
+      "description": "Denti Tuning Fork permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caverna risonante.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Denti Tuning Fork",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
@@ -741,6 +823,7 @@
     },
     "echi_risonanti": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "description": "Echi Risonanti permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Echi Risonanti",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
@@ -756,6 +839,7 @@
     },
     "eco_interno_riflesso": {
       "debolezza": "Estremamente disorientato da suoni o vibrazioni esterne forti e continue.",
+      "description": "Sonar interno che mappa l'ambiente attraverso vibrazioni corporee.",
       "fattore_mantenimento_energetico": "Medio (Emissioni e ricezione continua)",
       "label": "Riflesso dell'Eco Interno",
       "mutazione_indotta": "Organi interni che emettono ultrasuoni e li captano tramite lo scheletro.",
@@ -764,6 +848,7 @@
     },
     "empatia_coordinativa": {
       "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate warden scende.",
+      "description": "Rete empatica che sincronizza cure e difese dell'intera squadra.",
       "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
       "label": "Empatia Coordinativa",
       "mutazione_indotta": "Circuiti sensorio-emotivi collegati al feed HUD PI.",
@@ -772,6 +857,7 @@
     },
     "enzimi_antifase_termica": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "description": "Enzimi Antifase Termica permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di caldera glaciale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Enzimi Antifase Termica",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
@@ -780,6 +866,7 @@
     },
     "enzimi_antipredatori_algali": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "description": "Enzimi Antipredatori Algali permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di reef luminescente.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Enzimi Antipredatori Algali",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
@@ -788,6 +875,7 @@
     },
     "enzimi_chelanti": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "description": "Enzimi Chelanti permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Enzimi Chelanti",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -796,6 +884,7 @@
     },
     "enzimi_chelatori_rapidi": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "description": "Enzimi Chelatori Rapidi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Enzimi Chelatori Rapidi",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
@@ -804,6 +893,7 @@
     },
     "enzimi_metanoossidanti": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "description": "Enzimi Metanoossidanti permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di abisso vulcanico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Enzimi Metanoossidanti",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
@@ -812,6 +902,7 @@
     },
     "epidermide_dielettrica": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "description": "Epidermide Dielettrica permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di stratosfera tempestosa.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Epidermide Dielettrica",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
@@ -820,6 +911,7 @@
     },
     "epitelio_fosforescente": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "description": "Epitelio Fosforescente permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di reef luminescente.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Epitelio Fosforescente",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
@@ -835,15 +927,16 @@
     },
     "filamenti_digestivi_compattanti": {
       "debolezza": "Blocco intestinale se la dieta è priva di materiale 'legante'.",
+      "description": "Filamenti digestivi che compattano scarti e liberano spazio vitale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Filamenti Digestivi Compattanti",
       "mutazione_indotta": "Muscolatura rettale ipertrofica e organo appendice dedicato.",
       "spinta_selettiva": "Necessità di mantenere la pulizia del territorio/nido.",
-      "uso_funzione": "Espulsione compatta e ordinata di scorie.",
-      "description": "Filamenti digestivi che compattano scarti e liberano spazio vitale."
+      "uso_funzione": "Espulsione compatta e ordinata di scorie."
     },
     "filamenti_magnetotrofi": {
       "debolezza": "Risonanze errate possono generare microfratture.",
+      "description": "Filamenti Magnetotrofi permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Filamenti Magnetotrofi",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
@@ -852,6 +945,7 @@
     },
     "filamenti_superconduttivi": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "description": "Filamenti Superconduttivi permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caldera glaciale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Filamenti Superconduttivi",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
@@ -860,6 +954,7 @@
     },
     "filamenti_termoconduzione": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "description": "Filamenti Termoconduzione permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di dorsale termale tropicale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Filamenti Termoconduzione",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
@@ -868,6 +963,7 @@
     },
     "filtri_planctonici": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "description": "Filtri Planctonici permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di laguna bioreattiva.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Filtri Planctonici",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
@@ -876,6 +972,7 @@
     },
     "flagelli_ancoranti": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "description": "Flagelli Ancoranti permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di laguna bioreattiva.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Flagelli Ancoranti",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -884,6 +981,7 @@
     },
     "focus_frazionato": {
       "debolezza": "Rischio di overload mentale se tilt e aggro salgono oltre le soglie HUD.",
+      "description": "Cortex biforcato che mantiene due minacce in sorveglianza attiva.",
       "fattore_mantenimento_energetico": "Medio (Dividere l'attenzione su più canali)",
       "label": "Focus Frazionato",
       "mutazione_indotta": "Processore di priorità multi-thread per bersagli e obiettivi.",
@@ -899,6 +997,7 @@
     },
     "foliage_fotocatodico": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "description": "Foliage Fotocatodico permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Foliage Fotocatodico",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
@@ -907,6 +1006,7 @@
     },
     "foliaggio_spugna": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "description": "Foliaggio Spugna permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di mangrovieto cinetico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Foliaggio Spugna",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
@@ -915,6 +1015,7 @@
     },
     "frusta_fiammeggiante": {
       "debolezza": "Consumante: richiede costante dissipazione termica per non bruciare la matrice portante.",
+      "description": "Appendice di plasma vincolato capace di arpionare e incendiare bersagli.",
       "fattore_mantenimento_energetico": "Medio (Filamenti di plasma vincolato)",
       "label": "Frusta Fiammeggiante",
       "mutazione_indotta": "Genera appendici tentacolari avvolte da plasma infernale controllato.",
@@ -923,6 +1024,7 @@
     },
     "ghiaccio_piezoelettrico": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "description": "Ghiaccio Piezoelettrico permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caldera glaciale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiaccio Piezoelettrico",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
@@ -931,6 +1033,7 @@
     },
     "ghiandola_caustica": {
       "debolezza": "Gestione accurata delle riserve per non calare sotto i budget PE previsto.",
+      "description": "Ghiandola offensiva che spruzza acidi rapidi contro corazze leggere.",
       "fattore_mantenimento_energetico": "Medio (Produzione reagenti)",
       "label": "Ghiandola Caustica",
       "mutazione_indotta": "Sintesi rapida di composti caustici nei moduli d'attacco.",
@@ -939,6 +1042,7 @@
     },
     "ghiandole_cambio_salino": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "description": "Ghiandole Cambio Salino permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di laguna bioreattiva.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Cambio Salino",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
@@ -947,6 +1051,7 @@
     },
     "ghiandole_condensa_ozono": {
       "debolezza": "Risonanze errate possono generare microfratture.",
+      "description": "Ghiandole Condensa Ozono permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di stratosfera tempestosa.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Condensa Ozono",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
@@ -955,6 +1060,7 @@
     },
     "ghiandole_eco_mappanti": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "description": "Ghiandole Eco Mappanti permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Eco Mappanti",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
@@ -963,6 +1069,7 @@
     },
     "ghiandole_fango_calde": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "description": "Ghiandole Fango Calde permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di abisso vulcanico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Fango Calde",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
@@ -971,6 +1078,7 @@
     },
     "ghiandole_fango_coesivo": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "description": "Ghiandole Fango Coesivo permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di mangrovieto cinetico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Fango Coesivo",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
@@ -979,6 +1087,7 @@
     },
     "ghiandole_grafene": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "description": "Ghiandole Grafene permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di steppe algoritmiche.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Grafene",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -987,6 +1096,7 @@
     },
     "ghiandole_inchiostro_luce": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "description": "Ghiandole Inchiostro Luce permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di reef luminescente.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Inchiostro Luce",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
@@ -995,6 +1105,7 @@
     },
     "ghiandole_iodoattive": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "description": "Ghiandole Iodoattive permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di pianura salina iperarida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Iodoattive",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
@@ -1003,6 +1114,7 @@
     },
     "ghiandole_minerali": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "description": "Ghiandole Minerali permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di dorsale termale tropicale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Minerali",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
@@ -1011,6 +1123,7 @@
     },
     "ghiandole_nebbia_acida": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "description": "Ghiandole Nebbia Acida permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di foresta acida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Nebbia Acida",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
@@ -1019,6 +1132,7 @@
     },
     "ghiandole_nebbia_ionica": {
       "debolezza": "Risonanze errate possono generare microfratture.",
+      "description": "Ghiandole Nebbia Ionica permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di canopia ionica.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Nebbia Ionica",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
@@ -1027,6 +1141,7 @@
     },
     "ghiandole_resina_conduttiva": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "description": "Ghiandole Resina Conduttiva permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di canopia ionica.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Resina Conduttiva",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
@@ -1035,6 +1150,7 @@
     },
     "ghiandole_ventosa": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "description": "Ghiandole Ventosa permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di caldera glaciale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Ventosa",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
@@ -1043,6 +1159,7 @@
     },
     "giunti_antitorsione": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "description": "Giunti Antitorsione permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di mangrovieto cinetico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Giunti Antitorsione",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
@@ -1051,6 +1168,7 @@
     },
     "grassi_termici": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "description": "Grassi Termici permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Grassi Termici",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -1066,6 +1184,7 @@
     },
     "gusci_criovetro": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "description": "Gusci Criovetro permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di caldera glaciale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Gusci Criovetro",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
@@ -1074,6 +1193,7 @@
     },
     "gusci_magnesio": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "description": "Gusci Magnesio permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di dorsale termale tropicale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Gusci Magnesio",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
@@ -1089,6 +1209,7 @@
     },
     "lamelle_shear": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "description": "Lamelle Shear permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di stratosfera tempestosa.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Lamelle Shear",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
@@ -1097,6 +1218,7 @@
     },
     "lamelle_sincroniche": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "description": "Lamelle Sincroniche permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di steppe algoritmiche.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Lamelle Sincroniche",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
@@ -1105,6 +1227,7 @@
     },
     "lamelle_termoforetiche": {
       "debolezza": "Rende instabile la fisiologia in ambienti a gelo improvviso, con rischio di microfratture vascolari.",
+      "description": "Lamelle respiratorie che deviano gas estremi con gradienti termici.",
       "fattore_mantenimento_energetico": "Medio (Flusso continuo di fluidi caldi)",
       "label": "Lamelle Termoforetiche",
       "mutazione_indotta": "Canali lamellari mineralizzati che convogliano fluidi caldi tra branchie interne.",
@@ -1113,6 +1236,7 @@
     },
     "lamine_filtranti_aeree": {
       "debolezza": "Risonanze errate possono generare microfratture.",
+      "description": "Lamine Filtranti Aeree permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di mangrovieto cinetico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Lamine Filtranti Aeree",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
@@ -1121,6 +1245,7 @@
     },
     "lamine_scudo_silice": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "description": "Lamine Scudo Silice permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di dorsale termale tropicale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Lamine Scudo Silice",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
@@ -1129,6 +1254,7 @@
     },
     "linfa_tampone": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "description": "Linfa Tampone permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di foresta acida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Linfa Tampone",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
@@ -1137,6 +1263,7 @@
     },
     "lingua_cristallina": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "description": "Lingua Cristallina permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di pianura salina iperarida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Lingua Cristallina",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
@@ -1145,6 +1272,7 @@
     },
     "lingua_tattile_trama": {
       "debolezza": "Estrema vulnerabilità della lingua a contaminanti chimici o acidi.",
+      "description": "Lingua sensoriale che legge vibrazioni e fratture nascoste.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Lingua Tattile Trama-Sensibile",
       "mutazione_indotta": "Lingua sottile con papille tattili e meccanocettori avanzati.",
@@ -1153,6 +1281,7 @@
     },
     "luminescenza_aurorale": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
+      "description": "Luminescenza Aurorale permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di caldera glaciale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Luminescenza Aurorale",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
@@ -1161,6 +1290,7 @@
     },
     "luminescenza_hydrotermica": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
+      "description": "Luminescenza Hydrotermica permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di abisso vulcanico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Luminescenza Hydrotermica",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
@@ -1169,6 +1299,7 @@
     },
     "mantelli_geotermici": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
+      "description": "Mantelli Geotermici permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di caldera glaciale.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Mantelli Geotermici",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
@@ -1177,6 +1308,7 @@
     },
     "mantello_meteoritico": {
       "debolezza": "Vulnerabile a scariche di freddo gravitazionale che irrigidiscono il mantello.",
+      "description": "Strati ablativi rigeneranti che vaporizzano l'impatto convertendolo in impulso termico.",
       "fattore_mantenimento_energetico": "Alto (Rivestimento ablativo rigenerante)",
       "label": "Mantello Meteoritico",
       "mutazione_indotta": "Deposita strati sovrapposti di materiale meteorico che vaporizzano l'impatto e rilasciano radianza.",
@@ -1185,6 +1317,7 @@
     },
     "membrane_captura_rugiada": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
+      "description": "Membrane Captura Rugiada permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Membrane Captura Rugiada",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
@@ -1193,6 +1326,7 @@
     },
     "membrane_eliofiltranti": {
       "debolezza": "Atmosfere acide degradano rapidamente il film eliofiltrante.",
+      "description": "Membrane traslucide che schermano radiazioni e patogeni sospesi.",
       "fattore_mantenimento_energetico": "Basso (Auto-riparazione lenta)",
       "label": "Membrane Eliofiltranti",
       "mutazione_indotta": "Strati di mucopolisaccaridi trasparenti che filtrano radiazioni e microrganismi sospesi.",
@@ -1201,6 +1335,7 @@
     },
     "membrane_planata_vectored": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
+      "description": "Membrane Planata Vectored permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di canopia ionica.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Membrane Planata Vectored",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
@@ -1209,6 +1344,7 @@
     },
     "membrane_pneumatofori": {
       "debolezza": "Risonanze errate possono generare microfratture.",
+      "description": "Membrane Pneumatofori permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di mangrovieto cinetico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Membrane Pneumatofori",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
@@ -1217,6 +1353,7 @@
     },
     "midollo_antivibrazione": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
+      "description": "Midollo Antivibrazione permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Midollo Antivibrazione",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
@@ -1225,6 +1362,7 @@
     },
     "mimetismo_cromatico_passivo": {
       "debolezza": "La colorazione è fissa finché non c'è un nuovo contatto prolungato.",
+      "description": "Cromatofori passivi che replicano lentamente i colori circostanti.",
       "fattore_mantenimento_energetico": "Basso (Fase passiva)",
       "label": "Ghiandole di Mimetismo Cromatico Passivo",
       "mutazione_indotta": "Cromatofori che richiedono un input tattile prolungato per la ricarica.",
@@ -1240,6 +1378,7 @@
     },
     "mucillagine_simbionte_mangrovie": {
       "debolezza": "Acque eccessivamente pure diluiscono la mucillagine riducendo la protezione.",
+      "description": "Mucosa simbionte che assorbe veleni e sigilla ferite palustri.",
       "fattore_mantenimento_energetico": "Medio (Coltura simbiotica costante)",
       "label": "Mucillagine Simbionte delle Mangrovie",
       "mutazione_indotta": "Strati mucosi che ospitano microfauna detossificante proveniente dalle radici di mangrovia.",
@@ -1248,6 +1387,7 @@
     },
     "mucose_aderenza_sonica": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "description": "Mucose Aderenza Sonica permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di caverna risonante.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Mucose Aderenza Sonica",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
@@ -1256,6 +1396,7 @@
     },
     "mucose_barofile": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "description": "Mucose Barofile permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di abisso vulcanico.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Mucose Barofile",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
@@ -1264,6 +1405,7 @@
     },
     "nodi_micorrizici_oracolari": {
       "debolezza": "Se la rete micorrizica viene recisa, l'organismo soffre crisi percettive e perdita di orientamento.",
+      "description": "Nodi micorrizici che anticipano minacce tramite segnali fungini.",
       "fattore_mantenimento_energetico": "Medio (Scambio continuo di segnali con simbionti)",
       "label": "Nodi Micorrizici Oracolari",
       "mutazione_indotta": "Radici dermiche che intrecciano funghi psionici capaci di predire variazioni ambientali.",
@@ -1272,14 +1414,23 @@
     },
     "nucleo_ovomotore_rotante": {
       "debolezza": "Impossibilità di muoversi su superfici irregolari o in salita ripida.",
+      "description": "Nucleo rotante che trasforma il corpo in una ruota motrice.",
       "fattore_mantenimento_energetico": "Alto (Rotolamento)",
       "label": "Uovo rotaia, uovo grande e uova piccole dentro...",
       "mutazione_indotta": "Massa globulare rigida con giunto sferico al centro del petto.",
       "spinta_selettiva": "Necessità di spostarsi rapidamente su terreni uniformi in assenza di arti.",
       "uso_funzione": "Organo Motorio Rotante: usato come 'ruota' centrale per il rotolamento."
     },
+    "occhi_cristallo_modulare": {
+      "fattore_mantenimento_energetico": "Moderato (Attivo)",
+      "label": "Occhi di Cristallo Modulare",
+      "mutazione_indotta": "L'organo visivo si fraziona in lenti di cristallo sostituibili che modulano spettro e messa a fuoco in tempo reale.",
+      "spinta_selettiva": "Garantire riconoscimento rapido di minacce e risorse in scenari multibioma mantenendo resilienza a bagliori o accecamenti mirati.",
+      "uso_funzione": "Amplifica la raccolta dati a lunga distanza e consente di passare rapidamente da zoom tattici a panoramiche ambientali senza perdita di dettaglio."
+    },
     "occhi_infrarosso_composti": {
       "debolezza": "Accecamento temporaneo da fonti di calore intenso e concentrato.",
+      "description": "Ommatidi infrarossi che seguono scie termiche nell'oscurità.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Occhi Composti ad Infrarosso",
       "mutazione_indotta": "Sviluppo di un secondo strato retinico sensibile all'infrarosso.",
@@ -1288,6 +1439,7 @@
     },
     "olfatto_risonanza_magnetica": {
       "debolezza": "Sensibilità a forti interferenze elettromagnetiche (es. fulmini o minerali magnetici).",
+      "description": "Bulbi olfattivi che tracciano campi magnetici e vene metalliche.",
       "fattore_mantenimento_energetico": "Medio (Elaborazione sensoriale costante)",
       "label": "Olfatto di Risonanza Magnetica",
       "mutazione_indotta": "Organi sensoriali elettrorecettori concentrati su muso o antenne.",
@@ -1296,6 +1448,7 @@
     },
     "pathfinder": {
       "debolezza": "Valore ridotto in scenari a corridoio o con tilt già stabilizzato.",
+      "description": "Suite esplorativa che evidenzia rotte sicure tra biomi imprevedibili.",
       "fattore_mantenimento_energetico": "Basso (Sincronizzazione con HUD di esplorazione)",
       "label": "Pathfinder",
       "mutazione_indotta": "Suite sensoriale orientata a scouting e lettura minacce.",
@@ -1304,6 +1457,7 @@
     },
     "pianificatore": {
       "debolezza": "Rigidità tattica se gli input di telemetria arrivano in ritardo.",
+      "description": "Modulo strategico che mantiene priorità e finestre d'attacco allineate.",
       "fattore_mantenimento_energetico": "Medio (Analisi continua di stato squadre)",
       "label": "Pianificatore",
       "mutazione_indotta": "Protocollo decisionale adattivo con buffer informativi dedicati.",
@@ -1312,6 +1466,7 @@
     },
     "piume_solari_fotovoltaiche": {
       "debolezza": "Ombre prolungate o polveri dense riducono drasticamente la produzione energetica.",
+      "description": "Piumaggio fotovoltaico che immagazzina luce per lunghe missioni.",
       "fattore_mantenimento_energetico": "Alto (Richiede manutenzione delle lamine fotoreattive)",
       "label": "Piume Solari Fotovoltaiche",
       "mutazione_indotta": "Piumaggio stratificato con pigmenti piezo-fotovoltaici che immagazzinano luce.",
@@ -1320,6 +1475,7 @@
     },
     "polmoni_cristallini_alta_quota": {
       "debolezza": "Particolato pesante o sabbia vulcanica graffia i cristalli riducendo l'efficienza respiratoria.",
+      "description": "Polmoni cristallini che concentrano ossigeno rarefatto in quota.",
       "fattore_mantenimento_energetico": "Medio (Pulizia periodica dei cristalli)",
       "label": "Polmoni Cristallini d'Alta Quota",
       "mutazione_indotta": "Sistemi alveolari irrobustiti da strutture cristalline che catturano ossigeno rarefatto.",
@@ -1335,6 +1491,7 @@
     },
     "random": {
       "debolezza": "Bassa affidabilità: richiede slot aggiuntivi per mitigare risultati sfavorevoli.",
+      "description": "Slot sperimentale che estrae tratti casuali dal pool controllato.",
       "fattore_mantenimento_energetico": "Variabile (Dipende dal tratto estratto)",
       "label": "Trait Random",
       "mutazione_indotta": "Selezione casuale da pool controllata per esperimenti di build.",
@@ -1343,6 +1500,7 @@
     },
     "respiro_a_scoppio": {
       "debolezza": "Vulnerabilità respiratoria subito dopo l'utilizzo (tempo di ricarica).",
+      "description": "Valvole toraciche che rilasciano getti propulsivi istantanei.",
       "fattore_mantenimento_energetico": "Alto (Richiede ricarica polmonare)",
       "label": "Respiro a scoppio",
       "mutazione_indotta": "Polmoni o sacche aeree ad alta pressione con valvole di rilascio rapide.",
@@ -1351,6 +1509,7 @@
     },
     "risonanza_di_branco": {
       "debolezza": "Stress elevato se la coesione cala sotto i target di telemetria.",
+      "description": "Rete risonante che amplifica buff condivisi del branco.",
       "fattore_mantenimento_energetico": "Basso (Richiede mantenimento empatico)",
       "label": "Risonanza di Branco",
       "mutazione_indotta": "Reticolo empatico che collega i canali PI cooperativi.",
@@ -1366,6 +1525,7 @@
     },
     "sacche_galleggianti_ascensoriali": {
       "debolezza": "Rischio di barotrauma se la pressione esterna cambia troppo rapidamente.",
+      "description": "Sacche gassose regolabili per controllare assetto e profondità.",
       "fattore_mantenimento_energetico": "Medio (Per il controllo della pressione)",
       "label": "Sacche galleggianti ascensoriali",
       "mutazione_indotta": "Sacche ripiene di gas leggeri con pompe muscolari.",
@@ -1381,6 +1541,7 @@
     },
     "sacche_spore_stratosferiche": {
       "debolezza": "Correnti ionizzate possono incendiare le sacche rendendo l'organismo instabile.",
+      "description": "Vescicole stratosferiche che disperdono spore di supporto a lungo.",
       "fattore_mantenimento_energetico": "Alto (Coltura continua di spore portanti)",
       "label": "Sacche di Spore Stratosferiche",
       "mutazione_indotta": "Vescicole dermiche che rilasciano spore portatrici capaci di galleggiare per chilometri.",
@@ -1389,6 +1550,7 @@
     },
     "sangue_piroforico": {
       "debolezza": "Rischio di auto-combustione in caso di ferita profonda in atmosfera ricca di ossigeno.",
+      "description": "Fluido ematico che incendia l'aria colpendo chi perfora la corazza.",
       "fattore_mantenimento_energetico": "Medio (Sintesi dei composti)",
       "label": "Sangue che prende fuoco a contatto con l'ossigeno",
       "mutazione_indotta": "Presenza di composti piroforici nel sangue.",
@@ -1397,6 +1559,7 @@
     },
     "scheletro_idro_regolante": {
       "debolezza": "Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio.",
+      "description": "Ossa porose che modulano il contenuto idrico per mutare massa.",
       "fattore_mantenimento_energetico": "Medio (Scambio rapido di fluidi)",
       "label": "Scheletro Idro-Regolante",
       "mutazione_indotta": "Struttura ossea porosa capace di scambio rapido di fluidi.",
@@ -1412,6 +1575,7 @@
     },
     "secrezione_rallentante_palmi": {
       "debolezza": "Esaurimento rapido delle riserve di liquido con tempo di ricarica prolungato.",
+      "description": "Palmi che rilasciano gel rallentante per bloccare bersagli rapidi.",
       "fattore_mantenimento_energetico": "Medio (Produzione del liquido)",
       "label": "Mani secernano liquido rallentante",
       "mutazione_indotta": "Ghiandole mucose modificate sulle superfici prensili.",
@@ -1420,8 +1584,9 @@
     },
     "sensori_geomagnetici": {
       "debolezza": "Tempeste solari possono saturare il segnale magnetico, causando disorientamento prolungato.",
+      "description": "Cristalli cranici che mappano corridoi geomagnetici invisibili.",
       "fattore_mantenimento_energetico": "Basso (Ricettori passivi)",
-      "label": "Sensori Geomagnetici",
+      "label": "Sensori a Risonanza Geomagnetica",
       "mutazione_indotta": "Cristalli ferromagnetici allineati lungo il cranio che fungono da bussola psionica.",
       "spinta_selettiva": "Orientarsi in steppe polarizzate e tunnel sotterranei privi di riferimenti visivi.",
       "uso_funzione": "Traccia linee di campo e memorizza corridoi magnetici per la migrazione."
@@ -1435,6 +1600,7 @@
     },
     "sinapsi_coraline_polifoniche": {
       "debolezza": "Vibrazioni sintonizzate male possono generare feedback dolorosi e perdita di coscienza.",
+      "description": "Sinapsi coralline che trasmettono ordini tramite armoniche marine.",
       "fattore_mantenimento_energetico": "Medio (Scambio continuo di impulsi corallini)",
       "label": "Sinapsi Coraline Polifoniche",
       "mutazione_indotta": "Fibre nervose intrecciate con coralli sonori che trasmettono ordini tramite armoniche.",
@@ -1443,6 +1609,7 @@
     },
     "sonno_emisferico_alternato": {
       "debolezza": "Vulnerabilità a suoni/stimoli che colpiscono entrambi i lobi contemporaneamente.",
+      "description": "Cervello alternato che veglia con un emisfero mentre l'altro riposa.",
       "fattore_mantenimento_energetico": "Medio (Mantenimento attivo di metà cervello)",
       "label": "Dormire con solo metà cervello alla volta",
       "mutazione_indotta": "Encefalizzazione asimmetrica o due lobi cerebrali separati.",
@@ -1451,6 +1618,7 @@
     },
     "spore_psichiche_silenziate": {
       "debolezza": "Funzionalità ridotta in presenza di vento forte o umidità elevata.",
+      "description": "Spore psioniche che sedano e confondono i bersagli vicini.",
       "fattore_mantenimento_energetico": "Alto (Produzione e rilascio)",
       "label": "Spora Psichica Silenziosa",
       "mutazione_indotta": "Pori che rilasciano nano-particelle attive chimicamente o psichicamente.",
@@ -1459,6 +1627,7 @@
     },
     "squame_rifrangenti_deserto": {
       "debolezza": "Soffre danni da feedback termico se colpito da raggi concentrati o laser.",
+      "description": "Scaglie cristalline che diffondono calore e creano miraggi.",
       "fattore_mantenimento_energetico": "Medio (Richiede riallineamento delle placche)",
       "label": "Squame Rifrangenti del Deserto",
       "mutazione_indotta": "Placche cristalline sovrapposte che deviano luce e calore lungo superfici multiple.",
@@ -1474,6 +1643,7 @@
     },
     "struttura_elastica_amorfa": {
       "debolezza": "Vulnerabilità a danni da taglio o perforazione (difficile cauterizzazione).",
+      "description": "Corpo amorfo che si estende e si compatta per evadere vincoli.",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Struttura elastica, allungabile, amorfa, retrattile",
       "mutazione_indotta": "Tessuto con matrice di proteine elastiche iper-modificate.",
@@ -1489,6 +1659,7 @@
     },
     "tattiche_di_branco": {
       "debolezza": "Richiede formazione stabile; cala se la coesione precipita sotto il target.",
+      "description": "Protocollo tattico che coordina focus e prese condivise.",
       "fattore_mantenimento_energetico": "Medio (Broadcast continuo di segnali)",
       "label": "Tattiche di Branco",
       "mutazione_indotta": "Canale condiviso per marcature e ingaggi simultanei.",
@@ -1518,6 +1689,7 @@
     },
     "vello_condensatore_nebbie": {
       "debolezza": "In ambienti aridi accumula detriti che riducono la capacità di condensa.",
+      "description": "Vello capillare che condensa nebbia in riserve idriche mobili.",
       "fattore_mantenimento_energetico": "Basso (Strutture passive a microfilo)",
       "label": "Vello Condensatore di Nebbie",
       "mutazione_indotta": "Peli cavi microstriati che catturano e canalizzano la bruma atmosferica.",
@@ -1526,6 +1698,7 @@
     },
     "ventriglio_gastroliti": {
       "debolezza": "Usura e rottura del ventriglio se i gastroliti sono esauriti o troppo lisci.",
+      "description": "Ventriglio muscoloso che macina cibi duri con gastroliti.",
       "fattore_mantenimento_energetico": "Medio (Contrazione muscolare costante)",
       "label": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
       "mutazione_indotta": "Sviluppo di un organo muscolare (ventriglio) con gastroliti.",
@@ -1534,6 +1707,7 @@
     },
     "zampe_a_molla": {
       "debolezza": "Perdita di valore su mappe con spazi stretti o controllo setup elevato.",
+      "description": "Arti a molla che accumulano energia per balzi di riposizionamento.",
       "fattore_mantenimento_energetico": "Basso (Carica elastica a turni alterni)",
       "label": "Zampe a Molla",
       "mutazione_indotta": "Arti potenziati con ammortizzatori ad alta compressione.",
@@ -1542,6 +1716,7 @@
     },
     "zoccoli_risonanti_steppe": {
       "debolezza": "Suoli cedevoli come sabbie mobili annullano la vibrazione e riducono la trazione.",
+      "description": "Zoccoli cavi che inviano onde ritmiche al branco sulle steppe.",
       "fattore_mantenimento_energetico": "Basso (Vibrazione passiva del suolo)",
       "label": "Zoccoli Risonanti delle Steppe",
       "mutazione_indotta": "Placche cornee cave che emettono onde sismiche ritmiche al contatto con il terreno.",

--- a/reports/trait_fields_by_type.json
+++ b/reports/trait_fields_by_type.json
@@ -841,7 +841,7 @@
     ]
   },
   "Sensoriale/Visivo": {
-    "trait_count": 1,
+    "trait_count": 2,
     "fields": [
       "biome_tags",
       "completion_flags",

--- a/reports/trait_texts.json
+++ b/reports/trait_texts.json
@@ -1,502 +1,12 @@
 {
-  "antenne_plasmatiche_tempesta": {
+  "ali_fono_risonanti": {
     "en": {
-      "label": "Storm Plasma Antennae",
-      "description": "Channels storm lightning into psionic strikes or shields."
+      "label": "Phono-Resonant Wings",
+      "description": "Generate a wide sonic band while flying."
     },
     "it": {
-      "label": "Antenne Plasmatiche di Tempesta",
-      "description": "Convoglia fulmini atmosferici in attacchi mirati o scudi ionici."
-    }
-  },
-  "artigli_sette_vie": {
-    "en": {
-      "label": "Seven-Way Talons",
-      "description": "Multi-hook talons locking a steady grip on irregular surfaces."
-    },
-    "it": {
-      "label": "Artigli a Sette Vie",
-      "description": "Artigli multipli che assicurano presa stabile su superfici irregolari."
-    }
-  },
-  "artigli_sghiaccio_glaciale": {
-    "en": {
-      "label": "Artigli Sghiaccio Glaciale",
-      "description": "Cryogenic claws that freeze and pin targets on contact."
-    },
-    "it": {
-      "label": "Artigli Sghiaccio Glaciale",
-      "description": "Falangi criogeniche che congelano e fissano il bersaglio al contatto."
-    }
-  },
-  "branchie_osmotiche_salmastra": {
-    "en": {
-      "label": "Branchie Osmotiche Salmastre",
-      "description": "Psionic gills filtering salts and toxins in shifting waters."
-    },
-    "it": {
-      "label": "Branchie Osmotiche Salmastre",
-      "description": "Branchie psioniche che filtrano sali e tossine in acque variabili."
-    }
-  },
-  "bulbi_radici_permafrost": {
-    "en": {
-      "label": "Bulbi Radici del Permafrost",
-      "description": "Root bulbs releasing heat and stores to linked allies."
-    },
-    "it": {
-      "label": "Bulbi Radici del Permafrost",
-      "description": "Bulbi radice che rilasciano calore e nutrimento alle unità connesse."
-    }
-  },
-  "carapace_fase_variabile": {
-    "en": {
-      "label": "Phase-Shifting Carapace",
-      "description": "Shell shifts density to balance defense and mobility."
-    },
-    "it": {
-      "label": "Carapace a Variazione di Fase",
-      "description": "Corazza che varia densità per bilanciare difesa e mobilità."
-    }
-  },
-  "carapace_luminiscente_abissale": {
-    "en": {
-      "label": "Carapace Luminiscente Abissale",
-      "description": "Bioluminescent shell confusing predators in abyssal dark."
-    },
-    "it": {
-      "label": "Carapace Luminiscente Abissale",
-      "description": "Guscio bioluminescente che confonde i predatori nelle profondità."
-    }
-  },
-  "cartilagine_flessotermica_venti": {
-    "en": {
-      "label": "Cartilagine Flessotermica dei Venti",
-      "description": "Thermo-reactive cartilage optimizing aerial turns."
-    },
-    "it": {
-      "label": "Cartilagine Flessotermica dei Venti",
-      "description": "Cartilagine termoreattiva che ottimizza virate e planate aeree."
-    }
-  },
-  "cavita_risonanti_tundra": {
-    "en": {
-      "label": "Cavità Risonanti della Tundra",
-      "description": "Chest chambers projecting long-range calls through tundra frost."
-    },
-    "it": {
-      "label": "Cavità Risonanti della Tundra",
-      "description": "Camere toraciche che proiettano richiami a lunga distanza nel gelo."
-    }
-  },
-  "chioma_parassita_canopica": {
-    "en": {
-      "label": "Chioma Parassita Canopica",
-      "description": "Parasitic tendrils weaving energy lanes through canopy."
-    },
-    "it": {
-      "label": "Chioma Parassita Canopica",
-      "description": "Filamenti parassiti che creano corsie energetiche nella canopia."
-    }
-  },
-  "circolazione_bifasica_palude": {
-    "en": {
-      "label": "Swamp Biphase Circulation",
-      "description": "Dual blood circuits separating oxygen flow from toxins in stagnant wetlands."
-    },
-    "it": {
-      "label": "Circolazione Bifasica di Palude",
-      "description": "Doppio circuito sanguigno che separa ossigeno e agenti tossici in ambienti stagnanti."
-    }
-  },
-  "coda_frusta_cinetica": {
-    "en": {
-      "label": "Kinetic Lash Tail",
-      "description": "Elastic tail storing momentum for a devastating lash."
-    },
-    "it": {
-      "label": "Coda a Frusta Cinetica",
-      "description": "Coda elastica che accumula slancio per un colpo cinetico devastante."
-    }
-  },
-  "criostasi_adattiva": {
-    "en": {
-      "label": "Adaptive Cryostasis",
-      "description": "Suspended metabolism surviving protracted extreme seasons."
-    },
-    "it": {
-      "label": "Criostasi",
-      "description": "Metabolismo sospeso che sopravvive a stagioni estreme prolungate."
-    }
-  },
-  "eco_interno_riflesso": {
-    "en": {
-      "label": "Internal Echo Reflex",
-      "description": "Internal sonar mapping surroundings via body reverbs."
-    },
-    "it": {
-      "label": "Riflesso dell'Eco Interno",
-      "description": "Sonar interno che mappa l'ambiente attraverso vibrazioni corporee."
-    }
-  },
-  "empatia_coordinativa": {
-    "en": {
-      "label": "Coordinated Empathy",
-      "description": "Empathic mesh synchronizing team-wide heals and defenses."
-    },
-    "it": {
-      "label": "Empatia Coordinativa",
-      "description": "Rete empatica che sincronizza cure e difese dell'intera squadra."
-    }
-  },
-  "filamenti_digestivi_compattanti": {
-    "en": {
-      "label": "Digestive Compaction Filaments",
-      "description": "Digestive filaments compact waste to free vital space."
-    },
-    "it": {
-      "label": "Filamenti Digestivi Compattanti",
-      "description": "Filamenti digestivi che compattano scarti e liberano spazio vitale."
-    }
-  },
-  "focus_frazionato": {
-    "en": {
-      "label": "Fractional Focus",
-      "description": "Split cortex keeps two threats under active surveillance."
-    },
-    "it": {
-      "label": "Focus Frazionato",
-      "description": "Cortex biforcato che mantiene due minacce in sorveglianza attiva."
-    }
-  },
-  "ghiandola_caustica": {
-    "en": {
-      "label": "Caustic Gland",
-      "description": "Offensive gland spraying quick acid against light armor."
-    },
-    "it": {
-      "label": "Ghiandola Caustica",
-      "description": "Ghiandola offensiva che spruzza acidi rapidi contro corazze leggere."
-    }
-  },
-  "lamelle_termoforetiche": {
-    "en": {
-      "label": "Thermophoretic Lamellae",
-      "description": "Respiratory lamellae deflect extreme gases via heat gradients."
-    },
-    "it": {
-      "label": "Lamelle Termoforetiche",
-      "description": "Lamelle respiratorie che deviano gas estremi con gradienti termici."
-    }
-  },
-  "lingua_tattile_trama": {
-    "en": {
-      "label": "Texture-Sensing Tongue",
-      "description": "Sensory tongue reading hidden vibrations and fractures."
-    },
-    "it": {
-      "label": "Lingua Tattile Trama-Sensibile",
-      "description": "Lingua sensoriale che legge vibrazioni e fratture nascoste."
-    }
-  },
-  "membrane_eliofiltranti": {
-    "en": {
-      "label": "Membrane Eliofiltranti",
-      "description": "Translucent membranes screening radiation and airborne pathogens."
-    },
-    "it": {
-      "label": "Membrane Eliofiltranti",
-      "description": "Membrane traslucide che schermano radiazioni e patogeni sospesi."
-    }
-  },
-  "mimetismo_cromatico_passivo": {
-    "en": {
-      "label": "Passive Chromatic Mimicry",
-      "description": "Passive chromatophores slowly mirroring surrounding hues."
-    },
-    "it": {
-      "label": "Ghiandole di Mimetismo Cromatico Passivo",
-      "description": "Cromatofori passivi che replicano lentamente i colori circostanti."
-    }
-  },
-  "mucillagine_simbionte_mangrovie": {
-    "en": {
-      "label": "Mucillagine Simbionte delle Mangrovie",
-      "description": "Symbiotic mucus absorbing poisons and sealing swamp wounds."
-    },
-    "it": {
-      "label": "Mucillagine Simbionte delle Mangrovie",
-      "description": "Mucosa simbionte che assorbe veleni e sigilla ferite palustri."
-    }
-  },
-  "nodi_micorrizici_oracolari": {
-    "en": {
-      "label": "Nodi Micorrizici Oracolari",
-      "description": "Mycorrhizal nodes foreseeing threats via fungal signals."
-    },
-    "it": {
-      "label": "Nodi Micorrizici Oracolari",
-      "description": "Nodi micorrizici che anticipano minacce tramite segnali fungini."
-    }
-  },
-  "nucleo_ovomotore_rotante": {
-    "en": {
-      "label": "Rotating Ovomotor Core",
-      "description": "Rotating core turning the body into a driving wheel."
-    },
-    "it": {
-      "label": "Uovo rotaia, uovo grande e uova piccole dentro...",
-      "description": "Nucleo rotante che trasforma il corpo in una ruota motrice."
-    }
-  },
-  "occhi_infrarosso_composti": {
-    "en": {
-      "label": "Infrared Compound Eyes",
-      "description": "Infrared ommatidia tracking thermal trails in darkness."
-    },
-    "it": {
-      "label": "Occhi Composti ad Infrarosso",
-      "description": "Ommatidi infrarossi che seguono scie termiche nell'oscurità."
-    }
-  },
-  "olfatto_risonanza_magnetica": {
-    "en": {
-      "label": "Magnetic Resonance Scent",
-      "description": "Olfactory nodes tracing magnetic fields and metal veins."
-    },
-    "it": {
-      "label": "Olfatto di Risonanza Magnetica",
-      "description": "Bulbi olfattivi che tracciano campi magnetici e vene metalliche."
-    }
-  },
-  "pathfinder": {
-    "en": {
-      "label": "Pathfinder",
-      "description": "Exploration suite highlighting safe routes across shifting biomes."
-    },
-    "it": {
-      "label": "Pathfinder",
-      "description": "Suite esplorativa che evidenzia rotte sicure tra biomi imprevedibili."
-    }
-  },
-  "pianificatore": {
-    "en": {
-      "label": "Strategic Planner",
-      "description": "Strategic module keeping priorities and attack windows aligned."
-    },
-    "it": {
-      "label": "Pianificatore",
-      "description": "Modulo strategico che mantiene priorità e finestre d'attacco allineate."
-    }
-  },
-  "piume_solari_fotovoltaiche": {
-    "en": {
-      "label": "Piume Solari Fotovoltaiche",
-      "description": "Photovoltaic plumage storing sunlight for long sorties."
-    },
-    "it": {
-      "label": "Piume Solari Fotovoltaiche",
-      "description": "Piumaggio fotovoltaico che immagazzina luce per lunghe missioni."
-    }
-  },
-  "polmoni_cristallini_alta_quota": {
-    "en": {
-      "label": "Polmoni Cristallini d'Alta Quota",
-      "description": "Crystalline lungs concentrating thin high-altitude oxygen."
-    },
-    "it": {
-      "label": "Polmoni Cristallini d'Alta Quota",
-      "description": "Polmoni cristallini che concentrano ossigeno rarefatto in quota."
-    }
-  },
-  "random": {
-    "en": {
-      "label": "Trait Random",
-      "description": "Experimental slot drawing random traits from a curated pool."
-    },
-    "it": {
-      "label": "Trait Random",
-      "description": "Slot sperimentale che estrae tratti casuali dal pool controllato."
-    }
-  },
-  "respiro_a_scoppio": {
-    "en": {
-      "label": "Burst Breath Propulsion",
-      "description": "Thoracic valves unleashing instantaneous propulsion bursts."
-    },
-    "it": {
-      "label": "Respiro a scoppio",
-      "description": "Valvole toraciche che rilasciano getti propulsivi istantanei."
-    }
-  },
-  "risonanza_di_branco": {
-    "en": {
-      "label": "Pack Resonance",
-      "description": "Resonant lattice amplifying the pack's shared buffs."
-    },
-    "it": {
-      "label": "Risonanza di Branco",
-      "description": "Rete risonante che amplifica buff condivisi del branco."
-    }
-  },
-  "sacche_galleggianti_ascensoriali": {
-    "en": {
-      "label": "Elevating Buoyancy Sacs",
-      "description": "Adjustable gas sacs controlling buoyancy and depth."
-    },
-    "it": {
-      "label": "Sacche galleggianti ascensoriali",
-      "description": "Sacche gassose regolabili per controllare assetto e profondità."
-    }
-  },
-  "sacche_spore_stratosferiche": {
-    "en": {
-      "label": "Sacche di Spore Stratosferiche",
-      "description": "Stratospheric vesicles dispersing long-range support spores."
-    },
-    "it": {
-      "label": "Sacche di Spore Stratosferiche",
-      "description": "Vescicole stratosferiche che disperdono spore di supporto a lungo."
-    }
-  },
-  "sangue_piroforico": {
-    "en": {
-      "label": "Pyrophoric Blood",
-      "description": "Blood ignites on air contact, burning would-be piercers."
-    },
-    "it": {
-      "label": "Sangue che prende fuoco a contatto con l'ossigeno",
-      "description": "Fluido ematico che incendia l'aria colpendo chi perfora la corazza."
-    }
-  },
-  "scheletro_idro_regolante": {
-    "en": {
-      "label": "Hydro-Regulating Skeleton",
-      "description": "Porous bones modulate water content to shift body mass."
-    },
-    "it": {
-      "label": "Scheletro Idro-Regolante",
-      "description": "Ossa porose che modulano il contenuto idrico per mutare massa."
-    }
-  },
-  "secrezione_rallentante_palmi": {
-    "en": {
-      "label": "Retarding Palm Secretions",
-      "description": "Palms exude slowing gel to snare fast targets."
-    },
-    "it": {
-      "label": "Mani secernano liquido rallentante",
-      "description": "Palmi che rilasciano gel rallentante per bloccare bersagli rapidi."
-    }
-  },
-  "sensori_geomagnetici": {
-    "en": {
-      "label": "Geomagnetic Resonance Sensors",
-      "description": "Cranial crystals mapping invisible geomagnetic corridors."
-    },
-    "it": {
-      "label": "Sensori a Risonanza Geomagnetica",
-      "description": "Cristalli cranici che mappano corridoi geomagnetici invisibili."
-    }
-  },
-  "sinapsi_coraline_polifoniche": {
-    "en": {
-      "label": "Sinapsi Coraline Polifoniche",
-      "description": "Coralline synapses relaying orders through marine harmonics."
-    },
-    "it": {
-      "label": "Sinapsi Coraline Polifoniche",
-      "description": "Sinapsi coralline che trasmettono ordini tramite armoniche marine."
-    }
-  },
-  "sonno_emisferico_alternato": {
-    "en": {
-      "label": "Unihemispheric Sleep",
-      "description": "Alternating hemispheres keep watch while the other sleeps."
-    },
-    "it": {
-      "label": "Dormire con solo metà cervello alla volta",
-      "description": "Cervello alternato che veglia con un emisfero mentre l'altro riposa."
-    }
-  },
-  "spore_psichiche_silenziate": {
-    "en": {
-      "label": "Silent Psychic Spores",
-      "description": "Psionic spores that lull and confuse nearby targets."
-    },
-    "it": {
-      "label": "Spora Psichica Silenziosa",
-      "description": "Spore psioniche che sedano e confondono i bersagli vicini."
-    }
-  },
-  "squame_rifrangenti_deserto": {
-    "en": {
-      "label": "Squame Rifrangenti del Deserto",
-      "description": "Crystal scales diffusing heat and casting mirages."
-    },
-    "it": {
-      "label": "Squame Rifrangenti del Deserto",
-      "description": "Scaglie cristalline che diffondono calore e creano miraggi."
-    }
-  },
-  "struttura_elastica_amorfa": {
-    "en": {
-      "label": "Elastic Amorphous Frame",
-      "description": "Amorphous frame stretching or compressing to escape binds."
-    },
-    "it": {
-      "label": "Struttura elastica, allungabile, amorfa, retrattile",
-      "description": "Corpo amorfo che si estende e si compatta per evadere vincoli."
-    }
-  },
-  "tattiche_di_branco": {
-    "en": {
-      "label": "Pack Tactics",
-      "description": "Tactical protocol coordinating shared focus and grapples."
-    },
-    "it": {
-      "label": "Tattiche di Branco",
-      "description": "Protocollo tattico che coordina focus e prese condivise."
-    }
-  },
-  "vello_condensatore_nebbie": {
-    "en": {
-      "label": "Vello Condensatore di Nebbie",
-      "description": "Capillary fleece condensing fog into mobile water reserves."
-    },
-    "it": {
-      "label": "Vello Condensatore di Nebbie",
-      "description": "Vello capillare che condensa nebbia in riserve idriche mobili."
-    }
-  },
-  "ventriglio_gastroliti": {
-    "en": {
-      "label": "Gastrolith Grinding Gizzard",
-      "description": "Muscular gizzard grinding hard food with gastroliths."
-    },
-    "it": {
-      "label": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
-      "description": "Ventriglio muscoloso che macina cibi duri con gastroliti."
-    }
-  },
-  "zampe_a_molla": {
-    "en": {
-      "label": "Spring-Loaded Limbs",
-      "description": "Spring-loaded limbs storing energy for repositioning leaps."
-    },
-    "it": {
-      "label": "Zampe a Molla",
-      "description": "Arti a molla che accumulano energia per balzi di riposizionamento."
-    }
-  },
-  "zoccoli_risonanti_steppe": {
-    "en": {
-      "label": "Zoccoli Risonanti delle Steppe",
-      "description": "Hollow hooves sending rhythmic waves across the steppe pack."
-    },
-    "it": {
-      "label": "Zoccoli Risonanti delle Steppe",
-      "description": "Zoccoli cavi che inviano onde ritmiche al branco sulle steppe."
+      "label": "Ali Fono-Risonanti",
+      "description": "Generare ampia banda sonora in volo."
     }
   },
   "ali_fulminee": {
@@ -527,6 +37,16 @@
     "it": {
       "label": "Ali a Membrana Sonica",
       "description": "Piastre vibranti che dissipano energia e attenuano impatti corrosivi."
+    }
+  },
+  "ali_solari_fotoni": {
+    "en": {
+      "label": "Photonic Solar Wings",
+      "description": "Photovoltaic plumage converting light into thrust and radiant shielding."
+    },
+    "it": {
+      "label": "Ali Solari Fotoniche",
+      "description": "Piume fotovoltaiche che trasformano luce in spinta e schermature di radianza."
     }
   },
   "antenne_dustsense": {
@@ -567,6 +87,16 @@
     "it": {
       "label": "Antenne Microonde Cavernose",
       "description": "Antenne Microonde Cavernose permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caverna risonante."
+    }
+  },
+  "antenne_plasmatiche_tempesta": {
+    "en": {
+      "label": "Storm Plasma Antennae",
+      "description": "Channels storm lightning into psionic strikes or shields."
+    },
+    "it": {
+      "label": "Antenne Plasmatiche di Tempesta",
+      "description": "Convoglia fulmini atmosferici in attacchi mirati o scudi ionici."
     }
   },
   "antenne_reagenti": {
@@ -629,6 +159,36 @@
       "description": "Appendici Thermotattiche permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di abisso vulcanico."
     }
   },
+  "armatura_pietra_planare": {
+    "en": {
+      "label": "Planar Stone Plating",
+      "description": "Resonant plating carved from extradimensional stone that dampens shockwaves."
+    },
+    "it": {
+      "label": "Armatura di Pietra Planare",
+      "description": "Corazza risonante scolpita da roccia extradimensionale che smorza onde d'urto."
+    }
+  },
+  "articolazioni_a_leva_idraulica": {
+    "en": {
+      "label": "Hydraulic Lever Joints",
+      "description": "Amplify leaps and leg thrusts."
+    },
+    "it": {
+      "label": "Articolazioni a Leva Idraulica",
+      "description": "Amplificare salto e spinta delle zampe."
+    }
+  },
+  "articolazioni_multiassiali": {
+    "en": {
+      "label": "Multi-Axial Joints",
+      "description": "Rotate limbs for tight maneuvers."
+    },
+    "it": {
+      "label": "Articolazioni Multiassiali",
+      "description": "Ruotare arti per manovre strette."
+    }
+  },
   "artigli_acidofagi": {
     "en": {
       "label": "Artigli Acidofagi",
@@ -647,6 +207,16 @@
     "it": {
       "label": "Artigli Induzione",
       "description": "Artigli Induzione permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di canopia ionica."
+    }
+  },
+  "artigli_ipo_termici": {
+    "en": {
+      "label": "Hypothermal Claws",
+      "description": "Induce localized cold shock."
+    },
+    "it": {
+      "label": "Artigli Ipo-Termici",
+      "description": "Indurre shock da freddo localizzato."
     }
   },
   "artigli_radice": {
@@ -669,6 +239,26 @@
       "description": "Artigli Scivolo Silente permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di caverna risonante."
     }
   },
+  "artigli_sette_vie": {
+    "en": {
+      "label": "Seven-Way Talons",
+      "description": "Multi-hook talons locking a steady grip on irregular surfaces."
+    },
+    "it": {
+      "label": "Artigli a Sette Vie",
+      "description": "Artigli multipli che assicurano presa stabile su superfici irregolari."
+    }
+  },
+  "artigli_sghiaccio_glaciale": {
+    "en": {
+      "label": "Artigli Sghiaccio Glaciale",
+      "description": "Cryogenic claws that freeze and pin targets on contact."
+    },
+    "it": {
+      "label": "Artigli Sghiaccio Glaciale",
+      "description": "Falangi criogeniche che congelano e fissano il bersaglio al contatto."
+    }
+  },
   "artigli_vetrificati": {
     "en": {
       "label": "Artigli Vetrificati",
@@ -677,6 +267,36 @@
     "it": {
       "label": "Artigli Vetrificati",
       "description": "Artigli Vetrificati permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caldera glaciale."
+    }
+  },
+  "artiglio_cinetico_a_urto": {
+    "en": {
+      "label": "Kinetic Impact Claw",
+      "description": "Deliver shockwaves that fracture targets."
+    },
+    "it": {
+      "label": "Artiglio Cinetico a Urto",
+      "description": "Infliggere onda d’urto e frattura."
+    }
+  },
+  "aura_di_dispersione_mentale": {
+    "en": {
+      "label": "Mental Dispersion Aura",
+      "description": "Impart anxiety and vertigo to predators."
+    },
+    "it": {
+      "label": "Aura di Dispersione Mentale",
+      "description": "Indurre ansia e vertigini nei predatori."
+    }
+  },
+  "aura_scudo_radianza": {
+    "en": {
+      "label": "Radiant Shield Aura",
+      "description": "Photoplasmic field that deflects planar damage while syncing squad vitals."
+    },
+    "it": {
+      "label": "Aura Scudo di Radianza",
+      "description": "Campo fotoplasmatico che devia danni planari e sincronizza i battiti della squadra."
     }
   },
   "baffi_mareomotori": {
@@ -759,6 +379,16 @@
       "description": "Biofilm Iperarido permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di pianura salina iperarida."
     }
   },
+  "bozzolo_magnetico": {
+    "en": {
+      "label": "Magnetic Cocoon",
+      "description": "Shield against external electromagnetic fields."
+    },
+    "it": {
+      "label": "Bozzolo Magnetico",
+      "description": "Schermarsi da campi elettromagnetici esterni."
+    }
+  },
   "branchie_dual_mode": {
     "en": {
       "label": "Branchie Dual Mode",
@@ -799,6 +429,16 @@
       "description": "Branchie Microfiltri permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di reef luminescente."
     }
   },
+  "branchie_osmotiche_salmastra": {
+    "en": {
+      "label": "Branchie Osmotiche Salmastre",
+      "description": "Psionic gills filtering salts and toxins in shifting waters."
+    },
+    "it": {
+      "label": "Branchie Osmotiche Salmastre",
+      "description": "Branchie psioniche che filtrano sali e tossine in acque variabili."
+    }
+  },
   "branchie_solfatiche": {
     "en": {
       "label": "Branchie Solfatiche",
@@ -817,6 +457,16 @@
     "it": {
       "label": "Branchie Turbina",
       "description": "Branchie Turbina permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale."
+    }
+  },
+  "bulbi_radici_permafrost": {
+    "en": {
+      "label": "Bulbi Radici del Permafrost",
+      "description": "Root bulbs releasing heat and stores to linked allies."
+    },
+    "it": {
+      "label": "Bulbi Radici del Permafrost",
+      "description": "Bulbi radice che rilasciano calore e nutrimento alle unità connesse."
     }
   },
   "camere_anticorrosione": {
@@ -847,6 +497,36 @@
     "it": {
       "label": "Camere Nutrienti Vent",
       "description": "Camere Nutrienti Vent permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di dorsale termale tropicale."
+    }
+  },
+  "campo_di_interferenza_acustica": {
+    "en": {
+      "label": "Acoustic Interference Field",
+      "description": "Mask position and velocity."
+    },
+    "it": {
+      "label": "Campo di Interferenza Acustica",
+      "description": "Mascherare posizione e velocità."
+    }
+  },
+  "cannone_sonico_a_raggio": {
+    "en": {
+      "label": "Ray Sonic Cannon",
+      "description": "Stun or injure targets with a sonic beam."
+    },
+    "it": {
+      "label": "Cannone Sonico a Raggio",
+      "description": "Stordire o ferire con un raggio sonoro."
+    }
+  },
+  "canto_infrasonico_tattico": {
+    "en": {
+      "label": "Tactical Infrasonic Song",
+      "description": "Disorient predators and communicate at range."
+    },
+    "it": {
+      "label": "Canto Infrasonico Tattico",
+      "description": "Disorientare predatori e comunicare a distanza."
     }
   },
   "capillari_criogenici": {
@@ -889,6 +569,26 @@
       "description": "Capsule Paracadute permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di stratosfera tempestosa."
     }
   },
+  "carapace_fase_variabile": {
+    "en": {
+      "label": "Phase-Shifting Carapace",
+      "description": "Shell shifts density to balance defense and mobility."
+    },
+    "it": {
+      "label": "Carapace a Variazione di Fase",
+      "description": "Corazza che varia densità per bilanciare difesa e mobilità."
+    }
+  },
+  "carapace_luminiscente_abissale": {
+    "en": {
+      "label": "Carapace Luminiscente Abissale",
+      "description": "Bioluminescent shell confusing predators in abyssal dark."
+    },
+    "it": {
+      "label": "Carapace Luminiscente Abissale",
+      "description": "Guscio bioluminescente che confonde i predatori nelle profondità."
+    }
+  },
   "carapace_segmenti_logici": {
     "en": {
       "label": "Carapace Segmenti Logici",
@@ -907,6 +607,16 @@
     "it": {
       "label": "Carapaci Ferruginosi",
       "description": "Carapaci Ferruginosi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di abisso vulcanico."
+    }
+  },
+  "cartilagine_flessotermica_venti": {
+    "en": {
+      "label": "Cartilagine Flessotermica dei Venti",
+      "description": "Thermo-reactive cartilage optimizing aerial turns."
+    },
+    "it": {
+      "label": "Cartilagine Flessotermica dei Venti",
+      "description": "Cartilagine termoreattiva che ottimizza virate e planate aeree."
     }
   },
   "cartilagini_biofibre": {
@@ -949,6 +659,16 @@
       "description": "Cartilagini Pseudometalliche permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico."
     }
   },
+  "cavita_risonanti_tundra": {
+    "en": {
+      "label": "Cavità Risonanti della Tundra",
+      "description": "Chest chambers projecting long-range calls through tundra frost."
+    },
+    "it": {
+      "label": "Cavità Risonanti della Tundra",
+      "description": "Camere toraciche che proiettano richiami a lunga distanza nel gelo."
+    }
+  },
   "cervelletto_equilibrio_statico": {
     "en": {
       "label": "Cervelletto Equilibrio Statico",
@@ -957,6 +677,16 @@
     "it": {
       "label": "Cervelletto Equilibrio Statico",
       "description": "Cervelletto Equilibrio Statico permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di canopia ionica."
+    }
+  },
+  "cervello_a_bassa_latenza": {
+    "en": {
+      "label": "Low-Latency Brain",
+      "description": "Execute high-frequency maneuvers."
+    },
+    "it": {
+      "label": "Cervello a Bassa Latenza",
+      "description": "Eseguire manovre ad alta frequenza."
     }
   },
   "chemiorecettori_bromuro": {
@@ -969,6 +699,26 @@
       "description": "Chemiorecettori Bromuro permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di pianura salina iperarida."
     }
   },
+  "chioma_parassita_canopica": {
+    "en": {
+      "label": "Chioma Parassita Canopica",
+      "description": "Parasitic tendrils weaving energy lanes through canopy."
+    },
+    "it": {
+      "label": "Chioma Parassita Canopica",
+      "description": "Filamenti parassiti che creano corsie energetiche nella canopia."
+    }
+  },
+  "cinghia_iper_ciliare": {
+    "en": {
+      "label": "Hyper-Ciliary Belt",
+      "description": "Translate the body across smooth or rough ground."
+    },
+    "it": {
+      "label": "Cinghia Iper-Ciliare",
+      "description": "Traslare il corpo su terreni piani o ruvidi."
+    }
+  },
   "circolazione_bifasica": {
     "en": {
       "label": "Circolazione Bifasica",
@@ -977,6 +727,16 @@
     "it": {
       "label": "Circolazione Bifasica",
       "description": "Circolazione Bifasica permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di caldera glaciale."
+    }
+  },
+  "circolazione_bifasica_palude": {
+    "en": {
+      "label": "Swamp Biphase Circulation",
+      "description": "Dual blood circuits separating oxygen flow from toxins in stagnant wetlands."
+    },
+    "it": {
+      "label": "Circolazione Bifasica di Palude",
+      "description": "Doppio circuito sanguigno che separa ossigeno e agenti tossici in ambienti stagnanti."
     }
   },
   "circolazione_cooling_loop": {
@@ -1029,6 +789,16 @@
       "description": "Ciste Salmastre permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di pianura salina iperarida."
     }
   },
+  "cisti_di_ibernazione_minerale": {
+    "en": {
+      "label": "Mineral Hibernation Cyst",
+      "description": "Enter stasis under harsh conditions."
+    },
+    "it": {
+      "label": "Cisti di Ibernazione Minerale",
+      "description": "Entrare in stasi in condizioni avverse."
+    }
+  },
   "cisti_iperbariche": {
     "en": {
       "label": "Cisti Iperbariche",
@@ -1067,6 +837,26 @@
     "it": {
       "label": "Coda Coppia Retroattiva",
       "description": "Coda Coppia Retroattiva permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di steppe algoritmiche."
+    }
+  },
+  "coda_frusta_cinetica": {
+    "en": {
+      "label": "Kinetic Lash Tail",
+      "description": "Elastic tail storing momentum for a devastating lash."
+    },
+    "it": {
+      "label": "Coda a Frusta Cinetica",
+      "description": "Coda elastica che accumula slancio per un colpo cinetico devastante."
+    }
+  },
+  "coda_prensile_muscolare": {
+    "en": {
+      "label": "Muscular Prehensile Tail",
+      "description": "Hang and counterbalance weight."
+    },
+    "it": {
+      "label": "Coda Prensile Muscolare",
+      "description": "Appendere e controbilanciarsi."
     }
   },
   "coda_stabilizzatrice_filo": {
@@ -1109,6 +899,16 @@
       "description": "Colonne Vibromagnetiche permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caverna risonante."
     }
   },
+  "comunicazione_fotonica_coda_coda": {
+    "en": {
+      "label": "Tail-to-Tail Photonic Communication",
+      "description": "Exchange tactile light pulses."
+    },
+    "it": {
+      "label": "Comunicazione Fotonica Coda-Coda",
+      "description": "Scambiare impulsi luminosi tattili."
+    }
+  },
   "coralli_partner": {
     "en": {
       "label": "Coralli Partner",
@@ -1117,6 +917,36 @@
     "it": {
       "label": "Coralli Partner",
       "description": "Coralli Partner permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di reef luminescente."
+    }
+  },
+  "corna_psico_conduttive": {
+    "en": {
+      "label": "Psycho-Conductive Horns",
+      "description": "Transmit and receive slow neural signals."
+    },
+    "it": {
+      "label": "Corna Psico-Conduttive",
+      "description": "Trasmettere e ricevere segnali neurali lenti."
+    }
+  },
+  "coscienza_dalveare_diffusa": {
+    "en": {
+      "label": "Diffuse Hive Consciousness",
+      "description": "Merge decisions and short-term memory."
+    },
+    "it": {
+      "label": "Coscienza d’Alveare Diffusa",
+      "description": "Fondere decisioni e memoria a breve termine."
+    }
+  },
+  "criostasi_adattiva": {
+    "en": {
+      "label": "Adaptive Cryostasis",
+      "description": "Suspended metabolism surviving protracted extreme seasons."
+    },
+    "it": {
+      "label": "Criostasi",
+      "description": "Metabolismo sospeso che sopravvive a stagioni estreme prolungate."
     }
   },
   "cromofori_alert_acido": {
@@ -1229,6 +1059,46 @@
       "description": "Echi Risonanti permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante."
     }
   },
+  "eco_interno_riflesso": {
+    "en": {
+      "label": "Internal Echo Reflex",
+      "description": "Internal sonar mapping surroundings via body reverbs."
+    },
+    "it": {
+      "label": "Riflesso dell'Eco Interno",
+      "description": "Sonar interno che mappa l'ambiente attraverso vibrazioni corporee."
+    }
+  },
+  "ectotermia_dinamica": {
+    "en": {
+      "label": "Dynamic Ectothermy",
+      "description": "Raise body temperature for peak performance."
+    },
+    "it": {
+      "label": "Ectotermia Dinamica",
+      "description": "Alzare temperatura per performance."
+    }
+  },
+  "elettromagnete_biologico": {
+    "en": {
+      "label": "Biological Electromagnet",
+      "description": "Disrupt prey nervous systems."
+    },
+    "it": {
+      "label": "Elettromagnete Biologico",
+      "description": "Interferire con il sistema nervoso della preda."
+    }
+  },
+  "empatia_coordinativa": {
+    "en": {
+      "label": "Coordinated Empathy",
+      "description": "Empathic mesh synchronizing team-wide heals and defenses."
+    },
+    "it": {
+      "label": "Empatia Coordinativa",
+      "description": "Rete empatica che sincronizza cure e difese dell'intera squadra."
+    }
+  },
   "enzimi_antifase_termica": {
     "en": {
       "label": "Enzimi Antifase Termica",
@@ -1299,6 +1169,46 @@
       "description": "Epitelio Fosforescente permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di reef luminescente."
     }
   },
+  "ermafroditismo_cronologico": {
+    "en": {
+      "label": "Chronological Hermaphroditism",
+      "description": "Change sex after one or two incubations."
+    },
+    "it": {
+      "label": "Ermafroditismo Cronologico",
+      "description": "Cambiare sesso dopo 1–2 incubazioni."
+    }
+  },
+  "estroflessione_gastrica_acida": {
+    "en": {
+      "label": "Acidic Gastric Extrusion",
+      "description": "Liquefy tissues on contact and siphon them."
+    },
+    "it": {
+      "label": "Estroflessione Gastrica Acida",
+      "description": "Liquefare tessuti al contatto e aspirarli."
+    }
+  },
+  "fagocitosi_assorbente": {
+    "en": {
+      "label": "Absorptive Phagocytosis",
+      "description": "Engulf and digest entire biomass."
+    },
+    "it": {
+      "label": "Fagocitosi Assorbente",
+      "description": "Inglobare e digerire biomassa intera."
+    }
+  },
+  "filamenti_digestivi_compattanti": {
+    "en": {
+      "label": "Digestive Compaction Filaments",
+      "description": "Digestive filaments compact waste to free vital space."
+    },
+    "it": {
+      "label": "Filamenti Digestivi Compattanti",
+      "description": "Filamenti digestivi che compattano scarti e liberano spazio vitale."
+    }
+  },
   "filamenti_magnetotrofi": {
     "en": {
       "label": "Filamenti Magnetotrofi",
@@ -1329,6 +1239,16 @@
       "description": "Filamenti Termoconduzione permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di dorsale termale tropicale."
     }
   },
+  "filtrazione_osmotica": {
+    "en": {
+      "label": "Osmotic Filtration",
+      "description": "Neutralize self-generated toxins."
+    },
+    "it": {
+      "label": "Filtrazione Osmotica",
+      "description": "Neutralizzare tossine autogenerate."
+    }
+  },
   "filtri_planctonici": {
     "en": {
       "label": "Filtri Planctonici",
@@ -1339,6 +1259,16 @@
       "description": "Filtri Planctonici permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di laguna bioreattiva."
     }
   },
+  "filtro_metallofago": {
+    "en": {
+      "label": "Metallophagous Filter",
+      "description": "Sustain electrogenic organs."
+    },
+    "it": {
+      "label": "Filtro Metallofago",
+      "description": "Sostenere organi elettrogeni."
+    }
+  },
   "flagelli_ancoranti": {
     "en": {
       "label": "Flagelli Ancoranti",
@@ -1347,6 +1277,26 @@
     "it": {
       "label": "Flagelli Ancoranti",
       "description": "Flagelli Ancoranti permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di laguna bioreattiva."
+    }
+  },
+  "flusso_ameboide_controllato": {
+    "en": {
+      "label": "Controlled Amoeboid Flow",
+      "description": "Slide or climb along smooth surfaces."
+    },
+    "it": {
+      "label": "Flusso Ameboide Controllato",
+      "description": "Scivolare o risalire superfici lisce."
+    }
+  },
+  "focus_frazionato": {
+    "en": {
+      "label": "Fractional Focus",
+      "description": "Split cortex keeps two threats under active surveillance."
+    },
+    "it": {
+      "label": "Focus Frazionato",
+      "description": "Cortex biforcato che mantiene due minacce in sorveglianza attiva."
     }
   },
   "foliage_fotocatodico": {
@@ -1369,6 +1319,16 @@
       "description": "Foliaggio Spugna permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di mangrovieto cinetico."
     }
   },
+  "frusta_fiammeggiante": {
+    "en": {
+      "label": "Flame Lash",
+      "description": "Bound plasma appendage that can hook and ignite targets."
+    },
+    "it": {
+      "label": "Frusta Fiammeggiante",
+      "description": "Appendice di plasma vincolato capace di arpionare e incendiare bersagli."
+    }
+  },
   "ghiaccio_piezoelettrico": {
     "en": {
       "label": "Ghiaccio Piezoelettrico",
@@ -1377,6 +1337,16 @@
     "it": {
       "label": "Ghiaccio Piezoelettrico",
       "description": "Ghiaccio Piezoelettrico permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caldera glaciale."
+    }
+  },
+  "ghiandola_caustica": {
+    "en": {
+      "label": "Caustic Gland",
+      "description": "Offensive gland spraying quick acid against light armor."
+    },
+    "it": {
+      "label": "Ghiandola Caustica",
+      "description": "Ghiandola offensiva che spruzza acidi rapidi contro corazze leggere."
     }
   },
   "ghiandole_cambio_salino": {
@@ -1549,6 +1519,26 @@
       "description": "Gusci Magnesio permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di dorsale termale tropicale."
     }
   },
+  "integumento_bipolare": {
+    "en": {
+      "label": "Bipolar Integument",
+      "description": "Orient along magnetic field lines."
+    },
+    "it": {
+      "label": "Integumento Bipolare",
+      "description": "Orientarsi lungo le linee di campo."
+    }
+  },
+  "ipertrofia_muscolare_massiva": {
+    "en": {
+      "label": "Massive Muscular Hypertrophy",
+      "description": "Boost power and burst acceleration."
+    },
+    "it": {
+      "label": "Ipertrofia Muscolare Massiva",
+      "description": "Aumentare potenza e scatto."
+    }
+  },
   "lamelle_shear": {
     "en": {
       "label": "Lamelle Shear",
@@ -1567,6 +1557,16 @@
     "it": {
       "label": "Lamelle Sincroniche",
       "description": "Lamelle Sincroniche permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di steppe algoritmiche."
+    }
+  },
+  "lamelle_termoforetiche": {
+    "en": {
+      "label": "Thermophoretic Lamellae",
+      "description": "Respiratory lamellae deflect extreme gases via heat gradients."
+    },
+    "it": {
+      "label": "Lamelle Termoforetiche",
+      "description": "Lamelle respiratorie che deviano gas estremi con gradienti termici."
     }
   },
   "lamine_filtranti_aeree": {
@@ -1609,6 +1609,26 @@
       "description": "Lingua Cristallina permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di pianura salina iperarida."
     }
   },
+  "lingua_tattile_trama": {
+    "en": {
+      "label": "Texture-Sensing Tongue",
+      "description": "Sensory tongue reading hidden vibrations and fractures."
+    },
+    "it": {
+      "label": "Lingua Tattile Trama-Sensibile",
+      "description": "Lingua sensoriale che legge vibrazioni e fratture nascoste."
+    }
+  },
+  "locomozione_miriapode_ibrida": {
+    "en": {
+      "label": "Hybrid Myriapod Locomotion",
+      "description": "Grip and climb on nearly any surface."
+    },
+    "it": {
+      "label": "Locomozione Miriapode Ibrida",
+      "description": "Aderire e arrampicare su qualsiasi superficie."
+    }
+  },
   "luminescenza_aurorale": {
     "en": {
       "label": "Luminescenza Aurorale",
@@ -1639,6 +1659,26 @@
       "description": "Mantelli Geotermici permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di caldera glaciale."
     }
   },
+  "mantello_meteoritico": {
+    "en": {
+      "label": "Meteoric Mantle",
+      "description": "Regenerating ablative layers that vaporize impacts into thermal pulses."
+    },
+    "it": {
+      "label": "Mantello Meteoritico",
+      "description": "Strati ablativi rigeneranti che vaporizzano l'impatto convertendolo in impulso termico."
+    }
+  },
+  "membrana_plastica_continua": {
+    "en": {
+      "label": "Continuous Plastic Membrane",
+      "description": "Adopt different shapes and densities."
+    },
+    "it": {
+      "label": "Membrana Plastica Continua",
+      "description": "Assumere forme e densità diverse."
+    }
+  },
   "membrane_captura_rugiada": {
     "en": {
       "label": "Membrane Captura Rugiada",
@@ -1647,6 +1687,16 @@
     "it": {
       "label": "Membrane Captura Rugiada",
       "description": "Membrane Captura Rugiada permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida."
+    }
+  },
+  "membrane_eliofiltranti": {
+    "en": {
+      "label": "Membrane Eliofiltranti",
+      "description": "Translucent membranes screening radiation and airborne pathogens."
+    },
+    "it": {
+      "label": "Membrane Eliofiltranti",
+      "description": "Membrane traslucide che schermano radiazioni e patogeni sospesi."
     }
   },
   "membrane_planata_vectored": {
@@ -1669,6 +1719,16 @@
       "description": "Membrane Pneumatofori permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di mangrovieto cinetico."
     }
   },
+  "metabolismo_di_condivisione_energetica": {
+    "en": {
+      "label": "Shared Energy Metabolism",
+      "description": "Support wounded or young with collective reserves."
+    },
+    "it": {
+      "label": "Metabolismo di Condivisione Energetica",
+      "description": "Sostenere feriti o giovani con riserva collettiva."
+    }
+  },
   "midollo_antivibrazione": {
     "en": {
       "label": "Midollo Antivibrazione",
@@ -1677,6 +1737,46 @@
     "it": {
       "label": "Midollo Antivibrazione",
       "description": "Midollo Antivibrazione permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante."
+    }
+  },
+  "mimetismo_cromatico_passivo": {
+    "en": {
+      "label": "Passive Chromatic Mimicry",
+      "description": "Passive chromatophores slowly mirroring surrounding hues."
+    },
+    "it": {
+      "label": "Ghiandole di Mimetismo Cromatico Passivo",
+      "description": "Cromatofori passivi che replicano lentamente i colori circostanti."
+    }
+  },
+  "moltiplicazione_per_fusione": {
+    "en": {
+      "label": "Fusion Multiplication",
+      "description": "Grow mass and intellect by merging units."
+    },
+    "it": {
+      "label": "Moltiplicazione per Fusione",
+      "description": "Aumentare massa e intelligenza unendo unità."
+    }
+  },
+  "motore_biologico_silenzioso": {
+    "en": {
+      "label": "Silent Biological Engine",
+      "description": "Maintain extended flight at ultra-low sound pressure."
+    },
+    "it": {
+      "label": "Motore Biologico Silenzioso",
+      "description": "Garantire volo prolungato a bassissimo SPL."
+    }
+  },
+  "mucillagine_simbionte_mangrovie": {
+    "en": {
+      "label": "Mucillagine Simbionte delle Mangrovie",
+      "description": "Symbiotic mucus absorbing poisons and sealing swamp wounds."
+    },
+    "it": {
+      "label": "Mucillagine Simbionte delle Mangrovie",
+      "description": "Mucosa simbionte che assorbe veleni e sigilla ferite palustri."
     }
   },
   "mucose_aderenza_sonica": {
@@ -1699,44 +1799,454 @@
       "description": "Mucose Barofile permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di abisso vulcanico."
     }
   },
-  "aura_scudo_radianza": {
+  "nodi_micorrizici_oracolari": {
     "en": {
-      "label": "Radiant Shield Aura",
-      "description": "Photoplasmic field that deflects planar damage while syncing squad vitals."
+      "label": "Nodi Micorrizici Oracolari",
+      "description": "Mycorrhizal nodes foreseeing threats via fungal signals."
     },
     "it": {
-      "label": "Aura Scudo di Radianza",
-      "description": "Campo fotoplasmatico che devia danni planari e sincronizza i battiti della squadra."
+      "label": "Nodi Micorrizici Oracolari",
+      "description": "Nodi micorrizici che anticipano minacce tramite segnali fungini."
     }
   },
-  "frusta_fiammeggiante": {
+  "nucleo_ovomotore_rotante": {
     "en": {
-      "label": "Flame Lash",
-      "description": "Bound plasma appendage that can hook and ignite targets."
+      "label": "Rotating Ovomotor Core",
+      "description": "Rotating core turning the body into a driving wheel."
     },
     "it": {
-      "label": "Frusta Fiammeggiante",
-      "description": "Appendice di plasma vincolato capace di arpionare e incendiare bersagli."
+      "label": "Uovo rotaia, uovo grande e uova piccole dentro...",
+      "description": "Nucleo rotante che trasforma il corpo in una ruota motrice."
     }
   },
-  "mantello_meteoritico": {
+  "occhi_analizzatori_di_tensione": {
     "en": {
-      "label": "Meteoric Mantle",
-      "description": "Regenerating ablative layers that vaporize impacts into thermal pulses."
+      "label": "Tension-Analyzing Eyes",
+      "description": "Read strand tension and stress patterns."
     },
     "it": {
-      "label": "Mantello Meteoritico",
-      "description": "Strati ablativi rigeneranti che vaporizzano l'impatto convertendolo in impulso termico."
+      "label": "Occhi Analizzatori di Tensione",
+      "description": "Leggere tensioni nella seta e pattern di stress."
     }
   },
-  "armatura_pietra_planare": {
+  "occhi_cinetici": {
     "en": {
-      "label": "Planar Stone Plating",
-      "description": "Resonant plating carved from extradimensional stone that dampens shockwaves."
+      "label": "Kinetic Eyes",
+      "description": "See sound as patterns in the air."
     },
     "it": {
-      "label": "Armatura di Pietra Planare",
-      "description": "Corazza risonante scolpita da roccia extradimensionale che smorza onde d'urto."
+      "label": "Occhi Cinetici",
+      "description": "Vedere il suono come pattern d’aria."
+    }
+  },
+  "occhi_infrarosso_composti": {
+    "en": {
+      "label": "Infrared Compound Eyes",
+      "description": "Infrared ommatidia tracking thermal trails in darkness."
+    },
+    "it": {
+      "label": "Occhi Composti ad Infrarosso",
+      "description": "Ommatidi infrarossi che seguono scie termiche nell'oscurità."
+    }
+  },
+  "olfatto_risonanza_magnetica": {
+    "en": {
+      "label": "Magnetic Resonance Scent",
+      "description": "Olfactory nodes tracing magnetic fields and metal veins."
+    },
+    "it": {
+      "label": "Olfatto di Risonanza Magnetica",
+      "description": "Bulbi olfattivi che tracciano campi magnetici e vene metalliche."
+    }
+  },
+  "organi_sismici_cutanei": {
+    "en": {
+      "label": "Cutaneous Seismic Organs",
+      "description": "Sense ground vibrations."
+    },
+    "it": {
+      "label": "Organi Sismici Cutanei",
+      "description": "Percepire vibrazioni del suolo."
+    }
+  },
+  "pathfinder": {
+    "en": {
+      "label": "Pathfinder",
+      "description": "Exploration suite highlighting safe routes across shifting biomes."
+    },
+    "it": {
+      "label": "Pathfinder",
+      "description": "Suite esplorativa che evidenzia rotte sicure tra biomi imprevedibili."
+    }
+  },
+  "pelage_idrorepellente_avanzato": {
+    "en": {
+      "label": "Advanced Hydrophobic Pelage",
+      "description": "Insulate the body and stay afloat."
+    },
+    "it": {
+      "label": "Pelage Idrorepellente Avanzato",
+      "description": "Isolare e galleggiare."
+    }
+  },
+  "pianificatore": {
+    "en": {
+      "label": "Strategic Planner",
+      "description": "Strategic module keeping priorities and attack windows aligned."
+    },
+    "it": {
+      "label": "Pianificatore",
+      "description": "Modulo strategico che mantiene priorità e finestre d'attacco allineate."
+    }
+  },
+  "piume_solari_fotovoltaiche": {
+    "en": {
+      "label": "Piume Solari Fotovoltaiche",
+      "description": "Photovoltaic plumage storing sunlight for long sorties."
+    },
+    "it": {
+      "label": "Piume Solari Fotovoltaiche",
+      "description": "Piumaggio fotovoltaico che immagazzina luce per lunghe missioni."
+    }
+  },
+  "polmoni_cristallini_alta_quota": {
+    "en": {
+      "label": "Polmoni Cristallini d'Alta Quota",
+      "description": "Crystalline lungs concentrating thin high-altitude oxygen."
+    },
+    "it": {
+      "label": "Polmoni Cristallini d'Alta Quota",
+      "description": "Polmoni cristallini che concentrano ossigeno rarefatto in quota."
+    }
+  },
+  "random": {
+    "en": {
+      "label": "Trait Random",
+      "description": "Experimental slot drawing random traits from a curated pool."
+    },
+    "it": {
+      "label": "Trait Random",
+      "description": "Slot sperimentale che estrae tratti casuali dal pool controllato."
+    }
+  },
+  "respiro_a_scoppio": {
+    "en": {
+      "label": "Burst Breath Propulsion",
+      "description": "Thoracic valves unleashing instantaneous propulsion bursts."
+    },
+    "it": {
+      "label": "Respiro a scoppio",
+      "description": "Valvole toraciche che rilasciano getti propulsivi istantanei."
+    }
+  },
+  "rete_filtro_polmonare": {
+    "en": {
+      "label": "Pulmonary Filter Net",
+      "description": "Absorb nutrients suspended in the air."
+    },
+    "it": {
+      "label": "Rete Filtro-Polmonare",
+      "description": "Assorbire nutrienti aerodispersi."
+    }
+  },
+  "risonanza_di_branco": {
+    "en": {
+      "label": "Pack Resonance",
+      "description": "Resonant lattice amplifying the pack's shared buffs."
+    },
+    "it": {
+      "label": "Risonanza di Branco",
+      "description": "Rete risonante che amplifica buff condivisi del branco."
+    }
+  },
+  "rostro_emostatico_litico": {
+    "en": {
+      "label": "Hemolytic-Lytic Rostrum",
+      "description": "Inject toxins and enzymes and siphon fluids."
+    },
+    "it": {
+      "label": "Rostro Emostatico-Litico",
+      "description": "Inoculare tossine ed enzimi e aspirare fluidi."
+    }
+  },
+  "rostro_linguale_prensile": {
+    "en": {
+      "label": "Prehensile Lingual Rostrum",
+      "description": "Grab and manipulate at long reach."
+    },
+    "it": {
+      "label": "Rostro Linguale Prensile",
+      "description": "Afferrare e manipolare a lungo raggio."
+    }
+  },
+  "sacche_galleggianti_ascensoriali": {
+    "en": {
+      "label": "Elevating Buoyancy Sacs",
+      "description": "Adjustable gas sacs controlling buoyancy and depth."
+    },
+    "it": {
+      "label": "Sacche galleggianti ascensoriali",
+      "description": "Sacche gassose regolabili per controllare assetto e profondità."
+    }
+  },
+  "sacche_spore_stratosferiche": {
+    "en": {
+      "label": "Sacche di Spore Stratosferiche",
+      "description": "Stratospheric vesicles dispersing long-range support spores."
+    },
+    "it": {
+      "label": "Sacche di Spore Stratosferiche",
+      "description": "Vescicole stratosferiche che disperdono spore di supporto a lungo."
+    }
+  },
+  "sangue_piroforico": {
+    "en": {
+      "label": "Pyrophoric Blood",
+      "description": "Blood ignites on air contact, burning would-be piercers."
+    },
+    "it": {
+      "label": "Sangue che prende fuoco a contatto con l'ossigeno",
+      "description": "Fluido ematico che incendia l'aria colpendo chi perfora la corazza."
+    }
+  },
+  "scheletro_idraulico_a_pistoni": {
+    "en": {
+      "label": "Hydraulic Piston Skeleton",
+      "description": "Extend the skull rapidly to strike."
+    },
+    "it": {
+      "label": "Scheletro Idraulico a Pistoni",
+      "description": "Estendere rapidamente il cranio per colpire."
+    }
+  },
+  "scheletro_idro_regolante": {
+    "en": {
+      "label": "Hydro-Regulating Skeleton",
+      "description": "Porous bones modulate water content to shift body mass."
+    },
+    "it": {
+      "label": "Scheletro Idro-Regolante",
+      "description": "Ossa porose che modulano il contenuto idrico per mutare massa."
+    }
+  },
+  "scheletro_pneumatico_a_maglie": {
+    "en": {
+      "label": "Latticed Pneumatic Skeleton",
+      "description": "Lighten the load for slow, steady travel."
+    },
+    "it": {
+      "label": "Scheletro Pneumatico a Maglie",
+      "description": "Alleggerire il carico per spostamenti lenti ma costanti."
+    }
+  },
+  "scivolamento_magnetico": {
+    "en": {
+      "label": "Magnetic Gliding",
+      "description": "Reduce friction to glide."
+    },
+    "it": {
+      "label": "Scivolamento Magnetico",
+      "description": "Ridurre attrito e scivolare."
+    }
+  },
+  "scudo_gluteale_cheratinizzato": {
+    "en": {
+      "label": "Keratinized Gluteal Shield",
+      "description": "Absorb impacts from the rear."
+    },
+    "it": {
+      "label": "Scudo Gluteale Cheratinizzato",
+      "description": "Assorbire impatti posteriori."
+    }
+  },
+  "secrezione_rallentante_palmi": {
+    "en": {
+      "label": "Retarding Palm Secretions",
+      "description": "Palms exude slowing gel to snare fast targets."
+    },
+    "it": {
+      "label": "Mani secernano liquido rallentante",
+      "description": "Palmi che rilasciano gel rallentante per bloccare bersagli rapidi."
+    }
+  },
+  "sensori_geomagnetici": {
+    "en": {
+      "label": "Geomagnetic Resonance Sensors",
+      "description": "Cranial crystals mapping invisible geomagnetic corridors."
+    },
+    "it": {
+      "label": "Sensori a Risonanza Geomagnetica",
+      "description": "Cristalli cranici che mappano corridoi geomagnetici invisibili."
+    }
+  },
+  "seta_conduttiva_elettrica": {
+    "en": {
+      "label": "Conductive Electric Silk",
+      "description": "Stun prey with charges woven into the web."
+    },
+    "it": {
+      "label": "Seta Conduttiva Elettrica",
+      "description": "Stordire con scariche nella tela."
+    }
+  },
+  "siero_anti_gelo_naturale": {
+    "en": {
+      "label": "Natural Anti-Freeze Serum",
+      "description": "Prevent crystallization at low temperatures."
+    },
+    "it": {
+      "label": "Siero Anti-Gelo Naturale",
+      "description": "Impedire la cristallizzazione a basse temperature."
+    }
+  },
+  "sinapsi_coraline_polifoniche": {
+    "en": {
+      "label": "Sinapsi Coraline Polifoniche",
+      "description": "Coralline synapses relaying orders through marine harmonics."
+    },
+    "it": {
+      "label": "Sinapsi Coraline Polifoniche",
+      "description": "Sinapsi coralline che trasmettono ordini tramite armoniche marine."
+    }
+  },
+  "sistemi_chimio_sonici": {
+    "en": {
+      "label": "Chemo-Sonic Systems",
+      "description": "Map space and airflow without sight."
+    },
+    "it": {
+      "label": "Sistemi Chimio-Sonici",
+      "description": "Mappare spazio e correnti d’aria senza vista."
+    }
+  },
+  "sonno_emisferico_alternato": {
+    "en": {
+      "label": "Unihemispheric Sleep",
+      "description": "Alternating hemispheres keep watch while the other sleeps."
+    },
+    "it": {
+      "label": "Dormire con solo metà cervello alla volta",
+      "description": "Cervello alternato che veglia con un emisfero mentre l'altro riposa."
+    }
+  },
+  "spore_psichiche_silenziate": {
+    "en": {
+      "label": "Silent Psychic Spores",
+      "description": "Psionic spores that lull and confuse nearby targets."
+    },
+    "it": {
+      "label": "Spora Psichica Silenziosa",
+      "description": "Spore psioniche che sedano e confondono i bersagli vicini."
+    }
+  },
+  "squame_rifrangenti_deserto": {
+    "en": {
+      "label": "Squame Rifrangenti del Deserto",
+      "description": "Crystal scales diffusing heat and casting mirages."
+    },
+    "it": {
+      "label": "Squame Rifrangenti del Deserto",
+      "description": "Scaglie cristalline che diffondono calore e creano miraggi."
+    }
+  },
+  "struttura_elastica_amorfa": {
+    "en": {
+      "label": "Elastic Amorphous Frame",
+      "description": "Amorphous frame stretching or compressing to escape binds."
+    },
+    "it": {
+      "label": "Struttura elastica, allungabile, amorfa, retrattile",
+      "description": "Corpo amorfo che si estende e si compatta per evadere vincoli."
+    }
+  },
+  "tattiche_di_branco": {
+    "en": {
+      "label": "Pack Tactics",
+      "description": "Tactical protocol coordinating shared focus and grapples."
+    },
+    "it": {
+      "label": "Tattiche di Branco",
+      "description": "Protocollo tattico che coordina focus e prese condivise."
+    }
+  },
+  "unghie_a_micro_adesione": {
+    "en": {
+      "label": "Micro-Adhesion Claws",
+      "description": "Adhere to steep surfaces."
+    },
+    "it": {
+      "label": "Unghie a Micro-Adesione",
+      "description": "Aderire a superfici ripide."
+    }
+  },
+  "vello_condensatore_nebbie": {
+    "en": {
+      "label": "Vello Condensatore di Nebbie",
+      "description": "Capillary fleece condensing fog into mobile water reserves."
+    },
+    "it": {
+      "label": "Vello Condensatore di Nebbie",
+      "description": "Vello capillare che condensa nebbia in riserve idriche mobili."
+    }
+  },
+  "vello_di_assorbimento_totale": {
+    "en": {
+      "label": "Total Absorption Fleece",
+      "description": "Absorb nearly all incoming light."
+    },
+    "it": {
+      "label": "Vello di Assorbimento Totale",
+      "description": "Assorbire quasi tutta la luce incidente."
+    }
+  },
+  "ventriglio_gastroliti": {
+    "en": {
+      "label": "Gastrolith Grinding Gizzard",
+      "description": "Muscular gizzard grinding hard food with gastroliths."
+    },
+    "it": {
+      "label": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
+      "description": "Ventriglio muscoloso che macina cibi duri con gastroliti."
+    }
+  },
+  "visione_multi_spettrale_amplificata": {
+    "en": {
+      "label": "Amplified Multi-Spectral Vision",
+      "description": "See under extremely low luminance."
+    },
+    "it": {
+      "label": "Visione Multi-Spettrale Amplificata",
+      "description": "Vedere in luminanza estremamente bassa."
+    }
+  },
+  "zampe_a_molla": {
+    "en": {
+      "label": "Spring-Loaded Limbs",
+      "description": "Spring-loaded limbs storing energy for repositioning leaps."
+    },
+    "it": {
+      "label": "Zampe a Molla",
+      "description": "Arti a molla che accumulano energia per balzi di riposizionamento."
+    }
+  },
+  "zanne_idracida": {
+    "en": {
+      "label": "Hydra-Acid Tusks",
+      "description": "Corrode tissues and even metals."
+    },
+    "it": {
+      "label": "Zanne Idracida",
+      "description": "Corrodere tessuti e metalli."
+    }
+  },
+  "zoccoli_risonanti_steppe": {
+    "en": {
+      "label": "Zoccoli Risonanti delle Steppe",
+      "description": "Hollow hooves sending rhythmic waves across the steppe pack."
+    },
+    "it": {
+      "label": "Zoccoli Risonanti delle Steppe",
+      "description": "Zoccoli cavi che inviano onde ritmiche al branco sulle steppe."
     }
   }
 }


### PR DESCRIPTION
## Descrizione
- Allineati i campi di `occhi_cristallo_modulare` e dei trait in _drafts alle chiavi i18n e sincronizzate le localizzazioni italiane.
- Rigenerati i report `trait_fields_by_type.json` e `trait_texts.json`.

## Checklist guida stile & QA
- [x] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato
- [ ] Documentazione/processi aggiornati ove necessario

## Testing
- [x] `python tools/py/trait_template_validator.py --traits-dir data/traits --index data/traits/index.json`
- [x] `python tools/py/collect_trait_fields.py --output reports/trait_fields_by_type.json --glossary data/core/traits/glossary.json --glossary-output reports/trait_texts.json`
- [x] `python scripts/sync_trait_locales.py --traits-dir data/traits --locales-dir locales --language it --glossary data/core/traits/glossary.json`

## Note
- N/A

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ae08e604832887513fd91f6cd59c)