### PR TITLE
Document repository validation steps in migration pipeline

### DIFF
--- a/docs/Guida_Evo_Tactics_Pack_v2.md
+++ b/docs/Guida_Evo_Tactics_Pack_v2.md
@@ -153,6 +153,16 @@ Per aggiornare schede esistenti alla versione v2 si consiglia di seguire questa 
 
 Seguendo questa pipeline, le schede esistenti possono essere migrate senza perdere informazioni e diventando compatibili con gli strumenti del pacchetto v2.
 
+### Validazione nel repository Game
+
+Nel repository Game i controlli vanno eseguiti con la toolchain Python, che copre sia struttura dati sia glossari/localizzazioni:
+
+- `python tools/py/trait_template_validator.py ...`
+- `python tools/py/collect_trait_fields.py ...`
+- `python scripts/sync_trait_locales.py ...`
+
+Ricorrere a `scripts/validate.sh`/`ajv` solo per validare pacchetti esterni; per i file che entrano in repository usare i comandi Python sopra.
+
 ---
 
 ## Struttura del pacchetto

--- a/docs/evo-tactics/guida-ai-tratti-1.md
+++ b/docs/evo-tactics/guida-ai-tratti-1.md
@@ -183,6 +183,16 @@ Seguendo questa pipeline, le schede esistenti possono essere migrate
 senza perdere informazioni e diventando compatibili con gli strumenti
 del pacchetto v2.
 
+### Validazione nel repository Game
+
+Nel repository Game i controlli vanno eseguiti con la toolchain Python, che copre sia struttura dati sia glossari/localizzazioni:
+
+- `python tools/py/trait_template_validator.py ...`
+- `python tools/py/collect_trait_fields.py ...`
+- `python scripts/sync_trait_locales.py ...`
+
+Ricorrere a `scripts/validate.sh`/`ajv` solo per validare pacchetti esterni; per i file che entrano in repository usare i comandi Python sopra.
+
 ## Struttura del pacchetto {#evo-guida-ai-tratti-1-struttura-del-pacchetto}
 
 Il pacchetto completo è organizzato in cartelle:

--- a/docs/evo-tactics/guida-ai-tratti-2.md
+++ b/docs/evo-tactics/guida-ai-tratti-2.md
@@ -183,6 +183,16 @@ Seguendo questa pipeline, le schede esistenti possono essere migrate
 senza perdere informazioni e diventando compatibili con gli strumenti
 del pacchetto v2.
 
+### Validazione nel repository Game
+
+Nel repository Game i controlli vanno eseguiti con la toolchain Python, che copre sia struttura dati sia glossari/localizzazioni:
+
+- `python tools/py/trait_template_validator.py ...`
+- `python tools/py/collect_trait_fields.py ...`
+- `python scripts/sync_trait_locales.py ...`
+
+Ricorrere a `scripts/validate.sh`/`ajv` solo per validare pacchetti esterni; per i file che entrano in repository usare i comandi Python sopra.
+
 ## Struttura del pacchetto {#evo-guida-ai-tratti-2-struttura-del-pacchetto}
 
 Il pacchetto completo è organizzato in cartelle:

--- a/docs/evo-tactics/guida-ai-tratti-3-evo-tactics.md
+++ b/docs/evo-tactics/guida-ai-tratti-3-evo-tactics.md
@@ -184,6 +184,16 @@ Seguendo questa pipeline, le schede esistenti possono essere migrate
 senza perdere informazioni e diventando compatibili con gli strumenti
 del pacchetto v2.
 
+### Validazione nel repository Game
+
+Nel repository Game i controlli vanno eseguiti con la toolchain Python, che copre sia struttura dati sia glossari/localizzazioni:
+
+- `python tools/py/trait_template_validator.py ...`
+- `python tools/py/collect_trait_fields.py ...`
+- `python scripts/sync_trait_locales.py ...`
+
+Ricorrere a `scripts/validate.sh`/`ajv` solo per validare pacchetti esterni; per i file che entrano in repository usare i comandi Python sopra.
+
 ## Struttura del pacchetto {#evo-guida-ai-tratti-3-evo-tactics-struttura-del-pacchetto}
 
 Il pacchetto completo è organizzato in cartelle:

--- a/docs/evo-tactics/integrazioni-v2.md
+++ b/docs/evo-tactics/integrazioni-v2.md
@@ -184,6 +184,16 @@ Seguendo questa pipeline, le schede esistenti possono essere migrate
 senza perdere informazioni e diventando compatibili con gli strumenti
 del pacchetto v2.
 
+### Validazione nel repository Game
+
+Nel repository Game i controlli vanno eseguiti con la toolchain Python, che copre sia struttura dati sia glossari/localizzazioni:
+
+- `python tools/py/trait_template_validator.py ...`
+- `python tools/py/collect_trait_fields.py ...`
+- `python scripts/sync_trait_locales.py ...`
+
+Ricorrere a `scripts/validate.sh`/`ajv` solo per validare pacchetti esterni; per i file che entrano in repository usare i comandi Python sopra.
+
 ## Struttura del pacchetto {#evo-integrazioni-v2-struttura-del-pacchetto}
 
 Il pacchetto completo è organizzato in cartelle:

--- a/docs/traits_scheda_operativa.md
+++ b/docs/traits_scheda_operativa.md
@@ -5,6 +5,7 @@
 - [Guida autori](../README_HOWTO_AUTHOR_TRAIT.md)
 - [Template dati](traits_template.md)
 - [Reference catalogo](catalog/trait_reference.md)
+- [Checklist di validazione automatica](#checklist-di-validazione-automatica-comandi-rapidi)
 
 ## Compatibilità Evo Pack v2
 


### PR DESCRIPTION
## Summary
- add repository-specific validation subsections with Python commands to all v1→v2 migration pipelines
- clarify when to use ajv versus the Python toolchain depending on package provenance
- link the operative sheet directly to the automatic validation checklist for quick access

## Testing
- not run (documentation changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69210e5a11608328b1f1f405cc33ad8f)