### PR TITLE
Update packs and derived reference to v0.3

### DIFF
--- a/docs/planning/REF_PACKS_AND_DERIVED.md
+++ b/docs/planning/REF_PACKS_AND_DERIVED.md
@@ -1,7 +1,7 @@
 # REF_PACKS_AND_DERIVED – Pack, snapshot e fixture
 
-Versione: 0.1 (bozza)
-Data: 2025-11-23
+Versione: 0.3
+Data: 2025-11-24
 Owner: agente **archivist** (supporto: dev-tooling, coordinator)
 Stato: DRAFT – separazione core vs derived
 
@@ -33,19 +33,18 @@ Stato: DRAFT – separazione core vs derived
 - `REF_REPO_MIGRATION_PLAN` per decidere quando archiviare o rigenerare specifici derived.
 - Supporto di dev-tooling per standardizzare i comandi di rigenerazione e di coordinator per le priorità.
 
-## Prossimi passi
+## Prerequisiti (patchset)
 
-1. Redigere una tabella dei pack ufficiali e derived con colonne: percorso, tipo (ufficiale/snapshot/fixture/legacy), origine dai core, owner, rischio.
-2. Documentare il processo di rigenerazione di `packs/evo_tactics_pack` e verificare se esiste tooling automatizzato o manuale.
-3. Inventariare `data/derived/**` specificando quali directory sono fixture di test e quali snapshot legacy da archiviare.
-4. Collegare ciascun derived ai test/CI che lo consumano, segnando l’impatto di eventuale rigenerazione.
-5. Proporre criteri di deprecazione/archiviazione per pack/derived non più supportati, da attuare nelle patch successive.
+- **PATCHSET-01A – Catalogo incoming**: fornisce l'inventario dei sorgenti core da usare come input per rigenerare pack e fixture.
+- **PATCHSET-02A – Tooling di validazione**: abilita la modalità report/gate dei validator (pack e core) da eseguire prima e dopo la derivazione.
 
 ---
 
 ## Changelog
 
-- 2025-11-23: struttura iniziale separazione core vs derived (archivist).
+- 2025-11-23: versione 0.1 – struttura iniziale separazione core vs derived (archivist).
+- 2025-11-23: versione 0.2 – prime tabelle di inventario e regola base di rigenerazione (archivist).
+- 2025-11-24: versione 0.3 – inventario ampliato con file/dir chiave, mappa tooling per ogni step e collegamento ai prerequisiti 01A/02A (archivist).
 
 ---
 
@@ -53,34 +52,35 @@ Stato: DRAFT – separazione core vs derived
 
 ### `data/core/**`
 
-| Percorso / file chiave                                           | Relazione di derivazione                                                                         | Lacune note                                                                                                                |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `data/core/species.yaml` + `species/aliases.json`                | Fonte primaria del catalogo specie e mapping alias; atteso come sorgente per pack e fixture.     | Mancano note su release/tag a cui allineare derived e pack; nessuna checklist di validazione pre-rigenerazione.            |
-| `data/core/traits/glossary.json`, `traits/biome_pools.json`      | Glossari e pool biomi da cui derivare cataloghi e coperture env-trait.                           | Non è documentato come generare output di copertura (es. `env_traits.json` nel pack) né quali script usarli.               |
-| `data/core/biomes.yaml`, `biome_aliases.yaml`                    | Sorgente canonica per biomi e alias; dovrebbe alimentare ecosistemi/foodweb nel pack.            | Assenza di nota sul mapping verso file `data/ecosystems/*.yaml` del pack; non c'è pipeline per garantire sincronizzazione. |
-| `data/core/mating.yaml`, `telemetry.yaml`, `game_functions.yaml` | Tabelle core per compatibilità, telemetria e funzioni di gioco.                                  | Nessun consumer dichiarato nei pack/derived; serve mappa utilizzi.                                                         |
-| `data/core/missions/skydock_siege.yaml`                          | Missione core che dovrebbe essere referenziata nei report `data/derived/analysis/progression/*`. | Mancano script riproducibili per rigenerare i report progression da questa fonte.                                          |
-| `data/core/hud/layout.yaml`                                      | Layout HUD core.                                                                                 | Non è chiaro se sia utilizzato in pack o fixture; assente nota di derivazione.                                             |
+| Percorso / file chiave                                                               | Relazione di derivazione                                                                                     | Lacune note                                                                                                                                        |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data/core/species.yaml` + `data/core/species/aliases.json`                          | Fonte primaria del catalogo specie e mapping alias; atteso come sorgente per pack e fixture.                 | Mancano note su release/tag a cui allineare derived/pack; nessuna checklist di validazione pre-rigenerazione.                                      |
+| `data/core/traits/glossary.json`, `data/core/traits/biome_pools.json`                | Glossari e pool biomi da cui derivare cataloghi (pack docs/catalog) e coperture env-trait.                   | Non è documentato come generare output di copertura (es. `docs/catalog/env_traits.json` del pack) né quali script usare.                           |
+| `data/core/biomes.yaml`, `data/core/biome_aliases.yaml`                              | Sorgente canonica per biomi e alias; dovrebbe alimentare ecosistemi/foodweb nel pack.                        | Assenza di nota sul mapping verso `packs/evo_tactics_pack/data/ecosystems/*.yaml` e `data/foodwebs/*.yaml`; pipeline di sincronizzazione mancante. |
+| `data/core/mating.yaml`, `data/core/telemetry.yaml`, `data/core/game_functions.yaml` | Tabelle core per compatibilità, telemetria e funzioni di gioco; servono per snapshot/mock e validatori pack. | Non esiste mappa utilizzi nei derived; necessario dichiarare consumer (CI, pack, report).                                                          |
+| `data/core/missions/skydock_siege.yaml`                                              | Missione core che dovrebbe alimentare i report `data/derived/analysis/progression/*`.                        | Manca script riproducibile per rigenerare i report progression da questa fonte.                                                                    |
+| `data/core/hud/layout.yaml`                                                          | Layout HUD core.                                                                                             | Non è chiaro se sia utilizzato in pack o fixture; assente nota di derivazione.                                                                     |
 
 ### `data/derived/**`
 
-| Percorso / file chiave                                                                                                | Relazione di derivazione                                                                     | Lacune note                                                                                    |
-| --------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `analysis/trait_coverage_matrix.csv`, `trait_env_mapping.json`, `trait_gap_report.json`, `trait_coverage_report.json` | Dovrebbero essere calcolati da `data/core/traits/**` e specie core per analisi QA.           | Non è documentato lo script di generazione; manca timestamp/owner e legame con i test.         |
-| `analysis/progression/skydock_siege_xp*.{csv,json}`                                                                   | Snapshot analitico presumibilmente derivato da `data/core/missions/skydock_siege.yaml`.      | Nessuna procedura per rigenerare i report; rischio divergenza con missione core.               |
-| `exports/qa-telemetry-export.json`, `exports/*conversation.json`                                                      | Export conversazioni/telemetria da sessioni QA, probabilmente generate da strumenti esterni. | Origine e formato non documentati; non chiaro se rigenerabili o solo archivi.                  |
-| `mock/prod_snapshot/*` (biomes, species, telemetry, mating, packs)                                                    | Snapshot manuale della directory `data/` tramite rsync come fallback deploy.                 | Rigenerazione descritta solo in README con comando rsync; manca versione/controllo integrità.  |
-| `test-fixtures/minimal/*`                                                                                             | Dataset sintetico per test frontend (`docs/test-interface`).                                 | Procedura di aggiornamento non documentata; necessaria nota sugli impatti sui test end-to-end. |
+| Percorso / file chiave                                                                                                                                    | Relazione di derivazione                                                                                               | Lacune note                                                                                    |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `data/derived/analysis/trait_coverage_matrix.csv`, `trait_env_mapping.json`, `trait_coverage_report.json`, `trait_gap_report.json`, `trait_baseline.yaml` | Dovrebbero essere calcolati da `data/core/traits/**` (più specie core) per analisi QA di copertura/gap.                | Script di generazione non documentato; mancano timestamp/owner e collegamento ai test.         |
+| `data/derived/analysis/progression/skydock_siege_xp*.{csv,json}`                                                                                          | Snapshot analitico presumibilmente derivato da `data/core/missions/skydock_siege.yaml`.                                | Nessuna procedura per rigenerare i report; rischio divergenza con missione core.               |
+| `data/derived/exports/qa-telemetry-export.json`, `data/derived/exports/*conversation.json`                                                                | Export conversazioni/telemetria da sessioni QA, probabilmente generate da strumenti esterni.                           | Origine e formato non documentati; non chiaro se rigenerabili o solo archivi.                  |
+| `data/derived/mock/prod_snapshot/*` (biomes, species, telemetry, mating, packs)                                                                           | Snapshot manuale della directory `data/` tramite rsync come fallback deploy.                                           | Rigenerazione descritta solo in README con comando rsync; manca versione/controllo integrità.  |
+| `data/derived/test-fixtures/minimal/*`                                                                                                                    | Dataset sintetico per test frontend (`docs/test-interface`); dovrebbe essere estratto in modo deterministico dai core. | Procedura di aggiornamento non documentata; necessaria nota sugli impatti sui test end-to-end. |
 
 ### `packs/evo_tactics_pack/**`
 
-| Percorso / file chiave                                                                                             | Relazione di derivazione                                                                                         | Lacune note                                                                                                                          |
-| ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `data/species.yaml`, `data/ecosystems/*.yaml`, `data/foodwebs/*.yaml`, `data/ecosistemi/*.yaml`, `data/npg/*.json` | Dataset pack ufficiale, dovrebbe riflettere core specie/biomi e reti trofiche derivate.                          | Assente regola esplicita di sincronizzazione con `data/core/**`; non chiaro se dati vengono generati da script o curati manualmente. |
-| `docs/catalog/*.json` (catalogo, glossary, env_traits)                                                             | Cataloghi per generatori web; `update_evo_pack_catalog.js` arricchisce dati partendo dal pack e meta_ecosistema. | Manca dipendenza dichiarata verso core; non è specificato quando rigenerare rispetto a cambiamenti di traits/biomi core.             |
-| `validators/rules/*.py`, `tools/py/*.py`                                                                           | Validator e utilità per specie/ecosistemi/foodweb; `run_all_validators.py` esegue bundle di check.               | Non esiste pipeline documentata che li esegua su build pack; outcome solo in `out/validation/last_report.*` senza contesto.          |
-| `out/validation/last_report.{html,json}`                                                                           | Ultima esecuzione validator sul pack.                                                                            | Non è noto quale comando l'abbia prodotto né la data; serve procedura ripetibile.                                                    |
-| `tools/config/*.yaml`                                                                                              | Configurazioni per validator/generatori (es. preferenze specie).                                                 | Non legate a versioni core; rischio disallineamento se cambia schema core.                                                           |
+| Percorso / file chiave                                                                                                                    | Relazione di derivazione                                                                                                 | Lacune note                                                                                                                          |
+| ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `packs/evo_tactics_pack/data/species.yaml`, `data/ecosystems/*.yaml`, `data/foodwebs/*.yaml`, `data/ecosistemi/*.yaml`, `data/npg/*.json` | Dataset pack ufficiale, dovrebbe riflettere core specie/biomi e reti trofiche derivate.                                  | Assente regola esplicita di sincronizzazione con `data/core/**`; non chiaro se dati vengono generati da script o curati manualmente. |
+| `packs/evo_tactics_pack/docs/catalog/*.json` (catalogo, glossary, env_traits)                                                             | Cataloghi per generatori web; `scripts/update_evo_pack_catalog.js` arricchisce dati partendo dal pack e meta ecosistema. | Manca dipendenza dichiarata verso i core; non è specificato quando rigenerare rispetto a cambiamenti di traits/biomi core.           |
+| `packs/evo_tactics_pack/tools/py/derive_env_traits_v1_0.py`, `derive_crossbiome_traits_v1_0.py`                                           | Script Python per derivare set di trait ambientali/cross-biome a partire dal pack/core.                                  | Assenza di pipeline ufficiale che li esegua prima di build/catalog; log di esecuzione non tracciati.                                 |
+| `packs/evo_tactics_pack/validators/rules/*.py`, `packs/evo_tactics_pack/tools/py/run_all_validators.py`                                   | Validator specie/ecosistemi/foodweb; `run_all_validators.py` esegue bundle di check con output in `out/validation/`.     | Non esiste pipeline documentata che li esegua su build pack; outcome solo in `out/validation/last_report.*` senza contesto.          |
+| `packs/evo_tactics_pack/out/validation/last_report.{html,json}`                                                                           | Ultima esecuzione validator sul pack.                                                                                    | Non è noto quale comando l'abbia prodotta né la data; serve procedura ripetibile.                                                    |
+| `packs/evo_tactics_pack/tools/config/*.yaml`                                                                                              | Configurazioni per validator/generatori (es. preferenze specie).                                                         | Non legate a versioni core; rischio disallineamento se cambia schema core.                                                           |
 
 ---
 
@@ -90,7 +90,7 @@ Stato: DRAFT – separazione core vs derived
   - `scripts/update_evo_pack_catalog.js` (arricchisce catalogo partendo dai dati del pack e metadati ecosistemi).
   - `scripts/sync_evo_pack_assets.js` (sincronizza asset collegati ai dati del pack).
   - `scripts/build_evo_tactics_pack_dist.mjs` / `scripts/preview_evo_tactics_pack_dist.mjs` (impacchettano il pack per distribuzione/anteprima).
-- Validator pack (specie/ecosistemi/foodweb) eseguibili con `packs/evo_tactics_pack/tools/py/run_all_validators.py`; risultato atteso in `out/validation/`.
+- Validator pack (specie/ecosistemi/foodweb) eseguibili con `packs/evo_tactics_pack/tools/py/run_all_validators.py`; risultato atteso in `packs/evo_tactics_pack/out/validation/`.
 - Snapshot mock `data/derived/mock/prod_snapshot/*` → rigenerabili manualmente via `rsync -a --exclude 'mock' data/ data/derived/mock/prod_snapshot/` come da README.
 - Dataset `data/derived/test-fixtures/minimal` → rigenerazione da definire; necessita script/templating che estragga subset coerente da core (da creare).
 - Report `data/derived/analysis/**` (trait coverage/gap, progression) → nessuno script individuato in `scripts/` o `tools/`; servono generatori dedicati (es. `scripts/analysis/trait_coverage` e `scripts/analysis/progression_skydock`) per ridurre rischio divergenza.
@@ -99,12 +99,16 @@ Stato: DRAFT – separazione core vs derived
 
 ## Regola standard di rigenerazione (proposta)
 
-1. **Input canonici**: `data/core/**` (specie, traits, biomi, telemetry, missions) + configurazioni `tools/config`/`packs/evo_tactics_pack/tools/config` quando applicabile.
-2. **Pre-check**: validare gli input core con validator/schema esistenti (es. `scripts/validate.sh`, `tools/traits/`, validator Py del pack) e bloccare rigenerazione in caso di errori.
-3. **Pipeline di derivazione**:
-   - a) Generare dataset pack: eseguire script di arricchimento/catalogo (`scripts/update_evo_pack_catalog.js`), poi build/anteprima (`scripts/build_evo_tactics_pack_dist.mjs` o `scripts/preview_evo_tactics_pack_dist.mjs`), infine validator `packs/evo_tactics_pack/tools/py/run_all_validators.py` con output in `packs/evo_tactics_pack/out/validation/`.
-   - b) Generare fixture/snapshot: se serve fallback deploy, copiare core → `data/derived/mock/prod_snapshot/` con rsync; per fixture test creare subset riproducibile (script da aggiungere) che esporti pacchetti minimal in `data/derived/test-fixtures/`.
-   - c) Generare report analitici: introdurre script dedicati che leggano core (es. traits/missioni) e scrivano in `data/derived/analysis/` con metadati timestamp/owner.
+1. **Input canonici**: `data/core/**` (specie, traits, biomi, telemetry, missions) + configurazioni `tools/config`/`packs/evo_tactics_pack/tools/config` quando applicabile (dipendenza PATCHSET-01A per catalogo completo).
+2. **Pre-check**: validare gli input core con validator/schema esistenti (`scripts/validate.sh`, `scripts/validate-dataset.cjs`, validator Python del pack in modalità report-only – PATCHSET-02A) e bloccare rigenerazione in caso di errori.
+3. **Pipeline di derivazione** (step + copertura tooling attuale):
+   - a) **Allineare dataset pack** da core → `packs/evo_tactics_pack/data/**`: _gap_ (manca script di sync core→pack; oggi manuale).
+   - b) **Derivare trait/env cross-biome** → `packs/evo_tactics_pack/tools/py/derive_env_traits_v1_0.py`, `derive_crossbiome_traits_v1_0.py`: script esistenti ma non orchestrati in pipeline.
+   - c) **Arricchire catalogo pack** → `scripts/update_evo_pack_catalog.js` (usa dati pack + meta ecosistemi) e `scripts/sync_evo_pack_assets.js` (asset correlati).
+   - d) **Build/anteprima distributivo** → `scripts/build_evo_tactics_pack_dist.mjs` o `scripts/preview_evo_tactics_pack_dist.mjs`.
+   - e) **Validator pack** → `packs/evo_tactics_pack/tools/py/run_all_validators.py` (esegue regole in `validators/rules/`); output in `out/validation/` (Prereq PATCHSET-02A per gating CI).
+   - f) **Fixture/snapshot** → `rsync` per `data/derived/mock/prod_snapshot/` (fallback deploy); _gap_ per generare dataset sintetici `data/derived/test-fixtures/minimal/` da core.
+   - g) **Report analitici** (`data/derived/analysis/**`) → _gap_ totale: servono script dedicati per trait coverage e progression.
 4. **Output**: pack aggiornato (`packs/evo_tactics_pack/data/**` + `docs/catalog/**`), fixture (`data/derived/test-fixtures/**`), snapshot (`data/derived/mock/**`), report (`data/derived/analysis/**`). Ogni output deve includere log di comando e timestamp nel README locale.
 5. **Tracciabilità**: registrare comando, versione git e checksum principali nel README di ciascuna cartella derived/pack; allegare report validator in `out/validation/` e linkarlo nella documentazione.
-6. **Gate CI**: integrare la pipeline in CI dopo validazione manuale del flusso, facendo fallire build se gli output non sono aggiornati rispetto ai core o se i validator del pack falliscono.
+6. **Gate CI**: integrare la pipeline in CI dopo validazione manuale del flusso, facendo fallire build se gli output non sono aggiornati rispetto ai core o se i validator del pack falliscono (allineato con PATCHSET-02A).


### PR DESCRIPTION
## Descrizione
- Aggiorna `docs/planning/REF_PACKS_AND_DERIVED.md` alla versione 0.3 con inventario ampliato di core/derived/pack, prerequisiti 01A/02A e mappa tooling per la rigenerazione.

## Checklist guida stile & QA
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato
- [x] Documentazione/processi aggiornati ove necessario

## Testing
- [ ] `npm run style:check`
- [ ] Altro: non eseguito; modifica di documentazione

## Note
- Nessuna nota aggiuntiva.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692393bc888483288ceb05b6720e95ca)