### PR TITLE
Add incoming species data and validation log

### DIFF
--- a/docs/reports/evo/qa/status.md
+++ b/docs/reports/evo/qa/status.md
@@ -1,0 +1,7 @@
+# Stato QA – EVO
+
+## Validazione specie incoming
+
+- Comando: `AJV=./node_modules/.bin/ajv incoming/scripts/validate.sh`
+- Esito: tutti i 10 JSON specie in `incoming/species/` risultano validi rispetto a `incoming/templates/species.schema.json`. Anche i 5 trait esistenti sono stati validati con successo.
+- Output sintetico: `✅ Validazione completata`

--- a/incoming/species/anguis_magnetica.json
+++ b/incoming/species/anguis_magnetica.json
@@ -1,0 +1,28 @@
+{
+  "species": {
+    "scientific_name": "Anguis magnetica",
+    "common_names": ["Anguilla Geomagnetica"],
+    "classification": {
+      "macro_class": "Reptilia/Pisces",
+      "habitat": "corsi d’acqua e coste sabbiose"
+    },
+    "functional_signature": "Navigazione magnetica fine e scariche nervose a impulso; scivolamento silente riduci-attrito.",
+    "visual_description": "Serpiforme lucido, pelle scura con riflessi metallici; linea laterale evidente; movimenti fluidi senza rumore.",
+    "risk_profile": {
+      "danger_level": 2,
+      "vectors": ["scariche elettriche"]
+    },
+    "interactions": {
+      "predates_on": ["pesci d’acqua dolce", "anfibi"],
+      "predated_by": ["coccodrilli", "grossi pesci predatori"],
+      "symbiosis": "nessuna"
+    },
+    "constraints": [
+      "Scariche inefficaci in acque altamente conduttive/salmastre",
+      "Dipendenza da micro-metalli nella dieta"
+    ],
+    "sentience_index": "T1",
+    "ecotypes": ["Estuario Torbido", "Laguna Quieta"],
+    "trait_refs": ["TR-1801", "TR-1802", "TR-1803", "TR-1804", "TR-1805"]
+  }
+}

--- a/incoming/species/chemnotela_toxica.json
+++ b/incoming/species/chemnotela_toxica.json
@@ -1,0 +1,28 @@
+{
+  "species": {
+    "scientific_name": "Chemnotela toxica",
+    "common_names": ["Aracnide Alchemico"],
+    "classification": {
+      "macro_class": "Artropode",
+      "habitat": "foreste tropicali"
+    },
+    "functional_signature": "Acido industriale biologico e seta elettroconduttiva per trappole stordenti e corrosive.",
+    "visual_description": "Ragno massiccio con cheliceri prominenti, filiere ispessite e addome rigonfio. Cuticola lucida con bande metalliche.",
+    "risk_profile": {
+      "danger_level": 3,
+      "vectors": ["acidi forti", "scariche elettriche"]
+    },
+    "interactions": {
+      "predates_on": ["rettili arboricoli", "uccelli piccoli"],
+      "predated_by": ["ofidi grandi"],
+      "symbiosis": "alghe epifite su tela in radure umide"
+    },
+    "constraints": [
+      "Acido inefficace su basalto o ceramiche vetrose",
+      "Tela sensibile a piogge torrenziali"
+    ],
+    "sentience_index": "T1",
+    "ecotypes": ["Radura Acida", "Chioma Elettrofilo"],
+    "trait_refs": ["TR-1501", "TR-1502", "TR-1503", "TR-1504", "TR-1505"]
+  }
+}

--- a/incoming/species/elastovaranus_hydrus.json
+++ b/incoming/species/elastovaranus_hydrus.json
@@ -1,0 +1,28 @@
+{
+  "species": {
+    "scientific_name": "Elastovaranus hydrus",
+    "common_names": ["Viverna-Elastico"],
+    "classification": {
+      "macro_class": "Reptilia",
+      "habitat": "savana calda con gole rocciose"
+    },
+    "functional_signature": "Attacchi a proiettile con inoculazione multipla tramite rostro estensibile, guidati da sensibilità sismica.",
+    "visual_description": "Rettile allungato con cranio affusolato e rostro tubulare; fasci muscolari evidenti; squame opache con lamelle sensoriali. Postura semiflessa pronta allo scatto, coda come stabilizzatore. Colorazioni sabbia-oliva con pattern spezzato.",
+    "risk_profile": {
+      "danger_level": 3,
+      "vectors": ["tossine litiche", "emorragia"]
+    },
+    "interactions": {
+      "predates_on": ["antilopi piccole", "varani", "uccelli terricoli"],
+      "predated_by": ["felidi grandi", "rapaci diurni"],
+      "symbiosis": "nessuna"
+    },
+    "constraints": [
+      "Richiede pressione idraulica pre-caricata (cooldown dopo 3 colpi)",
+      "Prestazioni ridotte in freddo prolungato"
+    ],
+    "sentience_index": "T1",
+    "ecotypes": ["Gole Ventose", "Letti Fluviali"],
+    "trait_refs": ["TR-1101", "TR-1102", "TR-1103", "TR-1104", "TR-1105"]
+  }
+}

--- a/incoming/species/gulogluteus_scutiger.json
+++ b/incoming/species/gulogluteus_scutiger.json
@@ -1,0 +1,28 @@
+{
+  "species": {
+    "scientific_name": "Gulogluteus scutiger",
+    "common_names": ["Ghiotton-Scudo"],
+    "classification": {
+      "macro_class": "Mammalia",
+      "habitat": "foreste umide con corsi d'acqua"
+    },
+    "functional_signature": "Manipolazione a lungo raggio tramite lingua prensile quanto il corpo e stabilizzazione caudale; difesa passiva dorsale a placca cheratinizzata.",
+    "visual_description": "Mammifero robusto e basso, pelliccia scura lucida idrofoba; coda spessa prensile; regione glutea corazzata in rilievo; zampe corte ma molto mobili; lingua che si estende come una proboscide muscolare.",
+    "risk_profile": {
+      "danger_level": 2,
+      "vectors": ["schiacciamento", "graffi"]
+    },
+    "interactions": {
+      "predates_on": ["insetti lignicoli", "frutti duri", "uova"],
+      "predated_by": ["grossi felidi", "umani"],
+      "symbiosis": "dispersione di semi tramite pelliccia oleosa"
+    },
+    "constraints": [
+      "Alto costo elettrolitico per secrezioni oleose in siccità",
+      "La corazza riduce la velocità in sprint prolungati"
+    ],
+    "sentience_index": "T1",
+    "ecotypes": ["Chioma Umida", "Forre Umide"],
+    "trait_refs": ["TR-1201", "TR-1202", "TR-1203", "TR-1204", "TR-1205"]
+  }
+}

--- a/incoming/species/perfusuas_pedes.json
+++ b/incoming/species/perfusuas_pedes.json
@@ -1,0 +1,28 @@
+{
+  "species": {
+    "scientific_name": "Perfusuas pedes",
+    "common_names": ["Zannapiedi"],
+    "classification": {
+      "macro_class": "Mammalo-artropode",
+      "habitat": "foreste e sistemi carsici"
+    },
+    "functional_signature": "Predatore cieco che usa sonar e chimio-navigazione; attacco a urto e digestione extracorporea.",
+    "visual_description": "Corpo allungato corazzato da placche flessibili, centinaia di arti corti e rapidi. Regione cefalica protetta, un’appendice anteriore ipertrofica per l’urto. Addome con sacche ripiegabili.",
+    "risk_profile": {
+      "danger_level": 3,
+      "vectors": ["acidi proteolitici", "onda d’urto"]
+    },
+    "interactions": {
+      "predates_on": ["ungulati piccoli", "rettili cavernicoli"],
+      "predated_by": ["nessun predatore noto in età adulta"],
+      "symbiosis": "Ospita ostaggio-simbionte per supporto percettivo (dipendenza bio-cognitiva)"
+    },
+    "constraints": [
+      "Dipendenza sensoriale dall’ostaggio per compiti complessi",
+      "Alto costo energetico per secrezioni acide"
+    ],
+    "sentience_index": "T3",
+    "ecotypes": ["Cavernicolo", "Radura Notturna"],
+    "trait_refs": ["TR-1301", "TR-1302", "TR-1303", "TR-1304", "TR-1305"]
+  }
+}

--- a/incoming/species/proteus_plasma.json
+++ b/incoming/species/proteus_plasma.json
@@ -1,0 +1,25 @@
+{
+  "species": {
+    "scientific_name": "Proteus plasma",
+    "common_names": ["Mutaforma Cellulare"],
+    "classification": {
+      "macro_class": "Protista complesso",
+      "habitat": "zone umide, acque dolci"
+    },
+    "functional_signature": "Plasticità estrema di forma e funzione; ingestione per fagocitosi e stasi minerale.",
+    "visual_description": "Massa semi-trasparente, iridescenze deboli; estroflessioni pseudopodiali costanti. Variazione volumetrica rapida.",
+    "risk_profile": {
+      "danger_level": 2,
+      "vectors": ["anossia locale", "asfissia prede piccole"]
+    },
+    "interactions": {
+      "predates_on": ["detrito organico", "invertebrati lenti"],
+      "predated_by": ["pesci"],
+      "symbiosis": "nessuna"
+    },
+    "constraints": ["Sensibile alla disidratazione", "Limitata coesione in acqua turbolenta"],
+    "sentience_index": "T0",
+    "ecotypes": ["Stagno Quieto", "Torrente Lento"],
+    "trait_refs": ["TR-1601", "TR-1602", "TR-1603", "TR-1604", "TR-1605"]
+  }
+}

--- a/incoming/species/rupicapra_sensoria.json
+++ b/incoming/species/rupicapra_sensoria.json
@@ -1,0 +1,28 @@
+{
+  "species": {
+    "scientific_name": "Rupicapra sensoria",
+    "common_names": ["Camoscio Psionico"],
+    "classification": {
+      "macro_class": "Mammalia",
+      "habitat": "falesie e praterie montane"
+    },
+    "functional_signature": "Rete psionica di branco con difese mentali; capacità di arrampicata estrema.",
+    "visual_description": "Erbivoro agile, corna scolpite con circuiti naturali, zoccoli con micro-lamelle adesive; mantello bruno.",
+    "risk_profile": {
+      "danger_level": 1,
+      "vectors": ["confusione psichica"]
+    },
+    "interactions": {
+      "predates_on": [],
+      "predated_by": ["lupi", "aquile"],
+      "symbiosis": "nessuna"
+    },
+    "constraints": [
+      "Rete psionica degrada oltre 500 m di distanza",
+      "Affaticamento mentale dopo stress prolungato"
+    ],
+    "sentience_index": "T2",
+    "ecotypes": ["Cenge Calcarenitiche", "Dorsali Ventose"],
+    "trait_refs": ["TR-2001", "TR-2002", "TR-2003", "TR-2004", "TR-2005"]
+  }
+}

--- a/incoming/species/soniptera_resonans.json
+++ b/incoming/species/soniptera_resonans.json
@@ -1,0 +1,28 @@
+{
+  "species": {
+    "scientific_name": "Soniptera resonans",
+    "common_names": ["Libellula Sonica"],
+    "classification": {
+      "macro_class": "Insecta",
+      "habitat": "savanes e bacini termici"
+    },
+    "functional_signature": "Manipolazione sonora: dal mascheramento al raggio sonico; volo fine a latenza ridotta.",
+    "visual_description": "Insetto alato di grandi dimensioni; ali traslucide con venature ispessite; occhi composti lucidi; addome segmentato aerodinamico.",
+    "risk_profile": {
+      "danger_level": 2,
+      "vectors": ["onda sonora direzionale"]
+    },
+    "interactions": {
+      "predates_on": ["sciami di insetti", "uccelli molto piccoli"],
+      "predated_by": ["uccelli rapaci", "pipistrelli"],
+      "symbiosis": "nessuna"
+    },
+    "constraints": [
+      "Rendimento ridotto in pioggia intensa",
+      "Consumo energetico elevato in hovering prolungato"
+    ],
+    "sentience_index": "T1",
+    "ecotypes": ["Oasi Termica", "Prateria Arbustiva"],
+    "trait_refs": ["TR-1701", "TR-1702", "TR-1703", "TR-1704", "TR-1705"]
+  }
+}

--- a/incoming/species/terracetus_ambulator.json
+++ b/incoming/species/terracetus_ambulator.json
@@ -1,0 +1,25 @@
+{
+  "species": {
+    "scientific_name": "Terracetus ambulator",
+    "common_names": ["Megattera Terrestre"],
+    "classification": {
+      "macro_class": "Mammalia",
+      "habitat": "steppe e savane aperte"
+    },
+    "functional_signature": "Locomozione a tappeto ventrale e leggerezza scheletrica per lunghi spostamenti terrestri; infrasonica difensiva.",
+    "visual_description": "Colosso tondeggiante, ventre ampio con bande ciliari, arti vestigiali d’appoggio. Pelle spessa e rugosa, color blu-grigio, occhi piccoli; bocca ampia filtrante.",
+    "risk_profile": {
+      "danger_level": 1,
+      "vectors": ["infrasonico disorientante"]
+    },
+    "interactions": {
+      "predates_on": ["micro-organismi aerodispersi"],
+      "predated_by": ["nessuno in età adulta"],
+      "symbiosis": "nessuna"
+    },
+    "constraints": ["Scarsa capacità di arrampicata", "Vulnerabile a pendii ripidi"],
+    "sentience_index": "T0",
+    "ecotypes": ["Pianure Ventose", "Savanicola Notturno"],
+    "trait_refs": ["TR-1401", "TR-1402", "TR-1403", "TR-1404", "TR-1405"]
+  }
+}

--- a/incoming/species/umbra_alaris.json
+++ b/incoming/species/umbra_alaris.json
@@ -1,0 +1,28 @@
+{
+  "species": {
+    "scientific_name": "Umbra alaris",
+    "common_names": ["Uccello Ombra"],
+    "classification": {
+      "macro_class": "Aves",
+      "habitat": "foreste pluviali e canyon notturni"
+    },
+    "functional_signature": "Invisibilità ottica quasi totale e visione potenziata nel buio; attacchi ipotermici silenziosi.",
+    "visual_description": "Volatile nero opaco, sagoma che assorbe la luce; occhi grandi lucenti; artigli lunghi; volo felpato e manovrato.",
+    "risk_profile": {
+      "danger_level": 2,
+      "vectors": ["ipotermia localizzata"]
+    },
+    "interactions": {
+      "predates_on": ["roditori", "piccoli marsupiali"],
+      "predated_by": ["rapaci più grandi"],
+      "symbiosis": "nessuna"
+    },
+    "constraints": [
+      "Efficacia ridotta in nebbia densa (diffusione)",
+      "Bioluminescenza può tradire la posizione a distanza ravvicinata"
+    ],
+    "sentience_index": "T1",
+    "ecotypes": ["Canopy Ombrosa", "Canyon Notturno"],
+    "trait_refs": ["TR-1901", "TR-1902", "TR-1903", "TR-1904", "TR-1905"]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       ],
       "devDependencies": {
         "@playwright/test": "^1.48.2",
+        "ajv-cli": "^5.0.0",
         "husky": "^9.1.6",
         "mongodb-memory-server": "^10.1.4",
         "prettier": "^3.3.3",
@@ -1542,6 +1543,57 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-cli": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-cli/-/ajv-cli-5.0.0.tgz",
+      "integrity": "sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0",
+        "fast-json-patch": "^2.0.0",
+        "glob": "^7.1.0",
+        "js-yaml": "^3.14.0",
+        "json-schema-migrate": "^2.0.0",
+        "json5": "^2.1.3",
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "ajv": "dist/index.js"
+      },
+      "peerDependencies": {
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-cli/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/ajv-cli/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/angular": {
       "resolved": "packages/angular",
       "link": true
@@ -1659,6 +1711,13 @@
         "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bare-events": {
       "version": "2.8.1",
@@ -1793,6 +1852,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/bson": {
@@ -2091,6 +2161,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/confbox": {
       "version": "0.2.2",
@@ -2797,6 +2874,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-patch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
+      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "dev": true,
@@ -2925,6 +3022,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3082,6 +3186,28 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -3275,6 +3401,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
@@ -3453,11 +3591,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-migrate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
+      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -3610,6 +3771,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/minimist": {
@@ -4076,6 +4250,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-to-regexp": {
@@ -5089,6 +5273,13 @@
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
     "db:migrate:down": "python scripts/db/run_migrations.py down",
     "db:migrate:status": "python scripts/db/run_migrations.py status"
   },
-  "dependencies": {},
   "devDependencies": {
     "@playwright/test": "^1.48.2",
+    "ajv-cli": "^5.0.0",
     "husky": "^9.1.6",
     "mongodb-memory-server": "^10.1.4",
     "prettier": "^3.3.3",


### PR DESCRIPTION
## Summary
- add archived species JSON definitions to `incoming/species` following the v2 schema
- add `ajv-cli` as a dev dependency for local schema validation
- record the latest species validator results in `docs/reports/evo/qa/status.md`

## Testing
- AJV=./node_modules/.bin/ajv incoming/scripts/validate.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692286dd9028832896797c12d0924759)