### PR TITLE
Handle missing prisma in species biomes router

### DIFF
--- a/apps/backend/routes/speciesBiomes.js
+++ b/apps/backend/routes/speciesBiomes.js
@@ -40,11 +40,25 @@ function mapRelation(entry) {
 }
 
 function createSpeciesBiomesRouter({ prisma }) {
-  if (!prisma) {
-    throw new Error('prisma client richiesto per il router specie-biomi');
-  }
-
   const router = express.Router();
+
+  if (!prisma) {
+    const notConfigured = { error: 'Archivio specie/biomi non configurato' };
+
+    router.get('/species', (req, res) => {
+      res.status(501).json(notConfigured);
+    });
+
+    router.get('/biomes', (req, res) => {
+      res.status(501).json(notConfigured);
+    });
+
+    router.get('/species-biomes', (req, res) => {
+      res.status(501).json(notConfigured);
+    });
+
+    return router;
+  }
 
   router.get('/species', async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- add graceful fallback responses to species/biomes routes when prisma is not available

## Testing
- node --test tests/tools/deploy-checks.spec.js
- ./node_modules/.bin/tsx tests/scripts/tune_items.test.ts
- ./node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts
- ./node_modules/.bin/tsx tests/generation/flow-shell.spec.ts
- node --test tests/server/generationSnapshot.spec.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692129f541948328a0caf47ebb8ae12d)