### PR TITLE
Update planning references to PATCHSET-00 version 0.3

### DIFF
--- a/docs/planning/REF_INCOMING_CATALOG.md
+++ b/docs/planning/REF_INCOMING_CATALOG.md
@@ -1,9 +1,9 @@
 # REF_INCOMING_CATALOG – Catalogo incoming/backlog
 
 Versione: 0.3
-Data: 2025-11-24
+Data: 2025-12-17
 Owner: agente **archivist** (supporto: coordinator)
-Stato: DRAFT – inventario iniziale
+Stato: PATCHSET-00 PROPOSTA – inventario iniziale
 
 ---
 
@@ -31,6 +31,12 @@ Stato: DRAFT – inventario iniziale
 - `REF_PACKS_AND_DERIVED` per capire l’impatto del materiale incoming sui pack e sui derived.
 - `REF_REPO_MIGRATION_PLAN` per schedulare quando integrare/archiviare ciascuna fonte.
 - Supporto di coordinator per priorità e di dev-tooling per eventuali script di import/validazione.
+
+## Prerequisiti di governance
+
+- Owner umano identificato per la manutenzione del catalogo PATCHSET-00 e registrato in `logs/agent_activity.md`.
+- Branch dedicati per lavorare su triage incoming senza impattare `main` finché le tabelle non sono validate.
+- Log degli aggiornamenti di numerazione 01A–03B e delle approvazioni di triage nel file di audit centrale.
 
 ### Stato prerequisiti PATCHSET-01A
 
@@ -86,6 +92,7 @@ Stato: DRAFT – inventario iniziale
 
 ## Changelog
 
+- 2025-12-17: versione 0.3 – design completato e perimetro documentazione confermato per PATCHSET-00, numerazione 01A–03B bloccata con richiamo alle fasi GOLDEN_PATH e prerequisiti di governance rafforzati (owner umano, branch dedicati, logging su `logs/agent_activity.md`).
 - 2025-11-24: versione 0.3 – inventario arricchito con rischi e prossimi passi e prerequisiti PATCHSET-01A chiusi (archivist).
 - 2025-11-24: primo inventario con proposte di stato e candidati legacy/archive_cold (archivist).
 - 2025-11-23: struttura iniziale del catalogo incoming (archivist).

--- a/docs/planning/REF_PACKS_AND_DERIVED.md
+++ b/docs/planning/REF_PACKS_AND_DERIVED.md
@@ -3,7 +3,7 @@
 Versione: 0.3
 Data: 2025-11-24
 Owner: agente **archivist** (supporto: dev-tooling, coordinator)
-Stato: DRAFT – separazione core vs derived
+Stato: PATCHSET-00 PROPOSTA – separazione core vs derived
 
 ---
 
@@ -38,10 +38,17 @@ Stato: DRAFT – separazione core vs derived
 - **PATCHSET-01A – Catalogo incoming**: fornisce l'inventario dei sorgenti core da usare come input per rigenerare pack e fixture.
 - **PATCHSET-02A – Tooling di validazione**: abilita la modalità report/gate dei validator (pack e core) da eseguire prima e dopo la derivazione.
 
+## Prerequisiti di governance
+
+- Owner umano assegnato per il mantenimento di PATCHSET-00 e responsabile dell’allineamento pack/core.
+- Branch dedicati per testare rigenerazioni e validazioni dei pack prima di ogni merge su `main`.
+- Tracciamento in `logs/agent_activity.md` di esecuzioni, approvazioni e changelog pack/derived.
+
 ---
 
 ## Changelog
 
+- 2025-12-17: versione 0.3 – design completato per PATCHSET-00, perimetro documentazione confermato, numerazione 01A–03B bloccata con richiamo fasi GOLDEN_PATH e prerequisiti di governance (owner umano, branch dedicati, logging su `logs/agent_activity.md`).
 - 2025-11-23: versione 0.1 – struttura iniziale separazione core vs derived (archivist).
 - 2025-11-23: versione 0.2 – prime tabelle di inventario e regola base di rigenerazione (archivist).
 - 2025-11-24: versione 0.3 – inventario ampliato con file/dir chiave, mappa tooling per ogni step e collegamento ai prerequisiti 01A/02A (archivist).

--- a/docs/planning/REF_REPO_MIGRATION_PLAN.md
+++ b/docs/planning/REF_REPO_MIGRATION_PLAN.md
@@ -1,9 +1,9 @@
 # REF_REPO_MIGRATION_PLAN – Sequenza patchset
 
-Versione: 0.3 (bozza)
-Data: 2025-11-24
+Versione: 0.3
+Data: 2025-12-17
 Owner: agente **coordinator** (supporto: archivist, dev-tooling)
-Stato: DRAFT – sequenziare i patchset con matrice dipendenze
+Stato: PATCHSET-00 PROPOSTA – sequenziare i patchset con matrice dipendenze
 
 ---
 
@@ -115,6 +115,7 @@ Compatibilità GOLDEN_PATH: la sequenza mantiene allineamento con le Fasi 1–4 
 
 ## Changelog
 
+- 2025-12-17: versione 0.3 – design completato e perimetro documentazione consolidato per PATCHSET-00, numerazione 01A–03B bloccata con richiamo alle fasi GOLDEN_PATH e prerequisiti di governance ribaditi (owner umano, branch dedicati, logging in `logs/agent_activity.md`).
 - 2025-11-24: versione 0.3 – raffinata sequenza 01A–03B, aggiunta matrice dipendenze e nota compatibilità GOLDEN_PATH Fasi 1–4.
 - 2025-11-23: versione 0.2 – sequenza patchset per Fasi 1–4 con owner, prerequisiti, successo e rollback.
 - 2025-11-23: bozza di piano di migrazione basato su `REF_REPO_SCOPE` (coordinator).

--- a/docs/planning/REF_REPO_PATCH_PROPOSTA.md
+++ b/docs/planning/REF_REPO_PATCH_PROPOSTA.md
@@ -1,9 +1,9 @@
 # REF_REPO_PATCH_PROPOSTA – Applicazione iniziale dello scope
 
-Versione: 0.2 (design completato)
-Data: 2025-11-24
+Versione: 0.3
+Data: 2025-12-17
 Owner: **Documentazione (referente umano: Laura B.)** – coordinamento con coordinator/dev-tooling
-Stato: PROPOSTA – patch da validare
+Stato: PATCHSET-00 PROPOSTA – patch da validare
 
 ---
 
@@ -57,4 +57,5 @@ La numerazione delle uscite successive resta agganciata alla sequenza 01A–03B 
 
 ## Changelog
 
+- 2025-12-17: versione 0.3 – design completato confermato, perimetro documentazione fissato, numerazione 01A–03B bloccata con richiamo alle fasi GOLDEN_PATH; prerequisiti di governance ribaditi (owner umano, branch dedicati, logging in `logs/agent_activity.md`).
 - 2025-11-23: prima proposta di patch basata su `REF_REPO_SCOPE` (archivist).

--- a/docs/planning/REF_REPO_SCOPE.md
+++ b/docs/planning/REF_REPO_SCOPE.md
@@ -1,9 +1,9 @@
 # REF_REPO_SCOPE – Refactor globale repository Game / Evo Tactics
 
-Versione: 0.1 (bozza)
-Data: 2025-11-23
+Versione: 0.3
+Data: 2025-12-17
 Owner: agente **coordinator** (supporto: archivist, dev-tooling)
-Stato: DRAFT – bussola per le pipeline di refactor
+Stato: PATCHSET-00 PROPOSTA – bussola per le pipeline di refactor
 
 ---
 
@@ -44,6 +44,12 @@ Stato: DRAFT – bussola per le pipeline di refactor
 - Validatori/schema checker esistenti e workflow CI in `.github/workflows/**`.
 - Documenti collegati: `REF_REPO_PATCH_PROPOSTA`, `REF_REPO_SOURCES_OF_TRUTH`, `REF_INCOMING_CATALOG`, `REF_PACKS_AND_DERIVED`, `REF_TOOLING_AND_CI`, `REF_REPO_MIGRATION_PLAN`.
 
+## Prerequisiti di governance
+
+- Owner umano nominato per il ciclo PATCHSET-00 e registrato nei log di esecuzione.
+- Branch dedicati per ogni passo successivo, evitando merge diretti su `main` senza gate incrociati.
+- Logging delle attività e delle approvazioni in `logs/agent_activity.md` per audit e handoff.
+
 ## Prossimi passi
 
 1. Approvare questo scope come riferimento condiviso per tutte le PATCHSET e registrare variazioni nel changelog del file.
@@ -57,4 +63,5 @@ Stato: DRAFT – bussola per le pipeline di refactor
 
 ## Changelog
 
+- 2025-12-17: versione 0.3 – design completato, perimetro documentazione confermato, numerazione 01A–03B bloccata e riferimento alle fasi GOLDEN_PATH con prerequisiti di governance (owner umano, branch dedicati, logging) applicati a PATCHSET-00 (archivist).
 - 2025-11-23: versione iniziale del perimetro di refactor (coordinator).

--- a/docs/planning/REF_REPO_SOURCES_OF_TRUTH.md
+++ b/docs/planning/REF_REPO_SOURCES_OF_TRUTH.md
@@ -1,9 +1,9 @@
 # REF_REPO_SOURCES_OF_TRUTH – Canonico dati core
 
-Versione: 0.1 (bozza)
-Data: 2025-11-23
+Versione: 0.3
+Data: 2025-12-17
 Owner: agente **archivist** (supporto: trait-curator, species-curator, biome-ecosystem-curator)
-Stato: DRAFT – censimento sorgenti di verità
+Stato: PATCHSET-00 PROPOSTA – censimento sorgenti di verità
 
 ---
 
@@ -33,6 +33,12 @@ Stato: DRAFT – censimento sorgenti di verità
 - `REF_TOOLING_AND_CI` per legare i validatori ai percorsi core e alla CI.
 - Coordinamento con `REF_INCOMING_CATALOG` per evitare che materiale non classificato entri come sorgente di verità.
 
+## Prerequisiti di governance
+
+- Owner umano formalizzato per la custodia dei core (trait/specie/biomi) e registrato nel log di attività.
+- Branch dedicati per eventuali patch correttive su PATCHSET-00, separati dalle pipeline di feature.
+- Registrazione in `logs/agent_activity.md` di revisioni, approvazioni e triage sulle sorgenti di verità.
+
 ## Prossimi passi
 
 1. Redigere una tabella per dominio (trait, specie, biomi/ecosistemi) che indichi percorso canonico, formato e owner.
@@ -45,4 +51,5 @@ Stato: DRAFT – censimento sorgenti di verità
 
 ## Changelog
 
+- 2025-12-17: versione 0.3 – design completato, perimetro documentazione consolidato, numerazione 01A–03B bloccata e richiamo alle fasi GOLDEN_PATH; prerequisiti di governance esplicitati (owner umano, branch dedicati, logging su `logs/agent_activity.md`).
 - 2025-11-23: struttura iniziale e linee guida di censimento (archivist).

--- a/docs/planning/REF_TOOLING_AND_CI.md
+++ b/docs/planning/REF_TOOLING_AND_CI.md
@@ -1,9 +1,9 @@
 # REF_TOOLING_AND_CI – Allineamento tooling e CI
 
-Versione: 0.2
-Data: 2025-12-09
+Versione: 0.3
+Data: 2025-12-17
 Owner: agente **dev-tooling** (supporto: archivist, coordinator)
-Stato: DRAFT – allineare tooling/CI al nuovo assetto
+Stato: PATCHSET-00 PROPOSTA – allineare tooling/CI al nuovo assetto
 
 ---
 
@@ -38,6 +38,8 @@ Stato: DRAFT – allineare tooling/CI al nuovo assetto
 - Allineare i gate a quanto previsto dalla milestone **0.2**: niente merge su `main` senza artifact pack rigenerato e validato da `tools/py/validate_datasets.py` + `schema-validate` + smoke CLI.
 - Richiedere approvazione congiunta owner dati (core) + owner pack per modifiche che toccano sia `data/core/**` sia `packs/evo_tactics_pack/**`.
 - Documentare in ogni PR gli artifact pubblicati (pack dist, report lint) e collegarli al branch dedicato.
+- Nomina esplicita di un owner umano per PATCHSET-00 e registrazione delle attività correlate in `logs/agent_activity.md`.
+- Uso di branch sperimentali separati per validare nuove checklist/validator prima di proporli sui branch principali di tooling/CI.
 
 ## Prossimi passi
 
@@ -97,5 +99,6 @@ Stato: DRAFT – allineare tooling/CI al nuovo assetto
 
 ## Changelog
 
+- 2025-12-17: versione 0.3 – design completato e perimetro documentazione confermato per PATCHSET-00, numerazione 01A–03B bloccata con richiamo alle fasi GOLDEN_PATH e prerequisiti di governance espansi (owner umano, branch dedicati, logging in `logs/agent_activity.md`).
 - 2025-11-23: struttura iniziale di inventario tooling/CI (dev-tooling).
 - 2025-12-09: mappatura workflow/validatori estesa, checklist v0.2 con gate incrociati core/pack e prerequisiti branch dedicati.


### PR DESCRIPTION
## Summary
- bump planning references to version 0.3 with PATCHSET-00 PROPOSTA status and aligned dates
- document governance prerequisites (human owner, dedicated branches, logging in logs/agent_activity.md) across the planning set
- add changelog notes reflecting design completion, documentation perimeter lock, 01A–03B numbering, and GOLDEN_PATH references

## Testing
- Not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239aa2ea0083289a53dc846b3534f4)