### PR TITLE
Document SSoT sources and pack regeneration mapping

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,18 @@
 
 - _Nessuno segnalato._
 
+## [2025-12-17] Repository SSoT & Pack mapping 0.3
+
+### Added
+
+- Reference sorgenti di verità (`docs/planning/REF_REPO_SOURCES_OF_TRUTH.md`) con tabella dei percorsi canonici per trait/specie/biomi/ecosistemi e criteri core vs derived allineati a schema ALIENA/UCUM.
+- Mappa sintetica core → derived/pack (`docs/planning/REF_PACKS_AND_DERIVED.md`) con gap noti e script/tool già in repo per la rigenerazione standard (input core → output pack/fixture).
+
+### Changed
+
+- Regola standard di rigenerazione pack/fixture aggiornata per esplicitare dipendenze da `scripts/update_evo_pack_catalog.js`, tool Python `derive_*` e validator pack (`run_all_validators.py`) con step pre-check e gating.
+- Collegamento esplicito dei prerequisiti di governance ai patchset **01A – Catalogo incoming** e **02A – Tooling di validazione** per assicurare input canonici e validator in CI.
+
 ## [2025-12-06] HUD Smart Alerts & SquadSync bridge
 
 ### Added

--- a/docs/planning/REF_PACKS_AND_DERIVED.md
+++ b/docs/planning/REF_PACKS_AND_DERIVED.md
@@ -38,6 +38,14 @@ Stato: PATCHSET-00 PROPOSTA – separazione core vs derived
 - **PATCHSET-01A – Catalogo incoming**: fornisce l'inventario dei sorgenti core da usare come input per rigenerare pack e fixture.
 - **PATCHSET-02A – Tooling di validazione**: abilita la modalità report/gate dei validator (pack e core) da eseguire prima e dopo la derivazione.
 
+## Mappa sintetica core → derived/pack (gap noti)
+
+| Ambito                      | Input core canonico                                                                                                        | Output/derivati mirati                                                                                                                                | Script/tool dichiarati                                                                                                                                         | Gap da chiudere                                                                                 |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `data/core/**`              | Specie (`data/core/species.yaml`), biomi (`data/core/biomes.yaml`), trait (`data/core/traits/*.json`), missioni/telemetria | Pack dataset (`packs/evo_tactics_pack/data/**`), cataloghi pack (`packs/evo_tactics_pack/docs/catalog/*.json`), fixture/mock (`data/derived/mock/**`) | `scripts/update_evo_pack_catalog.js`, `scripts/sync_evo_pack_assets.js`, `packs/evo_tactics_pack/tools/py/derive_*`, `scripts/build_evo_tactics_pack_dist.mjs` | Manca sync automatica core→pack; fixture `data/derived/test-fixtures/minimal` senza generatore. |
+| `data/derived/**`           | Core + parametri QA                                                                                                        | Report analitici (`data/derived/analysis/**`), snapshot (`data/derived/mock/**`), export (`data/derived/exports/**`)                                  | `rsync` per `mock/prod_snapshot`; nessun tool consolidato per `analysis/**`                                                                                    | Script assenti per coverage/progression; export QA non tracciati da workflow.                   |
+| `packs/evo_tactics_pack/**` | Core + configurazioni pack                                                                                                 | Dataset pack, cataloghi, validator output (`out/validation/*`)                                                                                        | `packs/evo_tactics_pack/tools/py/run_all_validators.py`, tool Python `derive_*`, build/preview script `.mjs`                                                   | Pipeline ufficiale non orchestraita; validator non legati a gating CI (dip. 02A).               |
+
 ## Prerequisiti di governance
 
 - Owner umano assegnato per il mantenimento di PATCHSET-00 e responsabile dell’allineamento pack/core.
@@ -108,7 +116,7 @@ Stato: PATCHSET-00 PROPOSTA – separazione core vs derived
 
 1. **Input canonici**: `data/core/**` (specie, traits, biomi, telemetry, missions) + configurazioni `tools/config`/`packs/evo_tactics_pack/tools/config` quando applicabile (dipendenza PATCHSET-01A per catalogo completo).
 2. **Pre-check**: validare gli input core con validator/schema esistenti (`scripts/validate.sh`, `scripts/validate-dataset.cjs`, validator Python del pack in modalità report-only – PATCHSET-02A) e bloccare rigenerazione in caso di errori.
-3. **Pipeline di derivazione** (step + copertura tooling attuale):
+3. **Pipeline di derivazione** (input core → output pack/fixture), con script/tool esistenti:
    - a) **Allineare dataset pack** da core → `packs/evo_tactics_pack/data/**`: _gap_ (manca script di sync core→pack; oggi manuale).
    - b) **Derivare trait/env cross-biome** → `packs/evo_tactics_pack/tools/py/derive_env_traits_v1_0.py`, `derive_crossbiome_traits_v1_0.py`: script esistenti ma non orchestrati in pipeline.
    - c) **Arricchire catalogo pack** → `scripts/update_evo_pack_catalog.js` (usa dati pack + meta ecosistemi) e `scripts/sync_evo_pack_assets.js` (asset correlati).

--- a/docs/planning/REF_REPO_SOURCES_OF_TRUTH.md
+++ b/docs/planning/REF_REPO_SOURCES_OF_TRUTH.md
@@ -49,6 +49,19 @@ Stato: PATCHSET-00 PROPOSTA – censimento sorgenti di verità
 
 ---
 
+## Percorsi canonici e criteri di verità
+
+| Dominio                   | Core canonico                                                                                                                 | Derived/pack ammessi                                                                                                                           | Criterio di verità (core vs derived)                                                                                                                                                 |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Trait                     | `data/core/traits/glossary.json` (anagrafica), `data/core/traits/biome_pools.json` (pool ambientali)                          | Cataloghi pack (`packs/evo_tactics_pack/docs/catalog/*.json`), report QA (`data/derived/analysis/trait_*`), descrittivi `traits/**`            | Core = unica sorgente id/slug e pool validati via ALIENA/UCUM; derived devono essere rigenerati dai core e riportare versione/timestamp; documentazione è derivata e non fa testo.   |
+| Specie                    | `data/core/species.yaml`, `data/core/species/aliases.json`                                                                    | Dataset pack (`packs/evo_tactics_pack/data/species.yaml`), snapshot/mock (`data/derived/mock/**/species.yaml`)                                 | Core = unica lista specie e alias; derived ammessi solo se generati da core (o arricchiti) e marcati con checksum sorgente; alias pack devono riflettere `aliases.json`.             |
+| Biomi/Ecosistemi/Foodweb  | `data/core/biomes.yaml`, `data/core/biome_aliases.yaml`, `data/ecosystems/*.ecosystem.yaml`, `biomes/terraforming_bands.yaml` | Pack ecosistemi/foodweb (`packs/evo_tactics_pack/data/ecosystems/*.yaml`, `data/foodwebs/*.yaml`), report analisi (`data/derived/analysis/**`) | Core = biomi e bande di terraformazione validati ALIENA; ecosistemi pack devono essere sincronizzati con core (specie/biomi) e annotare script/versione usata; report solo derivati. |
+| Telemetria/funzioni gioco | `data/core/telemetry.yaml`, `data/core/game_functions.yaml`, `data/core/mating.yaml`, missioni (`data/core/missions/*.yaml`)  | Mock/snapshot (`data/derived/mock/**`), report progression (`data/derived/analysis/progression/*.json` / `*.csv`)                              | Core = parametri e missioni ufficiali; derived usabili per QA solo se rigenerati da core con log comando; mock sono derivati e non modificano la verità dei core.                    |
+
+**Regola generale**: il core è verità unica (ALIENA/UCUM + validator repo). Tutto ciò che vive fuori da `data/core/**` è derivato o documentazione; va rigenerato dai core e accompagnato da timestamp/versione git e log del comando usato. Nessuna modifica manuale ai derived senza backport nei core.
+
+---
+
 ## Changelog
 
 - 2025-12-17: versione 0.3 – design completato, perimetro documentazione consolidato, numerazione 01A–03B bloccata e richiamo alle fasi GOLDEN_PATH; prerequisiti di governance esplicitati (owner umano, branch dedicati, logging su `logs/agent_activity.md`).


### PR DESCRIPTION
## Summary
- add canonical path and truth criteria table for traits, species, biomes/ecosystems, telemetry datasets
- map core→derived→pack artifacts with tooling references and regenerate standard steps
- record release notes for v0.3 referencing PATCHSET-01A/02A prerequisites

## Testing
- not run (docs-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239ecffd1c832893983360f64d123a)