### PR TITLE
Add consolidated QA status log for validators and link checker

### DIFF
--- a/docs/reports/evo/qa/status.md
+++ b/docs/reports/evo/qa/status.md
@@ -1,0 +1,13 @@
+# Log di stato QA
+
+## Esiti validator
+- `incoming/scripts/validate.sh` → 5/5 trait JSON validati (`TR-1101.json`…`TR-1105.json`); nessun file presente per `incoming/templates/species.schema.json`, quindi lo schema specie è stato saltato.
+- `python tools/automation/evo_schema_lint.py schemas/evo --pattern schemas/evo/species.schema.json schemas/evo/trait.schema.json` → entrambi gli schemi hanno superato la validazione strutturale.
+
+## Link checker
+- `python tools/check_site_links.py docs` (npm script `docs:lint`) → tutti i collegamenti interni risultano validi.
+
+## Azioni residue e prossimo ciclo
+- Popolare il dataset specie (percorso `incoming/templates/species.schema.json` → `incoming/species/`) prima del prossimo giro di AJV, così da coprire anche le entità specie.
+- Convertire i cinque trait validati da `incoming/traits/` verso `data/traits/<categoria>/`, allineando glossario (`data/core/traits/glossary.json`) e i18n (`locales/`).
+- Rilanciare `incoming/scripts/validate.sh` e `npm run docs:lint` dopo le nuove aggiunte per aggiornare questo log di stato.


### PR DESCRIPTION
## Summary
- add a QA status log that aggregates validator and link checker results in one place
- outline remaining actions for species dataset population, trait conversion, and follow-up validation runs

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69228593fe008328b8b7fa48181ee302)