### PR TITLE
Fill planning references with actionable sections

### DIFF
--- a/docs/planning/REF_INCOMING_CATALOG.md
+++ b/docs/planning/REF_INCOMING_CATALOG.md
@@ -1,4 +1,4 @@
-# REF_INCOMING_CATALOG – Stub PATCHSET-00
+# REF_INCOMING_CATALOG – Catalogo incoming/backlog
 
 Versione: 0.1 (bozza)
 Data: 2025-11-23
@@ -7,18 +7,41 @@ Stato: DRAFT – struttura per mappare incoming/backlog
 
 ---
 
-## Scopo
+## Obiettivi
 
-Catalogare le fonti in `incoming/**` e `docs/incoming/**`, assegnando stato (INTEGRATO / DA_INTEGRARE / STORICO) e priorità di triage, come da `REF_REPO_SCOPE` (§2.3, §6.1).
+- Catalogare il contenuto di `incoming/**` e `docs/incoming/**` con stato (INTEGRATO / DA_INTEGRARE / STORICO) e priorità di triage.
+- Distinguere materiale attivo (buffer) da legacy o archivio, indicando percorso di destinazione o archiviazione.
+- Collegare le fonti incoming a patchset/ticket che ne gestiranno l’integrazione nei core o nei pack derivati.
 
-## Sezioni da compilare
+## Stato attuale
 
-- Tabella fonti principali con percorso, stato, note e next-step.
-- Linee guida per spostare materiale legacy vs buffer attivo.
-- Collegamenti a ticket/patchset dedicati.
-- Rischi di rumore o duplicati rispetto ai core.
+- Esistono cartelle `incoming/` e `docs/incoming/` senza una tabella centralizzata di stato e senza owner per fonte.
+- Non sono documentate le dipendenze tra materiale incoming e i core/pack già integrati.
+- Non è definito un criterio condiviso per spostare i file in `incoming/buffer`, `incoming/legacy` o `incoming/archive_cold`.
 
-## Note operative
+## Rischi
 
-- Nessuna riorganizzazione effettiva in PATCHSET-00: solo censimento e stato.
-- Rimandare le decisioni di archiviazione alle patch successive (es. PATCHSET-01).
+- Rumore e duplicati rispetto ai core o ai pack derivati se il materiale non viene etichettato prima dell’uso.
+- Incertezza sullo stato di integrazione può portare a reimport multipli o a perdere materiale utile.
+- Mancanza di tracciamento verso ticket/patchset rende difficile decidere priorità e responsabili.
+
+## Dipendenze
+
+- `REF_REPO_SOURCES_OF_TRUTH` per confrontare le fonti incoming con i dataset canonici.
+- `REF_PACKS_AND_DERIVED` per capire l’impatto del materiale incoming sui pack e sui derived.
+- `REF_REPO_MIGRATION_PLAN` per schedulare quando integrare/archiviare ciascuna fonte.
+- Supporto di coordinator per priorità e di dev-tooling per eventuali script di import/validazione.
+
+## Prossimi passi
+
+1. Creare una tabella con percorso sorgente, descrizione, stato, owner e link a ticket/patchset previsti.
+2. Etichettare le fonti esistenti assegnandole a `buffer`, `legacy` o `archive_cold` in base alla priorità e all’utilizzo.
+3. Segnalare le fonti che toccano dati core o pack ufficiali e allinearle con i responsabili di dominio (trait/specie/biomi).
+4. Definire regole minime di accettazione (formato, checksum, schema) prima di muovere una fonte da DA_INTEGRARE a INTEGRATO.
+5. Integrare la tabella nel flusso di PATCHSET successivi e mantenerla sincronizzata con `docs/incoming/README.md`.
+
+---
+
+## Changelog
+
+- 2025-11-23: struttura iniziale del catalogo incoming (archivist).

--- a/docs/planning/REF_PACKS_AND_DERIVED.md
+++ b/docs/planning/REF_PACKS_AND_DERIVED.md
@@ -1,24 +1,48 @@
-# REF_PACKS_AND_DERIVED – Stub PATCHSET-00
+# REF_PACKS_AND_DERIVED – Pack, snapshot e fixture
 
 Versione: 0.1 (bozza)
 Data: 2025-11-23
 Owner: agente **archivist** (supporto: dev-tooling, coordinator)
-Stato: DRAFT – struttura per separare core vs derived
+Stato: DRAFT – separazione core vs derived
 
 ---
 
-## Scopo
+## Obiettivi
 
-Mappare pack ufficiali, snapshot e fixture (`packs/**`, `data/derived/**`, `examples/`, eventuali legacy), chiarendo che i pack devono essere rigenerabili dai core, come da `REF_REPO_SCOPE` (§2.2, §6.1).
+- Mappare pack ufficiali, snapshot e fixture (`packs/**`, `data/derived/**`, `examples/`, eventuali layout legacy) e definirne lo stato di derivazione dai core.
+- Stabilire regole per la rigenerazione dei pack a partire dai core, compresi i requisiti di tooling e validazione.
+- Identificare duplicati o asset legacy da archiviare per ridurre il rischio di regressioni.
 
-## Sezioni da compilare
+## Stato attuale
 
-- Elenco pack ufficiali (es. `packs/evo_tactics_pack`) e stato di derivazione.
-- Snapshot/mock/test-fixtures in `data/derived/**` con scopo e rischio di divergenza.
-- Regole di rigenerazione da core e dipendenze di tooling.
-- Piano di archiviazione per layout legacy o duplicati.
+- `packs/evo_tactics_pack` è considerato pack ufficiale ma non è documentato se e come venga rigenerato automaticamente dai core.
+- `data/derived/**` contiene snapshot/mock/fixture senza un catalogo unico che ne spieghi scopo, data di origine e rischio di divergenza.
+- Alcuni esempi o report potrebbero contenere layout pack legacy non tracciati.
+- Non esiste una policy documentata per collegare i derived ai test/CI o per marcarli come deprecati.
 
-## Note operative
+## Rischi
 
-- Nessun cambiamento ai pack o dati derivati in PATCHSET-00.
-- Validatori/CI restano invariati; eventuali modifiche vanno pianificate in `REF_TOOLING_AND_CI.md`.
+- Derived non allineati ai core possono introdurre incoerenze nei test o nei pack distribuiti.
+- Rigenerazioni manuali senza checklist possono rompere compatibilità con CI o con gli schemi ALIENA/UCUM.
+- Pack legacy non etichettati possono essere riutilizzati erroneamente come sorgente di verità.
+
+## Dipendenze
+
+- `REF_REPO_SOURCES_OF_TRUTH` per i percorsi canonici dei core da cui rigenerare.
+- `REF_TOOLING_AND_CI` per definire script e workflow che producono/validano pack e derived.
+- `REF_REPO_MIGRATION_PLAN` per decidere quando archiviare o rigenerare specifici derived.
+- Supporto di dev-tooling per standardizzare i comandi di rigenerazione e di coordinator per le priorità.
+
+## Prossimi passi
+
+1. Redigere una tabella dei pack ufficiali e derived con colonne: percorso, tipo (ufficiale/snapshot/fixture/legacy), origine dai core, owner, rischio.
+2. Documentare il processo di rigenerazione di `packs/evo_tactics_pack` e verificare se esiste tooling automatizzato o manuale.
+3. Inventariare `data/derived/**` specificando quali directory sono fixture di test e quali snapshot legacy da archiviare.
+4. Collegare ciascun derived ai test/CI che lo consumano, segnando l’impatto di eventuale rigenerazione.
+5. Proporre criteri di deprecazione/archiviazione per pack/derived non più supportati, da attuare nelle patch successive.
+
+---
+
+## Changelog
+
+- 2025-11-23: struttura iniziale separazione core vs derived (archivist).

--- a/docs/planning/REF_REPO_MIGRATION_PLAN.md
+++ b/docs/planning/REF_REPO_MIGRATION_PLAN.md
@@ -1,24 +1,46 @@
-# REF_REPO_MIGRATION_PLAN – Stub PATCHSET-00
+# REF_REPO_MIGRATION_PLAN – Sequenza patchset
 
 Versione: 0.1 (bozza)
 Data: 2025-11-23
 Owner: agente **coordinator** (supporto: archivist, dev-tooling)
-Stato: DRAFT – struttura per sequenziare i patchset
+Stato: DRAFT – sequenziare i patchset
 
 ---
 
-## Scopo
+## Obiettivi
 
-Definire la sequenza dei patchset (PATCHSET-00, 01, 02, …) derivati da `REF_REPO_SCOPE`, con rischi, rollback e deliverable per ognuno.
+- Definire la timeline dei patchset (PATCHSET-00, 01, 02, …) derivati da `REF_REPO_SCOPE`, con criteri di entrata/uscita e responsabilità.
+- Rendere espliciti rischi, mitigazioni e strategie di rollback per ogni patchset.
+- Collegare ogni patchset ai deliverable attesi su dati core, pack/derived, incoming e tooling/CI.
 
-## Sezioni da compilare
+## Stato attuale
 
-- Timeline e dipendenze tra patchset (P0/P1/P2).
-- Entry/exit criteria per ogni patchset.
-- Rischi, mitigazioni, strategia di rollback.
-- Impatto atteso su dati core, pack, tooling, documentazione.
+- PATCHSET-00 è neutrale (documentazione e mappature) e dipende dall’approvazione di `REF_REPO_PATCH_PROPOSTA`.
+- Le fasi successive non hanno ancora un calendario né criteri di completamento definiti.
+- I rischi e le dipendenze tra patchset non sono stati documentati; manca una matrice P0/P1/P2 condivisa.
 
-## Note operative
+## Rischi
 
-- PATCHSET-00 resta neutrale (solo documentazione/stub).
-- Integrare link alle proposte specifiche quando approvate (es. `REF_REPO_PATCH_PROPOSTA`).
+- Avvio di patchset successivi senza criteri di uscita potrebbe lasciare il repo in stato intermedio.
+- Mancata sincronizzazione con tooling/CI può introdurre regressioni nei workflow esistenti.
+- Sovrapposizione tra patchset (es. incoming vs derived) può causare conflitti o doppi sforzi.
+
+## Dipendenze
+
+- `REF_REPO_SCOPE` e `REF_REPO_PATCH_PROPOSTA` come base di perimetro e patch neutrale.
+- `REF_REPO_SOURCES_OF_TRUTH`, `REF_PACKS_AND_DERIVED`, `REF_INCOMING_CATALOG`, `REF_TOOLING_AND_CI` per i deliverable specifici di ogni fase.
+- Golden Path e Command Library per orchestrare le pipeline e garantire compatibilità con STRICT MODE.
+
+## Prossimi passi
+
+1. Formalizzare la sequenza minima: PATCHSET-00 (doc neutrale) → PATCHSET-01 (censimento derived/fixture) → PATCHSET-02 (rigenerazione pack ufficiale) → eventuali PATCHSET-03+ (pulizia incoming/archivio, adeguamenti CI).
+2. Definire per ogni patchset entry/exit criteria, owner, rischi, rollback e impatto previsto su dati, pack, tooling e documentazione.
+3. Allineare le priorità P0/P1/P2 con le dipendenze cross-documento (sources of truth, incoming, pack/derived, tooling/CI).
+4. Integrare nel piano gli hook di validazione/CI che devono accompagnare la chiusura di ciascun patchset.
+5. Pubblicare la timeline in `docs/planning/` e collegarla ai ticket/patch di implementazione, aggiornandola a ogni approvazione.
+
+---
+
+## Changelog
+
+- 2025-11-23: bozza di piano di migrazione basato su `REF_REPO_SCOPE` (coordinator).

--- a/docs/planning/REF_REPO_PATCH_PROPOSTA.md
+++ b/docs/planning/REF_REPO_PATCH_PROPOSTA.md
@@ -9,39 +9,34 @@ Stato: PROPOSTA – patch da validare
 
 ## Obiettivo
 
-Tradurre il documento `REF_REPO_SCOPE` in un primo patchset operativo (PATCHSET-00) che non altera ancora i dati core ma prepara la struttura per i refactor successivi.
+Tradurre `REF_REPO_SCOPE` in **PATCHSET-00**: una proposta neutrale che non altera i dati core ma prepara la struttura di documentazione e cataloghi per i refactor successivi.
 
-## Ambito del patchset
+## Stato attuale
 
-- Documentazione: creare gli output di pianificazione elencati in `REF_REPO_SCOPE` (section 6.1), vuoti ma con scheletro condiviso.
-- Incoming/backlog: mappatura iniziale delle cartelle `incoming/` e `docs/incoming/` con README di stato.
-- Nessuna modifica a `data/core/**`, `packs/**` o tooling esistente (compatibilità Golden Path).
+- Deliverable proposti sono limitati a documentazione e mappature, senza toccare `data/core/**`, `packs/**` o tooling.
+- Gli stub richiesti in §6.1 di `REF_REPO_SCOPE` esistono ma vanno completati con sezioni operative.
+- Le cartelle `incoming/` e `docs/incoming/` sono solo censite; manca una tabella di stato condivisa.
 
-## Deliverable proposti (PATCHSET-00)
+## Rischi
 
-1. Stub dei documenti di pianificazione:
-   - `docs/planning/REF_REPO_SOURCES_OF_TRUTH.md`
-   - `docs/planning/REF_INCOMING_CATALOG.md`
-   - `docs/planning/REF_PACKS_AND_DERIVED.md`
-   - `docs/planning/REF_TOOLING_AND_CI.md`
-   - `docs/planning/REF_REPO_MIGRATION_PLAN.md`
-     Ogni file include: scopo, owner, stato (DRAFT), elenco sezioni da riempire.
+- Mancata approvazione o ambiguità di scope potrebbero bloccare PATCHSET-01/02.
+- Rischio di duplicare mappature se le tabelle di incoming non sono uniche e versionate.
+- Se gli owner non sono nominati per ogni deliverable, le sezioni restano senza manutenzione.
 
-2. Indicizzazione incoming/backlog:
-   - `incoming/README.md` con tabella INTEGRATO / DA_INTEGRARE / STORICO.
-   - `docs/incoming/README.md` con lo stesso schema e link alle fonti note.
+## Dipendenze
 
-## Motivazione
+- `REF_REPO_SCOPE` come bussola di perimetro e vincoli (STRICT MODE, Golden Path).
+- Coordinamento con `REF_REPO_MIGRATION_PLAN` per sequenziare PATCHSET-01/02.
+- Allineamento con `REF_INCOMING_CATALOG` e `REF_PACKS_AND_DERIVED` per evitare sovrapposizioni.
+- Coinvolgimento di coordinator, archivist e dev-tooling per convalida e rollout.
 
-- Rende espliciti gli output attesi (REF_REPO_SCOPE §6.1) prima di toccare dati o pack.
-- Crea un perimetro chiaro per il triage di incoming e derived senza introdurre regressioni.
-- Mantiene allineamento con STRICT MODE: tutto è preparato come patch proposta e può essere applicato/esteso in patchset successivi.
+## Prossimi passi
 
-## Passi successivi suggeriti
-
-- Approvare PATCHSET-00 come change-set neutrale (solo documentazione/stub).
-- Pianificare PATCHSET-01 per il censimento di `data/derived/**` e fixture test.
-- Pianificare PATCHSET-02 per la rigenerazione di `packs/evo_tactics_pack` a partire dai core.
+1. Validare formalmente PATCHSET-00 come change-set neutrale e approvare la struttura dei sei documenti di pianificazione.
+2. Popolare `REF_INCOMING_CATALOG` con la tabella di stato condivisa per `incoming/` e `docs/incoming/`, nominando un owner.
+3. Collegare `REF_REPO_SOURCES_OF_TRUTH` e `REF_PACKS_AND_DERIVED` con i percorsi canonici dei core e i criteri di derivazione.
+4. Allineare `REF_TOOLING_AND_CI` sugli impatti nulli di PATCHSET-00 e preparare la checklist di compatibilità per PATCHSET-01.
+5. Aggiornare `REF_REPO_MIGRATION_PLAN` con le exit/entry criteria e i trigger per passare da PATCHSET-00 a PATCHSET-01/02.
 
 ---
 

--- a/docs/planning/REF_REPO_SCOPE.md
+++ b/docs/planning/REF_REPO_SCOPE.md
@@ -3,272 +3,58 @@
 Versione: 0.1 (bozza)
 Data: 2025-11-23
 Owner: agente **coordinator** (supporto: archivist, dev-tooling)
-Stato: DRAFT – usata come bussola per le pipeline di refactor
+Stato: DRAFT – bussola per le pipeline di refactor
 
 ---
 
-## 1. Obiettivo
+## Obiettivi
 
-Definire il **perimetro**, i **vincoli** e le **priorità** del refactor globale del
-repository **Game / Evo Tactics**, usando il sistema di agenti e il Golden Path,
-in modalità **STRICT MODE** (nessuna modifica implicita ai file, solo patch esplicite).
+- Definire il perimetro, i vincoli e le priorità del refactor in **STRICT MODE**.
+- Centralizzare cataloghi (trait, specie, biomi, pack) distinguendo chiaramente core, derived/snapshot/test-fixtures e incoming/backlog.
+- Allineare documentazione, dati e tooling al Golden Path e ai vincoli di compatibilità (pack esistenti, CI, validatori).
 
-Il refactor deve:
+## Stato attuale
 
-- ridurre i file sparsi, ridondanze e duplicati;
-- centralizzare i **cataloghi** (traits, specie, biomi, ecosistemi, pack);
-- separare chiaramente:
-  - dati **core** (sorgente di verità),
-  - dati **derived / snapshot / test-fixtures**,
-  - materiale **incoming / backlog / archivio**;
-- allineare **documentazione, dati e codice/tooling**;
-- preservare compatibilità con:
-  - pack esistenti (`packs/evo_tactics_pack`),
-  - CI, test, validatori,
-  - pipeline GOLDEN PATH e Command Library.
+### Domini coperti e scopo
 
----
+- **Dati core & cataloghi** (`data/core/**`, `data/ecosystems/**`, `data/traits/**`, `biomes/**`, `traits/**`, `schemas/**`): identificare sorgenti di verità per trait, specie, biomi/ecosistemi, garantendo compatibilità con schema **ALIENA** e metriche UCUM.
+- **Pack, snapshot, derived & fixture** (`packs/evo_tactics_pack/**`, `data/derived/**`, `examples/`, `reports/`): distinguere pack ufficiali, snapshot/mock/test-fixtures e layout legacy; definire che i pack devono essere rigenerati dai core tramite tooling.
+- **Incoming/backlog/archivio** (`incoming/**`, `docs/incoming/**`, `docs/archive/**`): catalogare materiale attivo vs legacy, applicando etichette di stato (INTEGRATO / DA_INTEGRARE / STORICO) e segmentazione (buffer, legacy, archive_cold).
+- **Documentazione & knowledge base** (`docs/**`, entrypoint top-level come `README.md`, `AGENTS.md`, `MASTER_PROMPT.md`, pipeline): ridurre duplicati, spostare l’obsoleto in `docs/archive/**`, mantenere 1–2 entrypoint chiari per vision, agenti e pipeline.
+- **Tooling, engine, CI & test** (`src/**`, `engine/**`, `apps/**`, `services/**`, `packages/**`, `tools/**`, `scripts/**`, `ops/**`, `.github/workflows/**`, `tests/**`): assicurare che validatori e test usino i core come input principale e identificare workflow/script obsoleti o duplicati.
 
-## 2. Domini nel perimetro
+### Vincoli e priorità
 
-Questa sezione descrive i **domini principali** che il refactor deve toccare.
+- **Fuori scope attuale**: nuove feature di gameplay, riscritture profonde dell’engine/app, redesign di ALIENA; solo organizzazione e allineamento.
+- **Priorità P0**: definire sorgenti di verità per trait/specie/biomi, isolare derived/snapshot/fixture duplicati, catalogare `incoming/**`.
+- **Priorità P1**: consolidare documentazione e allineare tooling/CI ai core e alla rigenerazione dei pack.
+- **Priorità P2**: pulizia naming/slug, riordino `reports/` e script minori.
 
-### 2.1 Dati core & cataloghi
+## Rischi
 
-**Scope:**
+- Violare **STRICT MODE** o Golden Path introducendo modifiche ai core senza patch approvate.
+- Incertezza sui percorsi canonici può creare duplicati tra core, derived e incoming.
+- Aggiornamenti incompleti del tooling/CI possono rompere validatori o workflow esistenti.
+- Mancata tracciabilità dei pack legacy può impedire rollback o rigenerazione affidabile.
 
-- `data/core/**`
-- `data/ecosystems/**`
-- `data/traits/**` e `traits/**` (documentazione trait)
-- `biomes/**`
-- `configs/schemas/**` o equivalente (`schemas/`, `config/`)
+## Dipendenze
 
-**Obiettivo:**
+- Sistema agenti (`AGENTS.md`, `.ai/**`, `router.md`) e Command Library per orchestrare pipeline.
+- Pack ufficiale `packs/evo_tactics_pack` da mantenere compatibile come derivato dei core.
+- Validatori/schema checker esistenti e workflow CI in `.github/workflows/**`.
+- Documenti collegati: `REF_REPO_PATCH_PROPOSTA`, `REF_REPO_SOURCES_OF_TRUTH`, `REF_INCOMING_CATALOG`, `REF_PACKS_AND_DERIVED`, `REF_TOOLING_AND_CI`, `REF_REPO_MIGRATION_PLAN`.
 
-- Identificare, per ogni dominio:
-  - **Trait**: sorgente di verità per glossario, famiglie, pool di bioma.
-  - **Specie**: sorgente di verità per specie/unità/NPC.
-  - **Biomi / ecosistemi**: sorgente di verità per biomi ed ecosistemi giocabili.
-- Allineare i dataset core con lo schema ALIENA (trait, specie, biomi, ST, UCUM).
+## Prossimi passi
 
----
-
-### 2.2 Pack, snapshot, derived & test-fixtures
-
-**Scope:**
-
-- `packs/evo_tactics_pack/**`
-- `data/derived/**` (mock, prod_snapshot, test-fixtures)
-- eventuali struct pack in `packages/`, `examples/`, `reports/`, ecc.
-
-**Obiettivo:**
-
-- Distinguere:
-  - **pack ufficiali** (es. `evo_tactics_pack`) → sempre derivati dai core;
-  - **snapshot** (mock, prod_snapshot, test-fixtures) → usati per test/demo;
-  - **vecchi pack** o layout legacy → candidati per archivio.
-- Definire una regola chiara:
-  - i **core** si modificano a mano;
-  - i **pack/derived** si **rigenerano** da core tramite tooling/script.
+1. Approvare questo scope come riferimento condiviso per tutte le PATCHSET e registrare variazioni nel changelog del file.
+2. Completare i documenti di pianificazione elencati in §6.1 (sources of truth, incoming, pack/derived, tooling/CI, migration plan).
+3. Definire le etichette di stato e la segmentazione di `incoming/**` e `docs/incoming/**` insieme al censimento iniziale.
+4. Mappare i percorsi canonici dei core e le regole di derivazione dei pack in coordinamento con trait/species/biome curators.
+5. Inventariare tooling/CI e validatori per pianificare gli adeguamenti senza regressioni.
+6. Preparare PATCHSET numerati con scope limitato, rischi noti e strategia di rollback coerente con Golden Path.
 
 ---
 
-### 2.3 Incoming, backlog, archivio caldo/freddo
+## Changelog
 
-**Scope:**
-
-- `incoming/**` (pack zip, CSV, YAML, note, template, script)
-- `docs/incoming/**`
-- `docs/archive/**`
-- eventuali `incoming` in altre aree (es. `reports/`, `analytics/`)
-
-**Obiettivo:**
-
-- Catalogare il contenuto di `incoming/**`:
-  - pack già integrati,
-  - pack ancora da integrare,
-  - materiale puramente storico.
-- Introdurre una struttura più esplicita, ad es.:
-  - `incoming/buffer/` → materiale attivo da integrare;
-  - `incoming/legacy/` → materiale vecchio ma ancora utile come riferimento;
-  - `incoming/archive_cold/` → materiale storico che non deve più interferire.
-- Dare una “etichetta di stato” (es. INTEGRATO / DA_INTEGRARE / STORICO) alle
-  principali fonti che impattano trait/specie/biomi.
-
----
-
-### 2.4 Documentazione & knowledge base
-
-**Scope:**
-
-- `docs/**`, in particolare:
-  - `docs/00-INDEX.md` e indici correlati;
-  - `docs/biomes/**`, `docs/species/**`, `docs/traits/**` e manuali;
-  - `docs/evo-tactics-pack/**`;
-  - `docs/archive/**`, `docs/incoming/**`;
-  - `docs/COMMAND_LIBRARY.md`;
-  - `docs/pipelines/**`;
-  - `docs/AI_AGENT_AUDIT_LOG.md`.
-- File top-level:
-  - `README.md`,
-  - `MASTER_PROMPT.md`,
-  - `AGENTS.md`, `AGENT_WORKFLOW_GUIDE.md`,
-  - `agent_constitution.md`, `agent.md`, `router.md`.
-
-**Obiettivo:**
-
-- Ridurre documenti duplicati o superati:
-  - spostare il materiale obsoleto in `docs/archive/**`;
-  - mantenere 1–2 **entrypoint chiari** per:
-    - vision/overview (es. `README.md`, `docs/01-VISIONE.md`),
-    - sistema agenti (es. `AGENTS.md`, `AGENT_WORKFLOW_GUIDE.md`),
-    - pipeline (es. `docs/pipelines/GOLDEN_PATH.md`).
-- Allineare la documentazione al **sorgente di verità dei dati**:
-  - evitare di mantenere a mano copie dei cataloghi in `docs/` se possono
-    essere generate o referenziate direttamente da `data/core/**`.
-
----
-
-### 2.5 Tooling, engine, CI & test
-
-**Scope:**
-
-- Codice e runtime:
-  - `src/**`, `engine/**`, `apps/**`, `webapp/**`, `Trait Editor/**`,
-  - `services/**`, `packages/**`.
-- Tooling & script:
-  - `tools/**`, `scripts/**`, `ops/**`.
-- Config & schema:
-  - `config/**`, `schemas/**`.
-- CI & test:
-  - `.github/workflows/**`,
-  - `tests/**`, fixture in `data/derived/**`,
-  - qualunque validatore/schema-checker (es. `schema-validate`, ecc.).
-
-**Obiettivo:**
-
-- Allineare tooling e CI alla nuova struttura:
-  - i validatori devono usare i **core** come input principale;
-  - i test devono usare fixture consolidate e non snapshot duplicati.
-- Identificare script/workflow **obsoleti, duplicati o sperimentali** da:
-  - spostare in archivio,
-  - o consolidare in pochi comandi standard.
-
----
-
-## 3. Fuori scope (per questo ciclo di refactor)
-
-Le seguenti attività NON sono obiettivo diretto di questo refactor (possono
-emergere come follow-up, ma non guidano le decisioni):
-
-- Design di **nuove feature di gameplay** (nuovi biomi/specie/trait).
-- Riscrittura profonda dell’engine o delle app (es. migrazioni framework).
-- Refactor di “stile” sui testi di lore (solo organizzazione, non contenuto).
-- Evoluzione del **framework ALIENA** (solo applicazione alle strutture dati
-  esistenti, non redesign concettuale).
-
----
-
-## 4. Vincoli principali
-
-1. **STRICT MODE**
-   - Nessuna modifica diretta ai file.
-   - Qualsiasi cambiamento strutturale deve essere proposto come
-     **patch_proposta** (diff) e approvato prima di essere applicato.
-
-2. **Compatibilità Golden Path**
-   - Le pipeline in `docs/pipelines/GOLDEN_PATH*.md` devono restare valide
-     come concetto e come entrypoint.
-   - Il sistema di agenti (`AGENTS.md`, `agent_constitution.md`, `.ai/**`)
-     deve rimanere allineato ai file che descrivono il repo.
-
-3. **Pack esistenti**
-   - `packs/evo_tactics_pack` è considerato un pack **ufficiale**.
-   - Qualsiasi refactor che impatta i suoi asset deve:
-     - essere tracciato,
-     - prevedere, se possibile, una rigenerazione automatica dal core.
-
-4. **CI, test e validazione**
-   - I workflow `.github/workflows/**` non devono essere rotti senza un piano
-     di aggiornamento.
-   - I validatori di schema devono continuare a poter verificare i core
-     e, dove ha senso, i pack derivati.
-
-5. **ALIENA & metriche UCUM**
-   - I dataset strutturati (trait, specie, biomi, ecosistemi) devono rimanere
-     compatibili con:
-     - lo schema ALIENA (trait species-agnostici, specie, biomi/ecosistemi),
-     - le metriche in UCUM (nessuna regressione sui campi di misura).
-
----
-
-## 5. Priorità (P0 / P1 / P2)
-
-**P0 – Bloccanti / fondamentali**
-
-- Definire le **sorgenti di verità** per:
-  - trait,
-  - specie,
-  - biomi ed ecosistemi.
-- Mappare e isolare i dataset **derived/snapshot/test-fixtures** che duplicano
-  i core.
-- Catalogare e contenere il rumore in `incoming/**` e `docs/incoming/**`.
-
-**P1 – Importanti ma non bloccanti**
-
-- Consolidare la **documentazione**:
-  - entrypoint chiari per agenti, Golden Path, cataloghi.
-- Allineare tooling/CI in modo che:
-  - test e validatori usino i core come input principale,
-  - i pack vengano rigenerati da core.
-
-**P2 – Nice to have**
-
-- Pulizia e standardizzazione di naming, slug, ecc. (compatibili con ALIENA).
-- Migliorare la struttura di `reports/`, `analytics/`, log di playtest.
-- Mikro-refactor su script e workflow minori.
-
----
-
-## 6. Output attesi dal refactor
-
-A valle delle pipeline di refactor, ci si aspetta di avere:
-
-1. Un set di **documenti di pianificazione**:
-   - `REF_REPO_SOURCES_OF_TRUTH.md`
-   - `REF_INCOMING_CATALOG.md`
-   - `REF_PACKS_AND_DERIVED.md`
-   - `REF_TOOLING_AND_CI.md`
-   - `REF_REPO_MIGRATION_PLAN.md`
-
-2. Una struttura del repo più chiara:
-   - `data/core/**` come unico spazio canonico per i dati giocabili;
-   - `packs/**` generati dai core;
-   - `data/derived/**` confinato a snapshot/test dentro regole precise;
-   - `incoming/**` e `docs/archive/**` ripuliti e segmentati.
-
-3. Un set di **patchset numerati** (PATCHSET-01, 02, …) con:
-   - scope limitato,
-   - rischi noti,
-   - eventuale strategia di rollback.
-
----
-
-## 7. Collegamento con Golden Path & sistema agenti
-
-- Il refactor viene gestito come una “mega feature infrastrutturale” sotto
-  il **GOLDEN_PATH**:
-  - Fase 0: definizione scope (questo documento).
-  - Fase 1–N: pipeline dedicate (incoming, core/pack, docs, tooling/CI).
-
-- Agenti coinvolti:
-  - **coordinator**: orchestrazione pipeline, prioritizzazione.
-  - **archivist**: mappatura file, cataloghi, versioni.
-  - **dev-tooling**: agreggio script, validatori, CI.
-  - **trait-curator / species-curator / biome-ecosystem-curator**:
-    - allineamento semantico dei dataset core con ALIENA.
-  - **asset-prep** (se necessario): mappatura asset visivi/esterni.
-
-Questo documento è la base condivisa per tutte le **PATCHSET** successive.
-Eventuali cambiamenti di scope rilevanti vanno aggiunti come sezione “Changelog”
-in coda a questo file.
+- 2025-11-23: versione iniziale del perimetro di refactor (coordinator).

--- a/docs/planning/REF_REPO_SOURCES_OF_TRUTH.md
+++ b/docs/planning/REF_REPO_SOURCES_OF_TRUTH.md
@@ -1,25 +1,48 @@
-# REF_REPO_SOURCES_OF_TRUTH – Stub PATCHSET-00
+# REF_REPO_SOURCES_OF_TRUTH – Canonico dati core
 
 Versione: 0.1 (bozza)
 Data: 2025-11-23
 Owner: agente **archivist** (supporto: trait-curator, species-curator, biome-ecosystem-curator)
-Stato: DRAFT – struttura da completare prima del censimento dei dataset core
+Stato: DRAFT – censimento sorgenti di verità
 
 ---
 
-## Scopo
+## Obiettivi
 
-Definire le sorgenti di verità per trait, specie, biomi/ecosistemi e schemi correlati, come richiesto da `REF_REPO_SCOPE` (§2.1, §6.1).
+- Identificare le sorgenti di verità per trait, specie, biomi/ecosistemi e schemi correlati.
+- Stabilire la relazione tra dati strutturati (`data/core/**`, `data/ecosystems/**`, `data/traits/**`) e documentazione (`traits/**`, `docs/**`).
+- Definire lo standard di convalida (schema **ALIENA**, metriche UCUM) e i validatori da applicare ai core.
 
-## Sezioni da compilare
+## Stato attuale
 
-- Panoramica dei dataset core (`data/core/**`, `data/ecosystems/**`, `data/traits/**`, `biomes/**`).
-- Allineamento con schema ALIENA e metriche UCUM.
-- Relazione tra dati core e documentazione (`traits/**`, `docs/**`).
-- Mappa dei validatori/schema da usare sui core.
-- Rischi e gap noti (bloccanti/P0).
+- I dataset core sono distribuiti fra `data/core/**`, `data/ecosystems/**`, `data/traits/**`, `biomes/**` e documentazione descrittiva in `traits/**` e `docs/`.
+- Non esiste ancora una tabella unica che dichiari, per dominio, il file o la cartella canonica e la relativa versione.
+- I validatori/schema-checker esistono ma non sono centralizzati in un elenco e potrebbero riferirsi a snapshot legacy.
+- La compatibilità con ALIENA è un requisito implicito, non ancora verificato campo per campo.
 
-## Note operative
+## Rischi
 
-- Nessuna modifica ai dati core in PATCHSET-00.
-- I riferimenti ai pack derivati vanno rinviati al documento `REF_PACKS_AND_DERIVED.md`.
+- Duplicati o versioni divergenti tra core e documentazione possono generare pack incoerenti.
+- Validatori obsoleti potrebbero accettare dati non conformi allo schema aggiornato o rifiutare core validi.
+- Assenza di owner per dominio (trait/specie/biomi) rallenta il triage e l’allineamento con altre pipeline.
+
+## Dipendenze
+
+- Schema ALIENA e metriche UCUM per i controlli di struttura e unità di misura.
+- `REF_PACKS_AND_DERIVED` per garantire che i pack derivino solo dai core canonici.
+- `REF_TOOLING_AND_CI` per legare i validatori ai percorsi core e alla CI.
+- Coordinamento con `REF_INCOMING_CATALOG` per evitare che materiale non classificato entri come sorgente di verità.
+
+## Prossimi passi
+
+1. Redigere una tabella per dominio (trait, specie, biomi/ecosistemi) che indichi percorso canonico, formato e owner.
+2. Elencare i validatori/schema-checker disponibili, specificando input atteso e posizione degli schemi.
+3. Eseguire un check rapido di conformità ad ALIENA/UCUM sui core per identificare gap critici (solo report, nessuna modifica dati).
+4. Mappare dove la documentazione riporta copie manuali dei cataloghi e segnare quali voci devono diventare derivate/rigenerate.
+5. Collegare la tabella alle regole di derivazione dei pack in `REF_PACKS_AND_DERIVED` e alle pipeline CI in `REF_TOOLING_AND_CI`.
+
+---
+
+## Changelog
+
+- 2025-11-23: struttura iniziale e linee guida di censimento (archivist).

--- a/docs/planning/REF_TOOLING_AND_CI.md
+++ b/docs/planning/REF_TOOLING_AND_CI.md
@@ -1,24 +1,47 @@
-# REF_TOOLING_AND_CI – Stub PATCHSET-00
+# REF_TOOLING_AND_CI – Allineamento tooling e CI
 
 Versione: 0.1 (bozza)
 Data: 2025-11-23
 Owner: agente **dev-tooling** (supporto: archivist, coordinator)
-Stato: DRAFT – struttura per allineare tooling/CI al nuovo assetto
+Stato: DRAFT – allineare tooling/CI al nuovo assetto
 
 ---
 
-## Scopo
+## Obiettivi
 
-Raccogliere i workflow di validazione, test e generazione pack da adeguare al refactor, mantenendo compatibilità con Golden Path (`REF_REPO_SCOPE` §2.5, §4, §6.1).
+- Inventariare workflow CI, validatori e script di generazione pack per verificarne l’aderenza ai percorsi core e alle nuove regole di derivazione.
+- Definire una checklist di compatibilità che eviti regressioni su test, schema-checker e pipeline Golden Path.
+- Pianificare gli adeguamenti necessari per usare `data/core/**` come input primario e rigenerare i pack in modo ripetibile.
 
-## Sezioni da compilare
+## Stato attuale
 
-- Inventario workflow CI (.github/workflows) e dipendenze su dati core/derived.
-- Script/tooling in `tools/**`, `scripts/**`, `ops/**` rilevanti per pack/validazione.
-- Gap e rischi (es. schema-checker, fixture obsolete) con priorità P0/P1.
-- Linee guida per aggiornare validatori a usare `data/core/**` come input primario.
+- I workflow `.github/workflows/**` e gli script in `tools/**`, `scripts/**`, `ops/**` non sono correlati a un inventario unico.
+- Non è chiaro quali validatori usino core vs snapshot, né quali fixture in `data/derived/**` siano considerate canoniche per i test.
+- Mancano indicazioni su come i workflow interagiscano con `packs/evo_tactics_pack` e con eventuali pack legacy.
 
-## Note operative
+## Rischi
 
-- Nessun cambiamento ai workflow in PATCHSET-00: solo mappatura e piano.
-- Coordinarsi con `REF_PACKS_AND_DERIVED.md` per regole di rigenerazione pack.
+- Test o validatori possono puntare a snapshot obsoleti, mascherando regressioni sui core.
+- Rigenerazioni manuali o non documentate dei pack possono rompere la CI o la compatibilità con ALIENA/UCUM.
+- Assenza di ownership sugli script può bloccare la manutenzione o lasciare step critici non automatizzati.
+
+## Dipendenze
+
+- `REF_REPO_SOURCES_OF_TRUTH` per sapere quali percorsi core devono essere convalidati.
+- `REF_PACKS_AND_DERIVED` per le regole di rigenerazione dei pack e la classificazione delle fixture.
+- `REF_REPO_MIGRATION_PLAN` per schedulare gli adeguamenti tooling/CI per patchset.
+- Coordinamento con coordinator e archivist per prioritizzare P0/P1 e per evitare rotture del Golden Path.
+
+## Prossimi passi
+
+1. Elencare i workflow CI e gli script rilevanti con input, output, dipendenze e owner.
+2. Mappare quali validatori/schema-checker usano core vs derived e verificare la presenza degli schemi aggiornati.
+3. Definire una checklist minima per la rigenerazione dei pack (comandi, prerequisiti, validazioni) da integrare in CI o documentazione.
+4. Identificare fixture `data/derived/**` critiche per i test e pianificare la loro sostituzione con versioni rigenerate dai core.
+5. Proporre aggiornamenti incrementali ai workflow CI, allineandoli con i patchset definiti nel piano di migrazione.
+
+---
+
+## Changelog
+
+- 2025-11-23: struttura iniziale di inventario tooling/CI (dev-tooling).


### PR DESCRIPTION
## Summary
- Completed the planning references by adding objectives, current state, risks, dependencies, and numbered next steps across the repository refactor documents.
- Clarified PATCHSET-00 expectations and migration sequencing to align incoming cataloging, core sources of truth, derived packs, and tooling/CI readiness.

## Testing
- `npx prettier --write docs/planning/REF_*.md`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923878d6f0c8328aedeff158926e823)