### PR TITLE
Expand lint stack patterns to TypeScript

### DIFF
--- a/scripts/lint-stack.mjs
+++ b/scripts/lint-stack.mjs
@@ -3,11 +3,11 @@ import { execSync, spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 
 const STACK_PATTERNS = [
-  /^apps\/backend\/(.+\.(?:c|m)?js)$/,
+  /^apps\/backend\/(.+\.(?:(?:c|m)?js|ts|tsx|vue))$/,
   /^services\/(.+\.(?:(?:c|m)?js|ts|tsx|vue))$/,
   /^tests\/(.+\.(?:(?:c|m)?js|ts|tsx|vue))$/,
-  /^apps\/dashboard\/(.+\.(?:c|m)?js|.+\.(?:ts|tsx|vue))$/,
-  /^Trait Editor\/(.+\.(?:c|m)?js|.+\.(?:ts|tsx|vue))$/,
+  /^apps\/dashboard\/(.+\.(?:(?:c|m)?js|ts|tsx|vue))$/,
+  /^Trait Editor\/(.+\.(?:(?:c|m)?js|ts|tsx|vue))$/,
 ];
 
 const run = (command, options = {}) =>


### PR DESCRIPTION
## Summary
- include TypeScript/TSX/Vue files in backend stack lint scope to match other directories
- keep lint-stack coverage consistent across services, tests, dashboard, and Trait Editor entries

## Testing
- npm run lint:stack

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69229a4b884c83289f3c3b4652398f05)