### PR TITLE
Add client for service actor sessions API

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:lighthouse": "lhci autorun --config=./config/lighthouse/evo.lighthouserc.json",
     "schema:lint": "python tools/automation/evo_schema_lint.py schemas/evo",
     "ci:stack": "npm run lint:stack && npm run test:backend && npm run test --workspace apps/dashboard && VITE_BASE_PATH=./ npm run build --workspace apps/dashboard",
-    "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && node --test tests/server/generationSnapshot.spec.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-latency.spec.ts && ./node_modules/.bin/tsx tests/scripts/tune_items.test.ts && ./node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts && node --test tests/tools/deploy-checks.spec.js",
+    "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && node --test tests/server/generationSnapshot.spec.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-latency.spec.ts && ./node_modules/.bin/tsx tests/scripts/tune_items.test.ts && ./node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts && node --test tests/tools/deploy-checks.spec.js && ./node_modules/.bin/tsx tests/api/serviceActorSessions.spec.ts",
     "start:api": "node apps/backend/index.js",
     "docs:lint": "python tools/check_site_links.py docs",
     "docs:smoke": "node scripts/docs-smoke.js",

--- a/src/api/serviceActorSessions.ts
+++ b/src/api/serviceActorSessions.ts
@@ -1,0 +1,166 @@
+export interface ServiceActorSession {
+  readonly id: string;
+  readonly actor: string;
+  readonly status: string;
+  readonly createdAt: string;
+  readonly updatedAt?: string | null;
+  readonly expiresAt?: string | null;
+  readonly metadata?: Record<string, unknown> | null;
+}
+
+export interface CreateServiceActorSessionInput {
+  readonly actor: string;
+  readonly ttlSeconds?: number;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface HeartbeatSessionInput {
+  readonly ttlSeconds?: number;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface ServiceActorSessionsClientOptions {
+  readonly baseUrl?: string;
+  readonly fetch?: typeof fetch;
+}
+
+export const SERVICE_ACTOR_SESSIONS_ENDPOINT = '/api/service-actors/sessions';
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const normalizeNullableString = (value: unknown, field: string): string | null | undefined => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value === 'string') return value;
+  throw new Error(`Campo ${field} non valido nella risposta sessione.`);
+};
+
+const normalizeNullableRecord = (
+  value: unknown,
+  field: string,
+): Record<string, unknown> | null | undefined => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (isPlainObject(value)) return value;
+  throw new Error(`Campo ${field} non valido nella risposta sessione.`);
+};
+
+function ensureSessionPayload(value: unknown): ServiceActorSession {
+  if (!isPlainObject(value)) {
+    throw new Error('Risposta sessione non valida.');
+  }
+
+  const { id, actor, status, createdAt, updatedAt, expiresAt, metadata } = value;
+
+  if (typeof id !== 'string' || typeof actor !== 'string' || typeof status !== 'string') {
+    throw new Error('Risposta sessione non valida.');
+  }
+
+  if (typeof createdAt !== 'string') {
+    throw new Error('Risposta sessione non valida.');
+  }
+
+  return {
+    id,
+    actor,
+    status,
+    createdAt,
+    updatedAt: normalizeNullableString(updatedAt, 'updatedAt'),
+    expiresAt: normalizeNullableString(expiresAt, 'expiresAt'),
+    metadata: normalizeNullableRecord(metadata, 'metadata'),
+  };
+}
+
+const ensureSessionArray = (value: unknown): ServiceActorSession[] => {
+  if (!Array.isArray(value)) {
+    throw new Error('Risposta sessione non valida.');
+  }
+  return value.map(ensureSessionPayload);
+};
+
+const buildUrl = (baseUrl: string, suffix: string): string => {
+  if (!suffix) return baseUrl;
+  if (baseUrl.endsWith('/')) {
+    return `${baseUrl}${suffix.replace(/^\//, '')}`;
+  }
+  return `${baseUrl}/${suffix.replace(/^\//, '')}`;
+};
+
+export class ServiceActorSessionsClient {
+  private readonly baseUrl: string;
+  private readonly fetcher: typeof fetch;
+
+  constructor(options: ServiceActorSessionsClientOptions = {}) {
+    this.baseUrl = options.baseUrl ?? SERVICE_ACTOR_SESSIONS_ENDPOINT;
+    this.fetcher = options.fetch ?? (globalThis.fetch?.bind(globalThis) as typeof fetch);
+    if (!this.fetcher) {
+      throw new Error("ServiceActorSessionsClient richiede un'implementazione fetch disponibile.");
+    }
+  }
+
+  async createSession(payload: CreateServiceActorSessionInput): Promise<ServiceActorSession> {
+    const response = await this.fetcher(this.baseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Creazione sessione attore fallita con status ${response.status}`);
+    }
+
+    const body = await response.json();
+    return ensureSessionPayload(body);
+  }
+
+  async getSession(sessionId: string): Promise<ServiceActorSession> {
+    const url = buildUrl(this.baseUrl, sessionId);
+    const response = await this.fetcher(url, {
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Recupero sessione attore fallito con status ${response.status}`);
+    }
+
+    const body = await response.json();
+    return ensureSessionPayload(body);
+  }
+
+  async heartbeat(
+    sessionId: string,
+    payload: HeartbeatSessionInput = {},
+  ): Promise<ServiceActorSession> {
+    const url = buildUrl(this.baseUrl, `${sessionId}/heartbeat`);
+    const response = await this.fetcher(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Heartbeat sessione attore fallito con status ${response.status}`);
+    }
+
+    const body = await response.json();
+    return ensureSessionPayload(body);
+  }
+
+  async listSessions(actor?: string): Promise<ServiceActorSession[]> {
+    const query = actor ? `?actor=${encodeURIComponent(actor)}` : '';
+    const url = `${this.baseUrl}${query}`;
+    const response = await this.fetcher(url, {
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Elenco sessioni attore fallito con status ${response.status}`);
+    }
+
+    const body = await response.json();
+    return ensureSessionArray(body);
+  }
+}
+
+export default ServiceActorSessionsClient;

--- a/tests/api/serviceActorSessions.spec.ts
+++ b/tests/api/serviceActorSessions.spec.ts
@@ -1,0 +1,138 @@
+import { describe, it } from 'node:test';
+import assert from 'assert';
+import {
+  ServiceActorSessionsClient,
+  SERVICE_ACTOR_SESSIONS_ENDPOINT,
+  type ServiceActorSession,
+} from '../../src/api/serviceActorSessions';
+
+const sampleSession: ServiceActorSession = {
+  id: 'session-001',
+  actor: 'ingestor',
+  status: 'active',
+  createdAt: '2025-11-22T10:00:00.000Z',
+  updatedAt: '2025-11-22T10:00:00.000Z',
+  expiresAt: '2025-11-22T11:00:00.000Z',
+  metadata: { region: 'eu-west' },
+};
+
+describe('ServiceActorSessionsClient', () => {
+  it('crea una sessione inviando la richiesta al percorso previsto', async () => {
+    const captured: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchStub: typeof fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : (input as URL | Request).toString();
+      captured.push({ url, init });
+      return {
+        ok: true,
+        status: 201,
+        json: async () => sampleSession,
+      } as unknown as Response;
+    };
+
+    const client = new ServiceActorSessionsClient({
+      baseUrl: 'https://api.example.com/actors/sessions',
+      fetch: fetchStub,
+    });
+
+    const result = await client.createSession({
+      actor: 'ingestor',
+      ttlSeconds: 900,
+      metadata: { scope: 'full' },
+    });
+
+    assert.strictEqual(result.id, sampleSession.id);
+    assert.strictEqual(captured.length, 1, 'deve essere eseguita una sola richiesta');
+    assert.strictEqual(captured[0].url, 'https://api.example.com/actors/sessions');
+    assert.strictEqual(captured[0].init?.method, 'POST');
+    assert.deepStrictEqual(JSON.parse(String(captured[0].init?.body)), {
+      actor: 'ingestor',
+      ttlSeconds: 900,
+      metadata: { scope: 'full' },
+    });
+  });
+
+  it('recupera e valida una sessione esistente', async () => {
+    const fetchStub: typeof fetch = async () =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => sampleSession,
+      }) as unknown as Response;
+
+    const client = new ServiceActorSessionsClient({
+      baseUrl: 'https://api.example.com/sessions',
+      fetch: fetchStub,
+    });
+
+    const result = await client.getSession('session-001');
+    assert.strictEqual(result.actor, 'ingestor');
+    assert.strictEqual(result.status, 'active');
+    assert.strictEqual(result.updatedAt, sampleSession.updatedAt);
+  });
+
+  it('invia heartbeat e interpreta il payload restituito', async () => {
+    const capturedUrls: string[] = [];
+    const fetchStub: typeof fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : (input as URL | Request).toString();
+      capturedUrls.push(url);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ ...sampleSession, status: 'heartbeat', expiresAt: null }),
+      } as unknown as Response;
+    };
+
+    const client = new ServiceActorSessionsClient({
+      fetch: fetchStub,
+      baseUrl: SERVICE_ACTOR_SESSIONS_ENDPOINT,
+    });
+
+    const result = await client.heartbeat('session-002', {
+      ttlSeconds: 120,
+      metadata: { shards: 2 },
+    });
+
+    assert.strictEqual(result.status, 'heartbeat');
+    assert.strictEqual(result.expiresAt, null);
+    assert.strictEqual(capturedUrls[0], `${SERVICE_ACTOR_SESSIONS_ENDPOINT}/session-002/heartbeat`);
+  });
+
+  it('applica il filtro actor quando elenca le sessioni', async () => {
+    const captured: string[] = [];
+    const fetchStub: typeof fetch = async (input) => {
+      captured.push(typeof input === 'string' ? input : (input as URL | Request).toString());
+      return {
+        ok: true,
+        status: 200,
+        json: async () => [sampleSession],
+      } as unknown as Response;
+    };
+
+    const client = new ServiceActorSessionsClient({ fetch: fetchStub });
+    const result = await client.listSessions('ingestor');
+
+    assert.strictEqual(result.length, 1);
+    assert.ok(captured[0].includes('?actor=ingestor'));
+  });
+
+  it('propaga errori su risposte non valide o mancanza di fetch', async () => {
+    const originalFetch = globalThis.fetch;
+    // Forza il costruttore a non trovare un fetch disponibile
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = undefined;
+    const invalidClient = () =>
+      new ServiceActorSessionsClient({ fetch: undefined as unknown as typeof fetch });
+    assert.throws(invalidClient, /fetch disponibile/);
+    (globalThis as any).fetch = originalFetch;
+
+    const fetchStub: typeof fetch = async () =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => ({ foo: 'bar' }),
+      }) as unknown as Response;
+
+    const client = new ServiceActorSessionsClient({ fetch: fetchStub });
+    await assert.rejects(() => client.getSession('missing'), /Risposta sessione non valida/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a typed client for the service actor sessions API with request helpers and validation
- expose create, heartbeat, fetch, and listing utilities with a default endpoint constant
- add coverage for the new client and run it in the API test suite

## Testing
- ./node_modules/.bin/tsx tests/api/serviceActorSessions.spec.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921258e652c8328b910aafe44290ff3)