### PR TITLE
Clarify numbering and ownership for REF_REPO_PATCH_PROPOSTA

### DIFF
--- a/docs/planning/REF_REPO_PATCH_PROPOSTA.md
+++ b/docs/planning/REF_REPO_PATCH_PROPOSTA.md
@@ -1,8 +1,8 @@
 # REF_REPO_PATCH_PROPOSTA – Applicazione iniziale dello scope
 
-Versione: 0.1 (bozza)
-Data: 2025-11-23
-Owner: agente **archivist** (coordinamento con coordinator/dev-tooling)
+Versione: 0.2 (design completato)
+Data: 2025-11-24
+Owner: **Documentazione (referente umano: Laura B.)** – coordinamento con coordinator/dev-tooling
 Stato: PROPOSTA – patch da validare
 
 ---
@@ -11,8 +11,17 @@ Stato: PROPOSTA – patch da validare
 
 Tradurre `REF_REPO_SCOPE` in **PATCHSET-00**: una proposta neutrale che non altera i dati core ma prepara la struttura di documentazione e cataloghi per i refactor successivi.
 
+La numerazione delle uscite successive resta agganciata alla sequenza 01A–03B per il rollout graduale dopo approvazione.
+
+## Numerazione e riferimenti
+
+- Questa proposta è etichettata **PATCHSET-00** e mantiene l’allineamento con la sequenza di rollout 01A–03B prevista in `REF_REPO_SCOPE`.
+- I documenti collegati (scope, migration plan, incoming catalog) devono riportare la stessa nomenclatura 01A–03B per evitare divergenze di numbering.
+- Ogni nota di stato o approvazione deve citare esplicitamente il passo della sequenza (es. “01A approvata”, “03B in review”).
+
 ## Stato attuale
 
+- **0.2 completato (design)**; in attesa di approvazione per esecuzione delle fasi 01A–03B.
 - Deliverable proposti sono limitati a documentazione e mappature, senza toccare `data/core/**`, `packs/**` o tooling.
 - Gli stub richiesti in §6.1 di `REF_REPO_SCOPE` esistono ma vanno completati con sezioni operative.
 - Le cartelle `incoming/` e `docs/incoming/` sono solo censite; manca una tabella di stato condivisa.
@@ -30,13 +39,19 @@ Tradurre `REF_REPO_SCOPE` in **PATCHSET-00**: una proposta neutrale che non alte
 - Allineamento con `REF_INCOMING_CATALOG` e `REF_PACKS_AND_DERIVED` per evitare sovrapposizioni.
 - Coinvolgimento di coordinator, archivist e dev-tooling per convalida e rollout.
 
+## Prerequisiti generali
+
+- Ogni PATCHSET applicativa deve partire da un branch dedicato per garantire tracciabilità e rollback controllato.
+- Loggare le attività dell’agente su `logs/agent_activity.md` per mantenere audit trail e handoff tra owner umani.
+- Ogni documento di pianificazione deve riportare l’owner umano responsabile e l’aggiornamento va registrato nel log quando la numerazione 01A–03B cambia di stato.
+
 ## Prossimi passi
 
-1. Validare formalmente PATCHSET-00 come change-set neutrale e approvare la struttura dei sei documenti di pianificazione.
-2. Popolare `REF_INCOMING_CATALOG` con la tabella di stato condivisa per `incoming/` e `docs/incoming/`, nominando un owner.
-3. Collegare `REF_REPO_SOURCES_OF_TRUTH` e `REF_PACKS_AND_DERIVED` con i percorsi canonici dei core e i criteri di derivazione.
-4. Allineare `REF_TOOLING_AND_CI` sugli impatti nulli di PATCHSET-00 e preparare la checklist di compatibilità per PATCHSET-01.
-5. Aggiornare `REF_REPO_MIGRATION_PLAN` con le exit/entry criteria e i trigger per passare da PATCHSET-00 a PATCHSET-01/02.
+1. Validare formalmente PATCHSET-00 come change-set neutrale e approvare la struttura dei sei documenti di pianificazione. **Owner umano:** Laura B. (coordinator in supporto) – riferimento 01A.
+2. Popolare `REF_INCOMING_CATALOG` con la tabella di stato condivisa per `incoming/` e `docs/incoming/`, nominando un owner umano di riferimento (Laura B.) e collegando la voce di stato alla fase 01B/02A.
+3. Collegare `REF_REPO_SOURCES_OF_TRUTH` e `REF_PACKS_AND_DERIVED` con i percorsi canonici dei core e i criteri di derivazione. **Owner umano:** Laura B. (supporto dev-tooling) – allineamento con 02B.
+4. Allineare `REF_TOOLING_AND_CI` sugli impatti nulli di PATCHSET-00 e preparare la checklist di compatibilità per PATCHSET-01. **Owner umano:** Laura B. – riferimento 03A.
+5. Aggiornare `REF_REPO_MIGRATION_PLAN` con le exit/entry criteria e i trigger per passare da PATCHSET-00 a PATCHSET-01/02 (sequenza 01A–03B). **Owner umano:** Laura B. con coordinator/dev-tooling.
 
 ---
 


### PR DESCRIPTION
## Summary
- add explicit numbering references for PATCHSET-00 aligned to the 01A–03B sequence
- reinforce prerequisites with logging and owner tracking across planning docs
- assign human owners and sequencing cues to the next-step checklist

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692397f72734832894508bb27cc10e71)