### PR TITLE
Add PATCHSET-00 planning stubs and incoming triage scaffolding

### DIFF
--- a/docs/incoming/README.md
+++ b/docs/incoming/README.md
@@ -1,37 +1,14 @@
-# Incoming
+# Docs Incoming – Stato e triage (PATCHSET-00)
 
-Questa cartella raccoglie i materiali grezzi (appunti, PDF, zip, ecc.) che devono essere analizzati prima di essere integrati nel progetto.
+Schema di tracciamento per `docs/incoming/**`. Gli stati sono coerenti con `incoming/README.md`:
 
-## Generare i report
+- **INTEGRATO**, **DA_INTEGRARE**, **STORICO**.
 
-1. Posiziona in questa cartella i file o le directory che vuoi esaminare.
-2. Dal root del repository esegui lo script dedicato:
-   ```bash
-   ./scripts/report_incoming.sh
-   ```
-   Puoi passare argomenti aggiuntivi (ad esempio `--destination sessione-2024-05-19`) che verranno inoltrati al comando Python sottostante.
+| Fonte / descrizione | Percorso          | Stato        | Note / next-step                              |
+| ------------------- | ----------------- | ------------ | --------------------------------------------- |
+| _placeholder_       | docs/incoming/... | DA_INTEGRARE | Popolare durante il censimento (PATCHSET-01). |
 
-Lo script produce sia il report JSON sia quello HTML invocando `tools/py/game_cli.py`. I file vengono salvati nella directory `reports/incoming/<destinazione>/` con i nomi `report.json` e `report.html`. Se non specifichi una destinazione, viene usata automaticamente la sottocartella `reports/incoming/latest/`.
+Note:
 
-Se nella cartella sono presenti archivi `.zip`, lo script li estrae in una directory temporanea, esegue automaticamente i comandi
-
-```bash
-python tools/py/game_cli.py validate-datasets
-python tools/py/game_cli.py validate-ecosystem-pack
-```
-
-(il secondo solo quando il pack ecosistema è disponibile) e salva i log corrispondenti in `reports/incoming/validation/` assieme a un file `summary.txt` con gli esiti. Al termine, l'area temporanea viene ripulita automaticamente.
-
-Per evitare la creazione di file e ottenere solo l'output JSON su `stdout`, puoi lanciare:
-
-```bash
-./scripts/report_incoming.sh --destination -
-```
-
-Puoi anche eseguire direttamente il comando principale per le indagini:
-
-```bash
-python tools/py/game_cli.py investigate incoming --recursive --json --html --destination latest --max-preview 400
-```
-
-Il flag `--destination` accetta anche `-` per disabilitare la generazione di file sul disco, mentre `--max-preview` controlla la lunghezza delle anteprime testuali nel report.
+- Nessun riordino o archiviazione applicato in PATCHSET-00.
+- Tenere sincronizzato questo censimento con `docs/planning/REF_INCOMING_CATALOG.md`.

--- a/docs/planning/REF_INCOMING_CATALOG.md
+++ b/docs/planning/REF_INCOMING_CATALOG.md
@@ -1,0 +1,24 @@
+# REF_INCOMING_CATALOG – Stub PATCHSET-00
+
+Versione: 0.1 (bozza)
+Data: 2025-11-23
+Owner: agente **archivist** (supporto: coordinator)
+Stato: DRAFT – struttura per mappare incoming/backlog
+
+---
+
+## Scopo
+
+Catalogare le fonti in `incoming/**` e `docs/incoming/**`, assegnando stato (INTEGRATO / DA_INTEGRARE / STORICO) e priorità di triage, come da `REF_REPO_SCOPE` (§2.3, §6.1).
+
+## Sezioni da compilare
+
+- Tabella fonti principali con percorso, stato, note e next-step.
+- Linee guida per spostare materiale legacy vs buffer attivo.
+- Collegamenti a ticket/patchset dedicati.
+- Rischi di rumore o duplicati rispetto ai core.
+
+## Note operative
+
+- Nessuna riorganizzazione effettiva in PATCHSET-00: solo censimento e stato.
+- Rimandare le decisioni di archiviazione alle patch successive (es. PATCHSET-01).

--- a/docs/planning/REF_PACKS_AND_DERIVED.md
+++ b/docs/planning/REF_PACKS_AND_DERIVED.md
@@ -1,0 +1,24 @@
+# REF_PACKS_AND_DERIVED – Stub PATCHSET-00
+
+Versione: 0.1 (bozza)
+Data: 2025-11-23
+Owner: agente **archivist** (supporto: dev-tooling, coordinator)
+Stato: DRAFT – struttura per separare core vs derived
+
+---
+
+## Scopo
+
+Mappare pack ufficiali, snapshot e fixture (`packs/**`, `data/derived/**`, `examples/`, eventuali legacy), chiarendo che i pack devono essere rigenerabili dai core, come da `REF_REPO_SCOPE` (§2.2, §6.1).
+
+## Sezioni da compilare
+
+- Elenco pack ufficiali (es. `packs/evo_tactics_pack`) e stato di derivazione.
+- Snapshot/mock/test-fixtures in `data/derived/**` con scopo e rischio di divergenza.
+- Regole di rigenerazione da core e dipendenze di tooling.
+- Piano di archiviazione per layout legacy o duplicati.
+
+## Note operative
+
+- Nessun cambiamento ai pack o dati derivati in PATCHSET-00.
+- Validatori/CI restano invariati; eventuali modifiche vanno pianificate in `REF_TOOLING_AND_CI.md`.

--- a/docs/planning/REF_REPO_MIGRATION_PLAN.md
+++ b/docs/planning/REF_REPO_MIGRATION_PLAN.md
@@ -1,0 +1,24 @@
+# REF_REPO_MIGRATION_PLAN – Stub PATCHSET-00
+
+Versione: 0.1 (bozza)
+Data: 2025-11-23
+Owner: agente **coordinator** (supporto: archivist, dev-tooling)
+Stato: DRAFT – struttura per sequenziare i patchset
+
+---
+
+## Scopo
+
+Definire la sequenza dei patchset (PATCHSET-00, 01, 02, …) derivati da `REF_REPO_SCOPE`, con rischi, rollback e deliverable per ognuno.
+
+## Sezioni da compilare
+
+- Timeline e dipendenze tra patchset (P0/P1/P2).
+- Entry/exit criteria per ogni patchset.
+- Rischi, mitigazioni, strategia di rollback.
+- Impatto atteso su dati core, pack, tooling, documentazione.
+
+## Note operative
+
+- PATCHSET-00 resta neutrale (solo documentazione/stub).
+- Integrare link alle proposte specifiche quando approvate (es. `REF_REPO_PATCH_PROPOSTA`).

--- a/docs/planning/REF_REPO_PATCH_PROPOSTA.md
+++ b/docs/planning/REF_REPO_PATCH_PROPOSTA.md
@@ -1,0 +1,50 @@
+# REF_REPO_PATCH_PROPOSTA – Applicazione iniziale dello scope
+
+Versione: 0.1 (bozza)
+Data: 2025-11-23
+Owner: agente **archivist** (coordinamento con coordinator/dev-tooling)
+Stato: PROPOSTA – patch da validare
+
+---
+
+## Obiettivo
+
+Tradurre il documento `REF_REPO_SCOPE` in un primo patchset operativo (PATCHSET-00) che non altera ancora i dati core ma prepara la struttura per i refactor successivi.
+
+## Ambito del patchset
+
+- Documentazione: creare gli output di pianificazione elencati in `REF_REPO_SCOPE` (section 6.1), vuoti ma con scheletro condiviso.
+- Incoming/backlog: mappatura iniziale delle cartelle `incoming/` e `docs/incoming/` con README di stato.
+- Nessuna modifica a `data/core/**`, `packs/**` o tooling esistente (compatibilità Golden Path).
+
+## Deliverable proposti (PATCHSET-00)
+
+1. Stub dei documenti di pianificazione:
+   - `docs/planning/REF_REPO_SOURCES_OF_TRUTH.md`
+   - `docs/planning/REF_INCOMING_CATALOG.md`
+   - `docs/planning/REF_PACKS_AND_DERIVED.md`
+   - `docs/planning/REF_TOOLING_AND_CI.md`
+   - `docs/planning/REF_REPO_MIGRATION_PLAN.md`
+     Ogni file include: scopo, owner, stato (DRAFT), elenco sezioni da riempire.
+
+2. Indicizzazione incoming/backlog:
+   - `incoming/README.md` con tabella INTEGRATO / DA_INTEGRARE / STORICO.
+   - `docs/incoming/README.md` con lo stesso schema e link alle fonti note.
+
+## Motivazione
+
+- Rende espliciti gli output attesi (REF_REPO_SCOPE §6.1) prima di toccare dati o pack.
+- Crea un perimetro chiaro per il triage di incoming e derived senza introdurre regressioni.
+- Mantiene allineamento con STRICT MODE: tutto è preparato come patch proposta e può essere applicato/esteso in patchset successivi.
+
+## Passi successivi suggeriti
+
+- Approvare PATCHSET-00 come change-set neutrale (solo documentazione/stub).
+- Pianificare PATCHSET-01 per il censimento di `data/derived/**` e fixture test.
+- Pianificare PATCHSET-02 per la rigenerazione di `packs/evo_tactics_pack` a partire dai core.
+
+---
+
+## Changelog
+
+- 2025-11-23: prima proposta di patch basata su `REF_REPO_SCOPE` (archivist).

--- a/docs/planning/REF_REPO_SCOPE.md
+++ b/docs/planning/REF_REPO_SCOPE.md
@@ -1,0 +1,274 @@
+# REF_REPO_SCOPE – Refactor globale repository Game / Evo Tactics
+
+Versione: 0.1 (bozza)
+Data: 2025-11-23
+Owner: agente **coordinator** (supporto: archivist, dev-tooling)
+Stato: DRAFT – usata come bussola per le pipeline di refactor
+
+---
+
+## 1. Obiettivo
+
+Definire il **perimetro**, i **vincoli** e le **priorità** del refactor globale del
+repository **Game / Evo Tactics**, usando il sistema di agenti e il Golden Path,
+in modalità **STRICT MODE** (nessuna modifica implicita ai file, solo patch esplicite).
+
+Il refactor deve:
+
+- ridurre i file sparsi, ridondanze e duplicati;
+- centralizzare i **cataloghi** (traits, specie, biomi, ecosistemi, pack);
+- separare chiaramente:
+  - dati **core** (sorgente di verità),
+  - dati **derived / snapshot / test-fixtures**,
+  - materiale **incoming / backlog / archivio**;
+- allineare **documentazione, dati e codice/tooling**;
+- preservare compatibilità con:
+  - pack esistenti (`packs/evo_tactics_pack`),
+  - CI, test, validatori,
+  - pipeline GOLDEN PATH e Command Library.
+
+---
+
+## 2. Domini nel perimetro
+
+Questa sezione descrive i **domini principali** che il refactor deve toccare.
+
+### 2.1 Dati core & cataloghi
+
+**Scope:**
+
+- `data/core/**`
+- `data/ecosystems/**`
+- `data/traits/**` e `traits/**` (documentazione trait)
+- `biomes/**`
+- `configs/schemas/**` o equivalente (`schemas/`, `config/`)
+
+**Obiettivo:**
+
+- Identificare, per ogni dominio:
+  - **Trait**: sorgente di verità per glossario, famiglie, pool di bioma.
+  - **Specie**: sorgente di verità per specie/unità/NPC.
+  - **Biomi / ecosistemi**: sorgente di verità per biomi ed ecosistemi giocabili.
+- Allineare i dataset core con lo schema ALIENA (trait, specie, biomi, ST, UCUM).
+
+---
+
+### 2.2 Pack, snapshot, derived & test-fixtures
+
+**Scope:**
+
+- `packs/evo_tactics_pack/**`
+- `data/derived/**` (mock, prod_snapshot, test-fixtures)
+- eventuali struct pack in `packages/`, `examples/`, `reports/`, ecc.
+
+**Obiettivo:**
+
+- Distinguere:
+  - **pack ufficiali** (es. `evo_tactics_pack`) → sempre derivati dai core;
+  - **snapshot** (mock, prod_snapshot, test-fixtures) → usati per test/demo;
+  - **vecchi pack** o layout legacy → candidati per archivio.
+- Definire una regola chiara:
+  - i **core** si modificano a mano;
+  - i **pack/derived** si **rigenerano** da core tramite tooling/script.
+
+---
+
+### 2.3 Incoming, backlog, archivio caldo/freddo
+
+**Scope:**
+
+- `incoming/**` (pack zip, CSV, YAML, note, template, script)
+- `docs/incoming/**`
+- `docs/archive/**`
+- eventuali `incoming` in altre aree (es. `reports/`, `analytics/`)
+
+**Obiettivo:**
+
+- Catalogare il contenuto di `incoming/**`:
+  - pack già integrati,
+  - pack ancora da integrare,
+  - materiale puramente storico.
+- Introdurre una struttura più esplicita, ad es.:
+  - `incoming/buffer/` → materiale attivo da integrare;
+  - `incoming/legacy/` → materiale vecchio ma ancora utile come riferimento;
+  - `incoming/archive_cold/` → materiale storico che non deve più interferire.
+- Dare una “etichetta di stato” (es. INTEGRATO / DA_INTEGRARE / STORICO) alle
+  principali fonti che impattano trait/specie/biomi.
+
+---
+
+### 2.4 Documentazione & knowledge base
+
+**Scope:**
+
+- `docs/**`, in particolare:
+  - `docs/00-INDEX.md` e indici correlati;
+  - `docs/biomes/**`, `docs/species/**`, `docs/traits/**` e manuali;
+  - `docs/evo-tactics-pack/**`;
+  - `docs/archive/**`, `docs/incoming/**`;
+  - `docs/COMMAND_LIBRARY.md`;
+  - `docs/pipelines/**`;
+  - `docs/AI_AGENT_AUDIT_LOG.md`.
+- File top-level:
+  - `README.md`,
+  - `MASTER_PROMPT.md`,
+  - `AGENTS.md`, `AGENT_WORKFLOW_GUIDE.md`,
+  - `agent_constitution.md`, `agent.md`, `router.md`.
+
+**Obiettivo:**
+
+- Ridurre documenti duplicati o superati:
+  - spostare il materiale obsoleto in `docs/archive/**`;
+  - mantenere 1–2 **entrypoint chiari** per:
+    - vision/overview (es. `README.md`, `docs/01-VISIONE.md`),
+    - sistema agenti (es. `AGENTS.md`, `AGENT_WORKFLOW_GUIDE.md`),
+    - pipeline (es. `docs/pipelines/GOLDEN_PATH.md`).
+- Allineare la documentazione al **sorgente di verità dei dati**:
+  - evitare di mantenere a mano copie dei cataloghi in `docs/` se possono
+    essere generate o referenziate direttamente da `data/core/**`.
+
+---
+
+### 2.5 Tooling, engine, CI & test
+
+**Scope:**
+
+- Codice e runtime:
+  - `src/**`, `engine/**`, `apps/**`, `webapp/**`, `Trait Editor/**`,
+  - `services/**`, `packages/**`.
+- Tooling & script:
+  - `tools/**`, `scripts/**`, `ops/**`.
+- Config & schema:
+  - `config/**`, `schemas/**`.
+- CI & test:
+  - `.github/workflows/**`,
+  - `tests/**`, fixture in `data/derived/**`,
+  - qualunque validatore/schema-checker (es. `schema-validate`, ecc.).
+
+**Obiettivo:**
+
+- Allineare tooling e CI alla nuova struttura:
+  - i validatori devono usare i **core** come input principale;
+  - i test devono usare fixture consolidate e non snapshot duplicati.
+- Identificare script/workflow **obsoleti, duplicati o sperimentali** da:
+  - spostare in archivio,
+  - o consolidare in pochi comandi standard.
+
+---
+
+## 3. Fuori scope (per questo ciclo di refactor)
+
+Le seguenti attività NON sono obiettivo diretto di questo refactor (possono
+emergere come follow-up, ma non guidano le decisioni):
+
+- Design di **nuove feature di gameplay** (nuovi biomi/specie/trait).
+- Riscrittura profonda dell’engine o delle app (es. migrazioni framework).
+- Refactor di “stile” sui testi di lore (solo organizzazione, non contenuto).
+- Evoluzione del **framework ALIENA** (solo applicazione alle strutture dati
+  esistenti, non redesign concettuale).
+
+---
+
+## 4. Vincoli principali
+
+1. **STRICT MODE**
+   - Nessuna modifica diretta ai file.
+   - Qualsiasi cambiamento strutturale deve essere proposto come
+     **patch_proposta** (diff) e approvato prima di essere applicato.
+
+2. **Compatibilità Golden Path**
+   - Le pipeline in `docs/pipelines/GOLDEN_PATH*.md` devono restare valide
+     come concetto e come entrypoint.
+   - Il sistema di agenti (`AGENTS.md`, `agent_constitution.md`, `.ai/**`)
+     deve rimanere allineato ai file che descrivono il repo.
+
+3. **Pack esistenti**
+   - `packs/evo_tactics_pack` è considerato un pack **ufficiale**.
+   - Qualsiasi refactor che impatta i suoi asset deve:
+     - essere tracciato,
+     - prevedere, se possibile, una rigenerazione automatica dal core.
+
+4. **CI, test e validazione**
+   - I workflow `.github/workflows/**` non devono essere rotti senza un piano
+     di aggiornamento.
+   - I validatori di schema devono continuare a poter verificare i core
+     e, dove ha senso, i pack derivati.
+
+5. **ALIENA & metriche UCUM**
+   - I dataset strutturati (trait, specie, biomi, ecosistemi) devono rimanere
+     compatibili con:
+     - lo schema ALIENA (trait species-agnostici, specie, biomi/ecosistemi),
+     - le metriche in UCUM (nessuna regressione sui campi di misura).
+
+---
+
+## 5. Priorità (P0 / P1 / P2)
+
+**P0 – Bloccanti / fondamentali**
+
+- Definire le **sorgenti di verità** per:
+  - trait,
+  - specie,
+  - biomi ed ecosistemi.
+- Mappare e isolare i dataset **derived/snapshot/test-fixtures** che duplicano
+  i core.
+- Catalogare e contenere il rumore in `incoming/**` e `docs/incoming/**`.
+
+**P1 – Importanti ma non bloccanti**
+
+- Consolidare la **documentazione**:
+  - entrypoint chiari per agenti, Golden Path, cataloghi.
+- Allineare tooling/CI in modo che:
+  - test e validatori usino i core come input principale,
+  - i pack vengano rigenerati da core.
+
+**P2 – Nice to have**
+
+- Pulizia e standardizzazione di naming, slug, ecc. (compatibili con ALIENA).
+- Migliorare la struttura di `reports/`, `analytics/`, log di playtest.
+- Mikro-refactor su script e workflow minori.
+
+---
+
+## 6. Output attesi dal refactor
+
+A valle delle pipeline di refactor, ci si aspetta di avere:
+
+1. Un set di **documenti di pianificazione**:
+   - `REF_REPO_SOURCES_OF_TRUTH.md`
+   - `REF_INCOMING_CATALOG.md`
+   - `REF_PACKS_AND_DERIVED.md`
+   - `REF_TOOLING_AND_CI.md`
+   - `REF_REPO_MIGRATION_PLAN.md`
+
+2. Una struttura del repo più chiara:
+   - `data/core/**` come unico spazio canonico per i dati giocabili;
+   - `packs/**` generati dai core;
+   - `data/derived/**` confinato a snapshot/test dentro regole precise;
+   - `incoming/**` e `docs/archive/**` ripuliti e segmentati.
+
+3. Un set di **patchset numerati** (PATCHSET-01, 02, …) con:
+   - scope limitato,
+   - rischi noti,
+   - eventuale strategia di rollback.
+
+---
+
+## 7. Collegamento con Golden Path & sistema agenti
+
+- Il refactor viene gestito come una “mega feature infrastrutturale” sotto
+  il **GOLDEN_PATH**:
+  - Fase 0: definizione scope (questo documento).
+  - Fase 1–N: pipeline dedicate (incoming, core/pack, docs, tooling/CI).
+
+- Agenti coinvolti:
+  - **coordinator**: orchestrazione pipeline, prioritizzazione.
+  - **archivist**: mappatura file, cataloghi, versioni.
+  - **dev-tooling**: agreggio script, validatori, CI.
+  - **trait-curator / species-curator / biome-ecosystem-curator**:
+    - allineamento semantico dei dataset core con ALIENA.
+  - **asset-prep** (se necessario): mappatura asset visivi/esterni.
+
+Questo documento è la base condivisa per tutte le **PATCHSET** successive.
+Eventuali cambiamenti di scope rilevanti vanno aggiunti come sezione “Changelog”
+in coda a questo file.

--- a/docs/planning/REF_REPO_SOURCES_OF_TRUTH.md
+++ b/docs/planning/REF_REPO_SOURCES_OF_TRUTH.md
@@ -1,0 +1,25 @@
+# REF_REPO_SOURCES_OF_TRUTH – Stub PATCHSET-00
+
+Versione: 0.1 (bozza)
+Data: 2025-11-23
+Owner: agente **archivist** (supporto: trait-curator, species-curator, biome-ecosystem-curator)
+Stato: DRAFT – struttura da completare prima del censimento dei dataset core
+
+---
+
+## Scopo
+
+Definire le sorgenti di verità per trait, specie, biomi/ecosistemi e schemi correlati, come richiesto da `REF_REPO_SCOPE` (§2.1, §6.1).
+
+## Sezioni da compilare
+
+- Panoramica dei dataset core (`data/core/**`, `data/ecosystems/**`, `data/traits/**`, `biomes/**`).
+- Allineamento con schema ALIENA e metriche UCUM.
+- Relazione tra dati core e documentazione (`traits/**`, `docs/**`).
+- Mappa dei validatori/schema da usare sui core.
+- Rischi e gap noti (bloccanti/P0).
+
+## Note operative
+
+- Nessuna modifica ai dati core in PATCHSET-00.
+- I riferimenti ai pack derivati vanno rinviati al documento `REF_PACKS_AND_DERIVED.md`.

--- a/docs/planning/REF_TOOLING_AND_CI.md
+++ b/docs/planning/REF_TOOLING_AND_CI.md
@@ -1,0 +1,24 @@
+# REF_TOOLING_AND_CI – Stub PATCHSET-00
+
+Versione: 0.1 (bozza)
+Data: 2025-11-23
+Owner: agente **dev-tooling** (supporto: archivist, coordinator)
+Stato: DRAFT – struttura per allineare tooling/CI al nuovo assetto
+
+---
+
+## Scopo
+
+Raccogliere i workflow di validazione, test e generazione pack da adeguare al refactor, mantenendo compatibilità con Golden Path (`REF_REPO_SCOPE` §2.5, §4, §6.1).
+
+## Sezioni da compilare
+
+- Inventario workflow CI (.github/workflows) e dipendenze su dati core/derived.
+- Script/tooling in `tools/**`, `scripts/**`, `ops/**` rilevanti per pack/validazione.
+- Gap e rischi (es. schema-checker, fixture obsolete) con priorità P0/P1.
+- Linee guida per aggiornare validatori a usare `data/core/**` come input primario.
+
+## Note operative
+
+- Nessun cambiamento ai workflow in PATCHSET-00: solo mappatura e piano.
+- Coordinarsi con `REF_PACKS_AND_DERIVED.md` per regole di rigenerazione pack.

--- a/incoming/README.md
+++ b/incoming/README.md
@@ -1,0 +1,16 @@
+# Incoming – Stato e triage (PATCHSET-00)
+
+Questa tabella prepara il censimento delle fonti in `incoming/**`. Gli stati sono:
+
+- **INTEGRATO**: materiale già riversato nei core o in pack ufficiali.
+- **DA_INTEGRARE**: materiale da valutare/prioritizzare nelle prossime patch.
+- **STORICO**: materiale legacy/archivio che non deve interferire con i core.
+
+| Fonte / descrizione | Percorso     | Stato        | Note / next-step                              |
+| ------------------- | ------------ | ------------ | --------------------------------------------- |
+| _placeholder_       | incoming/... | DA_INTEGRARE | Popolare durante il censimento (PATCHSET-01). |
+
+Note:
+
+- Nessuno spostamento o archiviazione effettuato in PATCHSET-00.
+- Coordinare questo censimento con `docs/planning/REF_INCOMING_CATALOG.md`.


### PR DESCRIPTION
## Summary
- add planning stub documents for sources of truth, incoming catalog, packs/derived, tooling/CI, and migration sequencing
- introduce incoming and docs/incoming triage READMEs aligned with the PATCHSET-00 scope

## Testing
- npx prettier --write docs/planning/*.md incoming/README.md docs/incoming/README.md

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692373f514408328b14af692b8af6ab7)