### PR TITLE
Add IDs and i18n entries for TR-110x trait pack

### DIFF
--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2025-11-11T13:08:51+00:00",
+  "updated_at": "2025-11-22T13:10:03.882660+00:00",
   "sources": {
     "trait_reference": "data/traits/index.json"
   },
@@ -650,8 +650,8 @@
     "ectotermia_dinamica": {
       "label_it": "Ectotermia Dinamica",
       "label_en": "Dynamic Ectothermy",
-      "description_it": "Alzare temperatura per performance.",
-      "description_en": "Raise body temperature for peak performance."
+      "description_it": "Microscosse isometriche che innalzano rapidamente la temperatura corporea per picchi prestazionali.",
+      "description_en": "Isometric micro-shivers that rapidly raise body temperature for performance spikes."
     },
     "elettromagnete_biologico": {
       "label_it": "Elettromagnete Biologico",
@@ -926,8 +926,8 @@
     "ipertrofia_muscolare_massiva": {
       "label_it": "Ipertrofia Muscolare Massiva",
       "label_en": "Massive Muscular Hypertrophy",
-      "description_it": "Aumentare potenza e scatto.",
-      "description_en": "Boost power and burst acceleration."
+      "description_it": "Fibre ispessite e mitocondri densi che aumentano potenza, scatto e tolleranza allo sforzo breve.",
+      "description_en": "Thickened fibres with dense mitochondria boosting power, burst acceleration, and short-term strain tolerance."
     },
     "lamelle_shear": {
       "label_it": "Lamelle Shear",
@@ -1124,8 +1124,8 @@
     "organi_sismici_cutanei": {
       "label_it": "Organi Sismici Cutanei",
       "label_en": "Cutaneous Seismic Organs",
-      "description_it": "Percepire vibrazioni del suolo.",
-      "description_en": "Sense ground vibrations."
+      "description_it": "Lamelle meccano-recettive nelle squame che percepiscono vibrazioni del suolo e movimenti occultati.",
+      "description_en": "Mechano-receptive lamellae in the scales sensing ground vibrations and hidden movements."
     },
     "pathfinder": {
       "label_en": "Pathfinder",
@@ -1183,9 +1183,9 @@
     },
     "rostro_emostatico_litico": {
       "label_it": "Rostro Emostatico-Litico",
-      "label_en": "Hemolytic-Lytic Rostrum",
-      "description_it": "Inoculare tossine ed enzimi e aspirare fluidi.",
-      "description_en": "Inject toxins and enzymes and siphon fluids."
+      "label_en": "Hemo-Lytic Rostrum",
+      "description_it": "Rostro tubulare rigido che inietta enzimi coagulanti e litici aspirando fluidi dopo l’impatto.",
+      "description_en": "Rigid tubular rostrum that injects lytic and coagulant enzymes while drawing fluids after impact."
     },
     "rostro_linguale_prensile": {
       "label_it": "Rostro Linguale Prensile",
@@ -1213,9 +1213,9 @@
     },
     "scheletro_idraulico_a_pistoni": {
       "label_it": "Scheletro Idraulico a Pistoni",
-      "label_en": "Hydraulic Piston Skeleton",
-      "description_it": "Estendere rapidamente il cranio per colpire.",
-      "description_en": "Extend the skull rapidly to strike."
+      "label_en": "Piston Hydraulic Skeleton",
+      "description_it": "Ossa cave pressurizzate che scattano pistoni cranici per colpi-proiettile rapidissimi.",
+      "description_en": "Pressurised hollow bones that fire cranial pistons for ultra-fast projectile blows."
     },
     "scheletro_idro_regolante": {
       "label_en": "Hydro-Regulating Skeleton",

--- a/incoming/traits/TR-1101.json
+++ b/incoming/traits/TR-1101.json
@@ -1,13 +1,11 @@
 {
   "trait_code": "TR-1101",
-  "label": "Rostro Emostatico-Litico",
+  "label": "i18n:traits.rostro_emostatico_litico.label",
   "famiglia_tipologia": "Offensivo/Perforante",
   "fattore_mantenimento_energetico": "Medio",
   "tier": "T4",
   "slot": [],
-  "sinergie": [
-    "TR-1102"
-  ],
+  "sinergie": ["scheletro_idraulico_a_pistoni"],
   "conflitti": [],
   "requisiti_ambientali": [
     {
@@ -53,5 +51,7 @@
     "created": "2025-11-04",
     "updated": "2025-11-04",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "id": "rostro_emostatico_litico",
+  "data_origin": "incoming_tr1100_pack"
 }

--- a/incoming/traits/TR-1102.json
+++ b/incoming/traits/TR-1102.json
@@ -1,14 +1,11 @@
 {
   "trait_code": "TR-1102",
-  "label": "Scheletro Idraulico a Pistoni",
+  "label": "i18n:traits.scheletro_idraulico_a_pistoni.label",
   "famiglia_tipologia": "Locomotivo/Balistico",
   "fattore_mantenimento_energetico": "Medio",
   "tier": "T4",
   "slot": [],
-  "sinergie": [
-    "TR-1101",
-    "TR-1103"
-  ],
+  "sinergie": ["rostro_emostatico_litico", "ipertrofia_muscolare_massiva"],
   "conflitti": [],
   "requisiti_ambientali": [
     {
@@ -44,14 +41,14 @@
   },
   "applicability": {
     "clades": [],
-    "envo_terms": [
-      "http://purl.obolibrary.org/obo/ENVO_01000178"
-    ]
+    "envo_terms": ["http://purl.obolibrary.org/obo/ENVO_01000178"]
   },
   "version": "2.0.0",
   "versioning": {
     "created": "2025-11-04",
     "updated": "2025-11-04",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "id": "scheletro_idraulico_a_pistoni",
+  "data_origin": "incoming_tr1100_pack"
 }

--- a/incoming/traits/TR-1103.json
+++ b/incoming/traits/TR-1103.json
@@ -1,16 +1,12 @@
 {
   "trait_code": "TR-1103",
-  "label": "Ipertrofia Muscolare Massiva",
+  "label": "i18n:traits.ipertrofia_muscolare_massiva.label",
   "famiglia_tipologia": "Fisiologico/Metabolico",
   "fattore_mantenimento_energetico": "Alto",
   "tier": "T3",
   "slot": [],
-  "sinergie": [
-    "TR-1102"
-  ],
-  "conflitti": [
-    "TR-1105"
-  ],
+  "sinergie": ["scheletro_idraulico_a_pistoni"],
+  "conflitti": ["organi_sismici_cutanei"],
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -45,14 +41,14 @@
   },
   "applicability": {
     "clades": [],
-    "envo_terms": [
-      "http://purl.obolibrary.org/obo/ENVO_01000178"
-    ]
+    "envo_terms": ["http://purl.obolibrary.org/obo/ENVO_01000178"]
   },
   "version": "2.0.0",
   "versioning": {
     "created": "2025-11-04",
     "updated": "2025-11-04",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "id": "ipertrofia_muscolare_massiva",
+  "data_origin": "incoming_tr1100_pack"
 }

--- a/incoming/traits/TR-1104.json
+++ b/incoming/traits/TR-1104.json
@@ -1,13 +1,11 @@
 {
   "trait_code": "TR-1104",
-  "label": "Ectotermia Dinamica",
+  "label": "i18n:traits.ectotermia_dinamica.label",
   "famiglia_tipologia": "Fisiologico/Termico",
   "fattore_mantenimento_energetico": "Medio",
   "tier": "T3",
   "slot": [],
-  "sinergie": [
-    "TR-1103"
-  ],
+  "sinergie": ["ipertrofia_muscolare_massiva"],
   "conflitti": [],
   "requisiti_ambientali": [
     {
@@ -43,14 +41,14 @@
   },
   "applicability": {
     "clades": [],
-    "envo_terms": [
-      "http://purl.obolibrary.org/obo/ENVO_01000178"
-    ]
+    "envo_terms": ["http://purl.obolibrary.org/obo/ENVO_01000178"]
   },
   "version": "2.0.0",
   "versioning": {
     "created": "2025-11-04",
     "updated": "2025-11-04",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "id": "ectotermia_dinamica",
+  "data_origin": "incoming_tr1100_pack"
 }

--- a/incoming/traits/TR-1105.json
+++ b/incoming/traits/TR-1105.json
@@ -1,16 +1,12 @@
 {
   "trait_code": "TR-1105",
-  "label": "Organi Sismici Cutanei",
+  "label": "i18n:traits.organi_sismici_cutanei.label",
   "famiglia_tipologia": "Sensoriale/Tatto-Vibro",
   "fattore_mantenimento_energetico": "Basso",
   "tier": "T2",
   "slot": [],
-  "sinergie": [
-    "TR-1101"
-  ],
-  "conflitti": [
-    "TR-1103"
-  ],
+  "sinergie": ["rostro_emostatico_litico"],
+  "conflitti": ["ipertrofia_muscolare_massiva"],
   "requisiti_ambientali": [
     {
       "capacita_richieste": [],
@@ -45,14 +41,14 @@
   },
   "applicability": {
     "clades": [],
-    "envo_terms": [
-      "http://purl.obolibrary.org/obo/ENVO_01000178"
-    ]
+    "envo_terms": ["http://purl.obolibrary.org/obo/ENVO_01000178"]
   },
   "version": "2.0.0",
   "versioning": {
     "created": "2025-11-04",
     "updated": "2025-11-04",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "id": "organi_sismici_cutanei",
+  "data_origin": "incoming_tr1100_pack"
 }


### PR DESCRIPTION
## Summary
- assign definitive snake_case ids to the TR-1101–TR-1105 trait pack and update intra-pack synergies/conflicts
- switch trait labels to i18n references and record a shared data_origin for the new ids
- add bilingual label and description entries to the traits glossary for the new ids

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921b5b975388328b387b3d3a19365cd)