### PR TITLE
Allinea i tratti Evo v2 a glossario e i18n

### DIFF
--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2025-11-22T15:10:41+00:00",
+  "updated_at": "2025-11-22T21:38:18+00:00",
   "sources": {
     "trait_reference": "data/traits/index.json"
   },
@@ -176,8 +176,8 @@
     "aura_di_dispersione_mentale": {
       "label_it": "Aura di Dispersione Mentale",
       "label_en": "Mental Dispersion Aura",
-      "description_it": "Indurre ansia e vertigini nei predatori.",
-      "description_en": "Impart anxiety and vertigo to predators."
+      "description_it": "Campo di odori avversivi ed emissioni deboli che induce ansia e vertigini nei predatori.",
+      "description_en": "Aversive odors and weak emissions that instill anxiety and vertigo in predators."
     },
     "aura_scudo_radianza": {
       "label_it": "Aura Scudo di Radianza",
@@ -560,14 +560,14 @@
     "corna_psico_conduttive": {
       "label_it": "Corna Psico-Conduttive",
       "label_en": "Psycho-Conductive Horns",
-      "description_it": "Trasmettere e ricevere segnali neurali lenti.",
-      "description_en": "Transmit and receive slow neural signals."
+      "description_it": "Corna piezo-neurotoniche che trasmettono e ricevono segnali neurali lenti per allerta di branco.",
+      "description_en": "Piezo-neurotonic horns sending and receiving slow neural signals for pack alerts."
     },
     "coscienza_dalveare_diffusa": {
       "label_it": "Coscienza d’Alveare Diffusa",
       "label_en": "Diffuse Hive Consciousness",
-      "description_it": "Fondere decisioni e memoria a breve termine.",
-      "description_en": "Merge decisions and short-term memory."
+      "description_it": "Rete sinaptica inter-individuo temporanea che fonde decisioni e memoria a breve termine.",
+      "description_en": "Temporary inter-individual synaptic net merging decisions and short-term memory."
     },
     "criostasi_adattiva": {
       "label_en": "Adaptive Cryostasis",
@@ -1040,8 +1040,8 @@
     "metabolismo_di_condivisione_energetica": {
       "label_it": "Metabolismo di Condivisione Energetica",
       "label_en": "Shared Energy Metabolism",
-      "description_it": "Sostenere feriti o giovani con riserva collettiva.",
-      "description_en": "Support wounded or young with collective reserves."
+      "description_it": "Trasferimento di substrati via contatto per sostenere feriti o giovani con una riserva collettiva.",
+      "description_en": "Contact-based substrate transfer to sustain wounded or young with a collective reserve."
     },
     "midollo_antivibrazione": {
       "label_it": "Midollo Antivibrazione",
@@ -1310,8 +1310,8 @@
     "unghie_a_micro_adesione": {
       "label_it": "Unghie a Micro-Adesione",
       "label_en": "Micro-Adhesion Claws",
-      "description_it": "Aderire a superfici ripide.",
-      "description_en": "Adhere to steep surfaces."
+      "description_it": "Lamelle a micro-setole su zoccoli che aderiscono a superfici ripide per fughe verticali e pascolo.",
+      "description_en": "Micro-setae lamellae on hooves gripping steep surfaces for vertical escapes and browsing."
     },
     "vello_condensatore_nebbie": {
       "label_it": "Vello Condensatore di Nebbie",

--- a/data/traits/cognitivo/corna_psico_conduttive.json
+++ b/data/traits/cognitivo/corna_psico_conduttive.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.corna_psico_conduttive.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Cognitivo/Sociale",
-  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+  "fattore_mantenimento_energetico": "Basso",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/data/traits/cognitivo/coscienza_dalveare_diffusa.json
+++ b/data/traits/cognitivo/coscienza_dalveare_diffusa.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.coscienza_dalveare_diffusa.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Cognitivo/Sociale",
-  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+  "fattore_mantenimento_energetico": "Medio",
   "tier": "T4",
   "slot": [],
   "sinergie": [

--- a/data/traits/fisiologico/metabolismo_di_condivisione_energetica.json
+++ b/data/traits/fisiologico/metabolismo_di_condivisione_energetica.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.metabolismo_di_condivisione_energetica.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Fisiologico/Metabolico",
-  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+  "fattore_mantenimento_energetico": "Medio",
   "tier": "T3",
   "slot": [],
   "sinergie": [
@@ -15,7 +15,7 @@
   "spinta_selettiva": "i18n:traits.metabolismo_di_condivisione_energetica.spinta_selettiva",
   "metrics": [
     {
-      "name": "consumo_O2",
+      "name": "consumo_o2",
       "value": 50,
       "unit": "L/min"
     }

--- a/data/traits/locomotivo/unghie_a_micro_adesione.json
+++ b/data/traits/locomotivo/unghie_a_micro_adesione.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.unghie_a_micro_adesione.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Locomotivo/Arboricolo",
-  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+  "fattore_mantenimento_energetico": "Basso",
   "tier": "T2",
   "slot": [],
   "sinergie": [

--- a/data/traits/offensivo/aura_di_dispersione_mentale.json
+++ b/data/traits/offensivo/aura_di_dispersione_mentale.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.aura_di_dispersione_mentale.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Offensivo/Controllo",
-  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+  "fattore_mantenimento_energetico": "Medio",
   "tier": "T3",
   "slot": [],
   "sinergie": [

--- a/locales/it/traits.json
+++ b/locales/it/traits.json
@@ -221,7 +221,7 @@
       "uso_funzione": "Infliggere onda d’urto e frattura."
     },
     "aura_di_dispersione_mentale": {
-      "description": "Indurre ansia e vertigini nei predatori.",
+      "description": "Campo di odori avversivi ed emissioni deboli che induce ansia e vertigini nei predatori.",
       "label": "Aura di Dispersione Mentale",
       "mutazione_indotta": "Emissioni EM deboli e odori avversivi coordinati.",
       "spinta_selettiva": "Deterrenza senza scontro fisico.",
@@ -735,14 +735,14 @@
       "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
     },
     "corna_psico_conduttive": {
-      "description": "Trasmettere e ricevere segnali neurali lenti.",
+      "description": "Corna piezo-neurotoniche che trasmettono e ricevono segnali neurali lenti per allerta di branco.",
       "label": "Corna Psico-Conduttive",
       "mutazione_indotta": "Tessuti piezo-neurotonici nelle corna.",
       "spinta_selettiva": "Allerta precoce e tattiche di branco.",
       "uso_funzione": "Trasmettere/ricevere segnali neurali lenti."
     },
     "coscienza_dalveare_diffusa": {
-      "description": "Fondere decisioni e memoria a breve termine.",
+      "description": "Rete sinaptica inter-individuo temporanea che fonde decisioni e memoria a breve termine.",
       "label": "Coscienza d’Alveare Diffusa",
       "mutazione_indotta": "Rete sinaptica inter-individuo temporanea.",
       "spinta_selettiva": "Evasione collettiva e pianificazione rapida.",
@@ -1403,7 +1403,7 @@
       "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
     },
     "metabolismo_di_condivisione_energetica": {
-      "description": "Sostenere feriti o giovani con riserva collettiva.",
+      "description": "Trasferimento di substrati via contatto per sostenere feriti o giovani con una riserva collettiva.",
       "label": "Metabolismo di Condivisione Energetica",
       "mutazione_indotta": "Trasferimento di substrati via contatto/derma.",
       "spinta_selettiva": "Massimizzare sopravvivenza del branco.",
@@ -1818,7 +1818,7 @@
       "uso_funzione": "Tier Emergente (T3). Milestone: Senses mid+; AB 02–03 movement/carry."
     },
     "unghie_a_micro_adesione": {
-      "description": "Aderire a superfici ripide.",
+      "description": "Lamelle a micro-setole su zoccoli che aderiscono a superfici ripide per fughe verticali e pascolo.",
       "label": "Unghie a Micro-Adesione",
       "mutazione_indotta": "Lamelle a micro-setole tipo geco su zoccoli.",
       "spinta_selettiva": "Fuga verticale e pascolo in cenge.",

--- a/reports/trait_fields_by_type.json
+++ b/reports/trait_fields_by_type.json
@@ -362,7 +362,9 @@
       "spinta_selettiva",
       "testability",
       "tier",
-      "uso_funzione"
+      "uso_funzione",
+      "version",
+      "versioning"
     ]
   },
   "Fisiologico/Respiratorio": {
@@ -406,7 +408,9 @@
       "spinta_selettiva",
       "testability",
       "tier",
-      "uso_funzione"
+      "uso_funzione",
+      "version",
+      "versioning"
     ]
   },
   "Flessibile/Generico": {
@@ -521,7 +525,9 @@
       "spinta_selettiva",
       "testability",
       "tier",
-      "uso_funzione"
+      "uso_funzione",
+      "version",
+      "versioning"
     ]
   },
   "Locomotivo/Terrestre": {
@@ -975,7 +981,9 @@
       "spinta_selettiva",
       "testability",
       "tier",
-      "uso_funzione"
+      "uso_funzione",
+      "version",
+      "versioning"
     ]
   },
   "Offensivo/Termico": {
@@ -1351,7 +1359,9 @@
       "spinta_selettiva",
       "testability",
       "tier",
-      "uso_funzione"
+      "uso_funzione",
+      "version",
+      "versioning"
     ]
   },
   "Sensoriale/Uditivo-Olfattivo": {

--- a/reports/trait_texts.json
+++ b/reports/trait_texts.json
@@ -282,11 +282,11 @@
   "aura_di_dispersione_mentale": {
     "en": {
       "label": "Mental Dispersion Aura",
-      "description": "Impart anxiety and vertigo to predators."
+      "description": "Aversive odors and weak emissions that instill anxiety and vertigo in predators."
     },
     "it": {
       "label": "Aura di Dispersione Mentale",
-      "description": "Indurre ansia e vertigini nei predatori."
+      "description": "Campo di odori avversivi ed emissioni deboli che induce ansia e vertigini nei predatori."
     }
   },
   "aura_scudo_radianza": {
@@ -922,21 +922,21 @@
   "corna_psico_conduttive": {
     "en": {
       "label": "Psycho-Conductive Horns",
-      "description": "Transmit and receive slow neural signals."
+      "description": "Piezo-neurotonic horns sending and receiving slow neural signals for pack alerts."
     },
     "it": {
       "label": "Corna Psico-Conduttive",
-      "description": "Trasmettere e ricevere segnali neurali lenti."
+      "description": "Corna piezo-neurotoniche che trasmettono e ricevono segnali neurali lenti per allerta di branco."
     }
   },
   "coscienza_dalveare_diffusa": {
     "en": {
       "label": "Diffuse Hive Consciousness",
-      "description": "Merge decisions and short-term memory."
+      "description": "Temporary inter-individual synaptic net merging decisions and short-term memory."
     },
     "it": {
       "label": "Coscienza d’Alveare Diffusa",
-      "description": "Fondere decisioni e memoria a breve termine."
+      "description": "Rete sinaptica inter-individuo temporanea che fonde decisioni e memoria a breve termine."
     }
   },
   "criostasi_adattiva": {
@@ -1072,11 +1072,11 @@
   "ectotermia_dinamica": {
     "en": {
       "label": "Dynamic Ectothermy",
-      "description": "Isometric micro-shivers that rapidly raise body temperature for performance spikes."
+      "description": "Isometric micro-shivers that quickly elevate body temperature for performance peaks in cool climates."
     },
     "it": {
       "label": "Ectotermia Dinamica",
-      "description": "Microscosse isometriche che innalzano rapidamente la temperatura corporea per picchi prestazionali."
+      "description": "Microscosse isometriche che innalzano in fretta la temperatura corporea per picchi prestazionali in climi freschi."
     }
   },
   "elettromagnete_biologico": {
@@ -1532,11 +1532,11 @@
   "ipertrofia_muscolare_massiva": {
     "en": {
       "label": "Massive Muscular Hypertrophy",
-      "description": "Thickened fibres with dense mitochondria boosting power, burst acceleration, and short-term strain tolerance."
+      "description": "Broadened fibres with dense mitochondria that unleash power and acceleration while enduring short bursts."
     },
     "it": {
       "label": "Ipertrofia Muscolare Massiva",
-      "description": "Fibre ispessite e mitocondri densi che aumentano potenza, scatto e tolleranza allo sforzo breve."
+      "description": "Fibre a sezione aumentata e mitocondri densi che sprigionano potenza e scatto sostenendo sforzi brevi."
     }
   },
   "lamelle_shear": {
@@ -1722,11 +1722,11 @@
   "metabolismo_di_condivisione_energetica": {
     "en": {
       "label": "Shared Energy Metabolism",
-      "description": "Support wounded or young with collective reserves."
+      "description": "Contact-based substrate transfer to sustain wounded or young with a collective reserve."
     },
     "it": {
       "label": "Metabolismo di Condivisione Energetica",
-      "description": "Sostenere feriti o giovani con riserva collettiva."
+      "description": "Trasferimento di substrati via contatto per sostenere feriti o giovani con una riserva collettiva."
     }
   },
   "midollo_antivibrazione": {
@@ -1962,11 +1962,11 @@
   "rostro_emostatico_litico": {
     "en": {
       "label": "Hemo-Lytic Rostrum",
-      "description": "Rigid tubular rostrum that injects lytic and coagulant enzymes while drawing fluids after impact."
+      "description": "Reinforced tubular rostrum that injects toxins and enzymes, then draws fluids after impact."
     },
     "it": {
       "label": "Rostro Emostatico-Litico",
-      "description": "Rostro tubulare rigido che inietta enzimi coagulanti e litici aspirando fluidi dopo l’impatto."
+      "description": "Rostro tubulare rigidizzato che inocula tossine ed enzimi e aspira fluidi dopo l’impatto."
     }
   },
   "rostro_linguale_prensile": {
@@ -2172,11 +2172,11 @@
   "unghie_a_micro_adesione": {
     "en": {
       "label": "Micro-Adhesion Claws",
-      "description": "Adhere to steep surfaces."
+      "description": "Micro-setae lamellae on hooves gripping steep surfaces for vertical escapes and browsing."
     },
     "it": {
       "label": "Unghie a Micro-Adesione",
-      "description": "Aderire a superfici ripide."
+      "description": "Lamelle a micro-setole su zoccoli che aderiscono a superfici ripide per fughe verticali e pascolo."
     }
   },
   "vello_condensatore_nebbie": {


### PR DESCRIPTION
## Summary
- Aggiorna le voci di glossario per il lotto Evo v2 con descrizioni IT/EN allineate al naming snake_case
- Normalizza i file trait di corna psico-conduttive, coscienza d’alveare diffusa, aura di dispersione mentale, metabolismo di condivisione energetica e unghie a micro-adesione
- Sincronizza le stringhe locali e rigenera i report dei campi dei trait

## Testing
- python tools/py/trait_template_validator.py --summary
- python tools/py/collect_trait_fields.py --output reports/trait_fields_by_type.json --glossary data/core/traits/glossary.json --glossary-output reports/trait_texts.json
- python scripts/sync_trait_locales.py --traits-dir data/traits --locales-dir locales --language it --glossary data/core/traits/glossary.json


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69222c5dd4288328bb63d4186f8962ec)