### PR TITLE
Add CI workflow inventory and link from CI docs

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,19 +1,20 @@
 # Workflow CI e QA
 
-Questa pagina estende le note in [docs/ci-pipeline.md](ci-pipeline.md) descrivendo i workflow GitHub Actions dedicati a controlli specialistici oltre alla pipeline `CI` principale.
+Questa pagina estende le note in [docs/ci-pipeline.md](ci-pipeline.md) descrivendo i workflow GitHub Actions dedicati a controlli specialistici oltre alla pipeline `CI` principale. L'inventario dettagliato di tutti i workflow e degli script locali si trova in [docs/planning/ci-inventory.md](planning/ci-inventory.md).
 
 ## Panoramica rapida
 
-| Workflow | File | Trigger | Scopo principale |
-| --- | --- | --- | --- |
-| **Validate registry naming** | `.github/workflows/validate-naming.yml` | `push`/`pull_request` limitati a percorsi di registro (`config/project_index.json`, `packs/evo_tactics_pack/tools/config/registries/**`, ecc.) | Convalida naming e allineamento degli identificativi tramite `python tools/py/validate_registry_naming.py`. |
-| **Incoming CLI smoke** | `.github/workflows/incoming-smoke.yml` | `workflow_dispatch` con input opzionali | Esegue `scripts/cli_smoke.sh` in modalità `staging_incoming` contro asset decompressi per i caricamenti da `incoming/`. |
-| **HUD Canary** | `.github/workflows/hud.yml` | `push` sui file HUD e `workflow_dispatch` | Verifica rapida degli "smart alerts" HUD: se abilitati in `config/cli/hud.yaml` installa Node.js, builda `tools/ts` e segnala eventuali problemi. |
-| **QA KPI & Visual Monitor** | `.github/workflows/qa-kpi-monitor.yml` | `schedule` mensile (`0 6 1 * *`) e `workflow_dispatch` | Controlla regressioni metriche (`tests/validate_dashboard.py`, `report_kpi_alerts.py`) e confronta gli snapshot visivi (`visual_regression.py`). |
+| Workflow                     | File                                    | Trigger                                                                                                                                        | Scopo principale                                                                                                                                  |
+| ---------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Validate registry naming** | `.github/workflows/validate-naming.yml` | `push`/`pull_request` limitati a percorsi di registro (`config/project_index.json`, `packs/evo_tactics_pack/tools/config/registries/**`, ecc.) | Convalida naming e allineamento degli identificativi tramite `python tools/py/validate_registry_naming.py`.                                       |
+| **Incoming CLI smoke**       | `.github/workflows/incoming-smoke.yml`  | `workflow_dispatch` con input opzionali                                                                                                        | Esegue `scripts/cli_smoke.sh` in modalità `staging_incoming` contro asset decompressi per i caricamenti da `incoming/`.                           |
+| **HUD Canary**               | `.github/workflows/hud.yml`             | `push` sui file HUD e `workflow_dispatch`                                                                                                      | Verifica rapida degli "smart alerts" HUD: se abilitati in `config/cli/hud.yaml` installa Node.js, builda `tools/ts` e segnala eventuali problemi. |
+| **QA KPI & Visual Monitor**  | `.github/workflows/qa-kpi-monitor.yml`  | `schedule` mensile (`0 6 1 * *`) e `workflow_dispatch`                                                                                         | Controlla regressioni metriche (`tests/validate_dashboard.py`, `report_kpi_alerts.py`) e confronta gli snapshot visivi (`visual_regression.py`).  |
 
 ## Dettagli workflow
 
 ### CI
+
 - **Trigger**: `push` e `pull_request`. Un job preliminare (`paths-filter`) usa `dorny/paths-filter@v3` per valutare i percorsi toccati e abilita i job specializzati:
   - `typescript-tests` quando cambia la toolchain TS (`tools/ts/**`, `package.json`, `webapp/src/**`, …).
   - `cli-checks` quando vengono toccati la CLI o i dataset (`scripts/cli_smoke.sh`, `tools/py/game_cli.py`, `data/**`, `packs/**`).
@@ -23,32 +24,38 @@ Questa pagina estende le note in [docs/ci-pipeline.md](ci-pipeline.md) descriven
 - **Note operative**: le PR puramente documentali non abilitano alcun job, il workflow termina in stato `success` senza eseguire test.
 
 ### Validate registry naming
+
 - **Trigger**: push e pull request che toccano i file elencati nel blocco `paths` (registri, reference trait, script validator e workflow stesso).
 - **Job**: `naming` esegue Python 3.11, installa `tools/py/requirements.txt` e lancia `python tools/py/validate_registry_naming.py` per assicurare che i registri condivisi rispettino le convenzioni.
 - **Note operative**: usa gli stessi requisiti della toolchain Python condivisa, quindi eventuali nuove dipendenze vanno aggiunte in `tools/py/requirements.txt`.
 
 ### Incoming CLI smoke
+
 - **Trigger**: solo manuale (`workflow_dispatch`). Accetta due input opzionali (`data-root`, `pack-root`) che, se omessi, puntano a `incoming/decompressed/latest/...`.
 - **Job**: `smoke` prepara Python 3.11, installa i requisiti CLI e risolve i percorsi richiesti dal profilo `staging_incoming`. Lo script `./scripts/cli_smoke.sh --profile staging_incoming` viene eseguito contro i dataset indicati e archivia i log in `logs/incoming_smoke` come artefatti.
 - **Quando usarlo**: lanciare dopo aver caricato nuovi dump in `incoming/` per verificarne la sanità prima di importarli nei dataset ufficiali.
 
 ### HUD Canary
+
 - **Trigger**: push che coinvolgono asset HUD (`tools/ts/hud_alerts.ts`, `data/core/hud/**`, `public/hud/**`, ecc.) oppure lancio manuale (`workflow_dispatch`).
 - **Job**: `canary` controlla il flag `default` in `config/cli/hud.yaml`. Se impostato a `true`, installa Node.js 20, esegue `npm ci` + `npm run build --if-present` in `tools/ts` e produce il bundle HUD. Se il flag è `false`, il job termina con un messaggio informativo senza eseguire build.
 - **Uso pratico**: mantenere il flag attivo quando si desidera ricevere feedback immediato su modifiche agli "smart alerts"; disabilitarlo se si stanno lavorando draft non pronti.
 
 ### QA KPI & Visual Monitor
+
 - **Trigger**: schedulato il primo giorno del mese alle 06:00 UTC (`cron: '0 6 1 * *'`) e disponibile anche via `workflow_dispatch`.
 - **Job**: `kpi-visual` installa Python 3.11, Playwright con Chromium e lancia tre step principali:
   1. `python tests/validate_dashboard.py --metrics-output metrics.json` per produrre le metriche della dashboard.
   2. `python tools/py/report_kpi_alerts.py --metrics metrics.json` per verificare deviazioni rispetto ai KPI attesi.
   3. `python tools/py/visual_regression.py compare --tolerance 0.08 --engine auto` per il confronto visivo.
-  I risultati (log, `metrics.json`) vengono caricati come artefatti `visual-report`.
+     I risultati (log, `metrics.json`) vengono caricati come artefatti `visual-report`.
 - **Uso pratico**: monitora la salute della dashboard e segnala scostamenti dei KPI o regressioni visive tra i checkpoint mensili.
 
 ## Etichette PR
+
 Al momento **non sono configurate etichette** per forzare l'esecuzione di questi workflow. Se in futuro verranno introdotti override (es. `ci-force-registry`, `run-hud-canary`), documentare qui il nome della label e i casi d'uso previsti.
 
 ## Step successivi
+
 - Valutare l'introduzione di una GitHub Action dedicata (ad esempio `actions/github-script`) o di un bot interno che assegni automaticamente etichette basate sulle aree toccate dai file modificati nelle pull request.
 - Aggiornare i workflow affinché i job opzionali possano essere forzati tramite una condizione del tipo `if: contains(github.event.pull_request.labels.*.name, 'nome-label')`, così da permettere future modifiche che sbloccano esecuzioni on-demand tramite etichette dedicate.

--- a/docs/planning/ci-inventory.md
+++ b/docs/planning/ci-inventory.md
@@ -1,0 +1,49 @@
+# Inventario workflow CI e script locali
+
+Questa pagina riepiloga i workflow GitHub Actions e gli script locali citati dalla CI, con trigger, input/output principali e note su eventuale modalità _report-only_.
+
+## Workflow GitHub Actions
+
+- **CI (`.github/workflows/ci.yml`)** – `push`/`pull_request`. Usa filtri paths per attivare suite TypeScript, CLI Python, dataset e deploy. Esegue lint/test Node (`npm run lint:stack`, unit test dashboard/trait editor), CLI smoke (`scripts/cli_smoke.sh`, `tools/py/game_cli.py`), validazioni dati/trait (`scripts/trait_audit.py`, `tools/py/report_trait_coverage.py`), deploy checks (`scripts/run_deploy_checks.sh`) e genera report coverage/style guide. Output principali: artefatti Chrome bundle, metriche dashboard, baseline/coverage trait in `data/derived/analysis` e `reports/trait_style`. Non è report-only.
+- **E2E Tests (Playwright) (`.github/workflows/e2e.yml`)** – schedulato e `workflow_dispatch`. Installa `tests/playwright`, risolve `BASE_URL` e lancia `npx playwright test`; carica report `tests/playwright/playwright-report`. Non report-only (fallisce su test KO).
+- **Daily PR Summary (`.github/workflows/daily-pr-summary.yml`)** – schedulato + manuale. Script `tools/py/daily_pr_report.py` aggiorna changelog/roadmap e committa su main. Output: file docs aggiornati. Non report-only.
+- **Daily tracker refresh (`.github/workflows/daily-tracker-refresh.yml`)** – schedulato + manuale. Esegue `scripts/daily_tracker_refresh.py` con export `reports/daily_tracker_summary.json` e auto-commit. Non report-only.
+- **Data audit and validation (`.github/workflows/data-quality.yml`)** – PR su dati/pack. Installa deps, esegue `tools/py/validate_datasets.py`, `scripts/trait_audit.py --check`, `scripts/build_trait_index.js`, `tools/py/report_trait_coverage.py --strict`, `tools/py/trait_completion_dashboard.py`. Carica artefatti `reports/**` e `data/derived/analysis/*.json/csv`. Non report-only.
+- **Deploy site (`.github/workflows/deploy-test-interface.yml`)** – su `push` main/PR/manuale. Build tools/ts, HUD tests, CLI smoke, trait audit/baseline/coverage e `scripts/run_deploy_checks.sh`; prepara `dist` e pubblica GitHub Pages. Artefatti: Chromium bundle, test outputs, dist. Non report-only.
+- **Idea Intake Index (`.github/workflows/idea-intake-index.yml`)** – su modifiche `docs/ideas/submissions/**`. Script shell genera `IDEAS_INDEX.md`, promemoria changelog e auto-commit. Non report-only.
+- **Incoming CLI smoke (`.github/workflows/incoming-smoke.yml`)** – manuale con input percorsi dati/pack. Risolve path incoming e lancia `scripts/cli_smoke.sh --profile staging_incoming`, carica log `logs/incoming_smoke`. Non report-only.
+- **Validate JSON Schemas (`.github/workflows/schema-validate.yml`)** – push/PR su `schemas/**`. Valida tutti gli schemi via `jsonschema`. Nessun artefatto; non report-only.
+- **Validate registry naming (`.github/workflows/validate-naming.yml`)** – push/PR su registri/glossario. Esegue `tools/py/validate_registry_naming.py`. Non report-only.
+- **Validate Trait Catalog (`.github/workflows/validate_traits.yml`)** – push/PR su dati trait. Esegue `tools/py/trait_template_validator.py`, `scripts/build_trait_index.js`, `tools/py/report_trait_coverage.py --strict`, `scripts/trait_style_check.js`; carica `reports/**` e coverage. Non report-only.
+- **QA KPI & Visual Monitor (`.github/workflows/qa-kpi-monitor.yml`)** – mensile + manuale. Corre `tests/validate_dashboard.py` (metriche), `tools/py/report_kpi_alerts.py` e `tools/py/visual_regression.py compare`; carica `logs/visual_runs` e `metrics.json`. Non report-only.
+- **QA export manual (`.github/workflows/qa-export.yml`)** – manuale con input PR. Genera QA report via `scripts/export-qa-report.js`, carica artefatti QA e opzionale commento PR. Non report-only.
+- **QA reports (`.github/workflows/qa-reports.yml`)** – PR/manuale. Stesse pipeline di export QA e controllo che `reports/qa_badges.json` e `reports/trait_baseline.json` siano aggiornati. Non report-only.
+- **Telemetry export (`.github/workflows/telemetry-export.yml`)** – PR su file export. Esegue `tools/py/validate_export.py`, test UI `tools/ts/tests/export-modal.test.tsx`, e invia notifica Slack. Output: validazione schema, nessun artefatto; non report-only.
+- **Build Search Index (`.github/workflows/search-index.yml`)** – push su contenuti e manuale. Usa `ops/site-audit/generate_search_index.py` e auto-commit `public/search_index.json`/`ops/site-audit/_out/search_index.json`. Non report-only.
+- **HUD Canary (`.github/workflows/hud.yml`)** – push/manuale su HUD. Se flag in `config/cli/hud.yaml` abilitato, installa `tools/ts` e build HUD overlay; altrimenti salta. Non report-only (fallisce su build).
+- **Lighthouse CI (`.github/workflows/lighthouse.yml`)** – schedulato/manuale. Esegue `npm run lint:lighthouse` contro `SITE_BASE_URL` e carica `.lighthouseci` come artefatto. Non report-only.
+- **Update Evo tracker (check) (`.github/workflows/update-evo-tracker.yml`)** – richiamabile da altri workflow; esegue `make update-tracker TRACKER_CHECK=1` con eventuale input `batch`. Non report-only.
+- **Sync Evo traits glossary (`.github/workflows/traits-sync.yml`)** – schedulato/manuale. Esegue `tools/traits/sync_missing_index.py` e `tools/traits/evaluate_internal.py`, carica export interno/esterno e (se segreti) pubblica su S3. Non report-only.
+- **Run Evo Batch (`.github/workflows/evo-batch.yml`)** – manuale con input `batch`, `execute`, `ignore_errors`. Usa `tools/automation/evo_batch_runner.py` per pianificare/eseguire batch; dry-run di default. Non report-only (può eseguire comandi reali se `execute=true`).
+- **Evo documentation archive sync (`.github/workflows/evo-doc-backfill.yml`)** – schedulato/manuale. Script `scripts/evo_tactics_metadata_diff.py` produce diff/anchors/backfill, `ops/notifier.py` segnala gap e crea issue/alert. Artefatti: diff JSON/MD. Non report-only.
+- **Evo rollout status sync (`.github/workflows/evo-rollout-status.yml`)** – settimanale/manuale. `tools/roadmap/update_status.py` genera snapshot roadmap e carica `reports/evo/rollout/status_export.json` + md; mostra diff. Non report-only.
+
+## Script locali citati
+
+- `scripts/cli_smoke.sh` – profili smoke CLI; input opzionali (profilo, root dati/pack) e log in `logs/*`.
+- `scripts/trait_audit.py` – controlli coerenza catalogo trait; opzione `--check` per modalità verifica. Output baseline/coverage quando usato nei deploy.
+- `scripts/run_deploy_checks.sh` – orchestrazione check deploy (usa bundle Playwright, vari env `DEPLOY_*`).
+- `scripts/daily_tracker_refresh.py` – aggiorna tracker e JSON riepilogo.
+- `scripts/export-qa-report.js` – genera QA badges/baseline/changelog in `reports/`.
+- `scripts/build_trait_index.js` – costruisce indice trait.
+- `scripts/trait_style_check.js` – verifica style guide trait e genera report JSON/MD.
+- `scripts/evo_tactics_metadata_diff.py` – calcola diff/backfill archivio documentazione Evo.
+- `scripts/prepare_static_site.py` – compila asset statici per Pages.
+- `tools/py` utilities: `game_cli.py` (validate datasets/packs), `validate_datasets.py`, `report_trait_coverage.py`, `trait_completion_dashboard.py`, `trait_template_validator.py`, `styleguide_compliance_report.py`, `validate_registry_naming.py`, `validate_export.py`, `report_kpi_alerts.py`, `visual_regression.py`, `daily_pr_report.py`.
+- `tools/automation/evo_batch_runner.py` – pianifica/esegue batch CI/ops.
+- `tools/roadmap/update_status.py` – produce stato rollout settimanale.
+- `tools/traits/sync_missing_index.py` / `evaluate_internal.py` – sync glossario/valutazioni.
+- `ops/site-audit/generate_search_index.py` – costruisce indice ricerca e scrive in `public/search_index.json`.
+- `tests/validate_dashboard.py` – validazione dashboard con metriche.
+
+Nessuno script è marcato come "report-only" di default: quelli con flag `--check` o `--strict` falliscono in caso di errori.


### PR DESCRIPTION
## Summary
- add a consolidated inventory of CI workflows and local scripts under docs/planning
- link the existing CI README to the new inventory for easier discovery

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924add0018883288f57214c32ffbfe0)