### PR TITLE
Add report-only baseline for 02A validators

### DIFF
--- a/docs/planning/02A_validator_report.md
+++ b/docs/planning/02A_validator_report.md
@@ -1,0 +1,29 @@
+# PATCHSET-02A – Baseline validator (report-only)
+
+## Contesto e criteri di successo
+
+- Fase 3 del piano di migrazione (`PATCHSET-02A` in `REF_REPO_MIGRATION_PLAN`): esecuzione consultiva dei validator per core/pack senza modifiche ai workflow.
+- Branch attivo: `work` (dedicato a validator/report-only). Owner umano: **Master DD**; agente: **dev-tooling**.
+- Scopo: raccogliere baseline locale in modalità report-only per sbloccare il gate verso 03A, senza committare artefatti.
+
+## Comandi eseguiti (report-only)
+
+1. **Schema-only (core + pack)**
+   - Comando: `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack`
+   - Input: `schemas/**`, `data/core/**`, `packs/evo_tactics_pack/**` (solo validazione schema).
+   - Output principale: errori schema su `data/core/biomes.yaml` (chiavi mancanti e tipi non mappa per vari biomi).【e45b4f†L1-L36】
+2. **Trait audit (catalogo core/pack, check-only)**
+   - Comando: `python scripts/trait_audit.py --check`
+   - Input: dataset trait di default (core/pack) in sola lettura.
+   - Output principale: sinergie non definite per 23 trait; segnalato report mancante (`logs/trait_audit.md`) perché non generato in modalità check-only.【f54bdd†L1-L24】
+3. **Trait style check (lint stile i18n)**
+   - Comando: `node scripts/trait_style_check.js --output-json /tmp/trait_style.json --fail-on error`
+   - Input: `data/traits/**` con namespace i18n.
+   - Output principale: 465 suggerimenti (276 errori, 127 warning, 62 info) su 225 file; esempio di errori su campi `fattore_mantenimento_energetico` e i18n assente.【404e2b†L1-L12】
+
+## Baseline e note operative
+
+- Tutti i comandi eseguiti in modalità **report-only** senza generare o committare artefatti (output temporaneo in `/tmp`).
+- Gli esiti negativi costituiscono la baseline 02A: servono correzioni su `data/core/biomes.yaml`, sinergie mancanti nei trait e allineamento i18n/stile.
+- Nessun workflow CI modificato; i risultati sono pronti per essere rieseguiti in CI in modalità consultiva.
+- Richiesto via libera di **Master DD** per procedere al gate 03A (patch applicative) dopo la revisione di questa baseline.

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,11 @@
 # Agent activity log
 
+## 2026-02-10 – PATCHSET-02A baseline validator (report-only)
+- Owner: Master DD (approvatore umano) con agente dev-tooling; ticket di tracciamento: **[TKT-02A-VALIDATOR]** (report-only).
+- Avvio: esecuzione consultiva checklist 02A su branch `work` senza modifiche ai workflow CI (schema-only, trait audit, trait style check).
+- Publishing report: baseline registrata in `docs/planning/02A_validator_report.md` con esiti negativi su schema biomi, sinergie mancanti e lint i18n; nessun artefatto committato.
+- Richiesta: via libera di Master DD per procedere ai gate 03A usando questi esiti come baseline (validator in modalità report-only già pronti per ri-run in CI).
+
 ## 2026-02-09 – RIAPERTURA-2026-01A (registrazione preliminare)
 - Owner: Master DD (approvatore umano) con agente archivist per il logging in STRICT MODE.
 - File toccati: `logs/agent_activity.md` (registrazione ID passo prima di ulteriori modifiche; nessun altro file aggiornato).


### PR DESCRIPTION
## Descrizione
- Documentata in `docs/planning/02A_validator_report.md` la baseline report-only dei controlli 02A (schema-only, trait audit, trait style check) con input/output e note operative.
- Aggiornato `logs/agent_activity.md` con avvio e pubblicazione del report 02A, ticket di tracciamento e richiesta di via libera Master DD per procedere verso il gate 03A.

## Checklist guida stile & QA
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [x] Documentazione/processi aggiornati ove necessario

## Testing
- [ ] `npm run style:check`
- [x] Altro: `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack` (report-only)
- [x] Altro: `python scripts/trait_audit.py --check` (report-only)
- [x] Altro: `node scripts/trait_style_check.js --output-json /tmp/trait_style.json --fail-on error` (report-only)

## Note
- Baseline e dettagli output disponibili in `docs/planning/02A_validator_report.md`; nessun artefatto pubblicato, attesa approvazione Master DD per sblocco 03A.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c3570c688328ac6a3141aefac5a1)