### PR TITLE
Align planning docs with report v0.5

### DIFF
--- a/docs/planning/REF_INCOMING_CATALOG.md
+++ b/docs/planning/REF_INCOMING_CATALOG.md
@@ -1,7 +1,7 @@
 # REF_INCOMING_CATALOG – Catalogo incoming/backlog
 
-Versione: 0.3
-Data: 2025-12-23
+Versione: 0.5
+Data: 2025-12-30
 Owner: Laura B. (riferimento 01A)
 Stato: PATCHSET-01A – inventario aggiornato
 
@@ -97,6 +97,7 @@ Stato: PATCHSET-01A – inventario aggiornato
 
 ## Changelog
 
+- 2025-12-30: versione 0.5 – intestazione sincronizzata al report v0.5, mantenendo PATCHSET-01A e le tabelle di triage come baseline ufficiale.
 - 2025-12-23: versione 0.3 – tabelle normalizzate e allineate alle linee guida di triage senza rinominare/spostare asset.
 - 2025-12-17: versione 0.3 – design completato e perimetro documentazione confermato per PATCHSET-00, numerazione 01A–03B bloccata con richiamo alle fasi GOLDEN_PATH e prerequisiti di governance rafforzati (owner umano, branch dedicati, logging su `logs/agent_activity.md`).
 - 2025-11-24: versione 0.3 – inventario arricchito con rischi e prossimi passi e prerequisiti PATCHSET-01A chiusi (archivist).

--- a/docs/planning/REF_PACKS_AND_DERIVED.md
+++ b/docs/planning/REF_PACKS_AND_DERIVED.md
@@ -1,7 +1,7 @@
 # REF_PACKS_AND_DERIVED – Pack, snapshot e fixture
 
-Versione: 0.3
-Data: 2025-11-24
+Versione: 0.5
+Data: 2025-12-30
 Owner: agente **archivist** (supporto: dev-tooling, coordinator)
 Stato: PATCHSET-00 PROPOSTA – separazione core vs derived
 
@@ -56,6 +56,7 @@ Stato: PATCHSET-00 PROPOSTA – separazione core vs derived
 
 ## Changelog
 
+- 2025-12-30: versione 0.5 – intestazione aggiornata al report v0.5, confermata la separazione core/derived e la numerazione 01A–03B senza modifiche al perimetro.
 - 2025-12-17: versione 0.3 – design completato per PATCHSET-00, perimetro documentazione confermato, numerazione 01A–03B bloccata con richiamo fasi GOLDEN_PATH e prerequisiti di governance (owner umano, branch dedicati, logging su `logs/agent_activity.md`).
 - 2025-11-23: versione 0.1 – struttura iniziale separazione core vs derived (archivist).
 - 2025-11-23: versione 0.2 – prime tabelle di inventario e regola base di rigenerazione (archivist).

--- a/docs/planning/REF_REPO_MIGRATION_PLAN.md
+++ b/docs/planning/REF_REPO_MIGRATION_PLAN.md
@@ -1,7 +1,7 @@
 # REF_REPO_MIGRATION_PLAN – Sequenza patchset
 
-Versione: 0.4
-Data: 2025-12-17
+Versione: 0.5
+Data: 2025-12-30
 Owner: agente **coordinator** (supporto: archivist, dev-tooling)
 Stato: PATCHSET-00 PROPOSTA – sequenziare i patchset con matrice dipendenze
 
@@ -122,6 +122,7 @@ Compatibilità GOLDEN_PATH: la sequenza mantiene allineamento con le Fasi 1–4 
 
 ## Changelog
 
+- 2025-12-30: versione 0.5 – intestazione aggiornata al report v0.5, confermate le dipendenze 01A–03B e i trigger di fase GOLDEN_PATH senza variazioni alla sequenza.
 - 2025-12-17: versione 0.4 – matrice dipendenze con trigger di fase GOLDEN_PATH, criteri/rollback/rischi allineati per 01A–03B e prerequisiti generali ampliati (branch dedicati, gate incrociati, logging fase per fase).
 - 2025-12-17: versione 0.3 – design completato e perimetro documentazione consolidato per PATCHSET-00, numerazione 01A–03B bloccata con richiamo alle fasi GOLDEN_PATH e prerequisiti di governance ribaditi (owner umano, branch dedicati, logging in `logs/agent_activity.md`).
 - 2025-11-24: versione 0.3 – raffinata sequenza 01A–03B, aggiunta matrice dipendenze e nota compatibilità GOLDEN_PATH Fasi 1–4.

--- a/docs/planning/REF_REPO_PATCH_PROPOSTA.md
+++ b/docs/planning/REF_REPO_PATCH_PROPOSTA.md
@@ -1,7 +1,7 @@
 # REF_REPO_PATCH_PROPOSTA – Applicazione iniziale dello scope
 
-Versione: 0.3
-Data: 2025-12-17
+Versione: 0.5
+Data: 2025-12-30
 Owner: **Documentazione (referente umano: Laura B.)** – coordinamento con coordinator/dev-tooling
 Stato: PATCHSET-00 PROPOSTA – patch da validare
 
@@ -57,5 +57,6 @@ La numerazione delle uscite successive resta agganciata alla sequenza 01A–03B 
 
 ## Changelog
 
+- 2025-12-30: versione 0.5 – allineamento al report v0.5 con intestazione aggiornata e conferma del ruolo di PATCHSET-00 come proposta neutrale per la sequenza 01A–03B.
 - 2025-12-17: versione 0.3 – design completato confermato, perimetro documentazione fissato, numerazione 01A–03B bloccata con richiamo alle fasi GOLDEN_PATH; prerequisiti di governance ribaditi (owner umano, branch dedicati, logging in `logs/agent_activity.md`).
 - 2025-11-23: prima proposta di patch basata su `REF_REPO_SCOPE` (archivist).

--- a/docs/planning/REF_REPO_SCOPE.md
+++ b/docs/planning/REF_REPO_SCOPE.md
@@ -1,7 +1,7 @@
 # REF_REPO_SCOPE – Refactor globale repository Game / Evo Tactics
 
-Versione: 0.3
-Data: 2025-12-17
+Versione: 0.5
+Data: 2025-12-30
 Owner: agente **coordinator** (supporto: archivist, dev-tooling)
 Stato: PATCHSET-00 PROPOSTA – bussola per le pipeline di refactor
 
@@ -63,5 +63,6 @@ Stato: PATCHSET-00 PROPOSTA – bussola per le pipeline di refactor
 
 ## Changelog
 
+- 2025-12-30: versione 0.5 – intestazione riallineata al report v0.5, confermata la numerazione 01A–03B e lo scope come bussola per le patch successive.
 - 2025-12-17: versione 0.3 – design completato, perimetro documentazione confermato, numerazione 01A–03B bloccata e riferimento alle fasi GOLDEN_PATH con prerequisiti di governance (owner umano, branch dedicati, logging) applicati a PATCHSET-00 (archivist).
 - 2025-11-23: versione iniziale del perimetro di refactor (coordinator).

--- a/docs/planning/REF_REPO_SOURCES_OF_TRUTH.md
+++ b/docs/planning/REF_REPO_SOURCES_OF_TRUTH.md
@@ -1,7 +1,7 @@
 # REF_REPO_SOURCES_OF_TRUTH – Canonico dati core
 
-Versione: 0.3
-Data: 2025-12-17
+Versione: 0.5
+Data: 2025-12-30
 Owner: agente **archivist** (supporto: trait-curator, species-curator, biome-ecosystem-curator)
 Stato: PATCHSET-00 PROPOSTA – censimento sorgenti di verità
 
@@ -64,5 +64,6 @@ Stato: PATCHSET-00 PROPOSTA – censimento sorgenti di verità
 
 ## Changelog
 
+- 2025-12-30: versione 0.5 – intestazione riallineata al report v0.5, confermata la numerazione 01A–03B e il perimetro delle sorgenti canoniche.
 - 2025-12-17: versione 0.3 – design completato, perimetro documentazione consolidato, numerazione 01A–03B bloccata e richiamo alle fasi GOLDEN_PATH; prerequisiti di governance esplicitati (owner umano, branch dedicati, logging su `logs/agent_activity.md`).
 - 2025-11-23: struttura iniziale e linee guida di censimento (archivist).

--- a/docs/planning/REF_TOOLING_AND_CI.md
+++ b/docs/planning/REF_TOOLING_AND_CI.md
@@ -1,7 +1,7 @@
 # REF_TOOLING_AND_CI – Allineamento tooling e CI
 
-Versione: 0.3
-Data: 2025-12-17
+Versione: 0.5
+Data: 2025-12-30
 Owner: agente **dev-tooling** (supporto: archivist, coordinator)
 Stato: PATCHSET-00 PROPOSTA – allineare tooling/CI al nuovo assetto (nessuna modifica a dati/tooling prevista in questo stadio)
 
@@ -117,6 +117,7 @@ Stato: PATCHSET-00 PROPOSTA – allineare tooling/CI al nuovo assetto (nessuna m
 
 ## Changelog
 
+- 2025-12-30: versione 0.5 – intestazione aggiornata al report v0.5, confermata la numerazione 01A–03B e il perimetro di PATCHSET-00 senza impatti ai workflow.
 - 2025-12-17: versione 0.3 – design completato e perimetro documentazione confermato per PATCHSET-00, numerazione 01A–03B bloccata con richiamo alle fasi GOLDEN_PATH e prerequisiti di governance espansi (owner umano, branch dedicati, logging in `logs/agent_activity.md`).
 - 2025-11-23: struttura iniziale di inventario tooling/CI (dev-tooling).
 - 2025-12-09: mappatura workflow/validatori estesa, checklist v0.2 con gate incrociati core/pack e prerequisiti branch dedicati.


### PR DESCRIPTION
## Summary
- update planning document headers to version 0.5 dated 2025-12-30
- add changelog entries noting alignment with report v0.5 across planning references

## Testing
- none


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243997f79c83288c4ab4150449e416)