### PR TITLE
Add quick access navigation for trait docs

### DIFF
--- a/docs/traits_scheda_operativa.md
+++ b/docs/traits_scheda_operativa.md
@@ -1,5 +1,11 @@
 # Scheda operativa trait (con reference e checklist)
 
+## Accesso rapido
+
+- [Guida autori](../README_HOWTO_AUTHOR_TRAIT.md)
+- [Template dati](traits_template.md)
+- [Reference catalogo](catalog/trait_reference.md)
+
 ## Identità e versioning
 
 - `id` — snake*case, uguale al nome file, deciso in design e immutabile. # fonte: vincolo schema `^[a-z0-9*]+$`

--- a/docs/traits_template.md
+++ b/docs/traits_template.md
@@ -6,6 +6,7 @@ Questo documento descrive la struttura canonica dei trait archiviati in
 all'indice aggregato `data/traits/index.json`.
 
 Guida operativa completa: [docs/traits_scheda_operativa.md](traits_scheda_operativa.md).
+Ritorno rapido alla guida autori: [README_HOWTO_AUTHOR_TRAIT.md](../README_HOWTO_AUTHOR_TRAIT.md).
 
 Gli obiettivi principali del template sono:
 


### PR DESCRIPTION
## Summary
- add a quick Accesso rapido block to the trait operational sheet to link guide, template, and catalog reference
- add a return link from the trait template back to the authoring guide

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920baa7f4f4832897cac2e43fe67b78)