### PR TITLE
Expand stack lint patterns to TypeScript files

### DIFF
--- a/scripts/lint-stack.mjs
+++ b/scripts/lint-stack.mjs
@@ -4,8 +4,8 @@ import { existsSync } from 'node:fs';
 
 const STACK_PATTERNS = [
   /^apps\/backend\/(.+\.(?:c|m)?js)$/,
-  /^services\/(.+\.(?:c|m)?js)$/,
-  /^tests\/(.+\.(?:c|m)?js)$/,
+  /^services\/(.+\.(?:(?:c|m)?js|ts|tsx|vue))$/,
+  /^tests\/(.+\.(?:(?:c|m)?js|ts|tsx|vue))$/,
   /^apps\/dashboard\/(.+\.(?:c|m)?js|.+\.(?:ts|tsx|vue))$/,
   /^Trait Editor\/(.+\.(?:c|m)?js|.+\.(?:ts|tsx|vue))$/,
 ];


### PR DESCRIPTION
## Summary
- include TypeScript, TSX, and Vue files under services and tests in stack lint targets
- confirmed patterns match representative TypeScript filenames

## Testing
- npm run lint:stack

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69229abf1d2c8328a1dd4faf20e040c3)