### PR TITLE
Chiarisci id obbligatori e opzionalità campi Evo

### DIFF
--- a/docs/Guida_Evo_Tactics_Pack_v2.md
+++ b/docs/Guida_Evo_Tactics_Pack_v2.md
@@ -47,7 +47,7 @@ Per integrare i tratti provenienti da pacchetti Evo con il repository ufficiale,
 > - **label**: puntare sempre a `i18n:traits.<id>.label` (la stringa localizzata sta nei file i18n/glossario, non nel tratto).
 > - **data_origin**: usare solo gli slug ufficiali (vedi tabella in `docs/traits_evo_pack_alignment.md`).
 > - **famiglia_tipologia**, **fattore_mantenimento_energetico**, **tier**, **slot**: classificazione e livello energetico di base.
-> - **sinergie**/**conflitti**: liste di `id` (non `trait_code`) per la compatibilità interna.
+> - **sinergie**/**conflitti**: liste di `id` (non `trait_code`) per la compatibilità interna; evita alias TR-xxxx nei JSON del repository.
 > - **mutazione_indotta**, **uso_funzione**, **spinta_selettiva**: frasi brevi e misurabili, obbligatorie per ogni tratto.
 > - Rimandi: [scheda operativa dei trait](./traits_scheda_operativa.md), [guida autore](./README_HOWTO_AUTHOR_TRAIT.md), [template dati](./traits_template.md) e [piano operativo prossimo ciclo](./next_steps_trait_migration.md).
 >
@@ -57,6 +57,7 @@ Per integrare i tratti provenienti da pacchetti Evo con il repository ufficiale,
 > - **cost_profile**: suggerito per indicare i costi energetici (`rest`/`burst`/`sustained`).
 > - **testability**: raccomandato per fornire `observable` e `scene_prompt`, utile nei pacchetti ma non richiesto dai validator del repository.
 > - Altri campi estesi (es. `applicability`, `completion_flags`) restano facoltativi per il repository: se usati nel pack, convertili solo se compatibili con lo schema [riassunto nel template](./traits_template.md#schema-base-obbligatorio).
+> - Nota: questi campi aggiuntivi non diventano obbligatori nei file `data/traits/*.json`; rimuovili o mantienili solo se lo schema li supporta senza deroghe ai requisiti minimi sopra.
 >
 > **Esempio mappatura `trait_code` → `id`/`label`**
 >

--- a/docs/README_HOWTO_AUTHOR_TRAIT.md
+++ b/docs/README_HOWTO_AUTHOR_TRAIT.md
@@ -40,6 +40,8 @@ Per importare o riallineare tratti provenienti da pacchetti Evo, fai riferimento
 1. Duplica lo scheletro minimo dal template e salva in `data/traits/<tipologia>/<id>.json`.
 2. Popola i campi obbligatori (`id`, `label`, `famiglia_tipologia`, `tier`,
    `mutazione_indotta`, `uso_funzione`, `spinta_selettiva`, `sinergie`, `conflitti`).
+   - Per sinergie/conflitti usa solo gli `id` repository (nessun `trait_code`), come indicato nel box di esempio della [Guida Evo](./Guida_Evo_Tactics_Pack_v2.md#avvertenza-migrazione-pack--%E2%86%92-repository-game).
+   - I campi aggiuntivi del pack (`metrics`, `cost_profile`, `testability`, ecc.) restano facoltativi: portali nel repository solo se compatibili con lo schema base.
 3. Inserisci i testi come stringhe reali **solo** se stai creando il trait da
    zero; al termine eseguirai lo script di sincronizzazione che li convertirà in
    riferimenti `i18n:traits.<id>.<campo>`.

--- a/docs/traits_scheda_operativa.md
+++ b/docs/traits_scheda_operativa.md
@@ -20,6 +20,7 @@ Per importare tratti da pacchetti Evo, usa la mappa di conversione in `traits_ev
 > - `metrics[]` — array di misure UCUM per quantificare prestazioni/condizioni.
 > - `cost_profile.*` — costi energetici numerici (`rest`, `burst`, `sustained`) se disponibili.
 > - `testability.*` — osservabili e scenari di prova per rendere il tratto verificabile.
+> - Nota: questi campi non sono richiesti dai validator interni; se arrivano nei JSON del pack vanno tenuti solo quando rispettano lo schema base del repository.
 
 ## Identità e versioning
 
@@ -40,7 +41,7 @@ Per importare tratti da pacchetti Evo, usa la mappa di conversione in `traits_ev
 
 ## Relazioni e sinergie
 
-- `sinergie` / `conflitti` — array di ID trait compatibili/incompatibili (slug esistenti). # schema
+- `sinergie` / `conflitti` — array di ID trait compatibili/incompatibili (slug esistenti, niente `trait_code`). # schema — esempio pratico nel box sinergie/conflitti della [Guida Evo](Guida_Evo_Tactics_Pack_v2.md#avvertenza-migrazione-pack--%E2%86%92-repository-game)
 - `sinergie_pi.*` — co-occorrenze/combo/tabelle random per strumenti PI. # opzionale
 - `species_affinity[]` — `species_id`, ruoli, peso; solo se c’è relazione specie-trait. # modello esteso
 


### PR DESCRIPTION
## Summary
- Ribadito nei box sui campi obbligatori e sugli esempi sinergie/conflitti che vanno usati solo gli id repository, separando chiaramente i campi Evo opzionali.
- Annotata nella scheda operativa la natura facoltativa dei campi Evo e il riferimento all’esempio di sinergie/conflitti con soli id snake_case.
- Aggiornata la guida autori con promemoria su sinergie/conflitti basate su id e sull’opzionalità dei campi extra del pack.

## Testing
- Not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922845fa6f88328a040bd427c29ab28)