### PR TITLE
Align Evo Tactics Pack guide with operational fields

### DIFF
--- a/docs/Guida_Evo_Tactics_Pack_v2.md
+++ b/docs/Guida_Evo_Tactics_Pack_v2.md
@@ -116,6 +116,13 @@ Ogni Tratto (file in `traits/`) è un elemento atomico e deve includere:
 >
 > - Nel pack: `sinergie: ["condotto_laminare" (trait_code: TR-0421)]`, `conflitti: ["ipertermia_cronica" (trait_code: TR-0502)]`.
 > - Nel repository: usare solo gli `id` snake_case → `sinergie: ["condotto_laminare"]`, `conflitti: ["ipertermia_cronica"]`.
+>
+> **Promemoria mapping**
+>
+> | trait_code | id (repository)      | Note                                           |
+> | ---------- | -------------------- | ---------------------------------------------- |
+> | TR-0421    | `condotto_laminare`  | usa sempre l'`id` snake_case nei file JSON     |
+> | TR-0502    | `ipertermia_cronica` | il `trait_code` resta solo come alias nel pack |
 
 La definizione dei tratti deve evitare ridondanze: ogni tratto deve essere atomico, cioè con una funzione principale chiara e testabile. Per ogni super-abilità occorre indicare almeno un limite o contromisura (raffreddamento, saturazione, schermature, rumore di fondo…).
 
@@ -168,8 +175,8 @@ Per aggiornare schede esistenti alla versione v2 si consiglia di seguire questa 
    - “Idrorepellente” → “Pelage Idrorepellente”
    - “Cheratinoso” → “Cheratinizzato”.
 
-4. **Compilare testabilità e costi**  
-   Inserire campi `observable`, `scene_prompt` e `cost_profile` realistici per ogni tratto. Specificare sinergie e conflitti tramite codici.
+4. **Compilare testabilità e costi**
+   Nel pack arricchire, se disponibili, `observable`/`scene_prompt` (`testability`) e `cost_profile`; nel repository restano facoltativi. Specificare sinergie e conflitti tramite `id`.
 
 5. **Aggiungere versioning**  
    Per ogni file, introdurre la chiave `version` (SemVer) e la sezione `versioning` con date e autore.
@@ -341,11 +348,11 @@ La guida rapida per l’autore di tratti fornisce una checklist operativa per sc
   - definire la mutazione da cui deriva (`mutazione_indotta`),
   - definire la spinta selettiva (`spinta_selettiva`),
   - associare ambienti ENVO (`applicability.envo_terms`) e requisiti ambientali,
-  - impostare i costi (`fattore_mantenimento_energetico`, `cost_profile`),
+  - impostare i costi (`fattore_mantenimento_energetico`, facoltativo `cost_profile` nel pack),
   - definire i limiti (`limits`) e i trigger di attivazione,
-  - definire almeno una metrica UCUM (`metrics[{name,value,unit}]`),
+  - aggiungere una metrica UCUM (`metrics[{name,value,unit}]`) se disponibile nel pack (opzionale per il repository),
   - indicare sinergie e conflitti con altri tratti (`sinergie`, `conflitti`),
-  - compilare la testabilità (`observable`, `scene_prompt`),
+  - compilare la testabilità (`observable`, `scene_prompt`) se serve al materiale del pack (opzionale per il repository),
   - chiudere con `versioning` SemVer e date ISO.
 
 - **Validazione & CI**
@@ -360,19 +367,19 @@ La guida rapida per l’autore di tratti fornisce una checklist operativa per sc
 Questo documento definisce che cos’è un trait (unità atomica riusabile di funzionalità e morfologia) e descrive in modo approfondito i campi obbligatori e opzionali. Tra i punti chiave:
 
 - **Dizionario campi**
-  - il trait deve sempre contenere:
-    - `trait_code`,
-    - `label`,
+  - campi minimi per il repository (come da [scheda operativa](./traits_scheda_operativa.md)):
+    - `id`, `label` i18n,
     - `famiglia_tipologia`,
     - `fattore_mantenimento_energetico`,
     - `tier`,
+    - `slot` (può essere vuoto ma il campo va mantenuto),
+    - `sinergie`, `conflitti`,
+    - `data_origin`,
     - `mutazione_indotta`,
     - `uso_funzione`,
-    - `spinta_selettiva`,
-    - `sinergie`,
-    - `version`,
-    - `versioning`.
-  - altri campi sono opzionali ma consigliati (`slot`, `limits`, `output_effects`, `testability`, `cost_profile`, `applicability`, `requisiti_ambientali`...).
+    - `spinta_selettiva`.
+  - campi aggiuntivi del pack (da rimuovere prima dell'import): `trait_code`, `label_it/en`, eventuali `description_it/en` inline.
+  - campi opzionali/consigliati: `metrics`, `cost_profile`, `testability`, `version`/`versioning`, `slot_profile`, `limits`, `output_effects`, `applicability`, `requisiti_ambientali`, `compatibility` (solo per release di transizione).
 
 - **Tassonomia funzionale**
   - sistema di cluster:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+
 ### Added
+
 - Trait reference aggiornato (`docs/catalog/trait_reference.md`) con mappatura
   glossario IT/EN e workflow di sincronizzazione.
 - Guida operativa aggiornata per autori di trait
@@ -15,50 +17,66 @@
 - Calendario training per il team di gioco e canali di monitoraggio dedicati (`#trait-rollout`, report settimanali).
 
 ### Changed
+
 - Template trait, guida contributiva e processo di localizzazione aggiornati per
   includere glossario e checklist sincronizzata.
 - Note di rilascio aggiornate con canali di comunicazione e monitoraggio post-rollout, includendo reminder per `docs/publishing_calendar.md`.
+- Guida Evo Tactics Pack v2: verificati campi obbligatori con la scheda operativa, ribadita opzionalità di `metrics`/`cost_profile`/`testability`, esempi sinergie/conflitti aggiornati con `id` repository e promemoria mapping.
 
 ### Fixed
+
 - _Nessuna voce._
 
 ### Known Issues
+
 - _Nessuno segnalato._
 
 ## [2025-12-06] HUD Smart Alerts & SquadSync bridge
+
 ### Added
+
 - Dashboard canary HUD (`tools/feedback/hud_canary_dashboard.yaml`) collegata al canale `#feedback-enhancements` e ai mock aggiornati.
 - Tutorial rapidi per overlay HUD (`docs/tutorials/hud-overlay-quickstart.md`) e adaptive engine SquadSync (`docs/tutorials/adaptive-engine-quickstart.md`).
 - Mock aggiornati per HUD Smart Alerts e SquadSync (`assets/hud/overlay/mock-timeline.svg`, `assets/analytics/squadsync_mock.svg`) integrati in Canvas e README.
 
 ### Changed
+
 - README e Canvas aggiornati con la sezione "Sync HUD · dicembre 2025" e riferimenti incrociati a dashboard, changelog e routing Slack.
 - `tools/feedback/form_config.yaml` e `tools/feedback/collection_pipeline.yaml` estesi per la pipeline canary e le nuove cadence di sync.
 
 ### Fixed
+
 - Allineamento dei link dashboard/documentazione per gli owner feedback, evitando riferimenti obsoleti al canale `#feedback-intake`.
 
 ### Known Issues
+
 - In corso la validazione dei cron canary (`config/jobs/hud_canary.yaml`) per assicurare refresh puntuali sopra i 10 minuti.
 
 ## [2025-12-02] Feedback & Tutorial boost
+
 ### Added
+
 - Tutorial rapidi con schede SVG dedicate per CLI, Idea Engine e dashboard (`docs/tutorials/*`, `assets/tutorials/*`).
 - Integrazione del changelog nel `README.md` e nelle pagine indice dei documenti.
 - Canale Slack `#feedback-enhancements` collegato alle procedure di QA rapida.
 
 ### Changed
+
 - Modulo feedback dell'Idea Engine ora visibile anche senza API configurata, con fallback su Slack e template aggiornato.
 - `docs/public/embed.js` supporta il canale Slack configurabile e messaggi guida aggiornati.
 
 ### Fixed
+
 - Documentazione principale aggiornata con link coerenti verso tutorial e changelog.
 
 ### Known Issues
+
 - In attesa di nuove PR giornaliere per popolare la sezione "Unreleased".
 
 ### Riepilogo PR giornalieri
+
 <!-- daily-pr-summary:start -->
+
 - **2025-11-21** — [#700](https://github.com/MasterDD-L34D/Game/pull/700) Align workspaces and dev stack setup; [#701](https://github.com/MasterDD-L34D/Game/pull/701) Migrate backend storage to Prisma; [#702](https://github.com/MasterDD-L34D/Game/pull/702) Add Prisma-backed species-biome relations and dashboard wiring; [#703](https://github.com/MasterDD-L34D/Game/pull/703) Document Docker/Prisma bootstrap and env configuration; [#704](https://github.com/MasterDD-L34D/Game/pull/704) Fix Evo pack asset path rewrites; [#705](https://github.com/MasterDD-L34D/Game/pull/705) Preserve biome pool metadata for offline generation; [#706](https://github.com/MasterDD-L34D/Game/pull/706) Add tests for evo pack sync and biome metadata fallback; [#707](https://github.com/MasterDD-L34D/Game/pull/707) Update database tracker and runbook notes; [#708](https://github.com/MasterDD-L34D/Game/pull/708) Finalize data stack tracker and logs; [#709](https://github.com/MasterDD-L34D/Game/pull/709) Aggiorna riferimenti test indice documentazione; [#710](https://github.com/MasterDD-L34D/Game/pull/710) Update traits tracking index entry date; [#711](https://github.com/MasterDD-L34D/Game/pull/711) Add ali_solari_fotoni to trait glossary; [#712](https://github.com/MasterDD-L34D/Game/pull/712) Add pathfinder dataset modular crystal eyes trait; [#713](https://github.com/MasterDD-L34D/Game/pull/713) Add modular crystal eyes trait localization; [#714](https://github.com/MasterDD-L34D/Game/pull/714) Normalize trait entry and refresh coverage baselines; [#715](https://github.com/MasterDD-L34D/Game/pull/715) Refine trait operational sheet and links; [#716](https://github.com/MasterDD-L34D/Game/pull/716) Add quick reference link for trait authoring; [#717](https://github.com/MasterDD-L34D/Game/pull/717) Add references to trait operational guide; [#718](https://github.com/MasterDD-L34D/Game/pull/718) Add quick example to trait operational sheet; [#719](https://github.com/MasterDD-L34D/Game/pull/719) Add quick access navigation for trait docs; [#720](https://github.com/MasterDD-L34D/Game/pull/720) Aggiorna vincolo id traits. [Report](chatgpt_changes/daily-pr-summary-2025-11-21.md)
 - **2025-11-20** — [#699](https://github.com/MasterDD-L34D/Game/pull/699) Reorganize monorepo into backend and dashboard apps. [Report](chatgpt_changes/daily-pr-summary-2025-11-20.md)
 - **2025-11-19** — Nessun merge registrato.
@@ -76,13 +94,16 @@
 <!-- daily-pr-summary:end -->
 
 ## [v0.6.0-rc1] - 2025-11-07
+
 ### Added
+
 - Generatore VC potenziato con sintesi biomi procedurale, salvataggio filtri avanzati, timeline attività persistente e pannelli insight contestuali per condividere rapidamente i setup QA. Le esportazioni includono ora anteprime JSON/YAML e azioni rapide per dossier/ZIP.
 - Instrumentazione HUD risk alert consolidata: pipeline EMA → HUD → canale `pi.balance.alerts` con log dedicato e metriche risk/cohesion pronte per il pacchetto comunicazione `v0.6.0-rc1` (nuovi asset Canvas HUD inclusi).【F:docs/Canvas/feature-updates.md†L9-L23】
 - Automazione operativa alimentata dai report PR giornalieri: workflow `daily-pr-summary`, guida CLI/Smoke aggiornata, checklist marketing/prodotto sincronizzata e note Canvas/roadmap derivate automaticamente.【F:docs/chatgpt_changes/daily-pr-summary-2025-11-07.md†L1-L15】【F:docs/piani/roadmap.md†L72-L109】
 - Aggiornamenti dati e documentazione: allineamento trait PI ↔ environment registry, curva budget PI/telemetry ribilanciata e nuova documentazione playtest/roadmap per il RC di novembre 2025.【F:docs/checklist/project-setup-todo.md†L61-L109】【F:docs/playtest/SESSION-2025-11-12.md†L1-L76】
 
 ### Changed
+
 - Allineamento 2025-11-07: follow-up HUD overlay telemetrico (UI Systems — F. Conti), progressione Cipher PROG-04 (Progression Design — L. Serra) e contrasto EVT-03 (VFX/Lighting — G. Leone) registrati in daily summary, checklist e Canvas con checkpoint 2025-11-09.【F:docs/chatgpt_changes/daily-pr-summary-2025-11-07.md†L1-L15】【F:docs/checklist/milestones.md†L13-L16】【F:docs/Canvas/feature-updates.md†L24-L37】
 - Generatore e documentazione UI rifiniti: layout carte responsive, overlay radar e timeline filtrabili garantiscono lettura coerente su desktop/mobile, con preset manifest storici ripristinati accanto al bundle demo.【F:docs/Canvas/feature-updates.md†L9-L23】
 - Pipeline CI completa ristabilita (build/test + Pages) e helper catalog condivisi esposti agli strumenti browser/CLI per ridurre duplicazioni.【F:docs/ci-pipeline.md†L1-L48】
@@ -90,26 +111,33 @@
 - Calendario comunicazioni release raffinato con agenda cross-team confermata, allegati HUD/metriche distribuiti su Slack/Drive e notifica marketing/prodotto completata (Slack 16:00 CET, briefing Drive 18:00 CET).【F:docs/Canvas/feature-updates.md†L18-L34】【F:docs/piani/roadmap.md†L72-L85】
 
 ### Fixed
+
 - Ripristinate le API helper dello scanner tratti ambientali e l'ordine di inizializzazione del manifest per evitare preset mancanti nel generatore.【F:docs/checklist/project-setup-todo.md†L61-L104】
 - Documentazione CLI/playtest aggiornata con esiti verificati, inclusi log test interfaccia e parità `roll_pack` tra stack TS/Python.【F:docs/Canvas/feature-updates.md†L9-L23】【F:docs/playtest/SESSION-2025-11-12.md†L24-L76】
 
 ### Known Issues
+
 - Nessuno segnalato.
 
 ### Riepilogo PR giornalieri
+
 - **2025-11-07** — Nessun merge registrato; confermati owner e follow-up HUD/PROG-04/EVT-03 nel changelog con supporto di roadmap, Canvas e tool run report.【F:docs/chatgpt_changes/daily-pr-summary-2025-11-07.md†L1-L15】【F:docs/piani/roadmap.md†L72-L109】【F:docs/tool_run_report.md†L9-L22】
 
 ## [2025-11] VC Patch Note (RC)
+
 ### Stato feature
+
 - **HUD Risk/Cohesion Overlay** — Pronto per release; metriche QA 2025-11-05 confermano risk medio 0.57 (Delta 0.59, Echo 0.54) e coesione 0.76/0.80 con alert HUD mitigati entro 2 turni.【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L1-L88】
 - **Protocollo SquadSync Playbook** — Deploy confermato su Echo/Delta con cooldown supporti ottimizzato; mantenere monitoraggio su picchi risk 0.62 per eventi Aeon Overclock e ack PI automatici.【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L9-L83】
 - **Missione Skydock Siege (vertical slice)** — Contenuti narrativi e timer evacuazione completi; tuning Tier 3 stabile con tilt <0.46 e timer evacuazione a 6 turni.【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L1-L102】
 
 ### Issue note
+
 - **Alert risk Delta turno 11** — Picco 0.62 mitigato entro due turni con ack PI e cooldown relay; verificare replicabilità nel prossimo smoke test.【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L19-L83】
 - **Allineamento annunci** — Confermare agenda riunione cross-team 2025-11-06 (10:30 CET) e invio comunicazioni Slack/Drive post tag `v0.6.0-rc1` alle 16:00/18:00 CET del 2025-11-07.【F:docs/piani/roadmap.md†L72-L85】
 
 ### Prossimi passi
+
 - Pubblicare il tag `v0.6.0-rc1` dopo conferma QA 2025-11-05 e distribuire note VC al team ampliato.
 - Aggiornare materiali marketing/Canvas con screenshot HUD e grafici risk/cohesion aggiornati al playtest 2025-11-05 (Delta/Echo).【F:logs/playtests/2025-11-05-vc/session-metrics.yaml†L1-L88】【F:docs/Canvas/feature-updates.md†L17-L27】
 - Creare il tag Git ufficiale a chiusura QA, notificare Marketing Ops e Product con recap su asset HUD aggiornati e collegare la libreria screenshot revisionata.


### PR DESCRIPTION
## Summary
- clarify Evo Tactics Pack v2 required fields to mirror the operational trait sheet and mark optional pack-only metadata
- refresh synergy/conflict examples with repository IDs and an explicit trait_code to id mapping reminder
- log the documentation sweep in the internal changelog under Unreleased

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69227e33b19c832885a9e751b4d3381b)