### PR TITLE
Normalize evo legacy data naming

### DIFF
--- a/data/external/evo/species/species_catalog.json
+++ b/data/external/evo/species/species_catalog.json
@@ -49,7 +49,8 @@
         "created": "2025-11-22",
         "updated": "2025-11-22",
         "author": "GPT-5.1-Codex-Max"
-      }
+      },
+      "id": "anguis_magnetica"
     },
     {
       "scientific_name": "Chemnotela toxica",
@@ -100,7 +101,8 @@
         "created": "2025-11-22",
         "updated": "2025-11-22",
         "author": "GPT-5.1-Codex-Max"
-      }
+      },
+      "id": "chemnotela_toxica"
     },
     {
       "scientific_name": "Elastovaranus hydrus",
@@ -153,7 +155,8 @@
         "created": "2025-11-22",
         "updated": "2025-11-22",
         "author": "GPT-5.1-Codex-Max"
-      }
+      },
+      "id": "elastovaranus_hydrus"
     },
     {
       "scientific_name": "Gulogluteus scutiger",
@@ -206,7 +209,8 @@
         "created": "2025-11-22",
         "updated": "2025-11-22",
         "author": "GPT-5.1-Codex-Max"
-      }
+      },
+      "id": "gulogluteus_scutiger"
     },
     {
       "scientific_name": "Perfusuas pedes",
@@ -257,7 +261,8 @@
         "created": "2025-11-22",
         "updated": "2025-11-22",
         "author": "GPT-5.1-Codex-Max"
-      }
+      },
+      "id": "perfusuas_pedes"
     },
     {
       "scientific_name": "Proteus plasma",
@@ -308,7 +313,8 @@
         "created": "2025-11-22",
         "updated": "2025-11-22",
         "author": "GPT-5.1-Codex-Max"
-      }
+      },
+      "id": "proteus_plasma"
     },
     {
       "scientific_name": "Rupicapra sensoria",
@@ -356,7 +362,8 @@
         "created": "2025-11-22",
         "updated": "2025-11-22",
         "author": "GPT-5.1-Codex-Max"
-      }
+      },
+      "id": "rupicapra_sensoria"
     },
     {
       "scientific_name": "Soniptera resonans",
@@ -407,7 +414,8 @@
         "created": "2025-11-22",
         "updated": "2025-11-22",
         "author": "GPT-5.1-Codex-Max"
-      }
+      },
+      "id": "soniptera_resonans"
     },
     {
       "scientific_name": "Terracetus ambulator",
@@ -456,7 +464,8 @@
         "created": "2025-11-22",
         "updated": "2025-11-22",
         "author": "GPT-5.1-Codex-Max"
-      }
+      },
+      "id": "terracetus_ambulator"
     },
     {
       "scientific_name": "Umbra alaris",
@@ -506,7 +515,14 @@
         "created": "2025-11-22",
         "updated": "2025-11-22",
         "author": "GPT-5.1-Codex-Max"
-      }
+      },
+      "id": "umbra_alaris"
     }
-  ]
+  ],
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-23",
+    "updated": "2025-11-23",
+    "author": "GPT-5.1-Codex-Max"
+  }
 }

--- a/data/external/evo/species/species_ecotype_map.json
+++ b/data/external/evo/species/species_ecotype_map.json
@@ -25,7 +25,9 @@
       "biome_class": "acquatico_costiero",
       "matched_ecosystems": [],
       "unresolved_ecosystems": [],
-      "notes": "No direct ecosystem mapping for biome class"
+      "notes": "No direct ecosystem mapping for biome class",
+      "species_id": "anguis_magnetica",
+      "ecotype_slug": "estuario_torbido"
     },
     {
       "species": "Anguis magnetica",
@@ -34,7 +36,9 @@
       "biome_class": "acquatico_costiero",
       "matched_ecosystems": [],
       "unresolved_ecosystems": [],
-      "notes": "No direct ecosystem mapping for biome class"
+      "notes": "No direct ecosystem mapping for biome class",
+      "species_id": "anguis_magnetica",
+      "ecotype_slug": "laguna_quieta"
     },
     {
       "species": "Chemnotela toxica",
@@ -49,7 +53,9 @@
         }
       ],
       "unresolved_ecosystems": [],
-      "notes": null
+      "notes": null,
+      "species_id": "chemnotela_toxica",
+      "ecotype_slug": "radura_acida"
     },
     {
       "species": "Chemnotela toxica",
@@ -64,7 +70,9 @@
         }
       ],
       "unresolved_ecosystems": [],
-      "notes": null
+      "notes": null,
+      "species_id": "chemnotela_toxica",
+      "ecotype_slug": "chioma_elettrofilo"
     },
     {
       "species": "Elastovaranus hydrus",
@@ -79,7 +87,9 @@
         }
       ],
       "unresolved_ecosystems": [],
-      "notes": null
+      "notes": null,
+      "species_id": "elastovaranus_hydrus",
+      "ecotype_slug": "gole_ventose"
     },
     {
       "species": "Elastovaranus hydrus",
@@ -94,7 +104,9 @@
         }
       ],
       "unresolved_ecosystems": [],
-      "notes": null
+      "notes": null,
+      "species_id": "elastovaranus_hydrus",
+      "ecotype_slug": "letti_fluviali"
     },
     {
       "species": "Gulogluteus scutiger",
@@ -109,7 +121,9 @@
         }
       ],
       "unresolved_ecosystems": [],
-      "notes": null
+      "notes": null,
+      "species_id": "gulogluteus_scutiger",
+      "ecotype_slug": "chioma_umida"
     },
     {
       "species": "Gulogluteus scutiger",
@@ -124,7 +138,9 @@
         }
       ],
       "unresolved_ecosystems": [],
-      "notes": null
+      "notes": null,
+      "species_id": "gulogluteus_scutiger",
+      "ecotype_slug": "forre_umide"
     },
     {
       "species": "Perfusuas pedes",
@@ -133,7 +149,9 @@
       "biome_class": "sotterraneo",
       "matched_ecosystems": [],
       "unresolved_ecosystems": [],
-      "notes": "No direct ecosystem mapping for biome class"
+      "notes": "No direct ecosystem mapping for biome class",
+      "species_id": "perfusuas_pedes",
+      "ecotype_slug": "cavernicolo"
     },
     {
       "species": "Perfusuas pedes",
@@ -148,7 +166,9 @@
         }
       ],
       "unresolved_ecosystems": [],
-      "notes": null
+      "notes": null,
+      "species_id": "perfusuas_pedes",
+      "ecotype_slug": "radura_notturna"
     },
     {
       "species": "Proteus plasma",
@@ -157,7 +177,9 @@
       "biome_class": "acquatico_dolce",
       "matched_ecosystems": [],
       "unresolved_ecosystems": [],
-      "notes": "No direct ecosystem mapping for biome class"
+      "notes": "No direct ecosystem mapping for biome class",
+      "species_id": "proteus_plasma",
+      "ecotype_slug": "stagno_quieto"
     },
     {
       "species": "Proteus plasma",
@@ -166,7 +188,9 @@
       "biome_class": "acquatico_dolce",
       "matched_ecosystems": [],
       "unresolved_ecosystems": [],
-      "notes": "No direct ecosystem mapping for biome class"
+      "notes": "No direct ecosystem mapping for biome class",
+      "species_id": "proteus_plasma",
+      "ecotype_slug": "torrente_lento"
     },
     {
       "species": "Rupicapra sensoria",
@@ -181,7 +205,9 @@
         }
       ],
       "unresolved_ecosystems": [],
-      "notes": null
+      "notes": null,
+      "species_id": "rupicapra_sensoria",
+      "ecotype_slug": "cenge_calcarenitiche"
     },
     {
       "species": "Rupicapra sensoria",
@@ -196,7 +222,9 @@
         }
       ],
       "unresolved_ecosystems": [],
-      "notes": null
+      "notes": null,
+      "species_id": "rupicapra_sensoria",
+      "ecotype_slug": "dorsali_ventose"
     },
     {
       "species": "Soniptera resonans",
@@ -211,7 +239,9 @@
         }
       ],
       "unresolved_ecosystems": [],
-      "notes": null
+      "notes": null,
+      "species_id": "soniptera_resonans",
+      "ecotype_slug": "oasi_termica"
     },
     {
       "species": "Soniptera resonans",
@@ -226,7 +256,9 @@
         }
       ],
       "unresolved_ecosystems": [],
-      "notes": null
+      "notes": null,
+      "species_id": "soniptera_resonans",
+      "ecotype_slug": "prateria_arbustiva"
     },
     {
       "species": "Terracetus ambulator",
@@ -241,7 +273,9 @@
         }
       ],
       "unresolved_ecosystems": [],
-      "notes": null
+      "notes": null,
+      "species_id": "terracetus_ambulator",
+      "ecotype_slug": "pianure_ventose"
     },
     {
       "species": "Terracetus ambulator",
@@ -256,7 +290,9 @@
         }
       ],
       "unresolved_ecosystems": [],
-      "notes": null
+      "notes": null,
+      "species_id": "terracetus_ambulator",
+      "ecotype_slug": "savanicola_notturno"
     },
     {
       "species": "Umbra alaris",
@@ -271,7 +307,9 @@
         }
       ],
       "unresolved_ecosystems": [],
-      "notes": null
+      "notes": null,
+      "species_id": "umbra_alaris",
+      "ecotype_slug": "canopy_ombrosa"
     },
     {
       "species": "Umbra alaris",
@@ -286,7 +324,15 @@
         }
       ],
       "unresolved_ecosystems": [],
-      "notes": null
+      "notes": null,
+      "species_id": "umbra_alaris",
+      "ecotype_slug": "canyon_notturno"
     }
-  ]
+  ],
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-23",
+    "updated": "2025-11-23",
+    "author": "GPT-5.1-Codex-Max"
+  }
 }

--- a/data/external/evo/traits/TR-1101.json
+++ b/data/external/evo/traits/TR-1101.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1101",
+  "id": "rostro_emostatico_litico",
   "label": "Rostro Emostatico-Litico",
   "famiglia_tipologia": "Offensivo/Perforante",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1102.json
+++ b/data/external/evo/traits/TR-1102.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1102",
+  "id": "scheletro_idraulico_a_pistoni",
   "label": "Scheletro Idraulico a Pistoni",
   "famiglia_tipologia": "Locomotivo/Balistico",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1103.json
+++ b/data/external/evo/traits/TR-1103.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1103",
+  "id": "ipertrofia_muscolare_massiva",
   "label": "Ipertrofia Muscolare Massiva",
   "famiglia_tipologia": "Fisiologico/Metabolico",
   "fattore_mantenimento_energetico": "Alto",

--- a/data/external/evo/traits/TR-1104.json
+++ b/data/external/evo/traits/TR-1104.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1104",
+  "id": "ectotermia_dinamica",
   "label": "Ectotermia Dinamica",
   "famiglia_tipologia": "Fisiologico/Termico",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1105.json
+++ b/data/external/evo/traits/TR-1105.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1105",
+  "id": "organi_sismici_cutanei",
   "label": "Organi Sismici Cutanei",
   "famiglia_tipologia": "Sensoriale/Tatto-Vibro",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1201.json
+++ b/data/external/evo/traits/TR-1201.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1201",
+  "id": "pelage_idrorepellente_avanzato",
   "label": "Pelage Idrorepellente Avanzato",
   "famiglia_tipologia": "Difensivo/Termoregolazione",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1202.json
+++ b/data/external/evo/traits/TR-1202.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1202",
+  "id": "scudo_gluteale_cheratinizzato",
   "label": "Scudo Gluteale Cheratinizzato",
   "famiglia_tipologia": "Difensivo/Corazza",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1203.json
+++ b/data/external/evo/traits/TR-1203.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1203",
+  "id": "articolazioni_multiassiali",
   "label": "Articolazioni Multiassiali",
   "famiglia_tipologia": "Locomotivo/Terrestre",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1204.json
+++ b/data/external/evo/traits/TR-1204.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1204",
+  "id": "coda_prensile_muscolare",
   "label": "Coda Prensile Muscolare",
   "famiglia_tipologia": "Locomotivo/Arboricolo",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1205.json
+++ b/data/external/evo/traits/TR-1205.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1205",
+  "id": "rostro_linguale_prensile",
   "label": "Rostro Linguale Prensile",
   "famiglia_tipologia": "Manipolativo/Alimentare",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1301.json
+++ b/data/external/evo/traits/TR-1301.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1301",
+  "id": "ermafroditismo_cronologico",
   "label": "Ermafroditismo Cronologico",
   "famiglia_tipologia": "Riproduttivo/Cicli",
   "fattore_mantenimento_energetico": "Medio",
@@ -29,7 +30,7 @@
     {
       "name": "tasso_propaguli",
       "value": 50,
-      "unit": "1/season"
+      "unit": "1/a"
     }
   ],
   "cost_profile": {

--- a/data/external/evo/traits/TR-1302.json
+++ b/data/external/evo/traits/TR-1302.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1302",
+  "id": "locomozione_miriapode_ibrida",
   "label": "Locomozione Miriapode Ibrida",
   "famiglia_tipologia": "Locomotivo/Terrestre",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1303.json
+++ b/data/external/evo/traits/TR-1303.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1303",
+  "id": "estroflessione_gastrica_acida",
   "label": "Estroflessione Gastrica Acida",
   "famiglia_tipologia": "Offensivo/Chimico",
   "fattore_mantenimento_energetico": "Alto",

--- a/data/external/evo/traits/TR-1304.json
+++ b/data/external/evo/traits/TR-1304.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1304",
+  "id": "artiglio_cinetico_a_urto",
   "label": "Artiglio Cinetico a Urto",
   "famiglia_tipologia": "Offensivo/Contusivo",
   "fattore_mantenimento_energetico": "Alto",

--- a/data/external/evo/traits/TR-1305.json
+++ b/data/external/evo/traits/TR-1305.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1305",
+  "id": "sistemi_chimio_sonici",
   "label": "Sistemi Chimio-Sonici",
   "famiglia_tipologia": "Sensoriale/Uditivo-Olfattivo",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1401.json
+++ b/data/external/evo/traits/TR-1401.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1401",
+  "id": "scheletro_pneumatico_a_maglie",
   "label": "Scheletro Pneumatico a Maglie",
   "famiglia_tipologia": "Locomotivo/Terrestre",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1402.json
+++ b/data/external/evo/traits/TR-1402.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1402",
+  "id": "cinghia_iper_ciliare",
   "label": "Cinghia Iper-Ciliare",
   "famiglia_tipologia": "Locomotivo/Terrestre",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1403.json
+++ b/data/external/evo/traits/TR-1403.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1403",
+  "id": "rete_filtro_polmonare",
   "label": "Rete Filtro-Polmonare",
   "famiglia_tipologia": "Fisiologico/Respiratorio",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1404.json
+++ b/data/external/evo/traits/TR-1404.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1404",
+  "id": "canto_infrasonico_tattico",
   "label": "Canto Infrasonico Tattico",
   "famiglia_tipologia": "Offensivo/Controllo",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1405.json
+++ b/data/external/evo/traits/TR-1405.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1405",
+  "id": "siero_anti_gelo_naturale",
   "label": "Siero Anti-Gelo Naturale",
   "famiglia_tipologia": "Fisiologico/Termico",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1501.json
+++ b/data/external/evo/traits/TR-1501.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1501",
+  "id": "zanne_idracida",
   "label": "Zanne Idracida",
   "famiglia_tipologia": "Offensivo/Chimico",
   "fattore_mantenimento_energetico": "Alto",

--- a/data/external/evo/traits/TR-1502.json
+++ b/data/external/evo/traits/TR-1502.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1502",
+  "id": "seta_conduttiva_elettrica",
   "label": "Seta Conduttiva Elettrica",
   "famiglia_tipologia": "Offensivo/Elettrico",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1503.json
+++ b/data/external/evo/traits/TR-1503.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1503",
+  "id": "articolazioni_a_leva_idraulica",
   "label": "Articolazioni a Leva Idraulica",
   "famiglia_tipologia": "Locomotivo/Terrestre",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1504.json
+++ b/data/external/evo/traits/TR-1504.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1504",
+  "id": "filtrazione_osmotica",
   "label": "Filtrazione Osmotica",
   "famiglia_tipologia": "Fisiologico/Idrico",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1505.json
+++ b/data/external/evo/traits/TR-1505.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1505",
+  "id": "occhi_analizzatori_di_tensione",
   "label": "Occhi Analizzatori di Tensione",
   "famiglia_tipologia": "Sensoriale/Visivo",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1601.json
+++ b/data/external/evo/traits/TR-1601.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1601",
+  "id": "membrana_plastica_continua",
   "label": "Membrana Plastica Continua",
   "famiglia_tipologia": "Difensivo/Camuffamento",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1602.json
+++ b/data/external/evo/traits/TR-1602.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1602",
+  "id": "flusso_ameboide_controllato",
   "label": "Flusso Ameboide Controllato",
   "famiglia_tipologia": "Locomotivo/Terrestre",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1603.json
+++ b/data/external/evo/traits/TR-1603.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1603",
+  "id": "fagocitosi_assorbente",
   "label": "Fagocitosi Assorbente",
   "famiglia_tipologia": "Alimentazione/Digestione",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1604.json
+++ b/data/external/evo/traits/TR-1604.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1604",
+  "id": "moltiplicazione_per_fusione",
   "label": "Moltiplicazione per Fusione",
   "famiglia_tipologia": "Riproduttivo/Cicli",
   "fattore_mantenimento_energetico": "Basso",
@@ -29,7 +30,7 @@
     {
       "name": "tasso_propaguli",
       "value": 3,
-      "unit": "1/season"
+      "unit": "1/a"
     }
   ],
   "cost_profile": {

--- a/data/external/evo/traits/TR-1605.json
+++ b/data/external/evo/traits/TR-1605.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1605",
+  "id": "cisti_di_ibernazione_minerale",
   "label": "Cisti di Ibernazione Minerale",
   "famiglia_tipologia": "Difensivo/Resistenze",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1701.json
+++ b/data/external/evo/traits/TR-1701.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1701",
+  "id": "ali_fono_risonanti",
   "label": "Ali Fono-Risonanti",
   "famiglia_tipologia": "Locomotivo/Aereo",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1702.json
+++ b/data/external/evo/traits/TR-1702.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1702",
+  "id": "cannone_sonico_a_raggio",
   "label": "Cannone Sonico a Raggio",
   "famiglia_tipologia": "Offensivo/Controllo",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1703.json
+++ b/data/external/evo/traits/TR-1703.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1703",
+  "id": "campo_di_interferenza_acustica",
   "label": "Campo di Interferenza Acustica",
   "famiglia_tipologia": "Difensivo/Camuffamento",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1704.json
+++ b/data/external/evo/traits/TR-1704.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1704",
+  "id": "cervello_a_bassa_latenza",
   "label": "Cervello a Bassa Latenza",
   "famiglia_tipologia": "Cognitivo/Apprendimento",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1705.json
+++ b/data/external/evo/traits/TR-1705.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1705",
+  "id": "occhi_cinetici",
   "label": "Occhi Cinetici",
   "famiglia_tipologia": "Sensoriale/Visivo",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1801.json
+++ b/data/external/evo/traits/TR-1801.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1801",
+  "id": "integumento_bipolare",
   "label": "Integumento Bipolare",
   "famiglia_tipologia": "Sensoriale/Magneto-ricettivo",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1802.json
+++ b/data/external/evo/traits/TR-1802.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1802",
+  "id": "elettromagnete_biologico",
   "label": "Elettromagnete Biologico",
   "famiglia_tipologia": "Offensivo/Elettrico",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1803.json
+++ b/data/external/evo/traits/TR-1803.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1803",
+  "id": "scivolamento_magnetico",
   "label": "Scivolamento Magnetico",
   "famiglia_tipologia": "Locomotivo/Terrestre",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1804.json
+++ b/data/external/evo/traits/TR-1804.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1804",
+  "id": "filtro_metallofago",
   "label": "Filtro Metallofago",
   "famiglia_tipologia": "Alimentazione/Digestione",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1805.json
+++ b/data/external/evo/traits/TR-1805.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1805",
+  "id": "bozzolo_magnetico",
   "label": "Bozzolo Magnetico",
   "famiglia_tipologia": "Difensivo/Resistenze",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1901.json
+++ b/data/external/evo/traits/TR-1901.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1901",
+  "id": "vello_di_assorbimento_totale",
   "label": "Vello di Assorbimento Totale",
   "famiglia_tipologia": "Difensivo/Camuffamento",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1902.json
+++ b/data/external/evo/traits/TR-1902.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1902",
+  "id": "visione_multi_spettrale_amplificata",
   "label": "Visione Multi-Spettrale Amplificata",
   "famiglia_tipologia": "Sensoriale/Visivo",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1903.json
+++ b/data/external/evo/traits/TR-1903.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1903",
+  "id": "motore_biologico_silenzioso",
   "label": "Motore Biologico Silenzioso",
   "famiglia_tipologia": "Fisiologico/Metabolico",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-1904.json
+++ b/data/external/evo/traits/TR-1904.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1904",
+  "id": "artigli_ipo_termici",
   "label": "Artigli Ipo-Termici",
   "famiglia_tipologia": "Offensivo/Termico",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-1905.json
+++ b/data/external/evo/traits/TR-1905.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-1905",
+  "id": "comunicazione_fotonica_coda_coda",
   "label": "Comunicazione Fotonica Coda-Coda",
   "famiglia_tipologia": "Cognitivo/Sociale",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-2001.json
+++ b/data/external/evo/traits/TR-2001.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-2001",
+  "id": "corna_psico_conduttive",
   "label": "Corna Psico-Conduttive",
   "famiglia_tipologia": "Cognitivo/Sociale",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/TR-2002.json
+++ b/data/external/evo/traits/TR-2002.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-2002",
+  "id": "coscienza_d_alveare_diffusa",
   "label": "Coscienza d’Alveare Diffusa",
   "famiglia_tipologia": "Cognitivo/Sociale",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-2003.json
+++ b/data/external/evo/traits/TR-2003.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-2003",
+  "id": "aura_di_dispersione_mentale",
   "label": "Aura di Dispersione Mentale",
   "famiglia_tipologia": "Offensivo/Controllo",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-2004.json
+++ b/data/external/evo/traits/TR-2004.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-2004",
+  "id": "metabolismo_di_condivisione_energetica",
   "label": "Metabolismo di Condivisione Energetica",
   "famiglia_tipologia": "Fisiologico/Metabolico",
   "fattore_mantenimento_energetico": "Medio",

--- a/data/external/evo/traits/TR-2005.json
+++ b/data/external/evo/traits/TR-2005.json
@@ -1,5 +1,6 @@
 {
   "trait_code": "TR-2005",
+  "id": "unghie_a_micro_adesione",
   "label": "Unghie a Micro-Adesione",
   "famiglia_tipologia": "Locomotivo/Arboricolo",
   "fattore_mantenimento_energetico": "Basso",

--- a/data/external/evo/traits/traits_aggregate.json
+++ b/data/external/evo/traits/traits_aggregate.json
@@ -55,7 +55,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "rostro_emostatico_litico"
     },
     {
       "trait_code": "TR-1102",
@@ -112,7 +113,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "scheletro_idraulico_a_pistoni"
     },
     {
       "trait_code": "TR-1103",
@@ -170,7 +172,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "ipertrofia_muscolare_massiva"
     },
     {
       "trait_code": "TR-1104",
@@ -226,7 +229,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "ectotermia_dinamica"
     },
     {
       "trait_code": "TR-1105",
@@ -284,7 +288,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "organi_sismici_cutanei"
     },
     {
       "trait_code": "TR-1201",
@@ -342,7 +347,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "pelage_idrorepellente_avanzato"
     },
     {
       "trait_code": "TR-1202",
@@ -398,7 +404,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "scudo_gluteale_cheratinizzato"
     },
     {
       "trait_code": "TR-1203",
@@ -454,7 +461,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "articolazioni_multiassiali"
     },
     {
       "trait_code": "TR-1204",
@@ -511,7 +519,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "coda_prensile_muscolare"
     },
     {
       "trait_code": "TR-1205",
@@ -567,7 +576,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "rostro_linguale_prensile"
     },
     {
       "trait_code": "TR-1301",
@@ -600,7 +610,7 @@
         {
           "name": "tasso_propaguli",
           "value": 50,
-          "unit": "1/season"
+          "unit": "1/a"
         }
       ],
       "cost_profile": {
@@ -623,7 +633,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "ermafroditismo_cronologico"
     },
     {
       "trait_code": "TR-1302",
@@ -679,7 +690,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "locomozione_miriapode_ibrida"
     },
     {
       "trait_code": "TR-1303",
@@ -737,7 +749,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "estroflessione_gastrica_acida"
     },
     {
       "trait_code": "TR-1304",
@@ -793,7 +806,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "artiglio_cinetico_a_urto"
     },
     {
       "trait_code": "TR-1305",
@@ -851,7 +865,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "sistemi_chimio_sonici"
     },
     {
       "trait_code": "TR-1401",
@@ -907,7 +922,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "scheletro_pneumatico_a_maglie"
     },
     {
       "trait_code": "TR-1402",
@@ -963,7 +979,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "cinghia_iper_ciliare"
     },
     {
       "trait_code": "TR-1403",
@@ -1019,7 +1036,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-22",
         "author": "GPT-5.1-Codex-Max"
-      }
+      },
+      "id": "rete_filtro_polmonare"
     },
     {
       "trait_code": "TR-1404",
@@ -1075,7 +1093,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "canto_infrasonico_tattico"
     },
     {
       "trait_code": "TR-1405",
@@ -1131,7 +1150,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "siero_anti_gelo_naturale"
     },
     {
       "trait_code": "TR-1501",
@@ -1188,7 +1208,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "zanne_idracida"
     },
     {
       "trait_code": "TR-1502",
@@ -1244,7 +1265,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "seta_conduttiva_elettrica"
     },
     {
       "trait_code": "TR-1503",
@@ -1300,7 +1322,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "articolazioni_a_leva_idraulica"
     },
     {
       "trait_code": "TR-1504",
@@ -1356,7 +1379,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "filtrazione_osmotica"
     },
     {
       "trait_code": "TR-1505",
@@ -1412,7 +1436,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "occhi_analizzatori_di_tensione"
     },
     {
       "trait_code": "TR-1601",
@@ -1468,7 +1493,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "membrana_plastica_continua"
     },
     {
       "trait_code": "TR-1602",
@@ -1524,7 +1550,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "flusso_ameboide_controllato"
     },
     {
       "trait_code": "TR-1603",
@@ -1580,7 +1607,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "fagocitosi_assorbente"
     },
     {
       "trait_code": "TR-1604",
@@ -1613,7 +1641,7 @@
         {
           "name": "tasso_propaguli",
           "value": 3,
-          "unit": "1/season"
+          "unit": "1/a"
         }
       ],
       "cost_profile": {
@@ -1636,7 +1664,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "moltiplicazione_per_fusione"
     },
     {
       "trait_code": "TR-1605",
@@ -1692,7 +1721,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "cisti_di_ibernazione_minerale"
     },
     {
       "trait_code": "TR-1701",
@@ -1749,7 +1779,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "ali_fono_risonanti"
     },
     {
       "trait_code": "TR-1702",
@@ -1805,7 +1836,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "cannone_sonico_a_raggio"
     },
     {
       "trait_code": "TR-1703",
@@ -1861,7 +1893,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-22",
         "author": "GPT-5.1-Codex-Max"
-      }
+      },
+      "id": "campo_di_interferenza_acustica"
     },
     {
       "trait_code": "TR-1704",
@@ -1917,7 +1950,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "cervello_a_bassa_latenza"
     },
     {
       "trait_code": "TR-1705",
@@ -1973,7 +2007,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "occhi_cinetici"
     },
     {
       "trait_code": "TR-1801",
@@ -2030,7 +2065,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "integumento_bipolare"
     },
     {
       "trait_code": "TR-1802",
@@ -2086,7 +2122,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "elettromagnete_biologico"
     },
     {
       "trait_code": "TR-1803",
@@ -2142,7 +2179,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "scivolamento_magnetico"
     },
     {
       "trait_code": "TR-1804",
@@ -2198,7 +2236,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "filtro_metallofago"
     },
     {
       "trait_code": "TR-1805",
@@ -2254,7 +2293,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "bozzolo_magnetico"
     },
     {
       "trait_code": "TR-1901",
@@ -2310,7 +2350,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "vello_di_assorbimento_totale"
     },
     {
       "trait_code": "TR-1902",
@@ -2366,7 +2407,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "visione_multi_spettrale_amplificata"
     },
     {
       "trait_code": "TR-1903",
@@ -2422,7 +2464,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "motore_biologico_silenzioso"
     },
     {
       "trait_code": "TR-1904",
@@ -2478,7 +2521,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "artigli_ipo_termici"
     },
     {
       "trait_code": "TR-1905",
@@ -2534,7 +2578,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "comunicazione_fotonica_coda_coda"
     },
     {
       "trait_code": "TR-2001",
@@ -2590,7 +2635,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "corna_psico_conduttive"
     },
     {
       "trait_code": "TR-2002",
@@ -2646,7 +2692,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "coscienza_d_alveare_diffusa"
     },
     {
       "trait_code": "TR-2003",
@@ -2702,7 +2749,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "aura_di_dispersione_mentale"
     },
     {
       "trait_code": "TR-2004",
@@ -2758,7 +2806,8 @@
         "created": "2025-11-04",
         "updated": "2025-11-22",
         "author": "GPT-5.1-Codex-Max"
-      }
+      },
+      "id": "metabolismo_di_condivisione_energetica"
     },
     {
       "trait_code": "TR-2005",
@@ -2814,7 +2863,14 @@
         "created": "2025-11-04",
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
-      }
+      },
+      "id": "unghie_a_micro_adesione"
     }
-  ]
+  ],
+  "version": "2.0.0",
+  "versioning": {
+    "created": "2025-11-23",
+    "updated": "2025-11-23",
+    "author": "GPT-5.1-Codex-Max"
+  }
 }

--- a/schemas/evo/enums.json
+++ b/schemas/evo/enums.json
@@ -38,24 +38,12 @@
     "sentience_tier": {
       "type": "string",
       "description": "Livelli della Sentience Track T0–T6 utilizzati nel pacchetto Evo.",
-      "enum": [
-        "T0",
-        "T1",
-        "T2",
-        "T3",
-        "T4",
-        "T5",
-        "T6"
-      ]
+      "enum": ["T0", "T1", "T2", "T3", "T4", "T5", "T6"]
     },
     "energy_upkeep_level": {
       "type": "string",
       "description": "Range di mantenimento energetico (il vecchio stato 'blocked' è stato rimosso).",
-      "enum": [
-        "Basso",
-        "Medio",
-        "Alto"
-      ]
+      "enum": ["Basso", "Medio", "Alto"]
     },
     "danger_level": {
       "type": "integer",
@@ -68,7 +56,7 @@
       "description": "Unità UCUM utilizzate nelle metriche delle specie e dei tratti.",
       "enum": [
         "1",
-        "1/season",
+        "1/a",
         "A",
         "Cel",
         "Hz",

--- a/schemas/evo/trait.schema.json
+++ b/schemas/evo/trait.schema.json
@@ -10,6 +10,10 @@
       "type": "string",
       "pattern": "^TR-\\d{4}$"
     },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:_[a-z0-9]+)*$"
+    },
     "label": {
       "type": "string",
       "minLength": 1


### PR DESCRIPTION
## Summary
- add snake_case ids to Evo trait payloads and catalogs, including new aggregate/catalog version metadata
- convert legacy reproduction metrics to UCUM (1/a) and align the metric unit enum with the new standard
- enrich species catalog and ecotype map with slug identifiers plus SemVer/versioning blocks for consistent indexing

## Testing
- node scripts/validate-dataset.cjs schemas/evo/trait.schema.json data/external/evo/traits/TR-*.json
- scripts/validate.sh --dataset evo-species --schema schemas/evo/species.schema.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69226a32ac188328a49d6380a4740702)