### PR TITLE
Add version metadata to Evo species data and schema

### DIFF
--- a/data/external/evo/species/anguis_magnetica.json
+++ b/data/external/evo/species/anguis_magnetica.json
@@ -43,5 +43,11 @@
       "TR-1804",
       "TR-1805"
     ]
+  },
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
   }
 }

--- a/data/external/evo/species/anguis_magnetica_ecotypes.json
+++ b/data/external/evo/species/anguis_magnetica_ecotypes.json
@@ -35,5 +35,11 @@
         }
       ]
     }
-  ]
+  ],
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
+  }
 }

--- a/data/external/evo/species/chemnotela_toxica.json
+++ b/data/external/evo/species/chemnotela_toxica.json
@@ -43,5 +43,11 @@
       "TR-1504",
       "TR-1505"
     ]
+  },
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
   }
 }

--- a/data/external/evo/species/chemnotela_toxica_ecotypes.json
+++ b/data/external/evo/species/chemnotela_toxica_ecotypes.json
@@ -35,5 +35,11 @@
         }
       ]
     }
-  ]
+  ],
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
+  }
 }

--- a/data/external/evo/species/elastovaranus_hydrus.json
+++ b/data/external/evo/species/elastovaranus_hydrus.json
@@ -45,5 +45,11 @@
       "TR-1104",
       "TR-1105"
     ]
+  },
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
   }
 }

--- a/data/external/evo/species/elastovaranus_hydrus_ecotypes.json
+++ b/data/external/evo/species/elastovaranus_hydrus_ecotypes.json
@@ -49,5 +49,11 @@
         }
       ]
     }
-  ]
+  ],
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
+  }
 }

--- a/data/external/evo/species/gulogluteus_scutiger.json
+++ b/data/external/evo/species/gulogluteus_scutiger.json
@@ -45,5 +45,11 @@
       "TR-1204",
       "TR-1205"
     ]
+  },
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
   }
 }

--- a/data/external/evo/species/gulogluteus_scutiger_ecotypes.json
+++ b/data/external/evo/species/gulogluteus_scutiger_ecotypes.json
@@ -49,5 +49,11 @@
         }
       ]
     }
-  ]
+  ],
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
+  }
 }

--- a/data/external/evo/species/perfusuas_pedes.json
+++ b/data/external/evo/species/perfusuas_pedes.json
@@ -43,5 +43,11 @@
       "TR-1304",
       "TR-1305"
     ]
+  },
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
   }
 }

--- a/data/external/evo/species/perfusuas_pedes_ecotypes.json
+++ b/data/external/evo/species/perfusuas_pedes_ecotypes.json
@@ -42,5 +42,11 @@
         }
       ]
     }
-  ]
+  ],
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
+  }
 }

--- a/data/external/evo/species/proteus_plasma.json
+++ b/data/external/evo/species/proteus_plasma.json
@@ -43,5 +43,11 @@
       "TR-1604",
       "TR-1605"
     ]
+  },
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
   }
 }

--- a/data/external/evo/species/proteus_plasma_ecotypes.json
+++ b/data/external/evo/species/proteus_plasma_ecotypes.json
@@ -31,5 +31,11 @@
         }
       ]
     }
-  ]
+  ],
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
+  }
 }

--- a/data/external/evo/species/rupicapra_sensoria.json
+++ b/data/external/evo/species/rupicapra_sensoria.json
@@ -40,5 +40,11 @@
       "TR-2004",
       "TR-2005"
     ]
+  },
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
   }
 }

--- a/data/external/evo/species/rupicapra_sensoria_ecotypes.json
+++ b/data/external/evo/species/rupicapra_sensoria_ecotypes.json
@@ -42,5 +42,11 @@
         }
       ]
     }
-  ]
+  ],
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
+  }
 }

--- a/data/external/evo/species/soniptera_resonans.json
+++ b/data/external/evo/species/soniptera_resonans.json
@@ -43,5 +43,11 @@
       "TR-1704",
       "TR-1705"
     ]
+  },
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
   }
 }

--- a/data/external/evo/species/soniptera_resonans_ecotypes.json
+++ b/data/external/evo/species/soniptera_resonans_ecotypes.json
@@ -35,5 +35,11 @@
         }
       ]
     }
-  ]
+  ],
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
+  }
 }

--- a/data/external/evo/species/species_catalog.json
+++ b/data/external/evo/species/species_catalog.json
@@ -43,7 +43,13 @@
         "TR-1803",
         "TR-1804",
         "TR-1805"
-      ]
+      ],
+      "version": "2.0.0",
+      "versioning": {
+        "created": "2025-11-22",
+        "updated": "2025-11-22",
+        "author": "GPT-5.1-Codex-Max"
+      }
     },
     {
       "scientific_name": "Chemnotela toxica",
@@ -88,7 +94,13 @@
         "TR-1503",
         "TR-1504",
         "TR-1505"
-      ]
+      ],
+      "version": "2.0.0",
+      "versioning": {
+        "created": "2025-11-22",
+        "updated": "2025-11-22",
+        "author": "GPT-5.1-Codex-Max"
+      }
     },
     {
       "scientific_name": "Elastovaranus hydrus",
@@ -135,7 +147,13 @@
         "TR-1103",
         "TR-1104",
         "TR-1105"
-      ]
+      ],
+      "version": "2.0.0",
+      "versioning": {
+        "created": "2025-11-22",
+        "updated": "2025-11-22",
+        "author": "GPT-5.1-Codex-Max"
+      }
     },
     {
       "scientific_name": "Gulogluteus scutiger",
@@ -182,7 +200,13 @@
         "TR-1203",
         "TR-1204",
         "TR-1205"
-      ]
+      ],
+      "version": "2.0.0",
+      "versioning": {
+        "created": "2025-11-22",
+        "updated": "2025-11-22",
+        "author": "GPT-5.1-Codex-Max"
+      }
     },
     {
       "scientific_name": "Perfusuas pedes",
@@ -227,7 +251,13 @@
         "TR-1303",
         "TR-1304",
         "TR-1305"
-      ]
+      ],
+      "version": "2.0.0",
+      "versioning": {
+        "created": "2025-11-22",
+        "updated": "2025-11-22",
+        "author": "GPT-5.1-Codex-Max"
+      }
     },
     {
       "scientific_name": "Proteus plasma",
@@ -272,7 +302,13 @@
         "TR-1603",
         "TR-1604",
         "TR-1605"
-      ]
+      ],
+      "version": "2.0.0",
+      "versioning": {
+        "created": "2025-11-22",
+        "updated": "2025-11-22",
+        "author": "GPT-5.1-Codex-Max"
+      }
     },
     {
       "scientific_name": "Rupicapra sensoria",
@@ -314,7 +350,13 @@
         "TR-2003",
         "TR-2004",
         "TR-2005"
-      ]
+      ],
+      "version": "2.0.0",
+      "versioning": {
+        "created": "2025-11-22",
+        "updated": "2025-11-22",
+        "author": "GPT-5.1-Codex-Max"
+      }
     },
     {
       "scientific_name": "Soniptera resonans",
@@ -359,7 +401,13 @@
         "TR-1703",
         "TR-1704",
         "TR-1705"
-      ]
+      ],
+      "version": "2.0.0",
+      "versioning": {
+        "created": "2025-11-22",
+        "updated": "2025-11-22",
+        "author": "GPT-5.1-Codex-Max"
+      }
     },
     {
       "scientific_name": "Terracetus ambulator",
@@ -402,7 +450,13 @@
         "TR-1403",
         "TR-1404",
         "TR-1405"
-      ]
+      ],
+      "version": "2.0.0",
+      "versioning": {
+        "created": "2025-11-22",
+        "updated": "2025-11-22",
+        "author": "GPT-5.1-Codex-Max"
+      }
     },
     {
       "scientific_name": "Umbra alaris",
@@ -446,7 +500,13 @@
         "TR-1903",
         "TR-1904",
         "TR-1905"
-      ]
+      ],
+      "version": "2.0.0",
+      "versioning": {
+        "created": "2025-11-22",
+        "updated": "2025-11-22",
+        "author": "GPT-5.1-Codex-Max"
+      }
     }
   ]
 }

--- a/data/external/evo/species/terracetus_ambulator.json
+++ b/data/external/evo/species/terracetus_ambulator.json
@@ -41,5 +41,11 @@
       "TR-1404",
       "TR-1405"
     ]
+  },
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
   }
 }

--- a/data/external/evo/species/terracetus_ambulator_ecotypes.json
+++ b/data/external/evo/species/terracetus_ambulator_ecotypes.json
@@ -35,5 +35,11 @@
         }
       ]
     }
-  ]
+  ],
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
+  }
 }

--- a/data/external/evo/species/umbra_alaris.json
+++ b/data/external/evo/species/umbra_alaris.json
@@ -42,5 +42,11 @@
       "TR-1904",
       "TR-1905"
     ]
+  },
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
   }
 }

--- a/data/external/evo/species/umbra_alaris_ecotypes.json
+++ b/data/external/evo/species/umbra_alaris_ecotypes.json
@@ -35,5 +35,11 @@
         }
       ]
     }
-  ]
+  ],
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-22",
+    "updated": "2025-11-22",
+    "author": "GPT-5.1-Codex-Max"
+  }
 }

--- a/schemas/evo/species.schema.json
+++ b/schemas/evo/species.schema.json
@@ -4,20 +4,13 @@
   "title": "Evo Tactics Species",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "species"
-  ],
+  "required": ["species"],
   "properties": {
     "species": {
       "type": "object",
       "title": "Species payload",
       "additionalProperties": false,
-      "required": [
-        "scientific_name",
-        "classification",
-        "functional_signature",
-        "trait_refs"
-      ],
+      "required": ["scientific_name", "classification", "functional_signature", "trait_refs"],
       "properties": {
         "scientific_name": {
           "type": "string",
@@ -34,10 +27,7 @@
         "classification": {
           "type": "object",
           "additionalProperties": false,
-          "required": [
-            "macro_class",
-            "habitat"
-          ],
+          "required": ["macro_class", "habitat"],
           "properties": {
             "macro_class": {
               "$ref": "enums.json#/$defs/macro_class"
@@ -119,6 +109,32 @@
             "pattern": "^TR-\\d{4}$"
           },
           "uniqueItems": true
+        }
+      }
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z-.]+)?(?:\\+[0-9A-Za-z-.]+)?$"
+    },
+    "versioning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["created", "updated", "author"],
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date"
+        },
+        "author": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string"
         }
       }
     }

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -73,7 +73,8 @@ if [[ "$DATASET" == "evo-species" ]]; then
   # Exclude ecotype payloads and catalog aggregators from schema validation.
   mapfile -t FILES < <(find "$DATA_DIR" -maxdepth 1 -type f -name '*.json' \
     ! -name '*_ecotypes.json' \
-    ! -name 'species_catalog.json')
+    ! -name 'species_catalog.json' \
+    ! -name 'species_ecotype_map.json')
 fi
 
 if [[ ${#FILES[@]} -eq 0 ]]; then


### PR DESCRIPTION
## Descrizione
- Aggiunta la sezione di versioning SemVer a tutte le schede specie/ecotipo Evo e al catalogo aggregato.
- Esteso lo schema `species.schema.json` per accettare i nuovi campi di versioning e adeguato lo script di validazione.

## Checklist guida stile & QA
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato
- [x] Documentazione/processi aggiornati ove necessario

## Testing
- [x] `bash scripts/validate.sh --dataset evo-species --schema schemas/evo/species.schema.json`
- [ ] Altro: <!-- specificare -->

## Note
<!-- Link a report, artefatti o follow-up da pianificare. -->

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921cf396fec8328916caa4d1f890c81)