### PR TITLE
Aggiorna vincolo id traits

### DIFF
--- a/docs/traits_scheda_operativa.md
+++ b/docs/traits_scheda_operativa.md
@@ -8,7 +8,7 @@
 
 ## Identità e versioning
 
-- `id` — snake*case, uguale al nome file, deciso in design e immutabile. # fonte: vincolo schema `^[a-z0-9*]+$`
+- `id` — `snake_case`, uguale al nome file, deciso in design e immutabile. # fonte: vincolo schema `^[a-z0-9_]+$`
 - `label` — riferimento glossario `i18n:traits.<id>.label`, dopo registrazione IT/EN in `data/core/traits/glossary.json`. # fonte: glossario centralizzato
 - `data_origin` — slug editoriale da `docs/editorial/trait_sources.json`. # fonte: tabella sorgenti ufficiali
 - `version` / `versioning.*` — opzionale, SemVer + autore/aggiornamenti per tracciabilità. # fonte: convenzione interna


### PR DESCRIPTION
## Summary
- aggiorna il bullet del campo `id` nella scheda operativa con la dicitura `snake_case`
- allinea il vincolo regex del campo `id` a `^[a-z0-9_]+$`

## Testing
- npx prettier docs/traits_scheda_operativa.md --check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920d2fb90988328aa6bb6105e087d16)