### PR TITLE
Fix relative links in Evo Tactics guide

### DIFF
--- a/docs/Guida_Evo_Tactics_Pack_v2.md
+++ b/docs/Guida_Evo_Tactics_Pack_v2.md
@@ -2,9 +2,9 @@
 
 ## Accesso rapido
 
-- [Scheda operativa dei trait](docs/traits_scheda_operativa.md)
+- [Scheda operativa dei trait](./traits_scheda_operativa.md)
 - [Guida autore tratti](README_HOWTO_AUTHOR_TRAIT.md)
-- [Template dati dei tratti](docs/traits_template.md)
+- [Template dati dei tratti](./traits_template.md)
 - [Scala di senzienza (T0–T5)](README_SENTIENCE.md)
 
 ## Introduzione


### PR DESCRIPTION
## Descrizione
- correzione dei link di accesso rapido nella guida Evo Tactics Pack v2 per usare percorsi relativi dalla cartella docs
- controllo rapido che non ci siano rimandi interni con prefisso duplicato `docs/docs`

## Testing
- nessuno


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69210c38ea7c83288cf79838fc2c9a5e)