### PR TITLE
Clarify energy maintenance factor descriptions

### DIFF
--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2025-11-22T13:10:03.882660+00:00",
+  "updated_at": "2025-11-22T15:10:41+00:00",
   "sources": {
     "trait_reference": "data/traits/index.json"
   },
@@ -650,8 +650,8 @@
     "ectotermia_dinamica": {
       "label_it": "Ectotermia Dinamica",
       "label_en": "Dynamic Ectothermy",
-      "description_it": "Microscosse isometriche che innalzano rapidamente la temperatura corporea per picchi prestazionali.",
-      "description_en": "Isometric micro-shivers that rapidly raise body temperature for performance spikes."
+      "description_it": "Microscosse isometriche che innalzano in fretta la temperatura corporea per picchi prestazionali in climi freschi.",
+      "description_en": "Isometric micro-shivers that quickly elevate body temperature for performance peaks in cool climates."
     },
     "elettromagnete_biologico": {
       "label_it": "Elettromagnete Biologico",
@@ -926,8 +926,8 @@
     "ipertrofia_muscolare_massiva": {
       "label_it": "Ipertrofia Muscolare Massiva",
       "label_en": "Massive Muscular Hypertrophy",
-      "description_it": "Fibre ispessite e mitocondri densi che aumentano potenza, scatto e tolleranza allo sforzo breve.",
-      "description_en": "Thickened fibres with dense mitochondria boosting power, burst acceleration, and short-term strain tolerance."
+      "description_it": "Fibre a sezione aumentata e mitocondri densi che sprigionano potenza e scatto sostenendo sforzi brevi.",
+      "description_en": "Broadened fibres with dense mitochondria that unleash power and acceleration while enduring short bursts."
     },
     "lamelle_shear": {
       "label_it": "Lamelle Shear",
@@ -1184,8 +1184,8 @@
     "rostro_emostatico_litico": {
       "label_it": "Rostro Emostatico-Litico",
       "label_en": "Hemo-Lytic Rostrum",
-      "description_it": "Rostro tubulare rigido che inietta enzimi coagulanti e litici aspirando fluidi dopo l’impatto.",
-      "description_en": "Rigid tubular rostrum that injects lytic and coagulant enzymes while drawing fluids after impact."
+      "description_it": "Rostro tubulare rigidizzato che inocula tossine ed enzimi e aspira fluidi dopo l’impatto.",
+      "description_en": "Reinforced tubular rostrum that injects toxins and enzymes, then draws fluids after impact."
     },
     "rostro_linguale_prensile": {
       "label_it": "Rostro Linguale Prensile",

--- a/data/traits/_drafts/artigli_a_sette_vie.json
+++ b/data/traits/_drafts/artigli_a_sette_vie.json
@@ -2,7 +2,7 @@
   "id": "artigli_a_sette_vie",
   "label": "i18n:traits.artigli_a_sette_vie.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_a_sette_vie.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/balance_reflex.json
+++ b/data/traits/_drafts/balance_reflex.json
@@ -2,7 +2,7 @@
   "id": "balance_reflex",
   "label": "i18n:traits.balance_reflex.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.balance_reflex.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T2",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/coda_a_frusta_cinetica.json
+++ b/data/traits/_drafts/coda_a_frusta_cinetica.json
@@ -2,7 +2,7 @@
   "id": "coda_a_frusta_cinetica",
   "label": "i18n:traits.coda_a_frusta_cinetica.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_a_frusta_cinetica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/craft_loop.json
+++ b/data/traits/_drafts/craft_loop.json
@@ -2,7 +2,7 @@
   "id": "craft_loop",
   "label": "i18n:traits.craft_loop.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.craft_loop.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T5",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/criostasi.json
+++ b/data/traits/_drafts/criostasi.json
@@ -2,7 +2,7 @@
   "id": "criostasi",
   "label": "i18n:traits.criostasi.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.criostasi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/echoic_trace.json
+++ b/data/traits/_drafts/echoic_trace.json
@@ -2,7 +2,7 @@
   "id": "echoic_trace",
   "label": "i18n:traits.echoic_trace.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.echoic_trace.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T3",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/executive_loop.json
+++ b/data/traits/_drafts/executive_loop.json
@@ -2,7 +2,7 @@
   "id": "executive_loop",
   "label": "i18n:traits.executive_loop.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.executive_loop.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T6",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/focus_frazionato_2.json
+++ b/data/traits/_drafts/focus_frazionato_2.json
@@ -2,7 +2,7 @@
   "id": "focus_frazionato_2",
   "label": "i18n:traits.focus_frazionato_2.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.focus_frazionato_2.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/group_form.json
+++ b/data/traits/_drafts/group_form.json
@@ -2,7 +2,7 @@
   "id": "group_form",
   "label": "i18n:traits.group_form.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.group_form.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T4",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/interoception_seed.json
+++ b/data/traits/_drafts/interoception_seed.json
@@ -2,7 +2,7 @@
   "id": "interoception_seed",
   "label": "i18n:traits.interoception_seed.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.interoception_seed.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/mimicry_basic.json
+++ b/data/traits/_drafts/mimicry_basic.json
@@ -2,7 +2,7 @@
   "id": "mimicry_basic",
   "label": "i18n:traits.mimicry_basic.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.mimicry_basic.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T2",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/postural_endurance.json
+++ b/data/traits/_drafts/postural_endurance.json
@@ -2,7 +2,7 @@
   "id": "postural_endurance",
   "label": "i18n:traits.postural_endurance.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.postural_endurance.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T6",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/risonanza_di_branco_2.json
+++ b/data/traits/_drafts/risonanza_di_branco_2.json
@@ -2,7 +2,7 @@
   "id": "risonanza_di_branco_2",
   "label": "i18n:traits.risonanza_di_branco_2.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.risonanza_di_branco_2.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/sacche_galleggianti_ascensoriali_2.json
+++ b/data/traits/_drafts/sacche_galleggianti_ascensoriali_2.json
@@ -2,7 +2,7 @@
   "id": "sacche_galleggianti_ascensoriali_2",
   "label": "i18n:traits.sacche_galleggianti_ascensoriali_2.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.sacche_galleggianti_ascensoriali_2.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/scheletro_idro_regolante_2.json
+++ b/data/traits/_drafts/scheletro_idro_regolante_2.json
@@ -2,7 +2,7 @@
   "id": "scheletro_idro_regolante_2",
   "label": "i18n:traits.scheletro_idro_regolante_2.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.scheletro_idro_regolante_2.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/sheltering.json
+++ b/data/traits/_drafts/sheltering.json
@@ -2,7 +2,7 @@
   "id": "sheltering",
   "label": "i18n:traits.sheltering.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.sheltering.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T5",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/startle_reflex.json
+++ b/data/traits/_drafts/startle_reflex.json
@@ -2,7 +2,7 @@
   "id": "startle_reflex",
   "label": "i18n:traits.startle_reflex.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.startle_reflex.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/struttura_elastica_amorfa_2.json
+++ b/data/traits/_drafts/struttura_elastica_amorfa_2.json
@@ -2,7 +2,7 @@
   "id": "struttura_elastica_amorfa_2",
   "label": "i18n:traits.struttura_elastica_amorfa_2.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.struttura_elastica_amorfa_2.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/tattiche_di_branco_2.json
+++ b/data/traits/_drafts/tattiche_di_branco_2.json
@@ -2,7 +2,7 @@
   "id": "tattiche_di_branco_2",
   "label": "i18n:traits.tattiche_di_branco_2.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.tattiche_di_branco_2.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T1",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/teach_action.json
+++ b/data/traits/_drafts/teach_action.json
@@ -2,7 +2,7 @@
   "id": "teach_action",
   "label": "i18n:traits.teach_action.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.teach_action.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T4",
   "slot": [],
   "slot_profile": {

--- a/data/traits/_drafts/toolseed.json
+++ b/data/traits/_drafts/toolseed.json
@@ -2,7 +2,7 @@
   "id": "toolseed",
   "label": "i18n:traits.toolseed.label",
   "famiglia_tipologia": "TODO/import_esterno",
-  "fattore_mantenimento_energetico": "i18n:traits.toolseed.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Da definire (import esterno)",
   "tier": "T3",
   "slot": [],
   "slot_profile": {

--- a/data/traits/alimentazione/fagocitosi_assorbente.json
+++ b/data/traits/alimentazione/fagocitosi_assorbente.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.fagocitosi_assorbente.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Alimentazione/Digestione",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/alimentazione/filtro_metallofago.json
+++ b/data/traits/alimentazione/filtro_metallofago.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.filtro_metallofago.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Alimentazione/Digestione",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T2",
   "slot": [],
   "sinergie": [

--- a/data/traits/cognitivo/cervello_a_bassa_latenza.json
+++ b/data/traits/cognitivo/cervello_a_bassa_latenza.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.cervello_a_bassa_latenza.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Cognitivo/Apprendimento",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/cognitivo/comunicazione_fotonica_coda_coda.json
+++ b/data/traits/cognitivo/comunicazione_fotonica_coda_coda.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.comunicazione_fotonica_coda_coda.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Cognitivo/Sociale",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T2",
   "slot": [],
   "sinergie": [

--- a/data/traits/cognitivo/corna_psico_conduttive.json
+++ b/data/traits/cognitivo/corna_psico_conduttive.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.corna_psico_conduttive.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Cognitivo/Sociale",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/cognitivo/coscienza_dalveare_diffusa.json
+++ b/data/traits/cognitivo/coscienza_dalveare_diffusa.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.coscienza_dalveare_diffusa.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Cognitivo/Sociale",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T4",
   "slot": [],
   "sinergie": [

--- a/data/traits/difensivo/ali_membrana_sonica.json
+++ b/data/traits/difensivo/ali_membrana_sonica.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ali_membrana_sonica.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.ali_membrana_sonica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ali_membrana_sonica",
   "label": "i18n:traits.ali_membrana_sonica.label",
   "mutazione_indotta": "i18n:traits.ali_membrana_sonica.mutazione_indotta",

--- a/data/traits/difensivo/appendici_risonanti_marea.json
+++ b/data/traits/difensivo/appendici_risonanti_marea.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.appendici_risonanti_marea.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.appendici_risonanti_marea.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "appendici_risonanti_marea",
   "label": "i18n:traits.appendici_risonanti_marea.label",
   "mutazione_indotta": "i18n:traits.appendici_risonanti_marea.mutazione_indotta",

--- a/data/traits/difensivo/barriere_miasma_glaciale.json
+++ b/data/traits/difensivo/barriere_miasma_glaciale.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.barriere_miasma_glaciale.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.barriere_miasma_glaciale.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "barriere_miasma_glaciale",
   "label": "i18n:traits.barriere_miasma_glaciale.label",
   "mutazione_indotta": "i18n:traits.barriere_miasma_glaciale.mutazione_indotta",

--- a/data/traits/difensivo/bozzolo_magnetico.json
+++ b/data/traits/difensivo/bozzolo_magnetico.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.bozzolo_magnetico.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Difensivo/Resistenze",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T2",
   "slot": [],
   "sinergie": [

--- a/data/traits/difensivo/branchie_microfiltri.json
+++ b/data/traits/difensivo/branchie_microfiltri.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.branchie_microfiltri.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.branchie_microfiltri.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "branchie_microfiltri",
   "label": "i18n:traits.branchie_microfiltri.label",
   "mutazione_indotta": "i18n:traits.branchie_microfiltri.mutazione_indotta",

--- a/data/traits/difensivo/campo_di_interferenza_acustica.json
+++ b/data/traits/difensivo/campo_di_interferenza_acustica.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.campo_di_interferenza_acustica.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Difensivo/Camuffamento",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/difensivo/capsule_paracadute.json
+++ b/data/traits/difensivo/capsule_paracadute.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.capsule_paracadute.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.capsule_paracadute.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "capsule_paracadute",
   "label": "i18n:traits.capsule_paracadute.label",
   "mutazione_indotta": "i18n:traits.capsule_paracadute.mutazione_indotta",

--- a/data/traits/difensivo/circolazione_bifasica.json
+++ b/data/traits/difensivo/circolazione_bifasica.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.circolazione_bifasica.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.circolazione_bifasica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "circolazione_bifasica",
   "label": "i18n:traits.circolazione_bifasica.label",
   "mutazione_indotta": "i18n:traits.circolazione_bifasica.mutazione_indotta",

--- a/data/traits/difensivo/cisti_di_ibernazione_minerale.json
+++ b/data/traits/difensivo/cisti_di_ibernazione_minerale.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.cisti_di_ibernazione_minerale.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Difensivo/Resistenze",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T2",
   "slot": [],
   "sinergie": [

--- a/data/traits/difensivo/coda_coppia_retroattiva.json
+++ b/data/traits/difensivo/coda_coppia_retroattiva.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.coda_coppia_retroattiva.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_coppia_retroattiva.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "coda_coppia_retroattiva",
   "label": "i18n:traits.coda_coppia_retroattiva.label",
   "mutazione_indotta": "i18n:traits.coda_coppia_retroattiva.mutazione_indotta",

--- a/data/traits/difensivo/cute_resistente_sali.json
+++ b/data/traits/difensivo/cute_resistente_sali.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.cute_resistente_sali.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.cute_resistente_sali.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Attivazione situazionale)",
   "id": "cute_resistente_sali",
   "label": "i18n:traits.cute_resistente_sali.label",
   "mutazione_indotta": "i18n:traits.cute_resistente_sali.mutazione_indotta",

--- a/data/traits/difensivo/enzimi_antipredatori_algali.json
+++ b/data/traits/difensivo/enzimi_antipredatori_algali.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.enzimi_antipredatori_algali.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.enzimi_antipredatori_algali.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "enzimi_antipredatori_algali",
   "label": "i18n:traits.enzimi_antipredatori_algali.label",
   "mutazione_indotta": "i18n:traits.enzimi_antipredatori_algali.mutazione_indotta",

--- a/data/traits/difensivo/filtri_planctonici.json
+++ b/data/traits/difensivo/filtri_planctonici.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.filtri_planctonici.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.filtri_planctonici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "filtri_planctonici",
   "label": "i18n:traits.filtri_planctonici.label",
   "mutazione_indotta": "i18n:traits.filtri_planctonici.mutazione_indotta",

--- a/data/traits/difensivo/ghiandole_fango_coesivo.json
+++ b/data/traits/difensivo/ghiandole_fango_coesivo.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ghiandole_fango_coesivo.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_fango_coesivo.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_fango_coesivo",
   "label": "i18n:traits.ghiandole_fango_coesivo.label",
   "mutazione_indotta": "i18n:traits.ghiandole_fango_coesivo.mutazione_indotta",

--- a/data/traits/difensivo/giunti_antitorsione.json
+++ b/data/traits/difensivo/giunti_antitorsione.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.giunti_antitorsione.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.giunti_antitorsione.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "giunti_antitorsione",
   "label": "i18n:traits.giunti_antitorsione.label",
   "mutazione_indotta": "i18n:traits.giunti_antitorsione.mutazione_indotta",

--- a/data/traits/difensivo/lingua_cristallina.json
+++ b/data/traits/difensivo/lingua_cristallina.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.lingua_cristallina.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.lingua_cristallina.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "lingua_cristallina",
   "label": "i18n:traits.lingua_cristallina.label",
   "mutazione_indotta": "i18n:traits.lingua_cristallina.mutazione_indotta",

--- a/data/traits/difensivo/membrana_plastica_continua.json
+++ b/data/traits/difensivo/membrana_plastica_continua.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.membrana_plastica_continua.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Difensivo/Camuffamento",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/difensivo/mucose_barofile.json
+++ b/data/traits/difensivo/mucose_barofile.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.mucose_barofile.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.mucose_barofile.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "mucose_barofile",
   "label": "i18n:traits.mucose_barofile.label",
   "mutazione_indotta": "i18n:traits.mucose_barofile.mutazione_indotta",

--- a/data/traits/difensivo/pelage_idrorepellente_avanzato.json
+++ b/data/traits/difensivo/pelage_idrorepellente_avanzato.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.pelage_idrorepellente_avanzato.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Difensivo/Termoregolazione",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T2",
   "slot": [],
   "sinergie": [

--- a/data/traits/difensivo/scudo_gluteale_cheratinizzato.json
+++ b/data/traits/difensivo/scudo_gluteale_cheratinizzato.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.scudo_gluteale_cheratinizzato.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Difensivo/Corazza",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/difensivo/vello_di_assorbimento_totale.json
+++ b/data/traits/difensivo/vello_di_assorbimento_totale.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.vello_di_assorbimento_totale.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Difensivo/Camuffamento",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/difesa/armatura_pietra_planare.json
+++ b/data/traits/difesa/armatura_pietra_planare.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.armatura_pietra_planare.debolezza",
   "famiglia_tipologia": "Difesa/Strutturale",
-  "fattore_mantenimento_energetico": "i18n:traits.armatura_pietra_planare.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Risonanza geodetica stabile)",
   "id": "armatura_pietra_planare",
   "label": "i18n:traits.armatura_pietra_planare.label",
   "mutazione_indotta": "i18n:traits.armatura_pietra_planare.mutazione_indotta",

--- a/data/traits/difesa/mantello_meteoritico.json
+++ b/data/traits/difesa/mantello_meteoritico.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.mantello_meteoritico.debolezza",
   "famiglia_tipologia": "Difesa/Termoregolazione",
-  "fattore_mantenimento_energetico": "i18n:traits.mantello_meteoritico.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Rivestimento ablativo rigenerante)",
   "id": "mantello_meteoritico",
   "label": "i18n:traits.mantello_meteoritico.label",
   "mutazione_indotta": "i18n:traits.mantello_meteoritico.mutazione_indotta",

--- a/data/traits/digestivo/filamenti_digestivi_compattanti.json
+++ b/data/traits/digestivo/filamenti_digestivi_compattanti.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.filamenti_digestivi_compattanti.debolezza",
   "famiglia_tipologia": "Digestivo/Escretorio",
-  "fattore_mantenimento_energetico": "i18n:traits.filamenti_digestivi_compattanti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "filamenti_digestivi_compattanti",
   "label": "i18n:traits.filamenti_digestivi_compattanti.label",
   "mutazione_indotta": "i18n:traits.filamenti_digestivi_compattanti.mutazione_indotta",

--- a/data/traits/digestivo/ventriglio_gastroliti.json
+++ b/data/traits/digestivo/ventriglio_gastroliti.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ventriglio_gastroliti.debolezza",
   "famiglia_tipologia": "Digestivo/Alimentare",
-  "fattore_mantenimento_energetico": "i18n:traits.ventriglio_gastroliti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Contrazione muscolare costante)",
   "id": "ventriglio_gastroliti",
   "label": "i18n:traits.ventriglio_gastroliti.label",
   "mutazione_indotta": "i18n:traits.ventriglio_gastroliti.mutazione_indotta",

--- a/data/traits/escretorio/spore_psichiche_silenziate.json
+++ b/data/traits/escretorio/spore_psichiche_silenziate.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.spore_psichiche_silenziate.debolezza",
   "famiglia_tipologia": "Escretorio/Psichico",
-  "fattore_mantenimento_energetico": "i18n:traits.spore_psichiche_silenziate.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Produzione e rilascio)",
   "id": "spore_psichiche_silenziate",
   "label": "i18n:traits.spore_psichiche_silenziate.label",
   "mutazione_indotta": "i18n:traits.spore_psichiche_silenziate.mutazione_indotta",

--- a/data/traits/fisiologico/ectotermia_dinamica.json
+++ b/data/traits/fisiologico/ectotermia_dinamica.json
@@ -1,9 +1,9 @@
 {
   "id": "ectotermia_dinamica",
   "label": "i18n:traits.ectotermia_dinamica.label",
-  "data_origin": "coverage_q4_2025",
+  "data_origin": "incoming_tr1100_pack",
   "famiglia_tipologia": "Fisiologico/Termico",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [
@@ -47,5 +47,11 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
+  },
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-04",
+    "updated": "2025-11-04",
+    "author": "Master DD / GPT-5 Pro"
   }
 }

--- a/data/traits/fisiologico/filtrazione_osmotica.json
+++ b/data/traits/fisiologico/filtrazione_osmotica.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.filtrazione_osmotica.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Fisiologico/Idrico",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T2",
   "slot": [],
   "sinergie": [

--- a/data/traits/fisiologico/ipertrofia_muscolare_massiva.json
+++ b/data/traits/fisiologico/ipertrofia_muscolare_massiva.json
@@ -1,9 +1,9 @@
 {
   "id": "ipertrofia_muscolare_massiva",
   "label": "i18n:traits.ipertrofia_muscolare_massiva.label",
-  "data_origin": "coverage_q4_2025",
+  "data_origin": "incoming_tr1100_pack",
   "famiglia_tipologia": "Fisiologico/Metabolico",
-  "fattore_mantenimento_energetico": "Alto",
+  "fattore_mantenimento_energetico": "Alto (apporto costante o consumo continuo)",
   "tier": "T3",
   "slot": [],
   "sinergie": [
@@ -49,5 +49,11 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
+  },
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-04",
+    "updated": "2025-11-04",
+    "author": "Master DD / GPT-5 Pro"
   }
 }

--- a/data/traits/fisiologico/metabolismo_di_condivisione_energetica.json
+++ b/data/traits/fisiologico/metabolismo_di_condivisione_energetica.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.metabolismo_di_condivisione_energetica.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Fisiologico/Metabolico",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/fisiologico/motore_biologico_silenzioso.json
+++ b/data/traits/fisiologico/motore_biologico_silenzioso.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.motore_biologico_silenzioso.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Fisiologico/Metabolico",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T2",
   "slot": [],
   "sinergie": [

--- a/data/traits/fisiologico/rete_filtro_polmonare.json
+++ b/data/traits/fisiologico/rete_filtro_polmonare.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.rete_filtro_polmonare.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Fisiologico/Respiratorio",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/fisiologico/siero_anti_gelo_naturale.json
+++ b/data/traits/fisiologico/siero_anti_gelo_naturale.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.siero_anti_gelo_naturale.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Fisiologico/Termico",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T2",
   "slot": [],
   "sinergie": [

--- a/data/traits/idrostatico/sacche_galleggianti_ascensoriali.json
+++ b/data/traits/idrostatico/sacche_galleggianti_ascensoriali.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.sacche_galleggianti_ascensoriali.debolezza",
   "famiglia_tipologia": "Idrostatico/Locomotorio",
-  "fattore_mantenimento_energetico": "i18n:traits.sacche_galleggianti_ascensoriali.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Per il controllo della pressione)",
   "id": "sacche_galleggianti_ascensoriali",
   "label": "i18n:traits.sacche_galleggianti_ascensoriali.label",
   "mutazione_indotta": "i18n:traits.sacche_galleggianti_ascensoriali.mutazione_indotta",

--- a/data/traits/locomotivo/ali_fono_risonanti.json
+++ b/data/traits/locomotivo/ali_fono_risonanti.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.ali_fono_risonanti.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Locomotivo/Aereo",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/locomotivo/articolazioni_a_leva_idraulica.json
+++ b/data/traits/locomotivo/articolazioni_a_leva_idraulica.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.articolazioni_a_leva_idraulica.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Locomotivo/Terrestre",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/locomotivo/articolazioni_multiassiali.json
+++ b/data/traits/locomotivo/articolazioni_multiassiali.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.articolazioni_multiassiali.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Locomotivo/Terrestre",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/locomotivo/cinghia_iper_ciliare.json
+++ b/data/traits/locomotivo/cinghia_iper_ciliare.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.cinghia_iper_ciliare.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Locomotivo/Terrestre",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/locomotivo/coda_prensile_muscolare.json
+++ b/data/traits/locomotivo/coda_prensile_muscolare.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.coda_prensile_muscolare.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Locomotivo/Arboricolo",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/locomotivo/flusso_ameboide_controllato.json
+++ b/data/traits/locomotivo/flusso_ameboide_controllato.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.flusso_ameboide_controllato.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Locomotivo/Terrestre",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T2",
   "slot": [],
   "sinergie": [

--- a/data/traits/locomotivo/locomozione_miriapode_ibrida.json
+++ b/data/traits/locomotivo/locomozione_miriapode_ibrida.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.locomozione_miriapode_ibrida.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Locomotivo/Terrestre",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/locomotivo/scheletro_idraulico_a_pistoni.json
+++ b/data/traits/locomotivo/scheletro_idraulico_a_pistoni.json
@@ -1,9 +1,9 @@
 {
   "id": "scheletro_idraulico_a_pistoni",
   "label": "i18n:traits.scheletro_idraulico_a_pistoni.label",
-  "data_origin": "coverage_q4_2025",
+  "data_origin": "incoming_tr1100_pack",
   "famiglia_tipologia": "Locomotivo/Balistico",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T4",
   "slot": [],
   "sinergie": [
@@ -48,5 +48,11 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
+  },
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-04",
+    "updated": "2025-11-04",
+    "author": "Master DD / GPT-5 Pro"
   }
 }

--- a/data/traits/locomotivo/scheletro_pneumatico_a_maglie.json
+++ b/data/traits/locomotivo/scheletro_pneumatico_a_maglie.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.scheletro_pneumatico_a_maglie.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Locomotivo/Terrestre",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/locomotivo/scivolamento_magnetico.json
+++ b/data/traits/locomotivo/scivolamento_magnetico.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.scivolamento_magnetico.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Locomotivo/Terrestre",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/locomotivo/unghie_a_micro_adesione.json
+++ b/data/traits/locomotivo/unghie_a_micro_adesione.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.unghie_a_micro_adesione.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Locomotivo/Arboricolo",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T2",
   "slot": [],
   "sinergie": [

--- a/data/traits/locomotorio/ali_ioniche.json
+++ b/data/traits/locomotorio/ali_ioniche.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ali_ioniche.debolezza",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.ali_ioniche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ali_ioniche",
   "label": "i18n:traits.ali_ioniche.label",
   "mutazione_indotta": "i18n:traits.ali_ioniche.mutazione_indotta",

--- a/data/traits/locomotorio/antenne_wideband.json
+++ b/data/traits/locomotorio/antenne_wideband.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.antenne_wideband.debolezza",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_wideband.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_wideband",
   "label": "i18n:traits.antenne_wideband.label",
   "mutazione_indotta": "i18n:traits.antenne_wideband.mutazione_indotta",

--- a/data/traits/locomotorio/artigli_sette_vie.json
+++ b/data/traits/locomotorio/artigli_sette_vie.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.artigli_sette_vie.debolezza",
   "famiglia_tipologia": "Locomotorio/Prensile",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_sette_vie.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "artigli_sette_vie",
   "label": "i18n:traits.artigli_sette_vie.label",
   "mutazione_indotta": "i18n:traits.artigli_sette_vie.mutazione_indotta",

--- a/data/traits/locomotorio/artigli_sghiaccio_glaciale.json
+++ b/data/traits/locomotorio/artigli_sghiaccio_glaciale.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.artigli_sghiaccio_glaciale.debolezza",
   "famiglia_tipologia": "Locomotorio/Predatorio",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_sghiaccio_glaciale.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Raffreddamento endogeno controllato)",
   "id": "artigli_sghiaccio_glaciale",
   "label": "i18n:traits.artigli_sghiaccio_glaciale.label",
   "mutazione_indotta": "i18n:traits.artigli_sghiaccio_glaciale.mutazione_indotta",

--- a/data/traits/locomotorio/barbigli_sensori_plasma.json
+++ b/data/traits/locomotorio/barbigli_sensori_plasma.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.barbigli_sensori_plasma.debolezza",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.barbigli_sensori_plasma.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "barbigli_sensori_plasma",
   "label": "i18n:traits.barbigli_sensori_plasma.label",
   "mutazione_indotta": "i18n:traits.barbigli_sensori_plasma.mutazione_indotta",

--- a/data/traits/locomotorio/branchie_metalloidi.json
+++ b/data/traits/locomotorio/branchie_metalloidi.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.branchie_metalloidi.debolezza",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.branchie_metalloidi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "branchie_metalloidi",
   "label": "i18n:traits.branchie_metalloidi.label",
   "mutazione_indotta": "i18n:traits.branchie_metalloidi.mutazione_indotta",

--- a/data/traits/locomotorio/capillari_fotovoltaici.json
+++ b/data/traits/locomotorio/capillari_fotovoltaici.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.capillari_fotovoltaici.debolezza",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.capillari_fotovoltaici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "capillari_fotovoltaici",
   "label": "i18n:traits.capillari_fotovoltaici.label",
   "mutazione_indotta": "i18n:traits.capillari_fotovoltaici.mutazione_indotta",

--- a/data/traits/locomotorio/cartilagine_flessotermica_venti.json
+++ b/data/traits/locomotorio/cartilagine_flessotermica_venti.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.cartilagine_flessotermica_venti.debolezza",
   "famiglia_tipologia": "Locomotorio/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.cartilagine_flessotermica_venti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Richiede frequenti riallineamenti fibrosi)",
   "id": "cartilagine_flessotermica_venti",
   "label": "i18n:traits.cartilagine_flessotermica_venti.label",
   "mutazione_indotta": "i18n:traits.cartilagine_flessotermica_venti.mutazione_indotta",

--- a/data/traits/locomotorio/chemiorecettori_bromuro.json
+++ b/data/traits/locomotorio/chemiorecettori_bromuro.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.chemiorecettori_bromuro.debolezza",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.chemiorecettori_bromuro.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "chemiorecettori_bromuro",
   "label": "i18n:traits.chemiorecettori_bromuro.label",
   "mutazione_indotta": "i18n:traits.chemiorecettori_bromuro.mutazione_indotta",

--- a/data/traits/locomotorio/coda_contrappeso.json
+++ b/data/traits/locomotorio/coda_contrappeso.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.coda_contrappeso.debolezza",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_contrappeso.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "coda_contrappeso",
   "label": "i18n:traits.coda_contrappeso.label",
   "mutazione_indotta": "i18n:traits.coda_contrappeso.mutazione_indotta",

--- a/data/traits/locomotorio/coda_frusta_cinetica.json
+++ b/data/traits/locomotorio/coda_frusta_cinetica.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.coda_frusta_cinetica.debolezza",
   "famiglia_tipologia": "Locomotorio/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_frusta_cinetica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Mantenimento dell'energia accumulata)",
   "id": "coda_frusta_cinetica",
   "label": "i18n:traits.coda_frusta_cinetica.label",
   "mutazione_indotta": "i18n:traits.coda_frusta_cinetica.mutazione_indotta",

--- a/data/traits/locomotorio/cuscinetti_elettrostatici.json
+++ b/data/traits/locomotorio/cuscinetti_elettrostatici.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.cuscinetti_elettrostatici.debolezza",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.cuscinetti_elettrostatici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cuscinetti_elettrostatici",
   "label": "i18n:traits.cuscinetti_elettrostatici.label",
   "mutazione_indotta": "i18n:traits.cuscinetti_elettrostatici.mutazione_indotta",

--- a/data/traits/locomotorio/enzimi_antifase_termica.json
+++ b/data/traits/locomotorio/enzimi_antifase_termica.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.enzimi_antifase_termica.debolezza",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.enzimi_antifase_termica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "enzimi_antifase_termica",
   "label": "i18n:traits.enzimi_antifase_termica.label",
   "mutazione_indotta": "i18n:traits.enzimi_antifase_termica.mutazione_indotta",

--- a/data/traits/locomotorio/filamenti_termoconduzione.json
+++ b/data/traits/locomotorio/filamenti_termoconduzione.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.filamenti_termoconduzione.debolezza",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.filamenti_termoconduzione.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "filamenti_termoconduzione",
   "label": "i18n:traits.filamenti_termoconduzione.label",
   "mutazione_indotta": "i18n:traits.filamenti_termoconduzione.mutazione_indotta",

--- a/data/traits/locomotorio/ghiandole_fango_calde.json
+++ b/data/traits/locomotorio/ghiandole_fango_calde.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ghiandole_fango_calde.debolezza",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_fango_calde.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_fango_calde",
   "label": "i18n:traits.ghiandole_fango_calde.label",
   "mutazione_indotta": "i18n:traits.ghiandole_fango_calde.mutazione_indotta",

--- a/data/traits/locomotorio/ghiandole_ventosa.json
+++ b/data/traits/locomotorio/ghiandole_ventosa.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ghiandole_ventosa.debolezza",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_ventosa.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_ventosa",
   "label": "i18n:traits.ghiandole_ventosa.label",
   "mutazione_indotta": "i18n:traits.ghiandole_ventosa.mutazione_indotta",

--- a/data/traits/locomotorio/linfa_tampone.json
+++ b/data/traits/locomotorio/linfa_tampone.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.linfa_tampone.debolezza",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.linfa_tampone.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "linfa_tampone",
   "label": "i18n:traits.linfa_tampone.label",
   "mutazione_indotta": "i18n:traits.linfa_tampone.mutazione_indotta",

--- a/data/traits/locomotorio/mucose_aderenza_sonica.json
+++ b/data/traits/locomotorio/mucose_aderenza_sonica.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.mucose_aderenza_sonica.debolezza",
   "famiglia_tipologia": "Locomotorio/Mobilità",
-  "fattore_mantenimento_energetico": "i18n:traits.mucose_aderenza_sonica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "mucose_aderenza_sonica",
   "label": "i18n:traits.mucose_aderenza_sonica.label",
   "mutazione_indotta": "i18n:traits.mucose_aderenza_sonica.mutazione_indotta",

--- a/data/traits/locomotorio/zampe_a_molla.json
+++ b/data/traits/locomotorio/zampe_a_molla.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.zampe_a_molla.debolezza",
   "famiglia_tipologia": "Mobilità/Cinetico",
-  "fattore_mantenimento_energetico": "i18n:traits.zampe_a_molla.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Carica elastica a turni alterni)",
   "id": "zampe_a_molla",
   "label": "i18n:traits.zampe_a_molla.label",
   "mutazione_indotta": "i18n:traits.zampe_a_molla.mutazione_indotta",

--- a/data/traits/locomotorio/zoccoli_risonanti_steppe.json
+++ b/data/traits/locomotorio/zoccoli_risonanti_steppe.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.zoccoli_risonanti_steppe.debolezza",
   "famiglia_tipologia": "Locomotorio/Supporto",
-  "fattore_mantenimento_energetico": "i18n:traits.zoccoli_risonanti_steppe.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Vibrazione passiva del suolo)",
   "id": "zoccoli_risonanti_steppe",
   "label": "i18n:traits.zoccoli_risonanti_steppe.label",
   "mutazione_indotta": "i18n:traits.zoccoli_risonanti_steppe.mutazione_indotta",

--- a/data/traits/manipolativo/rostro_linguale_prensile.json
+++ b/data/traits/manipolativo/rostro_linguale_prensile.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.rostro_linguale_prensile.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Manipolativo/Alimentare",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/metabolico/antenne_dustsense.json
+++ b/data/traits/metabolico/antenne_dustsense.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.antenne_dustsense.debolezza",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_dustsense.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_dustsense",
   "label": "i18n:traits.antenne_dustsense.label",
   "mutazione_indotta": "i18n:traits.antenne_dustsense.mutazione_indotta",

--- a/data/traits/metabolico/appendici_thermotattiche.json
+++ b/data/traits/metabolico/appendici_thermotattiche.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.appendici_thermotattiche.debolezza",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.appendici_thermotattiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "appendici_thermotattiche",
   "label": "i18n:traits.appendici_thermotattiche.label",
   "mutazione_indotta": "i18n:traits.appendici_thermotattiche.mutazione_indotta",

--- a/data/traits/metabolico/batteri_endosimbionti_chemio.json
+++ b/data/traits/metabolico/batteri_endosimbionti_chemio.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.batteri_endosimbionti_chemio.debolezza",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.batteri_endosimbionti_chemio.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "batteri_endosimbionti_chemio",
   "label": "i18n:traits.batteri_endosimbionti_chemio.label",
   "mutazione_indotta": "i18n:traits.batteri_endosimbionti_chemio.mutazione_indotta",

--- a/data/traits/metabolico/branchie_solfatiche.json
+++ b/data/traits/metabolico/branchie_solfatiche.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.branchie_solfatiche.debolezza",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.branchie_solfatiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "branchie_solfatiche",
   "label": "i18n:traits.branchie_solfatiche.label",
   "mutazione_indotta": "i18n:traits.branchie_solfatiche.mutazione_indotta",

--- a/data/traits/metabolico/carapace_segmenti_logici.json
+++ b/data/traits/metabolico/carapace_segmenti_logici.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.carapace_segmenti_logici.debolezza",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.carapace_segmenti_logici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "carapace_segmenti_logici",
   "label": "i18n:traits.carapace_segmenti_logici.label",
   "mutazione_indotta": "i18n:traits.carapace_segmenti_logici.mutazione_indotta",

--- a/data/traits/metabolico/circolazione_bifasica_palude.json
+++ b/data/traits/metabolico/circolazione_bifasica_palude.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.circolazione_bifasica_palude.debolezza",
   "famiglia_tipologia": "Metabolico/Resilienza",
-  "fattore_mantenimento_energetico": "i18n:traits.circolazione_bifasica_palude.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Doppio circuito emolinfa/linfa)",
   "id": "circolazione_bifasica_palude",
   "label": "i18n:traits.circolazione_bifasica_palude.label",
   "mutazione_indotta": "i18n:traits.circolazione_bifasica_palude.mutazione_indotta",

--- a/data/traits/metabolico/circolazione_cooling_loop.json
+++ b/data/traits/metabolico/circolazione_cooling_loop.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.circolazione_cooling_loop.debolezza",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.circolazione_cooling_loop.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "circolazione_cooling_loop",
   "label": "i18n:traits.circolazione_cooling_loop.label",
   "mutazione_indotta": "i18n:traits.circolazione_cooling_loop.mutazione_indotta",

--- a/data/traits/metabolico/coda_stabilizzatrice_filo.json
+++ b/data/traits/metabolico/coda_stabilizzatrice_filo.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.coda_stabilizzatrice_filo.debolezza",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_stabilizzatrice_filo.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "coda_stabilizzatrice_filo",
   "label": "i18n:traits.coda_stabilizzatrice_filo.label",
   "mutazione_indotta": "i18n:traits.coda_stabilizzatrice_filo.mutazione_indotta",

--- a/data/traits/metabolico/criostasi_adattiva.json
+++ b/data/traits/metabolico/criostasi_adattiva.json
@@ -5,7 +5,7 @@
   ],
   "debolezza": "i18n:traits.criostasi_adattiva.debolezza",
   "famiglia_tipologia": "Metabolico/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.criostasi_adattiva.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Fase di risveglio/inizio) / Basso (Fase Criostasi).",
   "id": "criostasi_adattiva",
   "label": "i18n:traits.criostasi_adattiva.label",
   "mutazione_indotta": "i18n:traits.criostasi_adattiva.mutazione_indotta",

--- a/data/traits/metabolico/cuticole_cerose.json
+++ b/data/traits/metabolico/cuticole_cerose.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.cuticole_cerose.debolezza",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.cuticole_cerose.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cuticole_cerose",
   "label": "i18n:traits.cuticole_cerose.label",
   "mutazione_indotta": "i18n:traits.cuticole_cerose.mutazione_indotta",

--- a/data/traits/metabolico/enzimi_chelanti.json
+++ b/data/traits/metabolico/enzimi_chelanti.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.enzimi_chelanti.debolezza",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.enzimi_chelanti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "enzimi_chelanti",
   "label": "i18n:traits.enzimi_chelanti.label",
   "mutazione_indotta": "i18n:traits.enzimi_chelanti.mutazione_indotta",

--- a/data/traits/metabolico/flagelli_ancoranti.json
+++ b/data/traits/metabolico/flagelli_ancoranti.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.flagelli_ancoranti.debolezza",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.flagelli_ancoranti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "flagelli_ancoranti",
   "label": "i18n:traits.flagelli_ancoranti.label",
   "mutazione_indotta": "i18n:traits.flagelli_ancoranti.mutazione_indotta",

--- a/data/traits/metabolico/ghiandole_grafene.json
+++ b/data/traits/metabolico/ghiandole_grafene.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ghiandole_grafene.debolezza",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_grafene.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_grafene",
   "label": "i18n:traits.ghiandole_grafene.label",
   "mutazione_indotta": "i18n:traits.ghiandole_grafene.mutazione_indotta",

--- a/data/traits/metabolico/grassi_termici.json
+++ b/data/traits/metabolico/grassi_termici.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.grassi_termici.debolezza",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.grassi_termici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "grassi_termici",
   "label": "i18n:traits.grassi_termici.label",
   "mutazione_indotta": "i18n:traits.grassi_termici.mutazione_indotta",

--- a/data/traits/metabolico/luminescenza_aurorale.json
+++ b/data/traits/metabolico/luminescenza_aurorale.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.luminescenza_aurorale.debolezza",
   "famiglia_tipologia": "Digestivo/Metabolico",
-  "fattore_mantenimento_energetico": "i18n:traits.luminescenza_aurorale.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "luminescenza_aurorale",
   "label": "i18n:traits.luminescenza_aurorale.label",
   "mutazione_indotta": "i18n:traits.luminescenza_aurorale.mutazione_indotta",

--- a/data/traits/nervoso/sonno_emisferico_alternato.json
+++ b/data/traits/nervoso/sonno_emisferico_alternato.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.sonno_emisferico_alternato.debolezza",
   "famiglia_tipologia": "Nervoso/Omeostatico",
-  "fattore_mantenimento_energetico": "i18n:traits.sonno_emisferico_alternato.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Mantenimento attivo di metà cervello)",
   "id": "sonno_emisferico_alternato",
   "label": "i18n:traits.sonno_emisferico_alternato.label",
   "mutazione_indotta": "i18n:traits.sonno_emisferico_alternato.mutazione_indotta",

--- a/data/traits/offensivo/antenne_flusso_mareale.json
+++ b/data/traits/offensivo/antenne_flusso_mareale.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.antenne_flusso_mareale.debolezza",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_flusso_mareale.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_flusso_mareale",
   "label": "i18n:traits.antenne_flusso_mareale.label",
   "mutazione_indotta": "i18n:traits.antenne_flusso_mareale.mutazione_indotta",

--- a/data/traits/offensivo/artigli_induzione.json
+++ b/data/traits/offensivo/artigli_induzione.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.artigli_induzione.debolezza",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_induzione.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "artigli_induzione",
   "label": "i18n:traits.artigli_induzione.label",
   "mutazione_indotta": "i18n:traits.artigli_induzione.mutazione_indotta",

--- a/data/traits/offensivo/artigli_ipo_termici.json
+++ b/data/traits/offensivo/artigli_ipo_termici.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.artigli_ipo_termici.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Offensivo/Termico",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/offensivo/artiglio_cinetico_a_urto.json
+++ b/data/traits/offensivo/artiglio_cinetico_a_urto.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.artiglio_cinetico_a_urto.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Offensivo/Contusivo",
-  "fattore_mantenimento_energetico": "Alto",
+  "fattore_mantenimento_energetico": "Alto (apporto costante o consumo continuo)",
   "tier": "T4",
   "slot": [],
   "sinergie": [

--- a/data/traits/offensivo/aura_di_dispersione_mentale.json
+++ b/data/traits/offensivo/aura_di_dispersione_mentale.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.aura_di_dispersione_mentale.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Offensivo/Controllo",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/offensivo/biochip_memoria.json
+++ b/data/traits/offensivo/biochip_memoria.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.biochip_memoria.debolezza",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.biochip_memoria.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "biochip_memoria",
   "label": "i18n:traits.biochip_memoria.label",
   "mutazione_indotta": "i18n:traits.biochip_memoria.mutazione_indotta",

--- a/data/traits/offensivo/camere_anticorrosione.json
+++ b/data/traits/offensivo/camere_anticorrosione.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.camere_anticorrosione.debolezza",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.camere_anticorrosione.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "camere_anticorrosione",
   "label": "i18n:traits.camere_anticorrosione.label",
   "mutazione_indotta": "i18n:traits.camere_anticorrosione.mutazione_indotta",

--- a/data/traits/offensivo/cannone_sonico_a_raggio.json
+++ b/data/traits/offensivo/cannone_sonico_a_raggio.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.cannone_sonico_a_raggio.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Offensivo/Controllo",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T4",
   "slot": [],
   "sinergie": [

--- a/data/traits/offensivo/canto_infrasonico_tattico.json
+++ b/data/traits/offensivo/canto_infrasonico_tattico.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.canto_infrasonico_tattico.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Offensivo/Controllo",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T4",
   "slot": [],
   "sinergie": [

--- a/data/traits/offensivo/cartilagini_biofibre.json
+++ b/data/traits/offensivo/cartilagini_biofibre.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.cartilagini_biofibre.debolezza",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.cartilagini_biofibre.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cartilagini_biofibre",
   "label": "i18n:traits.cartilagini_biofibre.label",
   "mutazione_indotta": "i18n:traits.cartilagini_biofibre.mutazione_indotta",

--- a/data/traits/offensivo/circolazione_supercritica.json
+++ b/data/traits/offensivo/circolazione_supercritica.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.circolazione_supercritica.debolezza",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.circolazione_supercritica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "circolazione_supercritica",
   "label": "i18n:traits.circolazione_supercritica.label",
   "mutazione_indotta": "i18n:traits.circolazione_supercritica.mutazione_indotta",

--- a/data/traits/offensivo/coda_stabilizzatrice_vortex.json
+++ b/data/traits/offensivo/coda_stabilizzatrice_vortex.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.coda_stabilizzatrice_vortex.debolezza",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_stabilizzatrice_vortex.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "coda_stabilizzatrice_vortex",
   "label": "i18n:traits.coda_stabilizzatrice_vortex.label",
   "mutazione_indotta": "i18n:traits.coda_stabilizzatrice_vortex.mutazione_indotta",

--- a/data/traits/offensivo/denti_chelatanti.json
+++ b/data/traits/offensivo/denti_chelatanti.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.denti_chelatanti.debolezza",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.denti_chelatanti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "denti_chelatanti",
   "label": "i18n:traits.denti_chelatanti.label",
   "mutazione_indotta": "i18n:traits.denti_chelatanti.mutazione_indotta",

--- a/data/traits/offensivo/elettromagnete_biologico.json
+++ b/data/traits/offensivo/elettromagnete_biologico.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.elettromagnete_biologico.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Offensivo/Elettrico",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T4",
   "slot": [],
   "sinergie": [

--- a/data/traits/offensivo/enzimi_metanoossidanti.json
+++ b/data/traits/offensivo/enzimi_metanoossidanti.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.enzimi_metanoossidanti.debolezza",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.enzimi_metanoossidanti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "enzimi_metanoossidanti",
   "label": "i18n:traits.enzimi_metanoossidanti.label",
   "mutazione_indotta": "i18n:traits.enzimi_metanoossidanti.mutazione_indotta",

--- a/data/traits/offensivo/estroflessione_gastrica_acida.json
+++ b/data/traits/offensivo/estroflessione_gastrica_acida.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.estroflessione_gastrica_acida.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Offensivo/Chimico",
-  "fattore_mantenimento_energetico": "Alto",
+  "fattore_mantenimento_energetico": "Alto (apporto costante o consumo continuo)",
   "tier": "T4",
   "slot": [],
   "sinergie": [

--- a/data/traits/offensivo/foliaggio_spugna.json
+++ b/data/traits/offensivo/foliaggio_spugna.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.foliaggio_spugna.debolezza",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.foliaggio_spugna.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "foliaggio_spugna",
   "label": "i18n:traits.foliaggio_spugna.label",
   "mutazione_indotta": "i18n:traits.foliaggio_spugna.mutazione_indotta",

--- a/data/traits/offensivo/frusta_fiammeggiante.json
+++ b/data/traits/offensivo/frusta_fiammeggiante.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.frusta_fiammeggiante.debolezza",
   "famiglia_tipologia": "Offensivo/Controllo",
-  "fattore_mantenimento_energetico": "i18n:traits.frusta_fiammeggiante.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Filamenti di plasma vincolato)",
   "id": "frusta_fiammeggiante",
   "label": "i18n:traits.frusta_fiammeggiante.label",
   "mutazione_indotta": "i18n:traits.frusta_fiammeggiante.mutazione_indotta",

--- a/data/traits/offensivo/ghiandola_caustica.json
+++ b/data/traits/offensivo/ghiandola_caustica.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ghiandola_caustica.debolezza",
   "famiglia_tipologia": "Offensivo/Chimico",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandola_caustica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Produzione reagenti)",
   "id": "ghiandola_caustica",
   "label": "i18n:traits.ghiandola_caustica.label",
   "mutazione_indotta": "i18n:traits.ghiandola_caustica.mutazione_indotta",

--- a/data/traits/offensivo/ghiandole_iodoattive.json
+++ b/data/traits/offensivo/ghiandole_iodoattive.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ghiandole_iodoattive.debolezza",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_iodoattive.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_iodoattive",
   "label": "i18n:traits.ghiandole_iodoattive.label",
   "mutazione_indotta": "i18n:traits.ghiandole_iodoattive.mutazione_indotta",

--- a/data/traits/offensivo/gusci_magnesio.json
+++ b/data/traits/offensivo/gusci_magnesio.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.gusci_magnesio.debolezza",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.gusci_magnesio.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "gusci_magnesio",
   "label": "i18n:traits.gusci_magnesio.label",
   "mutazione_indotta": "i18n:traits.gusci_magnesio.mutazione_indotta",

--- a/data/traits/offensivo/mantelli_geotermici.json
+++ b/data/traits/offensivo/mantelli_geotermici.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.mantelli_geotermici.debolezza",
   "famiglia_tipologia": "Offensivo/Assalto",
-  "fattore_mantenimento_energetico": "i18n:traits.mantelli_geotermici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "mantelli_geotermici",
   "label": "i18n:traits.mantelli_geotermici.label",
   "mutazione_indotta": "i18n:traits.mantelli_geotermici.mutazione_indotta",

--- a/data/traits/offensivo/rostro_emostatico_litico.json
+++ b/data/traits/offensivo/rostro_emostatico_litico.json
@@ -1,9 +1,9 @@
 {
   "id": "rostro_emostatico_litico",
   "label": "i18n:traits.rostro_emostatico_litico.label",
-  "data_origin": "coverage_q4_2025",
+  "data_origin": "incoming_tr1100_pack",
   "famiglia_tipologia": "Offensivo/Perforante",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T4",
   "slot": [],
   "sinergie": [
@@ -48,5 +48,11 @@
       "http://purl.obolibrary.org/obo/ENVO_01000178",
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
+  },
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-04",
+    "updated": "2025-11-04",
+    "author": "Master DD / GPT-5 Pro"
   }
 }

--- a/data/traits/offensivo/sangue_piroforico.json
+++ b/data/traits/offensivo/sangue_piroforico.json
@@ -5,7 +5,7 @@
   ],
   "debolezza": "i18n:traits.sangue_piroforico.debolezza",
   "famiglia_tipologia": "Offensivo/Cinetico",
-  "fattore_mantenimento_energetico": "i18n:traits.sangue_piroforico.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Sintesi dei composti)",
   "id": "sangue_piroforico",
   "label": "i18n:traits.sangue_piroforico.label",
   "mutazione_indotta": "i18n:traits.sangue_piroforico.mutazione_indotta",

--- a/data/traits/offensivo/seta_conduttiva_elettrica.json
+++ b/data/traits/offensivo/seta_conduttiva_elettrica.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.seta_conduttiva_elettrica.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Offensivo/Elettrico",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T4",
   "slot": [],
   "sinergie": [

--- a/data/traits/offensivo/zanne_idracida.json
+++ b/data/traits/offensivo/zanne_idracida.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.zanne_idracida.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Offensivo/Chimico",
-  "fattore_mantenimento_energetico": "Alto",
+  "fattore_mantenimento_energetico": "Alto (apporto costante o consumo continuo)",
   "tier": "T4",
   "slot": [],
   "sinergie": [

--- a/data/traits/respiratorio/branchie_osmotiche_salmastra.json
+++ b/data/traits/respiratorio/branchie_osmotiche_salmastra.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.branchie_osmotiche_salmastra.debolezza",
   "famiglia_tipologia": "Respiratorio/Osmoregolazione",
-  "fattore_mantenimento_energetico": "i18n:traits.branchie_osmotiche_salmastra.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Pompe ioniche attive)",
   "id": "branchie_osmotiche_salmastra",
   "label": "i18n:traits.branchie_osmotiche_salmastra.label",
   "mutazione_indotta": "i18n:traits.branchie_osmotiche_salmastra.mutazione_indotta",

--- a/data/traits/respiratorio/lamelle_termoforetiche.json
+++ b/data/traits/respiratorio/lamelle_termoforetiche.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.lamelle_termoforetiche.debolezza",
   "famiglia_tipologia": "Respiratorio/Termoregolazione",
-  "fattore_mantenimento_energetico": "i18n:traits.lamelle_termoforetiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Flusso continuo di fluidi caldi)",
   "id": "lamelle_termoforetiche",
   "label": "i18n:traits.lamelle_termoforetiche.label",
   "mutazione_indotta": "i18n:traits.lamelle_termoforetiche.mutazione_indotta",

--- a/data/traits/respiratorio/membrane_eliofiltranti.json
+++ b/data/traits/respiratorio/membrane_eliofiltranti.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.membrane_eliofiltranti.debolezza",
   "famiglia_tipologia": "Respiratorio/Protezione",
-  "fattore_mantenimento_energetico": "i18n:traits.membrane_eliofiltranti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Auto-riparazione lenta)",
   "id": "membrane_eliofiltranti",
   "label": "i18n:traits.membrane_eliofiltranti.label",
   "mutazione_indotta": "i18n:traits.membrane_eliofiltranti.mutazione_indotta",

--- a/data/traits/respiratorio/polmoni_cristallini_alta_quota.json
+++ b/data/traits/respiratorio/polmoni_cristallini_alta_quota.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.polmoni_cristallini_alta_quota.debolezza",
   "famiglia_tipologia": "Respiratorio/Aerobico",
-  "fattore_mantenimento_energetico": "i18n:traits.polmoni_cristallini_alta_quota.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Pulizia periodica dei cristalli)",
   "id": "polmoni_cristallini_alta_quota",
   "label": "i18n:traits.polmoni_cristallini_alta_quota.label",
   "mutazione_indotta": "i18n:traits.polmoni_cristallini_alta_quota.mutazione_indotta",

--- a/data/traits/respiratorio/respiro_a_scoppio.json
+++ b/data/traits/respiratorio/respiro_a_scoppio.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.respiro_a_scoppio.debolezza",
   "famiglia_tipologia": "Respiratorio/Propulsivo",
-  "fattore_mantenimento_energetico": "i18n:traits.respiro_a_scoppio.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Richiede ricarica polmonare)",
   "id": "respiro_a_scoppio",
   "label": "i18n:traits.respiro_a_scoppio.label",
   "mutazione_indotta": "i18n:traits.respiro_a_scoppio.mutazione_indotta",

--- a/data/traits/riproduttivo/ermafroditismo_cronologico.json
+++ b/data/traits/riproduttivo/ermafroditismo_cronologico.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.ermafroditismo_cronologico.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Riproduttivo/Cicli",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/riproduttivo/moltiplicazione_per_fusione.json
+++ b/data/traits/riproduttivo/moltiplicazione_per_fusione.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.moltiplicazione_per_fusione.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Riproduttivo/Cicli",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T2",
   "slot": [],
   "sinergie": [

--- a/data/traits/riproduttivo/nucleo_ovomotore_rotante.json
+++ b/data/traits/riproduttivo/nucleo_ovomotore_rotante.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.nucleo_ovomotore_rotante.debolezza",
   "famiglia_tipologia": "Riproduttivo/Locomotorio",
-  "fattore_mantenimento_energetico": "i18n:traits.nucleo_ovomotore_rotante.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Rotolamento)",
   "id": "nucleo_ovomotore_rotante",
   "label": "i18n:traits.nucleo_ovomotore_rotante.label",
   "mutazione_indotta": "i18n:traits.nucleo_ovomotore_rotante.mutazione_indotta",

--- a/data/traits/sensoriale/ali_fulminee.json
+++ b/data/traits/sensoriale/ali_fulminee.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ali_fulminee.debolezza",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.ali_fulminee.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ali_fulminee",
   "label": "i18n:traits.ali_fulminee.label",
   "mutazione_indotta": "i18n:traits.ali_fulminee.mutazione_indotta",

--- a/data/traits/sensoriale/antenne_plasmatiche_tempesta.json
+++ b/data/traits/sensoriale/antenne_plasmatiche_tempesta.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.antenne_plasmatiche_tempesta.debolezza",
   "famiglia_tipologia": "Sensoriale/Offensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_plasmatiche_tempesta.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Canalizzazione costante di plasma atmosferico)",
   "id": "antenne_plasmatiche_tempesta",
   "label": "i18n:traits.antenne_plasmatiche_tempesta.label",
   "mutazione_indotta": "i18n:traits.antenne_plasmatiche_tempesta.mutazione_indotta",

--- a/data/traits/sensoriale/antenne_waveguide.json
+++ b/data/traits/sensoriale/antenne_waveguide.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.antenne_waveguide.debolezza",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_waveguide.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_waveguide",
   "label": "i18n:traits.antenne_waveguide.label",
   "mutazione_indotta": "i18n:traits.antenne_waveguide.mutazione_indotta",

--- a/data/traits/sensoriale/baffi_mareomotori.json
+++ b/data/traits/sensoriale/baffi_mareomotori.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.baffi_mareomotori.debolezza",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.baffi_mareomotori.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "baffi_mareomotori",
   "label": "i18n:traits.baffi_mareomotori.label",
   "mutazione_indotta": "i18n:traits.baffi_mareomotori.mutazione_indotta",

--- a/data/traits/sensoriale/branchie_eoliche.json
+++ b/data/traits/sensoriale/branchie_eoliche.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.branchie_eoliche.debolezza",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.branchie_eoliche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "branchie_eoliche",
   "label": "i18n:traits.branchie_eoliche.label",
   "mutazione_indotta": "i18n:traits.branchie_eoliche.mutazione_indotta",

--- a/data/traits/sensoriale/capillari_fluoridici.json
+++ b/data/traits/sensoriale/capillari_fluoridici.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.capillari_fluoridici.debolezza",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.capillari_fluoridici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "capillari_fluoridici",
   "label": "i18n:traits.capillari_fluoridici.label",
   "mutazione_indotta": "i18n:traits.capillari_fluoridici.mutazione_indotta",

--- a/data/traits/sensoriale/cavita_risonanti_tundra.json
+++ b/data/traits/sensoriale/cavita_risonanti_tundra.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.cavita_risonanti_tundra.debolezza",
   "famiglia_tipologia": "Sensoriale/Supporto",
-  "fattore_mantenimento_energetico": "i18n:traits.cavita_risonanti_tundra.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Camere di risonanza statiche)",
   "id": "cavita_risonanti_tundra",
   "label": "i18n:traits.cavita_risonanti_tundra.label",
   "mutazione_indotta": "i18n:traits.cavita_risonanti_tundra.mutazione_indotta",

--- a/data/traits/sensoriale/cervelletto_equilibrio_statico.json
+++ b/data/traits/sensoriale/cervelletto_equilibrio_statico.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.cervelletto_equilibrio_statico.debolezza",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.cervelletto_equilibrio_statico.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cervelletto_equilibrio_statico",
   "label": "i18n:traits.cervelletto_equilibrio_statico.label",
   "mutazione_indotta": "i18n:traits.cervelletto_equilibrio_statico.mutazione_indotta",

--- a/data/traits/sensoriale/coda_balanciere.json
+++ b/data/traits/sensoriale/coda_balanciere.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.coda_balanciere.debolezza",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_balanciere.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "coda_balanciere",
   "label": "i18n:traits.coda_balanciere.label",
   "mutazione_indotta": "i18n:traits.coda_balanciere.mutazione_indotta",

--- a/data/traits/sensoriale/cuore_multicamera_bassa_pressione.json
+++ b/data/traits/sensoriale/cuore_multicamera_bassa_pressione.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.cuore_multicamera_bassa_pressione.debolezza",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.cuore_multicamera_bassa_pressione.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cuore_multicamera_bassa_pressione",
   "label": "i18n:traits.cuore_multicamera_bassa_pressione.label",
   "mutazione_indotta": "i18n:traits.cuore_multicamera_bassa_pressione.mutazione_indotta",

--- a/data/traits/sensoriale/echi_risonanti.json
+++ b/data/traits/sensoriale/echi_risonanti.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.echi_risonanti.debolezza",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.echi_risonanti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "echi_risonanti",
   "label": "i18n:traits.echi_risonanti.label",
   "mutazione_indotta": "i18n:traits.echi_risonanti.mutazione_indotta",

--- a/data/traits/sensoriale/eco_interno_riflesso.json
+++ b/data/traits/sensoriale/eco_interno_riflesso.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.eco_interno_riflesso.debolezza",
   "famiglia_tipologia": "Sensoriale/Nervoso",
-  "fattore_mantenimento_energetico": "i18n:traits.eco_interno_riflesso.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Emissioni e ricezione continua)",
   "id": "eco_interno_riflesso",
   "label": "i18n:traits.eco_interno_riflesso.label",
   "mutazione_indotta": "i18n:traits.eco_interno_riflesso.mutazione_indotta",

--- a/data/traits/sensoriale/filamenti_superconduttivi.json
+++ b/data/traits/sensoriale/filamenti_superconduttivi.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.filamenti_superconduttivi.debolezza",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.filamenti_superconduttivi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "filamenti_superconduttivi",
   "label": "i18n:traits.filamenti_superconduttivi.label",
   "mutazione_indotta": "i18n:traits.filamenti_superconduttivi.mutazione_indotta",

--- a/data/traits/sensoriale/ghiandole_eco_mappanti.json
+++ b/data/traits/sensoriale/ghiandole_eco_mappanti.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ghiandole_eco_mappanti.debolezza",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_eco_mappanti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_eco_mappanti",
   "label": "i18n:traits.ghiandole_eco_mappanti.label",
   "mutazione_indotta": "i18n:traits.ghiandole_eco_mappanti.mutazione_indotta",

--- a/data/traits/sensoriale/ghiandole_resina_conduttiva.json
+++ b/data/traits/sensoriale/ghiandole_resina_conduttiva.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ghiandole_resina_conduttiva.debolezza",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_resina_conduttiva.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_resina_conduttiva",
   "label": "i18n:traits.ghiandole_resina_conduttiva.label",
   "mutazione_indotta": "i18n:traits.ghiandole_resina_conduttiva.mutazione_indotta",

--- a/data/traits/sensoriale/integumento_bipolare.json
+++ b/data/traits/sensoriale/integumento_bipolare.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.integumento_bipolare.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Sensoriale/Magneto-ricettivo",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/sensoriale/lamine_scudo_silice.json
+++ b/data/traits/sensoriale/lamine_scudo_silice.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.lamine_scudo_silice.debolezza",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.lamine_scudo_silice.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "lamine_scudo_silice",
   "label": "i18n:traits.lamine_scudo_silice.label",
   "mutazione_indotta": "i18n:traits.lamine_scudo_silice.mutazione_indotta",

--- a/data/traits/sensoriale/lingua_tattile_trama.json
+++ b/data/traits/sensoriale/lingua_tattile_trama.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.lingua_tattile_trama.debolezza",
   "famiglia_tipologia": "Sensoriale/Alimentare",
-  "fattore_mantenimento_energetico": "i18n:traits.lingua_tattile_trama.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "lingua_tattile_trama",
   "label": "i18n:traits.lingua_tattile_trama.label",
   "mutazione_indotta": "i18n:traits.lingua_tattile_trama.mutazione_indotta",

--- a/data/traits/sensoriale/midollo_antivibrazione.json
+++ b/data/traits/sensoriale/midollo_antivibrazione.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.midollo_antivibrazione.debolezza",
   "famiglia_tipologia": "Sensoriale/Analitico",
-  "fattore_mantenimento_energetico": "i18n:traits.midollo_antivibrazione.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "midollo_antivibrazione",
   "label": "i18n:traits.midollo_antivibrazione.label",
   "mutazione_indotta": "i18n:traits.midollo_antivibrazione.mutazione_indotta",

--- a/data/traits/sensoriale/occhi_analizzatori_di_tensione.json
+++ b/data/traits/sensoriale/occhi_analizzatori_di_tensione.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.occhi_analizzatori_di_tensione.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Sensoriale/Visivo",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T2",
   "slot": [],
   "sinergie": [

--- a/data/traits/sensoriale/occhi_cinetici.json
+++ b/data/traits/sensoriale/occhi_cinetici.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.occhi_cinetici.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Sensoriale/Visivo",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T2",
   "slot": [],
   "sinergie": [

--- a/data/traits/sensoriale/occhi_cristallo_modulare.json
+++ b/data/traits/sensoriale/occhi_cristallo_modulare.json
@@ -2,7 +2,7 @@
   "id": "occhi_cristallo_modulare",
   "label": "i18n:traits.occhi_cristallo_modulare.label",
   "famiglia_tipologia": "Sensoriale/Visivo",
-  "fattore_mantenimento_energetico": "i18n:traits.occhi_cristallo_modulare.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Moderato (Attivo)",
   "tier": "T2",
   "slot": [],
   "sinergie": [],

--- a/data/traits/sensoriale/occhi_infrarosso_composti.json
+++ b/data/traits/sensoriale/occhi_infrarosso_composti.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.occhi_infrarosso_composti.debolezza",
   "famiglia_tipologia": "Sensoriale/Visivo",
-  "fattore_mantenimento_energetico": "i18n:traits.occhi_infrarosso_composti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "occhi_infrarosso_composti",
   "label": "i18n:traits.occhi_infrarosso_composti.label",
   "mutazione_indotta": "i18n:traits.occhi_infrarosso_composti.mutazione_indotta",

--- a/data/traits/sensoriale/olfatto_risonanza_magnetica.json
+++ b/data/traits/sensoriale/olfatto_risonanza_magnetica.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.olfatto_risonanza_magnetica.debolezza",
   "famiglia_tipologia": "Sensoriale/Nervoso",
-  "fattore_mantenimento_energetico": "i18n:traits.olfatto_risonanza_magnetica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Elaborazione sensoriale costante)",
   "id": "olfatto_risonanza_magnetica",
   "label": "i18n:traits.olfatto_risonanza_magnetica.label",
   "mutazione_indotta": "i18n:traits.olfatto_risonanza_magnetica.mutazione_indotta",

--- a/data/traits/sensoriale/organi_sismici_cutanei.json
+++ b/data/traits/sensoriale/organi_sismici_cutanei.json
@@ -1,9 +1,9 @@
 {
   "id": "organi_sismici_cutanei",
   "label": "i18n:traits.organi_sismici_cutanei.label",
-  "data_origin": "coverage_q4_2025",
+  "data_origin": "incoming_tr1100_pack",
   "famiglia_tipologia": "Sensoriale/Tatto-Vibro",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T2",
   "slot": [],
   "sinergie": [
@@ -49,5 +49,11 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
+  },
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-04",
+    "updated": "2025-11-04",
+    "author": "Master DD / GPT-5 Pro"
   }
 }

--- a/data/traits/sensoriale/sensori_geomagnetici.json
+++ b/data/traits/sensoriale/sensori_geomagnetici.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.sensori_geomagnetici.debolezza",
   "famiglia_tipologia": "Sensoriale/Navigazione",
-  "fattore_mantenimento_energetico": "i18n:traits.sensori_geomagnetici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Ricettori passivi)",
   "id": "sensori_geomagnetici",
   "label": "i18n:traits.sensori_geomagnetici.label",
   "mutazione_indotta": "i18n:traits.sensori_geomagnetici.mutazione_indotta",

--- a/data/traits/sensoriale/sistemi_chimio_sonici.json
+++ b/data/traits/sensoriale/sistemi_chimio_sonici.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.sistemi_chimio_sonici.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Sensoriale/Uditivo-Olfattivo",
-  "fattore_mantenimento_energetico": "Basso",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/sensoriale/visione_multi_spettrale_amplificata.json
+++ b/data/traits/sensoriale/visione_multi_spettrale_amplificata.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.visione_multi_spettrale_amplificata.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Sensoriale/Visivo",
-  "fattore_mantenimento_energetico": "Medio",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/simbiotico/antenne_reagenti.json
+++ b/data/traits/simbiotico/antenne_reagenti.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.antenne_reagenti.debolezza",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_reagenti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_reagenti",
   "label": "i18n:traits.antenne_reagenti.label",
   "mutazione_indotta": "i18n:traits.antenne_reagenti.mutazione_indotta",

--- a/data/traits/simbiotico/artigli_scivolo_silente.json
+++ b/data/traits/simbiotico/artigli_scivolo_silente.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.artigli_scivolo_silente.debolezza",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_scivolo_silente.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "artigli_scivolo_silente",
   "label": "i18n:traits.artigli_scivolo_silente.label",
   "mutazione_indotta": "i18n:traits.artigli_scivolo_silente.mutazione_indotta",

--- a/data/traits/simbiotico/biofilm_iperarido.json
+++ b/data/traits/simbiotico/biofilm_iperarido.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.biofilm_iperarido.debolezza",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.biofilm_iperarido.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "biofilm_iperarido",
   "label": "i18n:traits.biofilm_iperarido.label",
   "mutazione_indotta": "i18n:traits.biofilm_iperarido.mutazione_indotta",

--- a/data/traits/simbiotico/bulbi_radici_permafrost.json
+++ b/data/traits/simbiotico/bulbi_radici_permafrost.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.bulbi_radici_permafrost.debolezza",
   "famiglia_tipologia": "Simbiotico/Nutrizione",
-  "fattore_mantenimento_energetico": "i18n:traits.bulbi_radici_permafrost.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Accumulo e rilascio lento di nutrienti)",
   "id": "bulbi_radici_permafrost",
   "label": "i18n:traits.bulbi_radici_permafrost.label",
   "mutazione_indotta": "i18n:traits.bulbi_radici_permafrost.mutazione_indotta",

--- a/data/traits/simbiotico/camere_nutrienti_vent.json
+++ b/data/traits/simbiotico/camere_nutrienti_vent.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.camere_nutrienti_vent.debolezza",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.camere_nutrienti_vent.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "camere_nutrienti_vent",
   "label": "i18n:traits.camere_nutrienti_vent.label",
   "mutazione_indotta": "i18n:traits.camere_nutrienti_vent.mutazione_indotta",

--- a/data/traits/simbiotico/cartilagini_flessoacustiche.json
+++ b/data/traits/simbiotico/cartilagini_flessoacustiche.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.cartilagini_flessoacustiche.debolezza",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.cartilagini_flessoacustiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cartilagini_flessoacustiche",
   "label": "i18n:traits.cartilagini_flessoacustiche.label",
   "mutazione_indotta": "i18n:traits.cartilagini_flessoacustiche.mutazione_indotta",

--- a/data/traits/simbiotico/chioma_parassita_canopica.json
+++ b/data/traits/simbiotico/chioma_parassita_canopica.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.chioma_parassita_canopica.debolezza",
   "famiglia_tipologia": "Simbiotico/Utility",
-  "fattore_mantenimento_energetico": "i18n:traits.chioma_parassita_canopica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Nutrimento condiviso con l'ospite arboreo)",
   "id": "chioma_parassita_canopica",
   "label": "i18n:traits.chioma_parassita_canopica.label",
   "mutazione_indotta": "i18n:traits.chioma_parassita_canopica.mutazione_indotta",

--- a/data/traits/simbiotico/ciste_salmastre.json
+++ b/data/traits/simbiotico/ciste_salmastre.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ciste_salmastre.debolezza",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.ciste_salmastre.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ciste_salmastre",
   "label": "i18n:traits.ciste_salmastre.label",
   "mutazione_indotta": "i18n:traits.ciste_salmastre.mutazione_indotta",

--- a/data/traits/simbiotico/coralli_partner.json
+++ b/data/traits/simbiotico/coralli_partner.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.coralli_partner.debolezza",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.coralli_partner.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "coralli_partner",
   "label": "i18n:traits.coralli_partner.label",
   "mutazione_indotta": "i18n:traits.coralli_partner.mutazione_indotta",

--- a/data/traits/simbiotico/denti_silice_termici.json
+++ b/data/traits/simbiotico/denti_silice_termici.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.denti_silice_termici.debolezza",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.denti_silice_termici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "denti_silice_termici",
   "label": "i18n:traits.denti_silice_termici.label",
   "mutazione_indotta": "i18n:traits.denti_silice_termici.mutazione_indotta",

--- a/data/traits/simbiotico/epitelio_fosforescente.json
+++ b/data/traits/simbiotico/epitelio_fosforescente.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.epitelio_fosforescente.debolezza",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.epitelio_fosforescente.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "epitelio_fosforescente",
   "label": "i18n:traits.epitelio_fosforescente.label",
   "mutazione_indotta": "i18n:traits.epitelio_fosforescente.mutazione_indotta",

--- a/data/traits/simbiotico/ghiandole_cambio_salino.json
+++ b/data/traits/simbiotico/ghiandole_cambio_salino.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ghiandole_cambio_salino.debolezza",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_cambio_salino.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_cambio_salino",
   "label": "i18n:traits.ghiandole_cambio_salino.label",
   "mutazione_indotta": "i18n:traits.ghiandole_cambio_salino.mutazione_indotta",

--- a/data/traits/simbiotico/ghiandole_nebbia_acida.json
+++ b/data/traits/simbiotico/ghiandole_nebbia_acida.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ghiandole_nebbia_acida.debolezza",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_nebbia_acida.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_nebbia_acida",
   "label": "i18n:traits.ghiandole_nebbia_acida.label",
   "mutazione_indotta": "i18n:traits.ghiandole_nebbia_acida.mutazione_indotta",

--- a/data/traits/simbiotico/lamelle_sincroniche.json
+++ b/data/traits/simbiotico/lamelle_sincroniche.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.lamelle_sincroniche.debolezza",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.lamelle_sincroniche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "lamelle_sincroniche",
   "label": "i18n:traits.lamelle_sincroniche.label",
   "mutazione_indotta": "i18n:traits.lamelle_sincroniche.mutazione_indotta",

--- a/data/traits/simbiotico/membrane_planata_vectored.json
+++ b/data/traits/simbiotico/membrane_planata_vectored.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.membrane_planata_vectored.debolezza",
   "famiglia_tipologia": "Simbiotico/Cooperativo",
-  "fattore_mantenimento_energetico": "i18n:traits.membrane_planata_vectored.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "membrane_planata_vectored",
   "label": "i18n:traits.membrane_planata_vectored.label",
   "mutazione_indotta": "i18n:traits.membrane_planata_vectored.mutazione_indotta",

--- a/data/traits/simbiotico/mucillagine_simbionte_mangrovie.json
+++ b/data/traits/simbiotico/mucillagine_simbionte_mangrovie.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.mucillagine_simbionte_mangrovie.debolezza",
   "famiglia_tipologia": "Simbiotico/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.mucillagine_simbionte_mangrovie.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Coltura simbiotica costante)",
   "id": "mucillagine_simbionte_mangrovie",
   "label": "i18n:traits.mucillagine_simbionte_mangrovie.label",
   "mutazione_indotta": "i18n:traits.mucillagine_simbionte_mangrovie.mutazione_indotta",

--- a/data/traits/simbiotico/nodi_micorrizici_oracolari.json
+++ b/data/traits/simbiotico/nodi_micorrizici_oracolari.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.nodi_micorrizici_oracolari.debolezza",
   "famiglia_tipologia": "Simbiotico/Nervoso",
-  "fattore_mantenimento_energetico": "i18n:traits.nodi_micorrizici_oracolari.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Scambio continuo di segnali con simbionti)",
   "id": "nodi_micorrizici_oracolari",
   "label": "i18n:traits.nodi_micorrizici_oracolari.label",
   "mutazione_indotta": "i18n:traits.nodi_micorrizici_oracolari.mutazione_indotta",

--- a/data/traits/simbiotico/sacche_spore_stratosferiche.json
+++ b/data/traits/simbiotico/sacche_spore_stratosferiche.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.sacche_spore_stratosferiche.debolezza",
   "famiglia_tipologia": "Simbiotico/Supporto",
-  "fattore_mantenimento_energetico": "i18n:traits.sacche_spore_stratosferiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Coltura continua di spore portanti)",
   "id": "sacche_spore_stratosferiche",
   "label": "i18n:traits.sacche_spore_stratosferiche.label",
   "mutazione_indotta": "i18n:traits.sacche_spore_stratosferiche.mutazione_indotta",

--- a/data/traits/simbiotico/sinapsi_coraline_polifoniche.json
+++ b/data/traits/simbiotico/sinapsi_coraline_polifoniche.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.sinapsi_coraline_polifoniche.debolezza",
   "famiglia_tipologia": "Simbiotico/Comunicazione",
-  "fattore_mantenimento_energetico": "i18n:traits.sinapsi_coraline_polifoniche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Scambio continuo di impulsi corallini)",
   "id": "sinapsi_coraline_polifoniche",
   "label": "i18n:traits.sinapsi_coraline_polifoniche.label",
   "mutazione_indotta": "i18n:traits.sinapsi_coraline_polifoniche.mutazione_indotta",

--- a/data/traits/strategia/antenne_microonde_cavernose.json
+++ b/data/traits/strategia/antenne_microonde_cavernose.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.antenne_microonde_cavernose.debolezza",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_microonde_cavernose.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_microonde_cavernose",
   "label": "i18n:traits.antenne_microonde_cavernose.label",
   "mutazione_indotta": "i18n:traits.antenne_microonde_cavernose.mutazione_indotta",

--- a/data/traits/strategia/artigli_radice.json
+++ b/data/traits/strategia/artigli_radice.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.artigli_radice.debolezza",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_radice.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "artigli_radice",
   "label": "i18n:traits.artigli_radice.label",
   "mutazione_indotta": "i18n:traits.artigli_radice.mutazione_indotta",

--- a/data/traits/strategia/biofilm_glow.json
+++ b/data/traits/strategia/biofilm_glow.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.biofilm_glow.debolezza",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.biofilm_glow.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "biofilm_glow",
   "label": "i18n:traits.biofilm_glow.label",
   "mutazione_indotta": "i18n:traits.biofilm_glow.mutazione_indotta",

--- a/data/traits/strategia/camere_mirage.json
+++ b/data/traits/strategia/camere_mirage.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.camere_mirage.debolezza",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.camere_mirage.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "camere_mirage",
   "label": "i18n:traits.camere_mirage.label",
   "mutazione_indotta": "i18n:traits.camere_mirage.mutazione_indotta",

--- a/data/traits/strategia/cartilagini_desertiche.json
+++ b/data/traits/strategia/cartilagini_desertiche.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.cartilagini_desertiche.debolezza",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.cartilagini_desertiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cartilagini_desertiche",
   "label": "i18n:traits.cartilagini_desertiche.label",
   "mutazione_indotta": "i18n:traits.cartilagini_desertiche.mutazione_indotta",

--- a/data/traits/strategia/ciste_riduttive.json
+++ b/data/traits/strategia/ciste_riduttive.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ciste_riduttive.debolezza",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.ciste_riduttive.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ciste_riduttive",
   "label": "i18n:traits.ciste_riduttive.label",
   "mutazione_indotta": "i18n:traits.ciste_riduttive.mutazione_indotta",

--- a/data/traits/strategia/colonne_vibromagnetiche.json
+++ b/data/traits/strategia/colonne_vibromagnetiche.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.colonne_vibromagnetiche.debolezza",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.colonne_vibromagnetiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "colonne_vibromagnetiche",
   "label": "i18n:traits.colonne_vibromagnetiche.label",
   "mutazione_indotta": "i18n:traits.colonne_vibromagnetiche.mutazione_indotta",

--- a/data/traits/strategia/denti_ossidoferro.json
+++ b/data/traits/strategia/denti_ossidoferro.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.denti_ossidoferro.debolezza",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.denti_ossidoferro.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "denti_ossidoferro",
   "label": "i18n:traits.denti_ossidoferro.label",
   "mutazione_indotta": "i18n:traits.denti_ossidoferro.mutazione_indotta",

--- a/data/traits/strategia/epidermide_dielettrica.json
+++ b/data/traits/strategia/epidermide_dielettrica.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.epidermide_dielettrica.debolezza",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.epidermide_dielettrica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "epidermide_dielettrica",
   "label": "i18n:traits.epidermide_dielettrica.label",
   "mutazione_indotta": "i18n:traits.epidermide_dielettrica.mutazione_indotta",

--- a/data/traits/strategia/focus_frazionato.json
+++ b/data/traits/strategia/focus_frazionato.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.focus_frazionato.debolezza",
   "famiglia_tipologia": "Strategico/Psionico",
-  "fattore_mantenimento_energetico": "i18n:traits.focus_frazionato.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Dividere l'attenzione su più canali)",
   "id": "focus_frazionato",
   "label": "i18n:traits.focus_frazionato.label",
   "mutazione_indotta": "i18n:traits.focus_frazionato.mutazione_indotta",

--- a/data/traits/strategia/ghiaccio_piezoelettrico.json
+++ b/data/traits/strategia/ghiaccio_piezoelettrico.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ghiaccio_piezoelettrico.debolezza",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiaccio_piezoelettrico.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiaccio_piezoelettrico",
   "label": "i18n:traits.ghiaccio_piezoelettrico.label",
   "mutazione_indotta": "i18n:traits.ghiaccio_piezoelettrico.mutazione_indotta",

--- a/data/traits/strategia/ghiandole_minerali.json
+++ b/data/traits/strategia/ghiandole_minerali.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ghiandole_minerali.debolezza",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_minerali.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_minerali",
   "label": "i18n:traits.ghiandole_minerali.label",
   "mutazione_indotta": "i18n:traits.ghiandole_minerali.mutazione_indotta",

--- a/data/traits/strategia/lamelle_shear.json
+++ b/data/traits/strategia/lamelle_shear.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.lamelle_shear.debolezza",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.lamelle_shear.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "lamelle_shear",
   "label": "i18n:traits.lamelle_shear.label",
   "mutazione_indotta": "i18n:traits.lamelle_shear.mutazione_indotta",

--- a/data/traits/strategia/membrane_captura_rugiada.json
+++ b/data/traits/strategia/membrane_captura_rugiada.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.membrane_captura_rugiada.debolezza",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.membrane_captura_rugiada.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "membrane_captura_rugiada",
   "label": "i18n:traits.membrane_captura_rugiada.label",
   "mutazione_indotta": "i18n:traits.membrane_captura_rugiada.mutazione_indotta",

--- a/data/traits/strategia/pathfinder.json
+++ b/data/traits/strategia/pathfinder.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.pathfinder.debolezza",
   "famiglia_tipologia": "Esplorazione/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.pathfinder.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Sincronizzazione con HUD di esplorazione)",
   "id": "pathfinder",
   "label": "i18n:traits.pathfinder.label",
   "mutazione_indotta": "i18n:traits.pathfinder.mutazione_indotta",

--- a/data/traits/strategia/pianificatore.json
+++ b/data/traits/strategia/pianificatore.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.pianificatore.debolezza",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.pianificatore.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Analisi continua di stato squadre)",
   "id": "pianificatore",
   "label": "i18n:traits.pianificatore.label",
   "mutazione_indotta": "i18n:traits.pianificatore.mutazione_indotta",

--- a/data/traits/strategia/random.json
+++ b/data/traits/strategia/random.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.random.debolezza",
   "famiglia_tipologia": "Flessibile/Generico",
-  "fattore_mantenimento_energetico": "i18n:traits.random.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Variabile (Dipende dal tratto estratto)",
   "id": "random",
   "label": "i18n:traits.random.label",
   "mutazione_indotta": "i18n:traits.random.mutazione_indotta",

--- a/data/traits/strategia/tattiche_di_branco.json
+++ b/data/traits/strategia/tattiche_di_branco.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.tattiche_di_branco.debolezza",
   "famiglia_tipologia": "Strategico/Tattico",
-  "fattore_mantenimento_energetico": "i18n:traits.tattiche_di_branco.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Broadcast continuo di segnali)",
   "id": "tattiche_di_branco",
   "label": "i18n:traits.tattiche_di_branco.label",
   "mutazione_indotta": "i18n:traits.tattiche_di_branco.mutazione_indotta",

--- a/data/traits/strutturale/antenne_tesla.json
+++ b/data/traits/strutturale/antenne_tesla.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.antenne_tesla.debolezza",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_tesla.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_tesla",
   "label": "i18n:traits.antenne_tesla.label",
   "mutazione_indotta": "i18n:traits.antenne_tesla.mutazione_indotta",

--- a/data/traits/strutturale/artigli_vetrificati.json
+++ b/data/traits/strutturale/artigli_vetrificati.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.artigli_vetrificati.debolezza",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_vetrificati.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "artigli_vetrificati",
   "label": "i18n:traits.artigli_vetrificati.label",
   "mutazione_indotta": "i18n:traits.artigli_vetrificati.mutazione_indotta",

--- a/data/traits/strutturale/branchie_dual_mode.json
+++ b/data/traits/strutturale/branchie_dual_mode.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.branchie_dual_mode.debolezza",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.branchie_dual_mode.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "branchie_dual_mode",
   "label": "i18n:traits.branchie_dual_mode.label",
   "mutazione_indotta": "i18n:traits.branchie_dual_mode.mutazione_indotta",

--- a/data/traits/strutturale/capillari_criogenici.json
+++ b/data/traits/strutturale/capillari_criogenici.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.capillari_criogenici.debolezza",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.capillari_criogenici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "capillari_criogenici",
   "label": "i18n:traits.capillari_criogenici.label",
   "mutazione_indotta": "i18n:traits.capillari_criogenici.mutazione_indotta",

--- a/data/traits/strutturale/carapace_fase_variabile.json
+++ b/data/traits/strutturale/carapace_fase_variabile.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.carapace_fase_variabile.debolezza",
   "famiglia_tipologia": "Strutturale/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.carapace_fase_variabile.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Richiede energia per il cambio di fase)",
   "id": "carapace_fase_variabile",
   "label": "i18n:traits.carapace_fase_variabile.label",
   "mutazione_indotta": "i18n:traits.carapace_fase_variabile.mutazione_indotta",

--- a/data/traits/strutturale/carapace_luminiscente_abissale.json
+++ b/data/traits/strutturale/carapace_luminiscente_abissale.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.carapace_luminiscente_abissale.debolezza",
   "famiglia_tipologia": "Strutturale/Sensoriale",
-  "fattore_mantenimento_energetico": "i18n:traits.carapace_luminiscente_abissale.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Bioluminescenza controllata)",
   "id": "carapace_luminiscente_abissale",
   "label": "i18n:traits.carapace_luminiscente_abissale.label",
   "mutazione_indotta": "i18n:traits.carapace_luminiscente_abissale.mutazione_indotta",

--- a/data/traits/strutturale/cartilagini_pseudometalliche.json
+++ b/data/traits/strutturale/cartilagini_pseudometalliche.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.cartilagini_pseudometalliche.debolezza",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.cartilagini_pseudometalliche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cartilagini_pseudometalliche",
   "label": "i18n:traits.cartilagini_pseudometalliche.label",
   "mutazione_indotta": "i18n:traits.cartilagini_pseudometalliche.mutazione_indotta",

--- a/data/traits/strutturale/cisti_iperbariche.json
+++ b/data/traits/strutturale/cisti_iperbariche.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.cisti_iperbariche.debolezza",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.cisti_iperbariche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cisti_iperbariche",
   "label": "i18n:traits.cisti_iperbariche.label",
   "mutazione_indotta": "i18n:traits.cisti_iperbariche.mutazione_indotta",

--- a/data/traits/strutturale/cromofori_alert_acido.json
+++ b/data/traits/strutturale/cromofori_alert_acido.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.cromofori_alert_acido.debolezza",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.cromofori_alert_acido.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cromofori_alert_acido",
   "label": "i18n:traits.cromofori_alert_acido.label",
   "mutazione_indotta": "i18n:traits.cromofori_alert_acido.mutazione_indotta",

--- a/data/traits/strutturale/denti_tuning_fork.json
+++ b/data/traits/strutturale/denti_tuning_fork.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.denti_tuning_fork.debolezza",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.denti_tuning_fork.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "denti_tuning_fork",
   "label": "i18n:traits.denti_tuning_fork.label",
   "mutazione_indotta": "i18n:traits.denti_tuning_fork.mutazione_indotta",

--- a/data/traits/strutturale/filamenti_magnetotrofi.json
+++ b/data/traits/strutturale/filamenti_magnetotrofi.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.filamenti_magnetotrofi.debolezza",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.filamenti_magnetotrofi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "filamenti_magnetotrofi",
   "label": "i18n:traits.filamenti_magnetotrofi.label",
   "mutazione_indotta": "i18n:traits.filamenti_magnetotrofi.mutazione_indotta",

--- a/data/traits/strutturale/ghiandole_condensa_ozono.json
+++ b/data/traits/strutturale/ghiandole_condensa_ozono.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ghiandole_condensa_ozono.debolezza",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_condensa_ozono.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_condensa_ozono",
   "label": "i18n:traits.ghiandole_condensa_ozono.label",
   "mutazione_indotta": "i18n:traits.ghiandole_condensa_ozono.mutazione_indotta",

--- a/data/traits/strutturale/ghiandole_nebbia_ionica.json
+++ b/data/traits/strutturale/ghiandole_nebbia_ionica.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ghiandole_nebbia_ionica.debolezza",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_nebbia_ionica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_nebbia_ionica",
   "label": "i18n:traits.ghiandole_nebbia_ionica.label",
   "mutazione_indotta": "i18n:traits.ghiandole_nebbia_ionica.mutazione_indotta",

--- a/data/traits/strutturale/lamine_filtranti_aeree.json
+++ b/data/traits/strutturale/lamine_filtranti_aeree.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.lamine_filtranti_aeree.debolezza",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.lamine_filtranti_aeree.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "lamine_filtranti_aeree",
   "label": "i18n:traits.lamine_filtranti_aeree.label",
   "mutazione_indotta": "i18n:traits.lamine_filtranti_aeree.mutazione_indotta",

--- a/data/traits/strutturale/membrane_pneumatofori.json
+++ b/data/traits/strutturale/membrane_pneumatofori.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.membrane_pneumatofori.debolezza",
   "famiglia_tipologia": "Strutturale/Adattivo",
-  "fattore_mantenimento_energetico": "i18n:traits.membrane_pneumatofori.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "membrane_pneumatofori",
   "label": "i18n:traits.membrane_pneumatofori.label",
   "mutazione_indotta": "i18n:traits.membrane_pneumatofori.mutazione_indotta",

--- a/data/traits/strutturale/scheletro_idro_regolante.json
+++ b/data/traits/strutturale/scheletro_idro_regolante.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.scheletro_idro_regolante.debolezza",
   "famiglia_tipologia": "Strutturale/Omeostatico",
-  "fattore_mantenimento_energetico": "i18n:traits.scheletro_idro_regolante.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Scambio rapido di fluidi)",
   "id": "scheletro_idro_regolante",
   "label": "i18n:traits.scheletro_idro_regolante.label",
   "mutazione_indotta": "i18n:traits.scheletro_idro_regolante.mutazione_indotta",

--- a/data/traits/strutturale/struttura_elastica_amorfa.json
+++ b/data/traits/strutturale/struttura_elastica_amorfa.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.struttura_elastica_amorfa.debolezza",
   "famiglia_tipologia": "Strutturale/Locomotorio",
-  "fattore_mantenimento_energetico": "i18n:traits.struttura_elastica_amorfa.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "struttura_elastica_amorfa",
   "label": "i18n:traits.struttura_elastica_amorfa.label",
   "mutazione_indotta": "i18n:traits.struttura_elastica_amorfa.mutazione_indotta",

--- a/data/traits/supporto/antenne_eco_turbina.json
+++ b/data/traits/supporto/antenne_eco_turbina.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.antenne_eco_turbina.debolezza",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.antenne_eco_turbina.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "antenne_eco_turbina",
   "label": "i18n:traits.antenne_eco_turbina.label",
   "mutazione_indotta": "i18n:traits.antenne_eco_turbina.mutazione_indotta",

--- a/data/traits/supporto/artigli_acidofagi.json
+++ b/data/traits/supporto/artigli_acidofagi.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.artigli_acidofagi.debolezza",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.artigli_acidofagi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "artigli_acidofagi",
   "label": "i18n:traits.artigli_acidofagi.label",
   "mutazione_indotta": "i18n:traits.artigli_acidofagi.mutazione_indotta",

--- a/data/traits/supporto/aura_scudo_radianza.json
+++ b/data/traits/supporto/aura_scudo_radianza.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.aura_scudo_radianza.debolezza",
   "famiglia_tipologia": "Supporto/Difesa",
-  "fattore_mantenimento_energetico": "i18n:traits.aura_scudo_radianza.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Canalizzazione fotonica continua)",
   "id": "aura_scudo_radianza",
   "label": "i18n:traits.aura_scudo_radianza.label",
   "mutazione_indotta": "i18n:traits.aura_scudo_radianza.mutazione_indotta",

--- a/data/traits/supporto/batteri_termofili_endosimbiosi.json
+++ b/data/traits/supporto/batteri_termofili_endosimbiosi.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.batteri_termofili_endosimbiosi.debolezza",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.batteri_termofili_endosimbiosi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "batteri_termofili_endosimbiosi",
   "label": "i18n:traits.batteri_termofili_endosimbiosi.label",
   "mutazione_indotta": "i18n:traits.batteri_termofili_endosimbiosi.mutazione_indotta",

--- a/data/traits/supporto/branchie_turbina.json
+++ b/data/traits/supporto/branchie_turbina.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.branchie_turbina.debolezza",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.branchie_turbina.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "branchie_turbina",
   "label": "i18n:traits.branchie_turbina.label",
   "mutazione_indotta": "i18n:traits.branchie_turbina.mutazione_indotta",

--- a/data/traits/supporto/carapaci_ferruginosi.json
+++ b/data/traits/supporto/carapaci_ferruginosi.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.carapaci_ferruginosi.debolezza",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.carapaci_ferruginosi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "carapaci_ferruginosi",
   "label": "i18n:traits.carapaci_ferruginosi.label",
   "mutazione_indotta": "i18n:traits.carapaci_ferruginosi.mutazione_indotta",

--- a/data/traits/supporto/circolazione_doppia.json
+++ b/data/traits/supporto/circolazione_doppia.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.circolazione_doppia.debolezza",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.circolazione_doppia.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "circolazione_doppia",
   "label": "i18n:traits.circolazione_doppia.label",
   "mutazione_indotta": "i18n:traits.circolazione_doppia.mutazione_indotta",

--- a/data/traits/supporto/coda_stabilizzatrice_geiser.json
+++ b/data/traits/supporto/coda_stabilizzatrice_geiser.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.coda_stabilizzatrice_geiser.debolezza",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.coda_stabilizzatrice_geiser.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "coda_stabilizzatrice_geiser",
   "label": "i18n:traits.coda_stabilizzatrice_geiser.label",
   "mutazione_indotta": "i18n:traits.coda_stabilizzatrice_geiser.mutazione_indotta",

--- a/data/traits/supporto/cuticole_neutralizzanti.json
+++ b/data/traits/supporto/cuticole_neutralizzanti.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.cuticole_neutralizzanti.debolezza",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.cuticole_neutralizzanti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "cuticole_neutralizzanti",
   "label": "i18n:traits.cuticole_neutralizzanti.label",
   "mutazione_indotta": "i18n:traits.cuticole_neutralizzanti.mutazione_indotta",

--- a/data/traits/supporto/empatia_coordinativa.json
+++ b/data/traits/supporto/empatia_coordinativa.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.empatia_coordinativa.debolezza",
   "famiglia_tipologia": "Supporto/Empatico",
-  "fattore_mantenimento_energetico": "i18n:traits.empatia_coordinativa.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
   "id": "empatia_coordinativa",
   "label": "i18n:traits.empatia_coordinativa.label",
   "mutazione_indotta": "i18n:traits.empatia_coordinativa.mutazione_indotta",

--- a/data/traits/supporto/enzimi_chelatori_rapidi.json
+++ b/data/traits/supporto/enzimi_chelatori_rapidi.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.enzimi_chelatori_rapidi.debolezza",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.enzimi_chelatori_rapidi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "enzimi_chelatori_rapidi",
   "label": "i18n:traits.enzimi_chelatori_rapidi.label",
   "mutazione_indotta": "i18n:traits.enzimi_chelatori_rapidi.mutazione_indotta",

--- a/data/traits/supporto/foliage_fotocatodico.json
+++ b/data/traits/supporto/foliage_fotocatodico.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.foliage_fotocatodico.debolezza",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.foliage_fotocatodico.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "foliage_fotocatodico",
   "label": "i18n:traits.foliage_fotocatodico.label",
   "mutazione_indotta": "i18n:traits.foliage_fotocatodico.mutazione_indotta",

--- a/data/traits/supporto/ghiandole_inchiostro_luce.json
+++ b/data/traits/supporto/ghiandole_inchiostro_luce.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.ghiandole_inchiostro_luce.debolezza",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_inchiostro_luce.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "ghiandole_inchiostro_luce",
   "label": "i18n:traits.ghiandole_inchiostro_luce.label",
   "mutazione_indotta": "i18n:traits.ghiandole_inchiostro_luce.mutazione_indotta",

--- a/data/traits/supporto/gusci_criovetro.json
+++ b/data/traits/supporto/gusci_criovetro.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.gusci_criovetro.debolezza",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.gusci_criovetro.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "gusci_criovetro",
   "label": "i18n:traits.gusci_criovetro.label",
   "mutazione_indotta": "i18n:traits.gusci_criovetro.mutazione_indotta",

--- a/data/traits/supporto/luminescenza_hydrotermica.json
+++ b/data/traits/supporto/luminescenza_hydrotermica.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.luminescenza_hydrotermica.debolezza",
   "famiglia_tipologia": "Supporto/Logistico",
-  "fattore_mantenimento_energetico": "i18n:traits.luminescenza_hydrotermica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
   "id": "luminescenza_hydrotermica",
   "label": "i18n:traits.luminescenza_hydrotermica.label",
   "mutazione_indotta": "i18n:traits.luminescenza_hydrotermica.mutazione_indotta",

--- a/data/traits/supporto/risonanza_di_branco.json
+++ b/data/traits/supporto/risonanza_di_branco.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.risonanza_di_branco.debolezza",
   "famiglia_tipologia": "Supporto/Coordinativo",
-  "fattore_mantenimento_energetico": "i18n:traits.risonanza_di_branco.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Richiede mantenimento empatico)",
   "id": "risonanza_di_branco",
   "label": "i18n:traits.risonanza_di_branco.label",
   "mutazione_indotta": "i18n:traits.risonanza_di_branco.mutazione_indotta",

--- a/data/traits/tegumentario/mimetismo_cromatico_passivo.json
+++ b/data/traits/tegumentario/mimetismo_cromatico_passivo.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.mimetismo_cromatico_passivo.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.mimetismo_cromatico_passivo.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Fase passiva)",
   "id": "mimetismo_cromatico_passivo",
   "label": "i18n:traits.mimetismo_cromatico_passivo.label",
   "mutazione_indotta": "i18n:traits.mimetismo_cromatico_passivo.mutazione_indotta",

--- a/data/traits/tegumentario/piume_solari_fotovoltaiche.json
+++ b/data/traits/tegumentario/piume_solari_fotovoltaiche.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.piume_solari_fotovoltaiche.debolezza",
   "famiglia_tipologia": "Tegumentario/Energetico",
-  "fattore_mantenimento_energetico": "i18n:traits.piume_solari_fotovoltaiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto (Richiede manutenzione delle lamine fotoreattive)",
   "id": "piume_solari_fotovoltaiche",
   "label": "i18n:traits.piume_solari_fotovoltaiche.label",
   "mutazione_indotta": "i18n:traits.piume_solari_fotovoltaiche.mutazione_indotta",

--- a/data/traits/tegumentario/secrezione_rallentante_palmi.json
+++ b/data/traits/tegumentario/secrezione_rallentante_palmi.json
@@ -5,7 +5,7 @@
   ],
   "debolezza": "i18n:traits.secrezione_rallentante_palmi.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.secrezione_rallentante_palmi.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Produzione del liquido)",
   "id": "secrezione_rallentante_palmi",
   "label": "i18n:traits.secrezione_rallentante_palmi.label",
   "mutazione_indotta": "i18n:traits.secrezione_rallentante_palmi.mutazione_indotta",

--- a/data/traits/tegumentario/squame_rifrangenti_deserto.json
+++ b/data/traits/tegumentario/squame_rifrangenti_deserto.json
@@ -4,7 +4,7 @@
   ],
   "debolezza": "i18n:traits.squame_rifrangenti_deserto.debolezza",
   "famiglia_tipologia": "Tegumentario/Difensivo",
-  "fattore_mantenimento_energetico": "i18n:traits.squame_rifrangenti_deserto.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio (Richiede riallineamento delle placche)",
   "id": "squame_rifrangenti_deserto",
   "label": "i18n:traits.squame_rifrangenti_deserto.label",
   "mutazione_indotta": "i18n:traits.squame_rifrangenti_deserto.mutazione_indotta",

--- a/data/traits/tegumentario/vello_condensatore_nebbie.json
+++ b/data/traits/tegumentario/vello_condensatore_nebbie.json
@@ -2,7 +2,7 @@
   "conflitti": [],
   "debolezza": "i18n:traits.vello_condensatore_nebbie.debolezza",
   "famiglia_tipologia": "Tegumentario/Idratazione",
-  "fattore_mantenimento_energetico": "i18n:traits.vello_condensatore_nebbie.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso (Strutture passive a microfilo)",
   "id": "vello_condensatore_nebbie",
   "label": "i18n:traits.vello_condensatore_nebbie.label",
   "mutazione_indotta": "i18n:traits.vello_condensatore_nebbie.mutazione_indotta",

--- a/locales/it/traits.json
+++ b/locales/it/traits.json
@@ -5,7 +5,6 @@
   "entries": {
     "ali_fono_risonanti": {
       "description": "Generare ampia banda sonora in volo.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Ali Fono-Risonanti",
       "mutazione_indotta": "Venature come corde vibranti controllate.",
       "spinta_selettiva": "Mappatura ambiente e segnalazione.",
@@ -14,7 +13,6 @@
     "ali_fulminee": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
       "description": "Ali Fulminee permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di stratosfera tempestosa.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ali Fulminee",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
@@ -23,7 +21,6 @@
     "ali_ioniche": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
       "description": "Membrane propulsive che rilasciano micro-scariche per scatti controllati.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ali Ioniche",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
@@ -32,7 +29,6 @@
     "ali_membrana_sonica": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
       "description": "Piastre vibranti che dissipano energia e attenuano impatti corrosivi.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ali a Membrana Sonica",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
@@ -41,7 +37,6 @@
     "antenne_dustsense": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "description": "Ricettori stratificati che stabilizzano l’assorbimento multi-fonte in deserti ionici.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Dustsense",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
@@ -50,7 +45,6 @@
     "antenne_eco_turbina": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "description": "Antenne Eco Turbina permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Eco Turbina",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
@@ -59,7 +53,6 @@
     "antenne_flusso_mareale": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
       "description": "Antenne Flusso Mareale permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di laguna bioreattiva.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Flusso Mareale",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
@@ -68,7 +61,6 @@
     "antenne_microonde_cavernose": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
       "description": "Antenne Microonde Cavernose permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caverna risonante.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Microonde Cavernose",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
@@ -77,7 +69,6 @@
     "antenne_plasmatiche_tempesta": {
       "debolezza": "Scariche elettriche massicce possono bruciare i recettori e compromettere la coordinazione.",
       "description": "Convoglia fulmini atmosferici in attacchi mirati o scudi ionici.",
-      "fattore_mantenimento_energetico": "Alto (Canalizzazione costante di plasma atmosferico)",
       "label": "Antenne Plasmatiche di Tempesta",
       "mutazione_indotta": "Flagelli coronati da nodi plasma-sensibili che captano e deviano fulmini.",
       "spinta_selettiva": "Comandare fulmini e navigare in cieli turbolenti durante campagne aeree.",
@@ -86,7 +77,6 @@
     "antenne_reagenti": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
       "description": "Antenne Reagenti permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di foresta acida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Reagenti",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
@@ -95,7 +85,6 @@
     "antenne_tesla": {
       "debolezza": "Risonanze errate possono generare microfratture.",
       "description": "Antenne Tesla permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di canopia ionica.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Tesla",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
@@ -104,7 +93,6 @@
     "antenne_waveguide": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
       "description": "Antenne Waveguide permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di reef luminescente.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Waveguide",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
@@ -113,7 +101,6 @@
     "antenne_wideband": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
       "description": "Antenne Wideband permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di steppe algoritmiche.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Antenne Wideband",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
@@ -122,7 +109,6 @@
     "appendici_risonanti_marea": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
       "description": "Appendici Risonanti Marea permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di laguna bioreattiva.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Appendici Risonanti Marea",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
@@ -131,7 +117,6 @@
     "appendici_thermotattiche": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "description": "Appendici Thermotattiche permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di abisso vulcanico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Appendici Thermotattiche",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
@@ -140,7 +125,6 @@
     "armatura_pietra_planare": {
       "debolezza": "Pesante: riduce mobilità in ambienti non supportati o a bassa gravità.",
       "description": "Corazza risonante scolpita da roccia extradimensionale che smorza onde d'urto.",
-      "fattore_mantenimento_energetico": "Basso (Risonanza geodetica stabile)",
       "label": "Armatura di Pietra Planare",
       "mutazione_indotta": "Cristallizza il dermascheletro con nodi rune che deviano energia.",
       "spinta_selettiva": "Stabilizzare varchi e proteggere infrastrutture dalle onde d'urto.",
@@ -148,7 +132,6 @@
     },
     "articolazioni_a_leva_idraulica": {
       "description": "Amplificare salto e spinta delle zampe.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Articolazioni a Leva Idraulica",
       "mutazione_indotta": "Camere pressurizzate nelle giunture.",
       "spinta_selettiva": "Aggancio rapido su prede/rami.",
@@ -156,14 +139,12 @@
     },
     "articolazioni_multiassiali": {
       "description": "Ruotare arti per manovre strette.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Articolazioni Multiassiali",
       "mutazione_indotta": "Glenoidi/acetaboli ampliati, cartilagini elastiche.",
       "spinta_selettiva": "Arrampicata su tronchi umidi/scogliere",
       "uso_funzione": "Ruotare arti per manovre strette"
     },
     "artigli_a_sette_vie": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Artigli a Sette Vie",
       "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Core Tier 1.",
       "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
@@ -172,7 +153,6 @@
     "artigli_acidofagi": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "description": "Artigli Acidofagi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Artigli Acidofagi",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
@@ -181,7 +161,6 @@
     "artigli_induzione": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
       "description": "Artigli Induzione permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di canopia ionica.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Artigli Induzione",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
@@ -189,7 +168,6 @@
     },
     "artigli_ipo_termici": {
       "description": "Indurre shock da freddo localizzato.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Artigli Ipo-Termici",
       "mutazione_indotta": "Reazioni endo-termiche locali in guaine artigli.",
       "spinta_selettiva": "Immobilizzazione rapida senza sangue.",
@@ -198,7 +176,6 @@
     "artigli_radice": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
       "description": "Artigli Radice permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di mangrovieto cinetico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Artigli Radice",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
@@ -207,7 +184,6 @@
     "artigli_scivolo_silente": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
       "description": "Artigli Scivolo Silente permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di caverna risonante.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Artigli Scivolo Silente",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
@@ -216,7 +192,6 @@
     "artigli_sette_vie": {
       "debolezza": "Angoli di presa limitati se la superficie è perfettamente liscia.",
       "description": "Artigli multipli che assicurano presa stabile su superfici irregolari.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Artigli a Sette Vie",
       "mutazione_indotta": "Dita lunghe e segmentate con punte a uncino multiplo.",
       "spinta_selettiva": "Arrampicarsi su pareti rocciose o vegetazione densa.",
@@ -225,7 +200,6 @@
     "artigli_sghiaccio_glaciale": {
       "debolezza": "In ambienti temperati i tessuti subiscono microfratture e richiedono continue riparazioni.",
       "description": "Falangi criogeniche che congelano e fissano il bersaglio al contatto.",
-      "fattore_mantenimento_energetico": "Medio (Raffreddamento endogeno controllato)",
       "label": "Artigli Sghiaccio Glaciale",
       "mutazione_indotta": "Falangi rivestite da ghiaccio strutturale che si espande creando lame traslucide.",
       "spinta_selettiva": "Cacciare su superfici gelate e pareti verticali di ghiaccio vivo.",
@@ -234,7 +208,6 @@
     "artigli_vetrificati": {
       "debolezza": "Risonanze errate possono generare microfratture.",
       "description": "Artigli Vetrificati permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caldera glaciale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Artigli Vetrificati",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
@@ -242,7 +215,6 @@
     },
     "artiglio_cinetico_a_urto": {
       "description": "Infliggere onda d’urto e frattura.",
-      "fattore_mantenimento_energetico": "Alto",
       "label": "Artiglio Cinetico a Urto",
       "mutazione_indotta": "Appendice scattante tipo mantide pavone.",
       "spinta_selettiva": "Neutralizzare rapidamente prede corazzate.",
@@ -250,7 +222,6 @@
     },
     "aura_di_dispersione_mentale": {
       "description": "Indurre ansia e vertigini nei predatori.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Aura di Dispersione Mentale",
       "mutazione_indotta": "Emissioni EM deboli e odori avversivi coordinati.",
       "spinta_selettiva": "Deterrenza senza scontro fisico.",
@@ -259,7 +230,6 @@
     "aura_scudo_radianza": {
       "debolezza": "Soffre saturazione se esposta a ombre gravitazionali o zone di antimagia.",
       "description": "Campo fotoplasmatico che devia danni planari e sincronizza i battiti della squadra.",
-      "fattore_mantenimento_energetico": "Alto (Canalizzazione fotonica continua)",
       "label": "Aura Scudo di Radianza",
       "mutazione_indotta": "Innesta organi fotoplasmatici che diffondono uno scudo radiante sugli alleati vicini.",
       "spinta_selettiva": "Proteggere gli hub di evacuazione durante tempeste di energia planare.",
@@ -268,14 +238,12 @@
     "baffi_mareomotori": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
       "description": "Baffi Mareomotori permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di mangrovieto cinetico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Baffi Mareomotori",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
     },
     "balance_reflex": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Balance Reflex",
       "mutazione_indotta": "Riduce penalità in piedi; sinergia con WA 03, WA 05.",
       "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
@@ -284,7 +252,6 @@
     "barbigli_sensori_plasma": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
       "description": "Barbigli Sensori Plasma permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di stratosfera tempestosa.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Barbigli Sensori Plasma",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
@@ -293,7 +260,6 @@
     "barriere_miasma_glaciale": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
       "description": "Barriere Miasma Glaciale permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di caldera glaciale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Barriere Miasma Glaciale",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
@@ -302,7 +268,6 @@
     "batteri_endosimbionti_chemio": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "description": "Batteri Endosimbionti Chemio permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di abisso vulcanico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Batteri Endosimbionti Chemio",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
@@ -311,7 +276,6 @@
     "batteri_termofili_endosimbiosi": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "description": "Batteri Termofili Endosimbiosi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Batteri Termofili Endosimbiosi",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
@@ -320,7 +284,6 @@
     "biochip_memoria": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
       "description": "Biochip Memoria permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di steppe algoritmiche.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Biochip Memoria",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
@@ -329,7 +292,6 @@
     "biofilm_glow": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
       "description": "Biofilm Glow permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di reef luminescente.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Biofilm Glow",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
@@ -338,7 +300,6 @@
     "biofilm_iperarido": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
       "description": "Biofilm Iperarido permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di pianura salina iperarida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Biofilm Iperarido",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
@@ -346,7 +307,6 @@
     },
     "bozzolo_magnetico": {
       "description": "Schermarsi da campi elettromagnetici esterni.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Bozzolo Magnetico",
       "mutazione_indotta": "Campo isolante stazionario a bassa frequenza.",
       "spinta_selettiva": "Riposo profondo e protezione da predatori elettrorecettivi.",
@@ -355,7 +315,6 @@
     "branchie_dual_mode": {
       "debolezza": "Risonanze errate possono generare microfratture.",
       "description": "Branchie Dual Mode permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di laguna bioreattiva.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Branchie Dual Mode",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
@@ -364,7 +323,6 @@
     "branchie_eoliche": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
       "description": "Branchie Eoliche permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di stratosfera tempestosa.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Branchie Eoliche",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
@@ -373,7 +331,6 @@
     "branchie_metalloidi": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
       "description": "Branchie Metalloidi permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di abisso vulcanico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Branchie Metalloidi",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
@@ -382,7 +339,6 @@
     "branchie_microfiltri": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
       "description": "Branchie Microfiltri permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di reef luminescente.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Branchie Microfiltri",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
@@ -391,7 +347,6 @@
     "branchie_osmotiche_salmastra": {
       "debolezza": "Richiede accesso costante ad acqua salmastra; ambienti d'acqua dolce provocano stress ionico.",
       "description": "Branchie psioniche che filtrano sali e tossine in acque variabili.",
-      "fattore_mantenimento_energetico": "Medio (Pompe ioniche attive)",
       "label": "Branchie Osmotiche Salmastre",
       "mutazione_indotta": "Lamelle branchiali multilivello con valvole che separano sali e tossine.",
       "spinta_selettiva": "Colonizzare mangrovie psioniche e barriere di estuario soggette a maree estreme.",
@@ -400,7 +355,6 @@
     "branchie_solfatiche": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "description": "Branchie Solfatiche permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di caldera glaciale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Branchie Solfatiche",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
@@ -409,7 +363,6 @@
     "branchie_turbina": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "description": "Branchie Turbina permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Branchie Turbina",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
@@ -418,7 +371,6 @@
     "bulbi_radici_permafrost": {
       "debolezza": "Disgeli improvvisi trasformano i bulbi in masse gelatinose che rallentano i movimenti.",
       "description": "Bulbi radice che rilasciano calore e nutrimento alle unità connesse.",
-      "fattore_mantenimento_energetico": "Medio (Accumulo e rilascio lento di nutrienti)",
       "label": "Bulbi Radici del Permafrost",
       "mutazione_indotta": "Bulbi radicali multipli che immagazzinano energia nelle stagioni fredde per rilasciarla durante le missioni.",
       "spinta_selettiva": "Sostenere campagne lunghe in climi artici con riserve nutrizionali concentrate.",
@@ -427,7 +379,6 @@
     "camere_anticorrosione": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
       "description": "Camere Anticorrosione permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di foresta acida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Camere Anticorrosione",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
@@ -436,7 +387,6 @@
     "camere_mirage": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
       "description": "Camere Mirage permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Camere Mirage",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
@@ -445,7 +395,6 @@
     "camere_nutrienti_vent": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
       "description": "Camere Nutrienti Vent permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di dorsale termale tropicale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Camere Nutrienti Vent",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
@@ -453,7 +402,6 @@
     },
     "campo_di_interferenza_acustica": {
       "description": "Mascherare posizione e velocità.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Campo di Interferenza Acustica",
       "mutazione_indotta": "Rumore bianco caotico a fase variabile.",
       "spinta_selettiva": "Evasione da pipistrelli/rapaci.",
@@ -461,7 +409,6 @@
     },
     "cannone_sonico_a_raggio": {
       "description": "Stordire o ferire con un raggio sonoro.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Cannone Sonico a Raggio",
       "mutazione_indotta": "Risonanza focale su membrana alare.",
       "spinta_selettiva": "Caccia rapida su sciami/uccelli piccoli.",
@@ -469,7 +416,6 @@
     },
     "canto_infrasonico_tattico": {
       "description": "Disorientare predatori e comunicare a distanza.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Canto Infrasonico Tattico",
       "mutazione_indotta": "Corde vocali modificate a bassa frequenza.",
       "spinta_selettiva": "Coordinamento di branco e deterrenza.",
@@ -478,7 +424,6 @@
     "capillari_criogenici": {
       "debolezza": "Risonanze errate possono generare microfratture.",
       "description": "Capillari Criogenici permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caldera glaciale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Capillari Criogenici",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
@@ -487,7 +432,6 @@
     "capillari_fluoridici": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
       "description": "Capillari Fluoridici permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di foresta acida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Capillari Fluoridici",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
@@ -496,7 +440,6 @@
     "capillari_fotovoltaici": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
       "description": "Capillari Fotovoltaici permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di canopia ionica.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Capillari Fotovoltaici",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
@@ -505,7 +448,6 @@
     "capsule_paracadute": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
       "description": "Capsule Paracadute permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di stratosfera tempestosa.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Capsule Paracadute",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
@@ -514,7 +456,6 @@
     "carapace_fase_variabile": {
       "debolezza": "Debolezza strutturale durante la transizione tra le fasi di durezza.",
       "description": "Corazza che varia densità per bilanciare difesa e mobilità.",
-      "fattore_mantenimento_energetico": "Alto (Richiede energia per il cambio di fase)",
       "label": "Carapace a Variazione di Fase",
       "mutazione_indotta": "Strutture minerali a legame reversibile o micro-strutture a rigidità controllata.",
       "spinta_selettiva": "Alternanza tra ambienti con attacchi cinetici pesanti e ambienti che richiedono velocità.",
@@ -523,7 +464,6 @@
     "carapace_luminiscente_abissale": {
       "debolezza": "Luce intensa di superficie sovraccarica i biofotoni rendendo la corazza fragile.",
       "description": "Guscio bioluminescente che confonde i predatori nelle profondità.",
-      "fattore_mantenimento_energetico": "Alto (Bioluminescenza controllata)",
       "label": "Carapace Luminiscente Abissale",
       "mutazione_indotta": "Placche chitino-minerali con microrganismi luminescenti che comunicano in pattern.",
       "spinta_selettiva": "Comunicare e mimetizzarsi nelle profondità prive di luce naturale.",
@@ -532,7 +472,6 @@
     "carapace_segmenti_logici": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "description": "Carapace Segmenti Logici permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di steppe algoritmiche.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Carapace Segmenti Logici",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
@@ -541,7 +480,6 @@
     "carapaci_ferruginosi": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "description": "Carapaci Ferruginosi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di abisso vulcanico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Carapaci Ferruginosi",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
@@ -550,7 +488,6 @@
     "cartilagine_flessotermica_venti": {
       "debolezza": "Temperature stabili riducono la reattività della cartilagine rendendo l'organismo lento.",
       "description": "Cartilagine termoreattiva che ottimizza virate e planate aeree.",
-      "fattore_mantenimento_energetico": "Medio (Richiede frequenti riallineamenti fibrosi)",
       "label": "Cartilagine Flessotermica dei Venti",
       "mutazione_indotta": "Giunzioni cartilaginee che cambiano rigidità in risposta a gradienti termici e eolici.",
       "spinta_selettiva": "Scalare falesie e planare tra correnti ascensionali turbolente.",
@@ -559,7 +496,6 @@
     "cartilagini_biofibre": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
       "description": "Cartilagini Biofibre permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di reef luminescente.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cartilagini Biofibre",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
@@ -568,7 +504,6 @@
     "cartilagini_desertiche": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
       "description": "Cartilagini Desertiche permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cartilagini Desertiche",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
@@ -577,7 +512,6 @@
     "cartilagini_flessoacustiche": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
       "description": "Cartilagini Flessoacustiche permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di caverna risonante.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cartilagini Flessoacustiche",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
@@ -586,7 +520,6 @@
     "cartilagini_pseudometalliche": {
       "debolezza": "Risonanze errate possono generare microfratture.",
       "description": "Cartilagini Pseudometalliche permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cartilagini Pseudometalliche",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
@@ -595,7 +528,6 @@
     "cavita_risonanti_tundra": {
       "debolezza": "In ambienti temperati l'eco interna produce rumori udibili che rivelano la posizione.",
       "description": "Camere toraciche che proiettano richiami a lunga distanza nel gelo.",
-      "fattore_mantenimento_energetico": "Basso (Camere di risonanza statiche)",
       "label": "Cavità Risonanti della Tundra",
       "mutazione_indotta": "Camere toraciche espanse che amplificano vibrazioni subsoniche nel permafrost.",
       "spinta_selettiva": "Coordinare branchi in lande aperte dove la visibilità è ridotta da bufere di ghiaccio.",
@@ -604,7 +536,6 @@
     "cervelletto_equilibrio_statico": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
       "description": "Cervelletto Equilibrio Statico permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di canopia ionica.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cervelletto Equilibrio Statico",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
@@ -612,7 +543,6 @@
     },
     "cervello_a_bassa_latenza": {
       "description": "Eseguire manovre ad alta frequenza.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Cervello a Bassa Latenza",
       "mutazione_indotta": "Circuiti neurali a tempi di integrazione ridotti.",
       "spinta_selettiva": "Predazione aerea in stormi.",
@@ -621,7 +551,6 @@
     "chemiorecettori_bromuro": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
       "description": "Chemiorecettori Bromuro permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di pianura salina iperarida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Chemiorecettori Bromuro",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
@@ -630,7 +559,6 @@
     "chioma_parassita_canopica": {
       "debolezza": "Se la pianta ospite muore la chioma psionica collassa causando shock sistemico.",
       "description": "Filamenti parassiti che creano corsie energetiche nella canopia.",
-      "fattore_mantenimento_energetico": "Medio (Nutrimento condiviso con l'ospite arboreo)",
       "label": "Chioma Parassita Canopica",
       "mutazione_indotta": "Filamenti vegetali che si intrecciano con la canopia ospite fornendo punti d'ancoraggio e energia.",
       "spinta_selettiva": "Stabilizzare piattaforme mobili e reti di trasporto tra gli alberi viventi.",
@@ -638,7 +566,6 @@
     },
     "cinghia_iper_ciliare": {
       "description": "Traslare il corpo su terreni piani o ruvidi.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Cinghia Iper-Ciliare",
       "mutazione_indotta": "Ciglia muscolari ventrali a tappeto mobile.",
       "spinta_selettiva": "Ridurre necessità di arti portanti tradizionali.",
@@ -647,7 +574,6 @@
     "circolazione_bifasica": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
       "description": "Circolazione Bifasica permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di caldera glaciale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Circolazione Bifasica",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
@@ -656,7 +582,6 @@
     "circolazione_bifasica_palude": {
       "debolezza": "Zone asciutte e calde causano stagnazione del circuito linfatico portando a tossicosi.",
       "description": "Doppio circuito sanguigno che separa ossigeno e agenti tossici in ambienti stagnanti.",
-      "fattore_mantenimento_energetico": "Medio (Doppio circuito emolinfa/linfa)",
       "label": "Circolazione Bifasica di Palude",
       "mutazione_indotta": "Cuori gemelli che pompano separatamente emolinfa ossigenata e linfa detossificante.",
       "spinta_selettiva": "Resistere a tossine e anossia tipiche delle paludi psioniche.",
@@ -665,7 +590,6 @@
     "circolazione_cooling_loop": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "description": "Circolazione Cooling Loop permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di steppe algoritmiche.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Circolazione Cooling Loop",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
@@ -674,7 +598,6 @@
     "circolazione_doppia": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "description": "Circolazione Doppia permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Circolazione Doppia",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
@@ -683,7 +606,6 @@
     "circolazione_supercritica": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
       "description": "Circolazione Supercritica permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di abisso vulcanico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Circolazione Supercritica",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
@@ -692,7 +614,6 @@
     "ciste_riduttive": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
       "description": "Ciste Riduttive permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di laguna bioreattiva.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ciste Riduttive",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
@@ -701,7 +622,6 @@
     "ciste_salmastre": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
       "description": "Ciste Salmastre permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di pianura salina iperarida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ciste Salmastre",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
@@ -709,7 +629,6 @@
     },
     "cisti_di_ibernazione_minerale": {
       "description": "Entrare in stasi in condizioni avverse.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Cisti di Ibernazione Minerale",
       "mutazione_indotta": "Parete silicea a prova di calore/pressione.",
       "spinta_selettiva": "Sopravvivenza a lungo termine.",
@@ -718,14 +637,12 @@
     "cisti_iperbariche": {
       "debolezza": "Risonanze errate possono generare microfratture.",
       "description": "Cisti Iperbariche permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cisti Iperbariche",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
     },
     "coda_a_frusta_cinetica": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Coda a Frusta Cinetica",
       "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Opzionali Tier 1.",
       "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
@@ -734,7 +651,6 @@
     "coda_balanciere": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
       "description": "Coda Balanciere permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Coda Balanciere",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
@@ -743,7 +659,6 @@
     "coda_contrappeso": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
       "description": "Coda Contrappeso permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di mangrovieto cinetico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Coda Contrappeso",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
@@ -752,7 +667,6 @@
     "coda_coppia_retroattiva": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
       "description": "Coda Coppia Retroattiva permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di steppe algoritmiche.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Coda Coppia Retroattiva",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
@@ -761,7 +675,6 @@
     "coda_frusta_cinetica": {
       "debolezza": "Richiede un periodo di inattività o movimento preparatorio per massimizzare il danno.",
       "description": "Coda elastica che accumula slancio per un colpo cinetico devastante.",
-      "fattore_mantenimento_energetico": "Medio (Mantenimento dell'energia accumulata)",
       "label": "Coda a Frusta Cinetica",
       "mutazione_indotta": "Muscolatura della coda densa con tendini e fibre che agiscono come molle.",
       "spinta_selettiva": "Necessità di un attacco di \"sfondamento\" dopo movimento preparatorio.",
@@ -769,7 +682,6 @@
     },
     "coda_prensile_muscolare": {
       "description": "Appendere e controbilanciarsi.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Coda Prensile Muscolare",
       "mutazione_indotta": "Fasci caudali spiralizzati, vertebre con verticilli.",
       "spinta_selettiva": "Foraggiamento in chioma; attraversamento gole",
@@ -778,7 +690,6 @@
     "coda_stabilizzatrice_filo": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "description": "Coda Stabilizzatrice Filo permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di canopia ionica.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Coda Stabilizzatrice Filo",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
@@ -787,7 +698,6 @@
     "coda_stabilizzatrice_geiser": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "description": "Coda Stabilizzatrice Geiser permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Coda Stabilizzatrice Geiser",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
@@ -796,7 +706,6 @@
     "coda_stabilizzatrice_vortex": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
       "description": "Coda Stabilizzatrice Vortex permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di stratosfera tempestosa.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Coda Stabilizzatrice Vortex",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
@@ -805,7 +714,6 @@
     "colonne_vibromagnetiche": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
       "description": "Colonne Vibromagnetiche permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caverna risonante.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Colonne Vibromagnetiche",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
@@ -813,7 +721,6 @@
     },
     "comunicazione_fotonica_coda_coda": {
       "description": "Scambiare impulsi luminosi tattili.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Comunicazione Fotonica Coda-Coda",
       "mutazione_indotta": "Piume codali con bioluminescenza debole.",
       "spinta_selettiva": "Coordinamento silente in stormo.",
@@ -822,7 +729,6 @@
     "coralli_partner": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
       "description": "Coralli Partner permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di reef luminescente.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Coralli Partner",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
@@ -830,7 +736,6 @@
     },
     "corna_psico_conduttive": {
       "description": "Trasmettere e ricevere segnali neurali lenti.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Corna Psico-Conduttive",
       "mutazione_indotta": "Tessuti piezo-neurotonici nelle corna.",
       "spinta_selettiva": "Allerta precoce e tattiche di branco.",
@@ -838,21 +743,18 @@
     },
     "coscienza_dalveare_diffusa": {
       "description": "Fondere decisioni e memoria a breve termine.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Coscienza d’Alveare Diffusa",
       "mutazione_indotta": "Rete sinaptica inter-individuo temporanea.",
       "spinta_selettiva": "Evasione collettiva e pianificazione rapida.",
       "uso_funzione": "Fondere decisioni e memoria a breve termine."
     },
     "craft_loop": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Craft Loop",
       "mutazione_indotta": "Riduce di 1 i colpi richiesti con strumenti; si cumula con BB AL 01.",
       "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
       "uso_funzione": "Tier Avanzato (T5). Milestone: Memorie echoic/iconic multiple; AB 11 pain."
     },
     "criostasi": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Criostasi",
       "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Opzionali Tier 1.",
       "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
@@ -861,7 +763,6 @@
     "criostasi_adattiva": {
       "debolezza": "Vulnerabilità estrema agli attacchi chimici (veleni) in fase Criostasi.",
       "description": "Metabolismo sospeso che sopravvive a stagioni estreme prolungate.",
-      "fattore_mantenimento_energetico": "Alto (Fase di risveglio/inizio) / Basso (Fase Criostasi).",
       "label": "Criostasi",
       "mutazione_indotta": "Sviluppo di enzimi crioprotettivi e tessuto adiposo isolante.",
       "spinta_selettiva": "Inverni prolungati o lunghi periodi di scarsità di cibo.",
@@ -870,7 +771,6 @@
     "cromofori_alert_acido": {
       "debolezza": "Risonanze errate possono generare microfratture.",
       "description": "Cromofori Alert Acido permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di foresta acida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cromofori Alert Acido",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
@@ -879,7 +779,6 @@
     "cuore_multicamera_bassa_pressione": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
       "description": "Cuore Multicamera Bassa Pressione permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di stratosfera tempestosa.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cuore Multicamera Bassa Pressione",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
@@ -888,7 +787,6 @@
     "cuscinetti_elettrostatici": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
       "description": "Cuscinetti Elettrostatici permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di pianura salina iperarida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cuscinetti Elettrostatici",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
@@ -897,7 +795,6 @@
     "cute_resistente_sali": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
       "description": "Cute Resistente Sali permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di badlands.",
-      "fattore_mantenimento_energetico": "Medio (Attivazione situazionale)",
       "label": "Cute Resistente Sali",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
@@ -906,7 +803,6 @@
     "cuticole_cerose": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "description": "Cuticole Cerose permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cuticole Cerose",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
@@ -915,7 +811,6 @@
     "cuticole_neutralizzanti": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "description": "Cuticole Neutralizzanti permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Cuticole Neutralizzanti",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
@@ -924,7 +819,6 @@
     "denti_chelatanti": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
       "description": "Denti Chelatanti permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di foresta acida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Denti Chelatanti",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
@@ -933,7 +827,6 @@
     "denti_ossidoferro": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
       "description": "Denti Ossidoferro permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di abisso vulcanico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Denti Ossidoferro",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
@@ -942,7 +835,6 @@
     "denti_silice_termici": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
       "description": "Denti Silice Termici permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di dorsale termale tropicale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Denti Silice Termici",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
@@ -951,7 +843,6 @@
     "denti_tuning_fork": {
       "debolezza": "Risonanze errate possono generare microfratture.",
       "description": "Denti Tuning Fork permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caverna risonante.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Denti Tuning Fork",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
@@ -960,14 +851,12 @@
     "echi_risonanti": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
       "description": "Echi Risonanti permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Echi Risonanti",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
       "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
     },
     "echoic_trace": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Echoic Trace",
       "mutazione_indotta": "Memorizza 1 target uditivo addizionale (sinergia BB SS 01).",
       "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
@@ -976,15 +865,13 @@
     "eco_interno_riflesso": {
       "debolezza": "Estremamente disorientato da suoni o vibrazioni esterne forti e continue.",
       "description": "Sonar interno che mappa l'ambiente attraverso vibrazioni corporee.",
-      "fattore_mantenimento_energetico": "Medio (Emissioni e ricezione continua)",
       "label": "Riflesso dell'Eco Interno",
       "mutazione_indotta": "Organi interni che emettono ultrasuoni e li captano tramite lo scheletro.",
       "spinta_selettiva": "Orientamento in ambienti completamente privi di luce.",
       "uso_funzione": "Utilizzo di onde sonore emesse internamente per mappare l'ambiente."
     },
     "ectotermia_dinamica": {
-      "description": "Microscosse isometriche che innalzano rapidamente la temperatura corporea per picchi prestazionali.",
-      "fattore_mantenimento_energetico": "Medio",
+      "description": "Microscosse isometriche che innalzano in fretta la temperatura corporea per picchi prestazionali in climi freschi.",
       "label": "Ectotermia Dinamica",
       "mutazione_indotta": "Microscosse isometriche per termogenesi rapida.",
       "spinta_selettiva": "Caccia all’alba/crepuscolo in climi freschi.",
@@ -992,7 +879,6 @@
     },
     "elettromagnete_biologico": {
       "description": "Interferire con il sistema nervoso della preda.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Elettromagnete Biologico",
       "mutazione_indotta": "Organo elettrico a pacchetti sincro.",
       "spinta_selettiva": "Immobilizzare pesci e piccoli rettili.",
@@ -1001,7 +887,6 @@
     "empatia_coordinativa": {
       "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate warden scende.",
       "description": "Rete empatica che sincronizza cure e difese dell'intera squadra.",
-      "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
       "label": "Empatia Coordinativa",
       "mutazione_indotta": "Circuiti sensorio-emotivi collegati al feed HUD PI.",
       "spinta_selettiva": "Turni lunghi con rischio alto in cui serve mitigare tilt e HP critici.",
@@ -1010,7 +895,6 @@
     "enzimi_antifase_termica": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
       "description": "Enzimi Antifase Termica permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di caldera glaciale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Enzimi Antifase Termica",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
@@ -1019,7 +903,6 @@
     "enzimi_antipredatori_algali": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
       "description": "Enzimi Antipredatori Algali permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di reef luminescente.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Enzimi Antipredatori Algali",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
@@ -1028,7 +911,6 @@
     "enzimi_chelanti": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "description": "Enzimi Chelanti permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Enzimi Chelanti",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
@@ -1037,7 +919,6 @@
     "enzimi_chelatori_rapidi": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "description": "Enzimi Chelatori Rapidi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Enzimi Chelatori Rapidi",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
@@ -1046,7 +927,6 @@
     "enzimi_metanoossidanti": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
       "description": "Enzimi Metanoossidanti permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di abisso vulcanico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Enzimi Metanoossidanti",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
@@ -1055,7 +935,6 @@
     "epidermide_dielettrica": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
       "description": "Epidermide Dielettrica permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di stratosfera tempestosa.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Epidermide Dielettrica",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
@@ -1064,7 +943,6 @@
     "epitelio_fosforescente": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
       "description": "Epitelio Fosforescente permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di reef luminescente.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Epitelio Fosforescente",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
@@ -1072,7 +950,6 @@
     },
     "ermafroditismo_cronologico": {
       "description": "Cambiare sesso dopo 1–2 incubazioni.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Ermafroditismo Cronologico",
       "mutazione_indotta": "Rimodellamento gonadico sequenziale.",
       "spinta_selettiva": "Ottimizzare successo riproduttivo in densità variabile.",
@@ -1080,14 +957,12 @@
     },
     "estroflessione_gastrica_acida": {
       "description": "Liquefare tessuti al contatto e aspirarli.",
-      "fattore_mantenimento_energetico": "Alto",
       "label": "Estroflessione Gastrica Acida",
       "mutazione_indotta": "Sacca digestiva everted con enzimi proteolitici.",
       "spinta_selettiva": "Cattura prede più grandi con rischio minimo.",
       "uso_funzione": "Liquefare tessuti su contatto e aspirare."
     },
     "executive_loop": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Executive Loop",
       "mutazione_indotta": "Concatena 1 azione gratuita di 'focus' o 'memorizza' tra due compiti.",
       "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
@@ -1095,7 +970,6 @@
     },
     "fagocitosi_assorbente": {
       "description": "Inglobare e digerire biomassa intera.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Fagocitosi Assorbente",
       "mutazione_indotta": "Invaginazione membranaria a vacuolo digestivo.",
       "spinta_selettiva": "Dieta onnivora opportunista.",
@@ -1104,7 +978,6 @@
     "filamenti_digestivi_compattanti": {
       "debolezza": "Blocco intestinale se la dieta è priva di materiale 'legante'.",
       "description": "Filamenti digestivi che compattano scarti e liberano spazio vitale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Filamenti Digestivi Compattanti",
       "mutazione_indotta": "Muscolatura rettale ipertrofica e organo appendice dedicato.",
       "spinta_selettiva": "Necessità di mantenere la pulizia del territorio/nido.",
@@ -1113,7 +986,6 @@
     "filamenti_magnetotrofi": {
       "debolezza": "Risonanze errate possono generare microfratture.",
       "description": "Filamenti Magnetotrofi permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Filamenti Magnetotrofi",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
@@ -1122,7 +994,6 @@
     "filamenti_superconduttivi": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
       "description": "Filamenti Superconduttivi permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caldera glaciale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Filamenti Superconduttivi",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
@@ -1131,7 +1002,6 @@
     "filamenti_termoconduzione": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
       "description": "Filamenti Termoconduzione permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di dorsale termale tropicale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Filamenti Termoconduzione",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
@@ -1139,7 +1009,6 @@
     },
     "filtrazione_osmotica": {
       "description": "Neutralizzare tossine autogenerate.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Filtrazione Osmotica",
       "mutazione_indotta": "Reni a multi-stadio con escrezione selettiva.",
       "spinta_selettiva": "Sopravvivere all’autointossicazione.",
@@ -1148,7 +1017,6 @@
     "filtri_planctonici": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
       "description": "Filtri Planctonici permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di laguna bioreattiva.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Filtri Planctonici",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
@@ -1156,7 +1024,6 @@
     },
     "filtro_metallofago": {
       "description": "Sostenere organi elettrogeni.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Filtro Metallofago",
       "mutazione_indotta": "Assorbimento selettivo di micro-metalli.",
       "spinta_selettiva": "Metabolismo efficiente in acque povere.",
@@ -1165,7 +1032,6 @@
     "flagelli_ancoranti": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "description": "Flagelli Ancoranti permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di laguna bioreattiva.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Flagelli Ancoranti",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
@@ -1173,7 +1039,6 @@
     },
     "flusso_ameboide_controllato": {
       "description": "Scivolare o risalire superfici lisce.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Flusso Ameboide Controllato",
       "mutazione_indotta": "Pseudopodi coordinati a pressione interna.",
       "spinta_selettiva": "Ricerca cibo in interstizi umidi.",
@@ -1182,14 +1047,12 @@
     "focus_frazionato": {
       "debolezza": "Rischio di overload mentale se tilt e aggro salgono oltre le soglie HUD.",
       "description": "Cortex biforcato che mantiene due minacce in sorveglianza attiva.",
-      "fattore_mantenimento_energetico": "Medio (Dividere l'attenzione su più canali)",
       "label": "Focus Frazionato",
       "mutazione_indotta": "Processore di priorità multi-thread per bersagli e obiettivi.",
       "spinta_selettiva": "Comunicazioni piatte dove occorre coprire minacce su più fronti.",
       "uso_funzione": "Permette di gestire due ingaggi paralleli senza perdere efficienza."
     },
     "focus_frazionato_2": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Focus Frazionato",
       "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Sinergie Tier 1.",
       "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
@@ -1198,7 +1061,6 @@
     "foliage_fotocatodico": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "description": "Foliage Fotocatodico permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Foliage Fotocatodico",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
@@ -1207,7 +1069,6 @@
     "foliaggio_spugna": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
       "description": "Foliaggio Spugna permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di mangrovieto cinetico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Foliaggio Spugna",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
@@ -1216,7 +1077,6 @@
     "frusta_fiammeggiante": {
       "debolezza": "Consumante: richiede costante dissipazione termica per non bruciare la matrice portante.",
       "description": "Appendice di plasma vincolato capace di arpionare e incendiare bersagli.",
-      "fattore_mantenimento_energetico": "Medio (Filamenti di plasma vincolato)",
       "label": "Frusta Fiammeggiante",
       "mutazione_indotta": "Genera appendici tentacolari avvolte da plasma infernale controllato.",
       "spinta_selettiva": "Creare distanza di sicurezza contro predatori d'élite nelle zone instabili.",
@@ -1225,7 +1085,6 @@
     "ghiaccio_piezoelettrico": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
       "description": "Ghiaccio Piezoelettrico permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caldera glaciale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiaccio Piezoelettrico",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
@@ -1234,7 +1093,6 @@
     "ghiandola_caustica": {
       "debolezza": "Gestione accurata delle riserve per non calare sotto i budget PE previsto.",
       "description": "Ghiandola offensiva che spruzza acidi rapidi contro corazze leggere.",
-      "fattore_mantenimento_energetico": "Medio (Produzione reagenti)",
       "label": "Ghiandola Caustica",
       "mutazione_indotta": "Sintesi rapida di composti caustici nei moduli d'attacco.",
       "spinta_selettiva": "Squadre che devono rispondere a guardie situazionali al turno 1-2.",
@@ -1243,7 +1101,6 @@
     "ghiandole_cambio_salino": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
       "description": "Ghiandole Cambio Salino permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di laguna bioreattiva.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Cambio Salino",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
@@ -1252,7 +1109,6 @@
     "ghiandole_condensa_ozono": {
       "debolezza": "Risonanze errate possono generare microfratture.",
       "description": "Ghiandole Condensa Ozono permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di stratosfera tempestosa.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Condensa Ozono",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
@@ -1261,7 +1117,6 @@
     "ghiandole_eco_mappanti": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
       "description": "Ghiandole Eco Mappanti permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Eco Mappanti",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
@@ -1270,7 +1125,6 @@
     "ghiandole_fango_calde": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
       "description": "Ghiandole Fango Calde permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di abisso vulcanico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Fango Calde",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
@@ -1279,7 +1133,6 @@
     "ghiandole_fango_coesivo": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
       "description": "Ghiandole Fango Coesivo permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di mangrovieto cinetico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Fango Coesivo",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
@@ -1288,7 +1141,6 @@
     "ghiandole_grafene": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "description": "Ghiandole Grafene permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di steppe algoritmiche.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Grafene",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
@@ -1297,7 +1149,6 @@
     "ghiandole_inchiostro_luce": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "description": "Ghiandole Inchiostro Luce permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di reef luminescente.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Inchiostro Luce",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
@@ -1306,7 +1157,6 @@
     "ghiandole_iodoattive": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
       "description": "Ghiandole Iodoattive permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di pianura salina iperarida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Iodoattive",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
@@ -1315,7 +1165,6 @@
     "ghiandole_minerali": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
       "description": "Ghiandole Minerali permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di dorsale termale tropicale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Minerali",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
@@ -1324,7 +1173,6 @@
     "ghiandole_nebbia_acida": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
       "description": "Ghiandole Nebbia Acida permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di foresta acida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Nebbia Acida",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
@@ -1333,7 +1181,6 @@
     "ghiandole_nebbia_ionica": {
       "debolezza": "Risonanze errate possono generare microfratture.",
       "description": "Ghiandole Nebbia Ionica permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di canopia ionica.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Nebbia Ionica",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
@@ -1342,7 +1189,6 @@
     "ghiandole_resina_conduttiva": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
       "description": "Ghiandole Resina Conduttiva permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di canopia ionica.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Resina Conduttiva",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
@@ -1351,7 +1197,6 @@
     "ghiandole_ventosa": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
       "description": "Ghiandole Ventosa permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di caldera glaciale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Ghiandole Ventosa",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
@@ -1360,7 +1205,6 @@
     "giunti_antitorsione": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
       "description": "Giunti Antitorsione permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di mangrovieto cinetico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Giunti Antitorsione",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
@@ -1369,14 +1213,12 @@
     "grassi_termici": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "description": "Grassi Termici permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Grassi Termici",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
       "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
     },
     "group_form": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Group Form",
       "mutazione_indotta": "Bonus posizionale con 2+ alleati adiacenti.",
       "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
@@ -1385,7 +1227,6 @@
     "gusci_criovetro": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "description": "Gusci Criovetro permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di caldera glaciale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Gusci Criovetro",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
@@ -1394,7 +1235,6 @@
     "gusci_magnesio": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
       "description": "Gusci Magnesio permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di dorsale termale tropicale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Gusci Magnesio",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
@@ -1402,22 +1242,19 @@
     },
     "integumento_bipolare": {
       "description": "Orientarsi lungo le linee di campo.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Integumento Bipolare",
       "mutazione_indotta": "Cristalli di magnetite dermici con neuriti afferenti.",
       "spinta_selettiva": "Migrazioni precise e caccia notturna.",
       "uso_funzione": "Orientarsi su linee di campo."
     },
     "interoception_seed": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Interoception Seed",
       "mutazione_indotta": "+1 ai tiri di Consapevolezza Corporea; segnali anticipati di fame/sete.",
       "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
       "uso_funzione": "Tier Proto‑Sentiente (T1). Milestone: Senses (core)."
     },
     "ipertrofia_muscolare_massiva": {
-      "description": "Fibre ispessite e mitocondri densi che aumentano potenza, scatto e tolleranza allo sforzo breve.",
-      "fattore_mantenimento_energetico": "Alto",
+      "description": "Fibre a sezione aumentata e mitocondri densi che sprigionano potenza e scatto sostenendo sforzi brevi.",
       "label": "Ipertrofia Muscolare Massiva",
       "mutazione_indotta": "Fibre a sezione aumentata e mitocondri densi.",
       "spinta_selettiva": "Selezione per cattura prede muscolose.",
@@ -1426,7 +1263,6 @@
     "lamelle_shear": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
       "description": "Lamelle Shear permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di stratosfera tempestosa.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Lamelle Shear",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
@@ -1435,7 +1271,6 @@
     "lamelle_sincroniche": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
       "description": "Lamelle Sincroniche permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di steppe algoritmiche.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Lamelle Sincroniche",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
@@ -1444,7 +1279,6 @@
     "lamelle_termoforetiche": {
       "debolezza": "Rende instabile la fisiologia in ambienti a gelo improvviso, con rischio di microfratture vascolari.",
       "description": "Lamelle respiratorie che deviano gas estremi con gradienti termici.",
-      "fattore_mantenimento_energetico": "Medio (Flusso continuo di fluidi caldi)",
       "label": "Lamelle Termoforetiche",
       "mutazione_indotta": "Canali lamellari mineralizzati che convogliano fluidi caldi tra branchie interne.",
       "spinta_selettiva": "Sopravvivere a fluidi tossici e temperature estreme nelle fumarole geotermiche.",
@@ -1453,7 +1287,6 @@
     "lamine_filtranti_aeree": {
       "debolezza": "Risonanze errate possono generare microfratture.",
       "description": "Lamine Filtranti Aeree permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di mangrovieto cinetico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Lamine Filtranti Aeree",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
@@ -1462,7 +1295,6 @@
     "lamine_scudo_silice": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
       "description": "Lamine Scudo Silice permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di dorsale termale tropicale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Lamine Scudo Silice",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
@@ -1471,7 +1303,6 @@
     "linfa_tampone": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
       "description": "Linfa Tampone permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di foresta acida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Linfa Tampone",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
@@ -1480,7 +1311,6 @@
     "lingua_cristallina": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
       "description": "Lingua Cristallina permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di pianura salina iperarida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Lingua Cristallina",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
@@ -1489,7 +1319,6 @@
     "lingua_tattile_trama": {
       "debolezza": "Estrema vulnerabilità della lingua a contaminanti chimici o acidi.",
       "description": "Lingua sensoriale che legge vibrazioni e fratture nascoste.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Lingua Tattile Trama-Sensibile",
       "mutazione_indotta": "Lingua sottile con papille tattili e meccanocettori avanzati.",
       "spinta_selettiva": "Individuare movimenti sismici o cibi sepolti.",
@@ -1497,7 +1326,6 @@
     },
     "locomozione_miriapode_ibrida": {
       "description": "Aderire e arrampicare su qualsiasi superficie.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Locomozione Miriapode Ibrida",
       "mutazione_indotta": "50–100 paia di arti segmentati.",
       "spinta_selettiva": "Predazione in tunnel e pareti rocciose.",
@@ -1506,7 +1334,6 @@
     "luminescenza_aurorale": {
       "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
       "description": "Luminescenza Aurorale permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di caldera glaciale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Luminescenza Aurorale",
       "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
       "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
@@ -1515,7 +1342,6 @@
     "luminescenza_hydrotermica": {
       "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
       "description": "Luminescenza Hydrotermica permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di abisso vulcanico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Luminescenza Hydrotermica",
       "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
       "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
@@ -1524,7 +1350,6 @@
     "mantelli_geotermici": {
       "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
       "description": "Mantelli Geotermici permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di caldera glaciale.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Mantelli Geotermici",
       "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
       "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
@@ -1533,7 +1358,6 @@
     "mantello_meteoritico": {
       "debolezza": "Vulnerabile a scariche di freddo gravitazionale che irrigidiscono il mantello.",
       "description": "Strati ablativi rigeneranti che vaporizzano l'impatto convertendolo in impulso termico.",
-      "fattore_mantenimento_energetico": "Alto (Rivestimento ablativo rigenerante)",
       "label": "Mantello Meteoritico",
       "mutazione_indotta": "Deposita strati sovrapposti di materiale meteorico che vaporizzano l'impatto e rilasciano radianza.",
       "spinta_selettiva": "Sopravvivere a bombardamenti planari e piogge di meteore dimensionali.",
@@ -1541,7 +1365,6 @@
     },
     "membrana_plastica_continua": {
       "description": "Assumere forme e densità diverse.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Membrana Plastica Continua",
       "mutazione_indotta": "Struttura citoscheletrica rimodulabile.",
       "spinta_selettiva": "Elusione predatori e passaggio micro-fessure.",
@@ -1550,7 +1373,6 @@
     "membrane_captura_rugiada": {
       "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
       "description": "Membrane Captura Rugiada permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Membrane Captura Rugiada",
       "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
       "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
@@ -1559,7 +1381,6 @@
     "membrane_eliofiltranti": {
       "debolezza": "Atmosfere acide degradano rapidamente il film eliofiltrante.",
       "description": "Membrane traslucide che schermano radiazioni e patogeni sospesi.",
-      "fattore_mantenimento_energetico": "Basso (Auto-riparazione lenta)",
       "label": "Membrane Eliofiltranti",
       "mutazione_indotta": "Strati di mucopolisaccaridi trasparenti che filtrano radiazioni e microrganismi sospesi.",
       "spinta_selettiva": "Proteggersi da radiazioni e agenti patogeni in altopiani ipersalini.",
@@ -1568,7 +1389,6 @@
     "membrane_planata_vectored": {
       "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
       "description": "Membrane Planata Vectored permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di canopia ionica.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Membrane Planata Vectored",
       "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
       "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
@@ -1577,7 +1397,6 @@
     "membrane_pneumatofori": {
       "debolezza": "Risonanze errate possono generare microfratture.",
       "description": "Membrane Pneumatofori permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di mangrovieto cinetico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Membrane Pneumatofori",
       "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
       "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
@@ -1585,7 +1404,6 @@
     },
     "metabolismo_di_condivisione_energetica": {
       "description": "Sostenere feriti o giovani con riserva collettiva.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Metabolismo di Condivisione Energetica",
       "mutazione_indotta": "Trasferimento di substrati via contatto/derma.",
       "spinta_selettiva": "Massimizzare sopravvivenza del branco.",
@@ -1594,7 +1412,6 @@
     "midollo_antivibrazione": {
       "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
       "description": "Midollo Antivibrazione permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Midollo Antivibrazione",
       "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
       "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
@@ -1603,14 +1420,12 @@
     "mimetismo_cromatico_passivo": {
       "debolezza": "La colorazione è fissa finché non c'è un nuovo contatto prolungato.",
       "description": "Cromatofori passivi che replicano lentamente i colori circostanti.",
-      "fattore_mantenimento_energetico": "Basso (Fase passiva)",
       "label": "Ghiandole di Mimetismo Cromatico Passivo",
       "mutazione_indotta": "Cromatofori che richiedono un input tattile prolungato per la ricarica.",
       "spinta_selettiva": "Ambiente con pattern cromatici molto variabili che cambiano lentamente.",
       "uso_funzione": "Assorbire e replicare il colore dell'ambiente circostante dopo contatto."
     },
     "mimicry_basic": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Mimicry Basic",
       "mutazione_indotta": "Il clan imita switch/alterazioni semplici (pieno con CM 06).",
       "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
@@ -1618,7 +1433,6 @@
     },
     "moltiplicazione_per_fusione": {
       "description": "Aumentare massa e intelligenza unendo unità.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Moltiplicazione per Fusione",
       "mutazione_indotta": "Scissione binaria e fusione selettiva.",
       "spinta_selettiva": "Resilienza in condizioni variabili.",
@@ -1626,7 +1440,6 @@
     },
     "motore_biologico_silenzioso": {
       "description": "Garantire volo prolungato a bassissimo SPL.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Motore Biologico Silenzioso",
       "mutazione_indotta": "Tendini frangi-rumore + piume a bordo seghettato.",
       "spinta_selettiva": "Caccia persistente con sorpresa tattica.",
@@ -1635,7 +1448,6 @@
     "mucillagine_simbionte_mangrovie": {
       "debolezza": "Acque eccessivamente pure diluiscono la mucillagine riducendo la protezione.",
       "description": "Mucosa simbionte che assorbe veleni e sigilla ferite palustri.",
-      "fattore_mantenimento_energetico": "Medio (Coltura simbiotica costante)",
       "label": "Mucillagine Simbionte delle Mangrovie",
       "mutazione_indotta": "Strati mucosi che ospitano microfauna detossificante proveniente dalle radici di mangrovia.",
       "spinta_selettiva": "Respinge tossine e predatori microbici tipici dei delta paludosi.",
@@ -1644,7 +1456,6 @@
     "mucose_aderenza_sonica": {
       "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
       "description": "Mucose Aderenza Sonica permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di caverna risonante.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Mucose Aderenza Sonica",
       "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
       "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
@@ -1653,7 +1464,6 @@
     "mucose_barofile": {
       "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
       "description": "Mucose Barofile permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di abisso vulcanico.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Mucose Barofile",
       "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
       "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
@@ -1662,7 +1472,6 @@
     "nodi_micorrizici_oracolari": {
       "debolezza": "Se la rete micorrizica viene recisa, l'organismo soffre crisi percettive e perdita di orientamento.",
       "description": "Nodi micorrizici che anticipano minacce tramite segnali fungini.",
-      "fattore_mantenimento_energetico": "Medio (Scambio continuo di segnali con simbionti)",
       "label": "Nodi Micorrizici Oracolari",
       "mutazione_indotta": "Radici dermiche che intrecciano funghi psionici capaci di predire variazioni ambientali.",
       "spinta_selettiva": "Anticipare frane psioniche e predatori guidati da reti vegetali senzienti.",
@@ -1671,7 +1480,6 @@
     "nucleo_ovomotore_rotante": {
       "debolezza": "Impossibilità di muoversi su superfici irregolari o in salita ripida.",
       "description": "Nucleo rotante che trasforma il corpo in una ruota motrice.",
-      "fattore_mantenimento_energetico": "Alto (Rotolamento)",
       "label": "Uovo rotaia, uovo grande e uova piccole dentro...",
       "mutazione_indotta": "Massa globulare rigida con giunto sferico al centro del petto.",
       "spinta_selettiva": "Necessità di spostarsi rapidamente su terreni uniformi in assenza di arti.",
@@ -1679,7 +1487,6 @@
     },
     "occhi_analizzatori_di_tensione": {
       "description": "Leggere tensioni nella seta e pattern di stress.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Occhi Analizzatori di Tensione",
       "mutazione_indotta": "Retina sensibile alla polarizzazione.",
       "spinta_selettiva": "Ottimizzare riparazioni e trappole.",
@@ -1687,14 +1494,12 @@
     },
     "occhi_cinetici": {
       "description": "Vedere il suono come pattern d’aria.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Occhi Cinetici",
       "mutazione_indotta": "Retina sensibile a distorsioni da vibrazione.",
       "spinta_selettiva": "Allineamento col cannone sonico.",
       "uso_funzione": "Vedere il suono come pattern d’aria."
     },
     "occhi_cristallo_modulare": {
-      "fattore_mantenimento_energetico": "Moderato (Attivo)",
       "label": "Occhi di Cristallo Modulare",
       "mutazione_indotta": "L'organo visivo si fraziona in lenti di cristallo sostituibili che modulano spettro e messa a fuoco in tempo reale.",
       "spinta_selettiva": "Garantire riconoscimento rapido di minacce e risorse in scenari multibioma mantenendo resilienza a bagliori o accecamenti mirati.",
@@ -1703,7 +1508,6 @@
     "occhi_infrarosso_composti": {
       "debolezza": "Accecamento temporaneo da fonti di calore intenso e concentrato.",
       "description": "Ommatidi infrarossi che seguono scie termiche nell'oscurità.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Occhi Composti ad Infrarosso",
       "mutazione_indotta": "Sviluppo di un secondo strato retinico sensibile all'infrarosso.",
       "spinta_selettiva": "Caccia notturna o nell'oscurità totale basata sul gradiente termico.",
@@ -1712,7 +1516,6 @@
     "olfatto_risonanza_magnetica": {
       "debolezza": "Sensibilità a forti interferenze elettromagnetiche (es. fulmini o minerali magnetici).",
       "description": "Bulbi olfattivi che tracciano campi magnetici e vene metalliche.",
-      "fattore_mantenimento_energetico": "Medio (Elaborazione sensoriale costante)",
       "label": "Olfatto di Risonanza Magnetica",
       "mutazione_indotta": "Organi sensoriali elettrorecettori concentrati su muso o antenne.",
       "spinta_selettiva": "Orientamento in ambienti sotterranei senza luce o caccia a prede metallifere.",
@@ -1720,7 +1523,6 @@
     },
     "organi_sismici_cutanei": {
       "description": "Lamelle meccano-recettive nelle squame che percepiscono vibrazioni del suolo e movimenti occultati.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Organi Sismici Cutanei",
       "mutazione_indotta": "Squame con lamelle meccano-recettive.",
       "spinta_selettiva": "Predazione in copertura e notturna.",
@@ -1729,7 +1531,6 @@
     "pathfinder": {
       "debolezza": "Valore ridotto in scenari a corridoio o con tilt già stabilizzato.",
       "description": "Suite esplorativa che evidenzia rotte sicure tra biomi imprevedibili.",
-      "fattore_mantenimento_energetico": "Basso (Sincronizzazione con HUD di esplorazione)",
       "label": "Pathfinder",
       "mutazione_indotta": "Suite sensoriale orientata a scouting e lettura minacce.",
       "spinta_selettiva": "Missioni con indice explore alto e opzioni opzionali da capitalizzare.",
@@ -1737,7 +1538,6 @@
     },
     "pelage_idrorepellente_avanzato": {
       "description": "Isolare e galleggiare.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Pelage Idrorepellente Avanzato",
       "mutazione_indotta": "Ghiandole olocrine con olio ad alta densità.",
       "spinta_selettiva": "Foraggiamento anfibio e notturno in climi umidi.",
@@ -1746,7 +1546,6 @@
     "pianificatore": {
       "debolezza": "Rigidità tattica se gli input di telemetria arrivano in ritardo.",
       "description": "Modulo strategico che mantiene priorità e finestre d'attacco allineate.",
-      "fattore_mantenimento_energetico": "Medio (Analisi continua di stato squadre)",
       "label": "Pianificatore",
       "mutazione_indotta": "Protocollo decisionale adattivo con buffer informativi dedicati.",
       "spinta_selettiva": "Squadre che devono mantenere priorità multiple su turni lunghi.",
@@ -1755,7 +1554,6 @@
     "piume_solari_fotovoltaiche": {
       "debolezza": "Ombre prolungate o polveri dense riducono drasticamente la produzione energetica.",
       "description": "Piumaggio fotovoltaico che immagazzina luce per lunghe missioni.",
-      "fattore_mantenimento_energetico": "Alto (Richiede manutenzione delle lamine fotoreattive)",
       "label": "Piume Solari Fotovoltaiche",
       "mutazione_indotta": "Piumaggio stratificato con pigmenti piezo-fotovoltaici che immagazzinano luce.",
       "spinta_selettiva": "Massimizzare l'autonomia energetica per migrazioni aeree sopra deserti e oceani.",
@@ -1764,14 +1562,12 @@
     "polmoni_cristallini_alta_quota": {
       "debolezza": "Particolato pesante o sabbia vulcanica graffia i cristalli riducendo l'efficienza respiratoria.",
       "description": "Polmoni cristallini che concentrano ossigeno rarefatto in quota.",
-      "fattore_mantenimento_energetico": "Medio (Pulizia periodica dei cristalli)",
       "label": "Polmoni Cristallini d'Alta Quota",
       "mutazione_indotta": "Sistemi alveolari irrobustiti da strutture cristalline che catturano ossigeno rarefatto.",
       "spinta_selettiva": "Operare in missioni d'alta quota senza supporto logistico esterno.",
       "uso_funzione": "Massimizza l'assorbimento di ossigeno rarefatto e filtra agenti nocivi."
     },
     "postural_endurance": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Postural Endurance",
       "mutazione_indotta": "Riduce consumo energia in piedi/corsa.",
       "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
@@ -1780,7 +1576,6 @@
     "random": {
       "debolezza": "Bassa affidabilità: richiede slot aggiuntivi per mitigare risultati sfavorevoli.",
       "description": "Slot sperimentale che estrae tratti casuali dal pool controllato.",
-      "fattore_mantenimento_energetico": "Variabile (Dipende dal tratto estratto)",
       "label": "Trait Random",
       "mutazione_indotta": "Selezione casuale da pool controllata per esperimenti di build.",
       "spinta_selettiva": "Draft rapidi o recuperi quando il tavolo necessita sorprese adattive.",
@@ -1789,7 +1584,6 @@
     "respiro_a_scoppio": {
       "debolezza": "Vulnerabilità respiratoria subito dopo l'utilizzo (tempo di ricarica).",
       "description": "Valvole toraciche che rilasciano getti propulsivi istantanei.",
-      "fattore_mantenimento_energetico": "Alto (Richiede ricarica polmonare)",
       "label": "Respiro a scoppio",
       "mutazione_indotta": "Polmoni o sacche aeree ad alta pressione con valvole di rilascio rapide.",
       "spinta_selettiva": "Spostamento rapido tramite getto d'aria in ambienti a bassa resistenza.",
@@ -1797,7 +1591,6 @@
     },
     "rete_filtro_polmonare": {
       "description": "Assorbire nutrienti aerodispersi.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Rete Filtro-Polmonare",
       "mutazione_indotta": "Ghiandole parenchimali filtranti in sacche polmonari.",
       "spinta_selettiva": "Sussistenza in ambienti poveri di vegetazione.",
@@ -1806,22 +1599,19 @@
     "risonanza_di_branco": {
       "debolezza": "Stress elevato se la coesione cala sotto i target di telemetria.",
       "description": "Rete risonante che amplifica buff condivisi del branco.",
-      "fattore_mantenimento_energetico": "Basso (Richiede mantenimento empatico)",
       "label": "Risonanza di Branco",
       "mutazione_indotta": "Reticolo empatico che collega i canali PI cooperativi.",
       "spinta_selettiva": "Forme che eccellono in difesa coordinata e scudi sovrapposti.",
       "uso_funzione": "Amplifica buff condivisi sincronizzando i timer di squadra."
     },
     "risonanza_di_branco_2": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Risonanza di Branco",
       "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Sinergie Tier 1.",
       "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
       "uso_funzione": "Bozza generata automaticamente dalla fonte A-CANVAS_ORIGINALE.txt. Controllare requisiti e slot per 'Risonanza di Branco'."
     },
     "rostro_emostatico_litico": {
-      "description": "Rostro tubulare rigido che inietta enzimi coagulanti e litici aspirando fluidi dopo l’impatto.",
-      "fattore_mantenimento_energetico": "Medio",
+      "description": "Rostro tubulare rigidizzato che inocula tossine ed enzimi e aspira fluidi dopo l’impatto.",
       "label": "Rostro Emostatico-Litico",
       "mutazione_indotta": "Mascellare tubulare rigidizzato.",
       "spinta_selettiva": "Predazione d'impatto a distanza ravvicinata.",
@@ -1829,7 +1619,6 @@
     },
     "rostro_linguale_prensile": {
       "description": "Afferrare e manipolare a lungo raggio.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Rostro Linguale Prensile",
       "mutazione_indotta": "Lingua muscolare adesiva con ioide esteso.",
       "spinta_selettiva": "Accesso a risorse in cavità/altezza senza muovere il corpo",
@@ -1838,14 +1627,12 @@
     "sacche_galleggianti_ascensoriali": {
       "debolezza": "Rischio di barotrauma se la pressione esterna cambia troppo rapidamente.",
       "description": "Sacche gassose regolabili per controllare assetto e profondità.",
-      "fattore_mantenimento_energetico": "Medio (Per il controllo della pressione)",
       "label": "Sacche galleggianti ascensoriali",
       "mutazione_indotta": "Sacche ripiene di gas leggeri con pompe muscolari.",
       "spinta_selettiva": "Vivere in un ambiente acquatico con forti correnti verticali.",
       "uso_funzione": "Controllo preciso della profondità e del movimento verticale."
     },
     "sacche_galleggianti_ascensoriali_2": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Sacche Galleggianti Ascensoriali",
       "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Opzionali Tier 1.",
       "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
@@ -1854,7 +1641,6 @@
     "sacche_spore_stratosferiche": {
       "debolezza": "Correnti ionizzate possono incendiare le sacche rendendo l'organismo instabile.",
       "description": "Vescicole stratosferiche che disperdono spore di supporto a lungo.",
-      "fattore_mantenimento_energetico": "Alto (Coltura continua di spore portanti)",
       "label": "Sacche di Spore Stratosferiche",
       "mutazione_indotta": "Vescicole dermiche che rilasciano spore portatrici capaci di galleggiare per chilometri.",
       "spinta_selettiva": "Dispersone genetica rapida tra arcipelaghi aerei e piattaforme galleggianti.",
@@ -1863,7 +1649,6 @@
     "sangue_piroforico": {
       "debolezza": "Rischio di auto-combustione in caso di ferita profonda in atmosfera ricca di ossigeno.",
       "description": "Fluido ematico che incendia l'aria colpendo chi perfora la corazza.",
-      "fattore_mantenimento_energetico": "Medio (Sintesi dei composti)",
       "label": "Sangue che prende fuoco a contatto con l'ossigeno",
       "mutazione_indotta": "Presenza di composti piroforici nel sangue.",
       "spinta_selettiva": "Difesa contro predatori che tentano di estrarre fluidi corporei.",
@@ -1871,7 +1656,6 @@
     },
     "scheletro_idraulico_a_pistoni": {
       "description": "Ossa cave pressurizzate che scattano pistoni cranici per colpi-proiettile rapidissimi.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Scheletro Idraulico a Pistoni",
       "mutazione_indotta": "Ossa cave pressurizzate con fluido.",
       "spinta_selettiva": "Vincere fughe brevi con colpi-proiettile.",
@@ -1880,14 +1664,12 @@
     "scheletro_idro_regolante": {
       "debolezza": "Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio.",
       "description": "Ossa porose che modulano il contenuto idrico per mutare massa.",
-      "fattore_mantenimento_energetico": "Medio (Scambio rapido di fluidi)",
       "label": "Scheletro Idro-Regolante",
       "mutazione_indotta": "Struttura ossea porosa capace di scambio rapido di fluidi.",
       "spinta_selettiva": "Alternare vita terrestre e vita acquatica/aerea.",
       "uso_funzione": "Assorbire o espellere rapidamente acqua dai tessuti ossei per modificare il peso."
     },
     "scheletro_idro_regolante_2": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Scheletro Idro-Regolante",
       "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Core Tier 1.",
       "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
@@ -1895,7 +1677,6 @@
     },
     "scheletro_pneumatico_a_maglie": {
       "description": "Alleggerire il carico per spostamenti lenti ma costanti.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Scheletro Pneumatico a Maglie",
       "mutazione_indotta": "Ossa porose con alveoli d’aria.",
       "spinta_selettiva": "Transito terrestre di megafauna fuori dall’acqua.",
@@ -1903,7 +1684,6 @@
     },
     "scivolamento_magnetico": {
       "description": "Ridurre attrito e scivolare.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Scivolamento Magnetico",
       "mutazione_indotta": "Rivestimento paramagnetico + micro-vibrazioni.",
       "spinta_selettiva": "Traslazione silente su superfici variabili.",
@@ -1911,7 +1691,6 @@
     },
     "scudo_gluteale_cheratinizzato": {
       "description": "Assorbire impatti posteriori.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Scudo Gluteale Cheratinizzato",
       "mutazione_indotta": "Placca subdermica cheratino-ossea su eminenze glutee.",
       "spinta_selettiva": "Predatori d’agguato; lotte in tana stretta",
@@ -1920,7 +1699,6 @@
     "secrezione_rallentante_palmi": {
       "debolezza": "Esaurimento rapido delle riserve di liquido con tempo di ricarica prolungato.",
       "description": "Palmi che rilasciano gel rallentante per bloccare bersagli rapidi.",
-      "fattore_mantenimento_energetico": "Medio (Produzione del liquido)",
       "label": "Mani secernano liquido rallentante",
       "mutazione_indotta": "Ghiandole mucose modificate sulle superfici prensili.",
       "spinta_selettiva": "Cattura di prede veloci o difesa da aggressori corpo a corpo.",
@@ -1929,7 +1707,6 @@
     "sensori_geomagnetici": {
       "debolezza": "Tempeste solari possono saturare il segnale magnetico, causando disorientamento prolungato.",
       "description": "Cristalli cranici che mappano corridoi geomagnetici invisibili.",
-      "fattore_mantenimento_energetico": "Basso (Ricettori passivi)",
       "label": "Sensori a Risonanza Geomagnetica",
       "mutazione_indotta": "Cristalli ferromagnetici allineati lungo il cranio che fungono da bussola psionica.",
       "spinta_selettiva": "Orientarsi in steppe polarizzate e tunnel sotterranei privi di riferimenti visivi.",
@@ -1937,14 +1714,12 @@
     },
     "seta_conduttiva_elettrica": {
       "description": "Stordire con scariche nella tela.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Seta Conduttiva Elettrica",
       "mutazione_indotta": "Seta con nano-metalli piezoresponsivi.",
       "spinta_selettiva": "Cattura prede veloci con trappola attiva.",
       "uso_funzione": "Stordire con scariche nella tela."
     },
     "sheltering": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Sheltering",
       "mutazione_indotta": "Riduce stress in pericolo vicino a costruzioni.",
       "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
@@ -1952,7 +1727,6 @@
     },
     "siero_anti_gelo_naturale": {
       "description": "Impedire la cristallizzazione a basse temperature.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Siero Anti-Gelo Naturale",
       "mutazione_indotta": "Proteine antigelo circolanti.",
       "spinta_selettiva": "Migrazione notturna in steppe fredde.",
@@ -1961,7 +1735,6 @@
     "sinapsi_coraline_polifoniche": {
       "debolezza": "Vibrazioni sintonizzate male possono generare feedback dolorosi e perdita di coscienza.",
       "description": "Sinapsi coralline che trasmettono ordini tramite armoniche marine.",
-      "fattore_mantenimento_energetico": "Medio (Scambio continuo di impulsi corallini)",
       "label": "Sinapsi Coraline Polifoniche",
       "mutazione_indotta": "Fibre nervose intrecciate con coralli sonori che trasmettono ordini tramite armoniche.",
       "spinta_selettiva": "Coordinare banchi e alleati in ambienti tridimensionali complessi.",
@@ -1969,7 +1742,6 @@
     },
     "sistemi_chimio_sonici": {
       "description": "Mappare spazio e correnti d’aria senza vista.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Sistemi Chimio-Sonici",
       "mutazione_indotta": "Echolocazione + spruzzi feromonali orientativi.",
       "spinta_selettiva": "Caccia in buio totale e gallerie fumose.",
@@ -1978,7 +1750,6 @@
     "sonno_emisferico_alternato": {
       "debolezza": "Vulnerabilità a suoni/stimoli che colpiscono entrambi i lobi contemporaneamente.",
       "description": "Cervello alternato che veglia con un emisfero mentre l'altro riposa.",
-      "fattore_mantenimento_energetico": "Medio (Mantenimento attivo di metà cervello)",
       "label": "Dormire con solo metà cervello alla volta",
       "mutazione_indotta": "Encefalizzazione asimmetrica o due lobi cerebrali separati.",
       "spinta_selettiva": "Monitoraggio costante dei predatori in ambienti ad alto rischio.",
@@ -1987,7 +1758,6 @@
     "spore_psichiche_silenziate": {
       "debolezza": "Funzionalità ridotta in presenza di vento forte o umidità elevata.",
       "description": "Spore psioniche che sedano e confondono i bersagli vicini.",
-      "fattore_mantenimento_energetico": "Alto (Produzione e rilascio)",
       "label": "Spora Psichica Silenziosa",
       "mutazione_indotta": "Pori che rilasciano nano-particelle attive chimicamente o psichicamente.",
       "spinta_selettiva": "Neutralizzare gruppi di prede o predatori senza impegnare in combattimento.",
@@ -1996,14 +1766,12 @@
     "squame_rifrangenti_deserto": {
       "debolezza": "Soffre danni da feedback termico se colpito da raggi concentrati o laser.",
       "description": "Scaglie cristalline che diffondono calore e creano miraggi.",
-      "fattore_mantenimento_energetico": "Medio (Richiede riallineamento delle placche)",
       "label": "Squame Rifrangenti del Deserto",
       "mutazione_indotta": "Placche cristalline sovrapposte che deviano luce e calore lungo superfici multiple.",
       "spinta_selettiva": "Sopravvivere a intensi flare termici e accecanti miraggi desertici.",
       "uso_funzione": "Rifrange la luce generando miraggi e dissipando attacchi energetici."
     },
     "startle_reflex": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Startle Reflex",
       "mutazione_indotta": "Reazioni di fuga più rapide (sinergia con MS 02 se presente).",
       "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
@@ -2012,14 +1780,12 @@
     "struttura_elastica_amorfa": {
       "debolezza": "Vulnerabilità a danni da taglio o perforazione (difficile cauterizzazione).",
       "description": "Corpo amorfo che si estende e si compatta per evadere vincoli.",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
       "label": "Struttura elastica, allungabile, amorfa, retrattile",
       "mutazione_indotta": "Tessuto con matrice di proteine elastiche iper-modificate.",
       "spinta_selettiva": "Fuga rapida da predatori in spazi confinati.",
       "uso_funzione": "Flessibilità estrema e capacità di assumere forme diverse."
     },
     "struttura_elastica_amorfa_2": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Struttura Elastica Amorfa",
       "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Core Tier 1.",
       "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
@@ -2028,28 +1794,24 @@
     "tattiche_di_branco": {
       "debolezza": "Richiede formazione stabile; cala se la coesione precipita sotto il target.",
       "description": "Protocollo tattico che coordina focus e prese condivise.",
-      "fattore_mantenimento_energetico": "Medio (Broadcast continuo di segnali)",
       "label": "Tattiche di Branco",
       "mutazione_indotta": "Canale condiviso per marcature e ingaggi simultanei.",
       "spinta_selettiva": "Squadre che puntano a style bonus tramite assist e controllo spazio.",
       "uso_funzione": "Coordina prese e focus bersaglio condividendo segnali di priorità."
     },
     "tattiche_di_branco_2": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Tattiche di Branco",
       "mutazione_indotta": "Estratto da Canvas A — Originale — sezione Sinergie Tier 1.",
       "spinta_selettiva": "Origine esterna: Canvas A — Originale. Validare integrazione prima del catalogo.",
       "uso_funzione": "Bozza generata automaticamente dalla fonte A-CANVAS_ORIGINALE.txt. Controllare requisiti e slot per 'Tattiche di Branco'."
     },
     "teach_action": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Teach Action",
       "mutazione_indotta": "Insegna 1 azione pratica al clan (switch/alter/transport).",
       "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
       "uso_funzione": "Tier Civico (T4). Milestone: Sound Awareness/Chemotopy full; AB 05–09 climb/carry."
     },
     "toolseed": {
-      "fattore_mantenimento_energetico": "Da definire (import esterno)",
       "label": "Toolseed",
       "mutazione_indotta": "Progetti Rozzi: +5% successo alterazioni; si cumula con AL 01–03.",
       "spinta_selettiva": "Origine esterna: EvoTactics.Sentience. Validare allineamento con catalogo principale.",
@@ -2057,7 +1819,6 @@
     },
     "unghie_a_micro_adesione": {
       "description": "Aderire a superfici ripide.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Unghie a Micro-Adesione",
       "mutazione_indotta": "Lamelle a micro-setole tipo geco su zoccoli.",
       "spinta_selettiva": "Fuga verticale e pascolo in cenge.",
@@ -2066,7 +1827,6 @@
     "vello_condensatore_nebbie": {
       "debolezza": "In ambienti aridi accumula detriti che riducono la capacità di condensa.",
       "description": "Vello capillare che condensa nebbia in riserve idriche mobili.",
-      "fattore_mantenimento_energetico": "Basso (Strutture passive a microfilo)",
       "label": "Vello Condensatore di Nebbie",
       "mutazione_indotta": "Peli cavi microstriati che catturano e canalizzano la bruma atmosferica.",
       "spinta_selettiva": "Garantire idratazione in climi montani dove l'acqua liquida è scarsa ma la nebbia abbondante.",
@@ -2074,7 +1834,6 @@
     },
     "vello_di_assorbimento_totale": {
       "description": "Assorbire quasi tutta la luce incidente.",
-      "fattore_mantenimento_energetico": "Basso",
       "label": "Vello di Assorbimento Totale",
       "mutazione_indotta": "Nano-strutture piumari tipo vantablack biologico.",
       "spinta_selettiva": "Caccia e fuga in oscurità totale.",
@@ -2083,7 +1842,6 @@
     "ventriglio_gastroliti": {
       "debolezza": "Usura e rottura del ventriglio se i gastroliti sono esauriti o troppo lisci.",
       "description": "Ventriglio muscoloso che macina cibi duri con gastroliti.",
-      "fattore_mantenimento_energetico": "Medio (Contrazione muscolare costante)",
       "label": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
       "mutazione_indotta": "Sviluppo di un organo muscolare (ventriglio) con gastroliti.",
       "spinta_selettiva": "Dieta basata su semi, conchiglie o insetti corazzati.",
@@ -2091,7 +1849,6 @@
     },
     "visione_multi_spettrale_amplificata": {
       "description": "Vedere in luminanza estremamente bassa.",
-      "fattore_mantenimento_energetico": "Medio",
       "label": "Visione Multi-Spettrale Amplificata",
       "mutazione_indotta": "Bastoncelli potenziati + recettori IR/UV.",
       "spinta_selettiva": "Predazione su prede a sangue caldo.",
@@ -2100,7 +1857,6 @@
     "zampe_a_molla": {
       "debolezza": "Perdita di valore su mappe con spazi stretti o controllo setup elevato.",
       "description": "Arti a molla che accumulano energia per balzi di riposizionamento.",
-      "fattore_mantenimento_energetico": "Basso (Carica elastica a turni alterni)",
       "label": "Zampe a Molla",
       "mutazione_indotta": "Arti potenziati con ammortizzatori ad alta compressione.",
       "spinta_selettiva": "Metagame con forte pressione di aggro e necessità di riposizionamento.",
@@ -2108,7 +1864,6 @@
     },
     "zanne_idracida": {
       "description": "Corrodere tessuti e metalli.",
-      "fattore_mantenimento_energetico": "Alto",
       "label": "Zanne Idracida",
       "mutazione_indotta": "Ghiandole acido-termiche nei cheliceri.",
       "spinta_selettiva": "Predazione su prede in corazza minerale.",
@@ -2117,7 +1872,6 @@
     "zoccoli_risonanti_steppe": {
       "debolezza": "Suoli cedevoli come sabbie mobili annullano la vibrazione e riducono la trazione.",
       "description": "Zoccoli cavi che inviano onde ritmiche al branco sulle steppe.",
-      "fattore_mantenimento_energetico": "Basso (Vibrazione passiva del suolo)",
       "label": "Zoccoli Risonanti delle Steppe",
       "mutazione_indotta": "Placche cornee cave che emettono onde sismiche ritmiche al contatto con il terreno.",
       "spinta_selettiva": "Mantenere coesione di branchi su grandi distanze e rilevare predatori sotterranei.",

--- a/tools/py/normalize_trait_style.py
+++ b/tools/py/normalize_trait_style.py
@@ -26,7 +26,6 @@ TEXT_FIELDS = (
     "uso_funzione",
     "spinta_selettiva",
     "debolezza",
-    "fattore_mantenimento_energetico",
 )
 
 


### PR DESCRIPTION
## Summary
- add explicit defaults for energy maintenance factors so Basso/Medio/Alto values stay descriptive without i18n
- restore non-localised fields during locale sync and drop redundant locale entries for the energy factor
- resync trait files to embed the clarified maintenance factor text inline

## Testing
- python scripts/sync_trait_locales.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921d15f1a3c832896a47554c0d6de2b)