### PR TITLE
Add quick example to trait operational sheet

### DIFF
--- a/docs/traits_scheda_operativa.md
+++ b/docs/traits_scheda_operativa.md
@@ -2,7 +2,7 @@
 
 ## Identità e versioning
 
-- `id` — snake_case, uguale al nome file, deciso in design e immutabile. # fonte: vincolo schema `^[a-z0-9_]+$`
+- `id` — snake*case, uguale al nome file, deciso in design e immutabile. # fonte: vincolo schema `^[a-z0-9*]+$`
 - `label` — riferimento glossario `i18n:traits.<id>.label`, dopo registrazione IT/EN in `data/core/traits/glossary.json`. # fonte: glossario centralizzato
 - `data_origin` — slug editoriale da `docs/editorial/trait_sources.json`. # fonte: tabella sorgenti ufficiali
 - `version` / `versioning.*` — opzionale, SemVer + autore/aggiornamenti per tracciabilità. # fonte: convenzione interna
@@ -44,12 +44,12 @@
 
 ## Box “Flusso operativo end-to-end”
 
-1) Preparazione tassonomia/slot.  
-2) Aggiornamento glossario (IT/EN).  
-3) Compilazione file trait con scheletro minimo.  
-4) Validazione schema (`trait_template_validator`).  
-5) Sync localizzazioni e rigenerazione report (campi/testi, indici/coverage).  
-6) Revisione diff e checklist PR.
+1. Preparazione tassonomia/slot.
+2. Aggiornamento glossario (IT/EN).
+3. Compilazione file trait con scheletro minimo.
+4. Validazione schema (`trait_template_validator`).
+5. Sync localizzazioni e rigenerazione report (campi/testi, indici/coverage).
+6. Revisione diff e checklist PR.
 
 ## Richiamo “Template e vincoli”
 
@@ -68,10 +68,52 @@
 - Sync localizzazioni: `python scripts/sync_trait_locales.py --traits-dir data/traits --locales-dir locales --language it --glossary data/core/traits/glossary.json`
 - (Opz.) Indici/coverage: `build_trait_index.js`, `report_trait_coverage.py` se previsti dalla checklist.
 
+## Esempio rapido
+
+Estratto minimale in linea con lo schema (regex rispettate) e con i riferimenti `i18n:` già puntati al glossario:
+
+```json
+{
+  "id": "esempio_trait_minimo",
+  "label": "i18n:traits.esempio_trait_minimo.label",
+  "famiglia_tipologia": "Offensivo/Assalto",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
+  "tier": "T1",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "data_origin": "controllo_psionico",
+  "mutazione_indotta": "Sintesi breve dell'adattamento.",
+  "uso_funzione": "Funzione primaria concisa.",
+  "spinta_selettiva": "Motivazione evolutiva o tattica."
+}
+```
+
+Entry corrispondente nel glossario `data/core/traits/glossary.json` (i campi EN/IT sono obbligatori e alimentano la sync `scripts/sync_trait_locales.py`):
+
+```json
+{
+  "esempio_trait_minimo": {
+    "label_it": "Label approvata (IT)",
+    "label_en": "Approved label (EN)",
+    "description_it": "Descrizione concisa e coerente con il tono del bestiario.",
+    "description_en": "Concise description aligned with bestiary tone."
+  }
+}
+```
+
+Placeholder da sostituire prima della PR:
+
+- `esempio_trait_minimo` → `<id>` definitivo (snake_case, coincide con il nome file).
+- `Offensivo/Assalto` → `<tipologia>` coerente con la tassonomia esistente.
+- `controllo_psionico` → `data_origin` scelto dagli slug ufficiali in `docs/editorial/trait_sources.json`.
+
+Ricorda di eseguire i comandi di validazione già elencati sopra per confermare schema, sync e report (`trait_template_validator`, `collect_trait_fields`, `sync_trait_locales`).
+
 ## Inserimento nel repo e collegamenti
 
-- **Posizionamento:** salva il file in `docs/traits_scheda_operativa.md`.  
-- **Link entrata:** in `README_HOWTO_AUTHOR_TRAIT.md` aggiungi un bullet nella sezione “Prima di iniziare” che punti alla scheda come reference operativo.  
-- **Link tecnico:** in `docs/traits_template.md`, subito dopo l’introduzione, inserisci una riga “Per la scheda operativa completa vedere `docs/traits_scheda_operativa.md`”.  
-- **Riferimento testi:** nel nuovo file rimanda a `docs/catalog/trait_reference.md` per esempi di label/description approvate.  
+- **Posizionamento:** salva il file in `docs/traits_scheda_operativa.md`.
+- **Link entrata:** in `README_HOWTO_AUTHOR_TRAIT.md` aggiungi un bullet nella sezione “Prima di iniziare” che punti alla scheda come reference operativo.
+- **Link tecnico:** in `docs/traits_template.md`, subito dopo l’introduzione, inserisci una riga “Per la scheda operativa completa vedere `docs/traits_scheda_operativa.md`”.
+- **Riferimento testi:** nel nuovo file rimanda a `docs/catalog/trait_reference.md` per esempi di label/description approvate.
 - **Uso in PR:** cita la scheda nella checklist PR per indicare che glossario, file trait, report e locali sono stati allineati.


### PR DESCRIPTION
## Descrizione
- Aggiunto blocco "Esempio rapido" alla scheda operativa dei trait con JSON minimo e voce di glossario corrispondente.
- Evidenziati i placeholder da sostituire e richiamati i comandi di sync/validazione già elencati.

## Checklist guida stile & QA
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [x] Documentazione/processi aggiornati ove necessario

## Testing
- [ ] `npm run style:check`
- [ ] Altro: <!-- specificare -->

## Note
N/A

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920b9e08fec8328bce1d33506fd898c)