### PR TITLE
Fix trait documentation links and indexes

### DIFF
--- a/docs/00-INDEX.md
+++ b/docs/00-INDEX.md
@@ -28,6 +28,10 @@
 
 - [INTEGRAZIONE GUIDE — SSoT](INTEGRAZIONE_GUIDE.md)
 - [Trait Reference Manual (SSoT)](trait_reference_manual.md)
+- [Scheda operativa trait](traits_scheda_operativa.md)
+- [Template dati trait](traits_template.md)
+- [Guida autori trait](README_HOWTO_AUTHOR_TRAIT.md)
+- [Trait Reference & Glossario](catalog/trait_reference.md)
 - [Sentience Track — guida rapida](README_SENTIENCE.md)
 - Schemi e cataloghi canònici: `packs/evo_tactics_pack/docs/catalog/`
   - `trait_entry.schema.json`, `trait_catalog.schema.json`, `trait_reference.json`

--- a/docs/Guida_Evo_Tactics_Pack_v2.md
+++ b/docs/Guida_Evo_Tactics_Pack_v2.md
@@ -1129,7 +1129,7 @@ I **gate di qualità** da rispettare in ogni PR includono:
 
 ## Come applicarlo nel repo Game
 
-Per integrare nuovi tratti o pacchetti in questo repository, segui il [flusso operativo end-to-end](docs/traits_scheda_operativa.md#box-flusso-operativo-end-to-end): prepara tassonomia e glossario, compila il file usando il [template dati](docs/traits_template.md), valida schema e contenuti con i comandi della [checklist automatica](docs/traits_scheda_operativa.md#checklist-di-validazione-automatica-comandi-rapidi), sincronizza le localizzazioni e chiudi la PR riportando gli esiti QA.
+Per integrare nuovi tratti o pacchetti in questo repository, segui il [flusso operativo end-to-end](traits_scheda_operativa.md#box-flusso-operativo-end-to-end): prepara tassonomia e glossario, compila il file usando il [template dati](traits_template.md), valida schema e contenuti con i comandi della [checklist automatica](traits_scheda_operativa.md#checklist-di-validazione-automatica-comandi-rapidi), sincronizza le localizzazioni e chiudi la PR riportando gli esiti QA.
 
 ## Conclusioni e prospettive
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,17 +4,19 @@ description: Mappa di navigazione aggiornata della documentazione principale con
 tags:
   - documentazione
   - indice
-updated: 2025-11-14
+updated: 2025-11-22
 ---
 
 # Indice Documentazione
 
 ## Panoramica
+
 - [00-INDEX.md](00-INDEX.md) — indice operativo storico e canvas.
 - [README.md](README.md) — guida rapida a settori operativi, procedure e changelog.
 - [archive/](archive/) — materiale storico e placeholder archiviati, incluso l'ex hub Evo-Tactics.
 
 ## Evo-Tactics
+
 - [Hub documentale](evo-tactics/README.md) — panoramica aggiornata, strumenti correlati e accesso rapido all'archivio log.
 - [Visione & Struttura](evo-tactics/guides/visione-struttura.md) — visione di prodotto, pilastri tattici e workflow di integrazione.
 - [Template PTPF](evo-tactics/guides/template-ptpf.md) — struttura compilabile con checklist per missioni, specie e loop telemetrici.
@@ -22,7 +24,16 @@ updated: 2025-11-14
 - [Integration Log (archivio)](archive/evo-tactics/integration-log.md) — cronologia DOC-01/DOC-02/DOC-03 conservata per riferimento storico.
 - [Archivio storico](archive/evo-tactics/README.md) — testo introduttivo pre-normalizzazione conservato per contesto.
 
+## Trait — workflow e reference
+
+- [Scheda operativa trait](traits_scheda_operativa.md) — requisiti minimi, checklist automatica e flusso end-to-end.
+- [Template dati](traits_template.md) — schema JSON canonico con esempi per tipologia.
+- [Guida autori](README_HOWTO_AUTHOR_TRAIT.md) — percorso rapido glossario → file trait → validazioni.
+- [Trait Reference & Glossario](catalog/trait_reference.md) — label/description approvate e sincronizzazione glossario/localizzazioni.
+- [Trait Reference Manual (omnibus)](trait_reference_manual.md) — indice dei capitoli tematici in `docs/traits-manuale/`.
+
 ## Strumenti incoming
+
 - [incoming/docs/obsidian_template.md](../incoming/docs/obsidian_template.md) — vault suggerito per note locali.
 - [incoming/docs/yaml_validator.py](../incoming/docs/yaml_validator.py) — validazione dataset telemetrici.
 - [incoming/docs/bioma_encounters.yaml](../incoming/docs/bioma_encounters.yaml) — base encounter per sincronizzazione VC.


### PR DESCRIPTION
## Summary
- fix the trait workflow links in the Evo guide after the documentation move
- add a trait workflow section to docs/INDEX.md with updated metadata
- expand docs/00-INDEX.md to link directly to the relocated trait guides and references

## Testing
- python tools/check_site_links.py docs


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692119c394948328b8e5ae6d68687c04)