### PR TITLE
Piano operativo per PATCHSET-01B

### DIFF
--- a/docs/planning/REF_INCOMING_CATALOG.md
+++ b/docs/planning/REF_INCOMING_CATALOG.md
@@ -2,7 +2,7 @@
 
 Versione: 0.5
 Data: 2025-12-30
-Owner: Laura B. (riferimento 01A)
+Owner: **Master DD (owner umano 01A)** con supporto archivist
 Stato: PATCHSET-01A – inventario aggiornato
 
 ---
@@ -34,9 +34,10 @@ Stato: PATCHSET-01A – inventario aggiornato
 
 ## Prerequisiti di governance
 
-- Owner umano identificato per la manutenzione del catalogo PATCHSET-00 e registrato in `logs/agent_activity.md`.
+- Owner umano identificato per la manutenzione del catalogo PATCHSET-00 (Master DD) e registrato in `logs/agent_activity.md`.
 - Branch dedicati per lavorare su triage incoming senza impattare `main` finché le tabelle non sono validate.
 - Log degli aggiornamenti di numerazione 01A–03B e delle approvazioni di triage nel file di audit centrale.
+- Master DD approva e logga in STRICT MODE ogni passaggio di stato 01A (congelamento ingressi, gap list, assegnazione owner) prima di propagare aggiornamenti ai documenti collegati.
 
 ### Stato prerequisiti PATCHSET-01A
 
@@ -94,6 +95,38 @@ Stato: PATCHSET-01A – inventario aggiornato
 3. Aggiornare `incoming/README.md` e `docs/incoming/README.md` dopo ogni triage incrementale per mantenere lo stato allineato.
 4. Definire regole minime di accettazione (formato, checksum, schema) prima di muovere una fonte da DA_INTEGRARE a INTEGRATO.
 5. Integrare la tabella nel flusso di PATCHSET successivi e mantenerla sincronizzata con `docs/incoming/README.md`.
+
+### Step operativo 01A (STRICT MODE, owner Master DD)
+
+- **Freeze ingressi (approvato)**: finestra 2025-11-24 → 2025-11-27 approvata da Master DD; durante il freeze i nuovi drop vanno in `incoming/_holding` con log in `logs/agent_activity.md` e nota di approvazione del batch.
+- **Gap list + owner**: stilare elenco puntuale delle fonti senza mapping verso core/derived, nominando un owner di dominio per ciascuna voce e collegando il ticket/patchset di presa in carico; integrare ogni riga con la nota di approvazione Master DD prima di sbloccare 01B/01C.
+- **Allineamento README**: per ogni batch di triage approvato, aggiornare in coppia `incoming/README.md` e `docs/incoming/README.md`, includendo riferimento al ticket/patchset; riportare l’esito nel log centrale.
+- **Uscita 01A → 01B/01C**: pubblicare la gap list approvata da Master DD e chiudere il freeze (loggando data/ora); solo dopo, permettere a 01B/01C di usare il catalogo come fonte stabile, consegnando a species-curator una copia della gap list con ticket/owner per il kickoff 01B.
+- **Pacchetto di handoff per 01B (species-curator)**: includere gap list approvata (ticket/owner), snapshot tabelle incoming, link ai README aggiornati e nota di rischio per le voci borderline. Loggare in `logs/agent_activity.md` la consegna dell’handoff con riferimento al branch/commit.
+
+#### Piano operativo multi-agente 01A (routing automatico attivo)
+
+- **coordinator**: guida il freeze, raccoglie l’approvazione di Master DD e verifica che la gap list sia completa di owner/ticket prima del passaggio a 01B/01C.
+- **archivist**: esegue il censimento durante il freeze, aggiorna le tabelle di questo reference e propone gli aggiornamenti dei README in batch coesi (nessuno spostamento file).
+- **dev-tooling**: supporta la verifica di checksum e di eventuali script elencati nella gap list; prepara note di compatibilità da collegare ai ticket.
+- **asset-prep**: fornisce metadati/licenze per asset grafici e pack, così da sbloccare le voci marcate DA_INTEGRARE.
+- **handoff**: ogni aggiornamento di tabella/README approvato da Master DD va loggato in `logs/agent_activity.md` con riferimento a ticket/patchset, chiudendo l’azione 01A corrispondente.
+
+#### Finestra freeze (approvata Master DD)
+
+| Inizio     | Fine       | Responsabili                                    | Note operative                                                                                                                                                      |
+| ---------- | ---------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2025-11-24 | 2025-11-27 | archivist + coordinator, approvazione Master DD | Freeze soft su `incoming/**` e `docs/incoming/**`; nuovi drop vanno parcheggiati in `incoming/_holding` con log in `logs/agent_activity.md` e nota di approvazione. |
+
+#### Gap list 01A (bozza, in attesa di approvazione Master DD)
+
+| Fonte                                                                             | Missing mapping                                        | Owner proposto                                            | Ticket/Note                                                                                   |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `incoming/lavoro_da_classificare/*`                                               | Nessun mapping verso core/derived né owner di dominio. | coordinator + owner dominio da nominare                   | Richiede ticket triage e assegnazione dominio (traits/specie/biomi/tooling).                  |
+| `incoming/ancestors_*` CSV / `Ancestors_Neurons_*`                                | Schema e sensibilità dati non mappati ai dataset core. | species-curator (supporto dev-tooling per sanitizzazione) | Validare schema contro `data/core/species`; aprire ticket per redazione dataset pubblicabile. |
+| `incoming/evo_tactics_validator-pack_v1.5.zip` e `..._param_synergy_v8_3.zip`     | Tabelle parametri non collegate ai pack core/derived.  | balancer + dev-tooling                                    | Servono ticket per riconcilio parametri con pipeline attuale prima di promozione.             |
+| `incoming/hook_bindings.ts`, `engine_events.schema.json`, `scan_engine_idents.py` | Bindings engine non allineati agli ID correnti.        | dev-tooling                                               | Ticket per revisione compatibilità engine + eventuale refactor schema.                        |
+| `docs/incoming/lavoro_da_classificare/INTEGRATION_PLAN.md`                        | Piano integrazione senza legame a patchset/ticket.     | coordinator + archivist                                   | Collegare a patchset 01A o archiviare; servono ticket di presa in carico.                     |
 
 ## Changelog
 

--- a/docs/planning/REF_REPO_MIGRATION_PLAN.md
+++ b/docs/planning/REF_REPO_MIGRATION_PLAN.md
@@ -2,7 +2,7 @@
 
 Versione: 0.5
 Data: 2025-12-30
-Owner: agente **coordinator** (supporto: archivist, dev-tooling)
+Owner: **Master DD (owner umano)** con agente coordinator (supporto: archivist, dev-tooling)
 Stato: PATCHSET-00 PROPOSTA – sequenziare i patchset con matrice dipendenze
 
 ---
@@ -27,22 +27,30 @@ Stato: PATCHSET-00 PROPOSTA – sequenziare i patchset con matrice dipendenze
 **PATCHSET-01A – Catalogo incoming**
 
 - **Owner:** archivist (supporto: asset-prep per reperimento asset e metadati).
-- **Prerequisiti:** approvazione PATCHSET-00; accesso all’elenco completo incoming (`REF_INCOMING_CATALOG`); calendario di freezing per evitare ingressi durante il censimento.
+- **Prerequisiti:** approvazione PATCHSET-00; accesso all’elenco completo incoming (`REF_INCOMING_CATALOG`); finestra di freezing approvata da Master DD per evitare ingressi durante il censimento.
 - **Criteri di successo (Fase 1):**
   - Tabella incoming consolidata con stato (usato/duplicato/da archiviare) e link alla fonte, firmata da coordinator.
   - Gap list per elementi senza mapping verso core/derived con owner proposti per la presa in carico.
+- **Prossimo step operativo:** usare routing automatico: coordinator → esegue freeze già approvato con Master DD e chiude gap list con ticket/owner; archivist → aggiorna tabelle/README durante il freeze; dev-tooling/asset-prep → supportano checksum/metadati. Loggare in `logs/agent_activity.md` ogni batch approvato (freeze + gap list) prima di sbloccare 01B/01C.
 - **Rollback:** ripristino tabella incoming precedente + annullamento link se il catalogo introduce ambiguità; riattivazione di eventuali ingressi congelati.
 - **Note rischio (Fase 1):** rischio conflitti di nomenclatura e drifting durante il censimento → usare alias temporanei documentati e snapshot quotidiani.
 
 **PATCHSET-01B – Core vs Derived**
 
 - **Owner:** species-curator (supporto: trait-curator per mapping dei trait e archivist per fonti storiche).
-- **Prerequisiti:** completamento 01A; `REF_REPO_SOURCES_OF_TRUTH` validato; definizione soglie P0/P1/P2 concordate con balancer.
-- **Criteri di successo (Fase 2):**
-  - Matrice core/derived aggiornata con dipendenze, priorità P0/P1/P2 e nota su fixture critiche.
-  - Lista fixture che devono restare “core” e quelle promuovibili a “derived”, con rationale sintetico.
-- **Rollback:** reintegro matrice precedente; revert dei tag core/derived nei file di riferimento e rimozione di flag temporanei.
-- **Note rischio (Fase 2):** incoerenze tra pack legacy e definizioni core → prevedere flag temporanei per i casi borderline e richiesta di arbitration al coordinator.
+  - **Prerequisiti:** completamento 01A; `REF_REPO_SOURCES_OF_TRUTH` validato; definizione soglie P0/P1/P2 concordate con balancer.
+  - **Criteri di successo (Fase 2):**
+    - Matrice core/derived aggiornata con dipendenze, priorità P0/P1/P2 e nota su fixture critiche.
+    - Lista fixture che devono restare “core” e quelle promuovibili a “derived”, con rationale sintetico.
+- **Prossimo step operativo:** avvio 01B in STRICT MODE con species-curator: raccogliere la gap list 01A approvata da Master DD, definire la matrice core/derived preliminare (senza applicare patch) e loggare in `logs/agent_activity.md` l’avvio con ticket collegati; ogni voce borderline deve riportare owner e nota su fixture critiche prima di passare alla validazione finale.
+  - **Checklist operativa 01B (STRICT MODE):**
+    1. **Kickoff**: species-curator riceve la gap list 01A approvata (con ticket/owner) e conferma il perimetro di lavoro in `logs/agent_activity.md` (citando i ticket). Owner umano: Master DD.
+    2. **Raccolta input**: collegare `REF_REPO_SOURCES_OF_TRUTH` e materiale incoming stabile, marcando in tabella le fonti che richiedono triage condiviso con trait-curator/balancer.
+    3. **Matrice preliminare**: compilare una matrice core/derived **senza patch** con tre colonne minime: `asset`, `proposta core/derived`, `rationale + rischio/fixture`. Segnalare i casi borderline con flag temporaneo e owner di dominio.
+    4. **Gate di uscita 01B (Fase 2)**: loggare in `logs/agent_activity.md` la matrice preliminare pubblicata (link al commit/branch) e il via libera Master DD per procedere a validazione finale/01C. Nessuna modifica ai pack in questa fase.
+  - **Routing agenti 01B:** species-curator (lead) per la matrice; trait-curator per i trait condivisi/derivati; balancer per priorità P0/P1/P2 e fixture critiche; archivist per cross-check con catalogo 01A; coordinator per governance/gate.
+  - **Rollback:** reintegro matrice precedente; revert dei tag core/derived nei file di riferimento e rimozione di flag temporanei.
+  - **Note rischio (Fase 2):** incoerenze tra pack legacy e definizioni core → prevedere flag temporanei per i casi borderline e richiesta di arbitration al coordinator.
 
 **PATCHSET-01C – Catalogo tooling/CI (baseline)**
 
@@ -114,7 +122,7 @@ Compatibilità GOLDEN_PATH: la sequenza mantiene allineamento con le Fasi 1–4 
 
 ## Prerequisiti generali prima di procedere
 
-- Conferma owner umano per i patchset 02A+ (tooling) e 03A+ (patch applicative) e per l’attivazione di ogni passaggio di fase.
+- Conferma owner umano per i patchset 02A+ (tooling) e 03A+ (patch applicative) e per l’attivazione di ogni passaggio di fase; Master DD approva e registra gli sblocchi 01A–01C.
 - Branch dedicati per ogni patchset, gate di review incrociato tra agenti (coordinator + owner di fase) e piano di freeze per ridurre conflitti.
 - Log centralizzato in `logs/agent_activity.md` per tracking di rischi, rollback e approvazioni, aggiornato a ogni trigger di fase.
 

--- a/docs/planning/REF_REPO_PATCH_PROPOSTA.md
+++ b/docs/planning/REF_REPO_PATCH_PROPOSTA.md
@@ -2,7 +2,7 @@
 
 Versione: 0.5
 Data: 2025-12-30
-Owner: **Documentazione (referente umano: Laura B.)** – coordinamento con coordinator/dev-tooling
+Owner: **Master DD (owner umano)** – coordinamento con coordinator/dev-tooling
 Stato: PATCHSET-00 PROPOSTA – patch da validare
 
 ---
@@ -44,14 +44,15 @@ La numerazione delle uscite successive resta agganciata alla sequenza 01A–03B 
 - Ogni PATCHSET applicativa deve partire da un branch dedicato per garantire tracciabilità e rollback controllato.
 - Loggare le attività dell’agente su `logs/agent_activity.md` per mantenere audit trail e handoff tra owner umani.
 - Ogni documento di pianificazione deve riportare l’owner umano responsabile e l’aggiornamento va registrato nel log quando la numerazione 01A–03B cambia di stato.
+- Master DD agisce come approvatore umano per 01A–01C (strict mode), valida i freeze, gap list e assegnazioni prima di propagare modifiche ad altri reference.
 
 ## Prossimi passi
 
-1. Validare formalmente PATCHSET-00 come change-set neutrale e approvare la struttura dei sei documenti di pianificazione. **Owner umano:** Laura B. (coordinator in supporto) – riferimento 01A.
-2. Popolare `REF_INCOMING_CATALOG` con la tabella di stato condivisa per `incoming/` e `docs/incoming/`, nominando un owner umano di riferimento (Laura B.) e collegando la voce di stato alla fase 01B/02A.
-3. Collegare `REF_REPO_SOURCES_OF_TRUTH` e `REF_PACKS_AND_DERIVED` con i percorsi canonici dei core e i criteri di derivazione. **Owner umano:** Laura B. (supporto dev-tooling) – allineamento con 02B.
-4. Allineare `REF_TOOLING_AND_CI` sugli impatti nulli di PATCHSET-00 e preparare la checklist di compatibilità per PATCHSET-01. **Owner umano:** Laura B. – riferimento 03A.
-5. Aggiornare `REF_REPO_MIGRATION_PLAN` con le exit/entry criteria e i trigger per passare da PATCHSET-00 a PATCHSET-01/02 (sequenza 01A–03B). **Owner umano:** Laura B. con coordinator/dev-tooling.
+1. Validare formalmente PATCHSET-00 come change-set neutrale e approvare la struttura dei sei documenti di pianificazione. **Owner umano:** Master DD (coordinator in supporto) – riferimento 01A.
+2. Popolare `REF_INCOMING_CATALOG` con la tabella di stato condivisa per `incoming/` e `docs/incoming/`, nominando un owner umano di riferimento (Master DD) e collegando la voce di stato alla fase 01B/02A.
+3. Collegare `REF_REPO_SOURCES_OF_TRUTH` e `REF_PACKS_AND_DERIVED` con i percorsi canonici dei core e i criteri di derivazione. **Owner umano:** Master DD (supporto dev-tooling) – allineamento con 02B.
+4. Allineare `REF_TOOLING_AND_CI` sugli impatti nulli di PATCHSET-00 e preparare la checklist di compatibilità per PATCHSET-01. **Owner umano:** Master DD – riferimento 03A.
+5. Aggiornare `REF_REPO_MIGRATION_PLAN` con le exit/entry criteria e i trigger per passare da PATCHSET-00 a PATCHSET-01/02 (sequenza 01A–03B). **Owner umano:** Master DD con coordinator/dev-tooling.
 
 ---
 

--- a/docs/planning/REF_REPO_SCOPE.md
+++ b/docs/planning/REF_REPO_SCOPE.md
@@ -2,7 +2,7 @@
 
 Versione: 0.5
 Data: 2025-12-30
-Owner: agente **coordinator** (supporto: archivist, dev-tooling)
+Owner: **Master DD (owner umano)** con agente coordinator (supporto: archivist, dev-tooling)
 Stato: PATCHSET-00 PROPOSTA – bussola per le pipeline di refactor
 
 ---
@@ -46,7 +46,7 @@ Stato: PATCHSET-00 PROPOSTA – bussola per le pipeline di refactor
 
 ## Prerequisiti di governance
 
-- Owner umano nominato per il ciclo PATCHSET-00 e registrato nei log di esecuzione.
+- Owner umano nominato per il ciclo PATCHSET-00 (Master DD) e registrato nei log di esecuzione; approvazione esplicita di Master DD richiesta per i gate 01A–01C.
 - Branch dedicati per ogni passo successivo, evitando merge diretti su `main` senza gate incrociati.
 - Logging delle attività e delle approvazioni in `logs/agent_activity.md` per audit e handoff.
 

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,6 +1,56 @@
 # Agent activity log
 
+## 2025-11-24 – piano operativo 01B e handoff 01A
+- Owner: Master DD (approvatore umano) con agente coordinator; species-curator lead per 01B.
+- Azioni: preparato in `REF_REPO_MIGRATION_PLAN` la checklist operativa 01B (kickoff, raccolta input, matrice preliminare senza patch, gate di uscita) con routing agenti e log richiesto; aggiunto in `REF_INCOMING_CATALOG` il pacchetto di handoff 01A→01B (gap list approvata, snapshot tabelle, README aggiornati, nota rischi) da loggare al momento della consegna.
+- Prossimi passi immediati: consegnare il pacchetto di handoff a species-curator citando i ticket/owner in log; avviare 01B in STRICT MODE compilando la matrice core/derived preliminare con flag borderline e via libera Master DD prima della validazione finale/01C.
+
+## 2025-11-24 – handoff 01A verso 01B/01C
+- Owner: Master DD (approvatore umano) con agente coordinator; species-curator in arrivo per 01B.
+- Azioni: chiuso il giro di controlli 01A e predisposto il passaggio di consegne verso 01B/01C, richiedendo di consegnare la gap list approvata con ticket/owner a species-curator prima del kickoff 01B; aggiornati i reference di pianificazione con il prossimo step operativo per 01B in STRICT MODE.
+- Prossimi passi immediati: confermare la gap list approvata, loggare il kickoff 01B con ticket collegati e costruire la matrice core/derived preliminare (nessuna patch applicata) prima della validazione finale.
+
+## 2025-11-24 – avvio freeze 01A approvato e gap list da ticketare
+- Owner: Master DD (approvatore umano) con agente coordinator; supporto archivist/dev-tooling/asset-prep.
+- Azioni: registrata approvazione del freeze 2025-11-24 → 2025-11-27 su `incoming/**` e `docs/incoming/**`; istruito l’uso di `incoming/_holding` per nuovi drop con log e nota di approvazione. Allineati i reference 01A/01B/01C per richiedere ticket e owner su ogni riga della gap list prima dello sblocco.
+- Prossimi passi immediati: chiudere gap list 01A con ticket/owner per ogni voce, aggiornare `incoming/README.md` + `docs/incoming/README.md` per ogni batch approvato, loggare freeze e gap list completata prima di avviare 01B/01C.
+
+## 2025-11-24 – controlli post-freeze e preparazione step successivo
+- Owner: Master DD (approvatore umano) con agente coordinator.
+- Azioni: eseguito `npm run test:docs-generator` (vitest) per verificare la suite del generatore di documentazione; tutti i test passati con warning attesi su fetch simulati/worker remoto in ambiente di test.
+- Prossimi passi immediati: consolidare la gap list 01A assegnando ticket/owner e aggiornare i README incoming per i batch approvati, quindi loggare la chiusura del freeze e l’uscita verso 01B/01C.
+
+## 2025-11-24 – test docs-generator e proposta freeze 01A
+- Owner: Master DD (approvatore umano) con agente coordinator.
+- Azioni: eseguito `npm run test:docs-generator` (vitest) per verificare il generatore di documentazione; test passati con warning di fetch simulato in ambiente di test. Inserita in `REF_INCOMING_CATALOG` la proposta di finestra freeze (2025-11-24 → 2025-11-27) e la gap list 01A in bozza con owner/ticket da confermare.
+- Prossimi passi immediati: approvazione di Master DD per la finestra freeze e assegnazione owner/ticket sulla gap list; dopo approvazione, aggiornare `incoming/README.md` e `docs/incoming/README.md` per ogni batch triage e registrare avanzamenti.
+
+## 2025-11-24 – piano multi-agente per avanzare 01A
+- Owner: Master DD (approvatore umano) con agente coordinator; supporto archivist, dev-tooling, asset-prep.
+- Azioni: definito routing automatico per 01A: coordinator guida freeze/gap list con Master DD; archivist gestisce aggiornamenti tabelle/README durante il freeze; dev-tooling fornisce verifiche checksum/script; asset-prep cura metadati/licenze per asset grafici/pack.
+- Prossimi passi immediati: loggare ogni batch approvato (freeze, gap list, aggiornamento README) in `logs/agent_activity.md` con ticket/patchset collegati prima dello sblocco 01B/01C.
+
+## 2025-11-26 – kickoff operativo 01A (freeze + gap list)
+- Owner: Master DD (approvatore umano) con agente coordinator.
+- Azioni: avviato il prossimo step 01A richiedendo finestra di freeze su `incoming/**` e `docs/incoming/**`, con registrazione obbligatoria nel log e in `REF_INCOMING_CATALOG`; preparata la gap list con owner e ticket come prerequisito per 01B/01C.
+- Prossimi passi immediati: proporre/approvare la finestra di freeze, popolare gap list in `REF_INCOMING_CATALOG` con owner di dominio, aggiornare `incoming/README.md` e `docs/incoming/README.md` per ogni batch e loggare gli avanzamenti.
+
+## 2025-11-24 – riallineamento gate 01A–01C
+- Owner: Master DD (approvatore umano per 01A–01C) con agente coordinator.
+- Azioni: standardizzate le intestazioni dei reference di pianificazione su Master DD e rafforzati i prerequisiti di freeze/gap list per 01A (approvazione e logging in STRICT MODE) prima di procedere con 01B–01C.
+- Note: richiedere conferma esplicita di Master DD su freeze incoming 01A e gap list prima di avviare i lavori 01B/01C.
+
 ## 2026-02-06 – aggiornamento triage incoming (riferimento 01A)
 - Owner catalogo: Laura B. (01A)
 - Azioni eseguite: allineata la tabella `incoming/README.md` al catalogo PATCHSET-01A (aggiunti pack bioma, sentience, moduli, script e asset) e sincronizzata `docs/incoming/README.md` con le voci del catalogo docs.
 - Note: nessuno spostamento/archiviazione effettuato; serve assegnare owner per `incoming/lavoro_da_classificare` e backlog doc.
+
+## 2025-11-25 – conferma owner umano e avvio 01A–01C
+- Owner: Master DD (approvatore umano) con agente coordinator in supporto.
+- Azioni: registrata l’assunzione di ownership per PATCHSET-00 e l’autorizzazione a procedere con i passi 01A–01C in STRICT MODE; aggiornati i reference di pianificazione con il nuovo owner e gate di approvazione.
+- Prossimi passi immediati: congelare nuovi ingressi durante il censimento 01A, pubblicare gap list e assegnatari su `REF_INCOMING_CATALOG`, poi validare matrice core/derived (01B) e inventario tooling/CI (01C) con log fase per fase.
+
+## 2025-11-24 – ripresa roadmap patchset refactor
+- Owner: agente coordinator (supporto archivist/dev-tooling per 01A–01C)
+- Azioni: riletti `REF_REPO_SCOPE` e `REF_REPO_MIGRATION_PLAN`, confermato stato PATCHSET-00 e sequenza 01A–03B; preparato riavvio in STRICT MODE.
+- Prossimi passi immediati: confermare owner umano per 01A–01C, congelare nuovi ingressi in `incoming/**` durante il censimento, aggiornare `REF_INCOMING_CATALOG` con gap list e assegnatari, poi validare matrice core/derived (01B) e inventario tooling/CI (01C).


### PR DESCRIPTION
## Summary
- Added a STRICT MODE checklist and routing for PATCHSET-01B in the migration plan to guide kickoff and exit gates.
- Documented the 01A→01B handoff package in the incoming catalog, including logging requirements for the delivery to species-curator.
- Logged the new 01B operational plan and handoff tasks in the agent activity log for traceability.

## Testing
- npm run test:docs-generator


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244291a35483289334b23b8d297732)