### PR TITLE
Add quick reference link for trait authoring

### DIFF
--- a/README_HOWTO_AUTHOR_TRAIT.md
+++ b/README_HOWTO_AUTHOR_TRAIT.md
@@ -6,13 +6,14 @@ per autori e reviewer e integra la documentazione tecnica presente in `docs/`.
 
 ## 1. Prima di iniziare
 
+- Consulta la [scheda operativa completa](docs/traits_scheda_operativa.md) per
+  campi, vincoli e checklist.
+
 1. Identifica il ruolo narrativo e tattico del trait (slot, tier, macro-tipologia).
 2. Recupera i riferimenti dal [template dati](docs/traits_template.md) e dai
    report correnti (`reports/trait_fields_by_type.json`, `reports/trait_texts.json`).
 3. Allinea label e descrizioni con il team di design/localization prima di
    procedere agli update dei file.
-4. Consulta la [scheda operativa completa](docs/traits_scheda_operativa.md) per
-   check rapidi su vincoli, tassonomia e comandi di validazione.
 
 ## 2. Aggiornare il glossario
 


### PR DESCRIPTION
## Summary
- add a quick-reference bullet in the trait authoring guide pointing to the full operational sheet

## Testing
- not run (docs change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920b6d5bde8832881c35cd03fa30033)