### PR TITLE
Update EVO QA status report

### DIFF
--- a/docs/reports/evo/qa/status.md
+++ b/docs/reports/evo/qa/status.md
@@ -3,5 +3,12 @@
 ## Validazione specie incoming
 
 - Comando: `AJV=./node_modules/.bin/ajv incoming/scripts/validate.sh`
-- Esito: tutti i 10 JSON specie in `incoming/species/` risultano validi rispetto a `incoming/templates/species.schema.json`. Anche i 5 trait esistenti sono stati validati con successo.
+- Esito: validati con successo tutti i 10 JSON specie in `incoming/species/` rispetto a `incoming/templates/species.schema.json`.
+- Note: nessun file trait presente in `incoming/traits/`, il che ha prodotto solo un avviso informativo dal validatore.
 - Output sintetico: `✅ Validazione completata`
+
+## Verifica collegamenti documentazione
+
+- Comando: `npm run docs:lint`
+- Esito: `tools/check_site_links.py` non ha rilevato collegamenti interni rotti nella directory `docs/`.
+- Azioni residue: nessuna.


### PR DESCRIPTION
## Summary
- document the latest incoming species validation results and note the absence of trait files
- record successful documentation link linting for the docs directory

## Testing
- AJV=./node_modules/.bin/ajv incoming/scripts/validate.sh
- npm run docs:lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69228b4221048328bf032d6e6839b0a2)