### PR TITLE
Rerun validator reports for patch/03A-core-derived

### DIFF
--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,11 @@
 # Agent activity log
 
+# 2026-02-14 – Rerun validator 02A (report-only su patch/03A-core-derived)
+- Step ID: 02A-RERUN-VALIDATOR-2026-02-14; ticket: **[TKT-02A-VALIDATOR]**; owner: Master DD (approvatore umano) con agente dev-tooling.
+- Comandi: `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack`; `python scripts/trait_audit.py --check`; `node scripts/trait_style_check.js --output-json /tmp/trait_style.json --fail-on error`.
+- Report: log console salvati in `reports/temp/patch-03A-core-derived/schema_only.log`, `reports/temp/patch-03A-core-derived/trait_audit.log`, `reports/temp/patch-03A-core-derived/trait_style.log`; JSON: `reports/temp/patch-03A-core-derived/trait_style.json`.
+- Note: esecuzione in STRICT MODE senza modifiche ai workflow CI; esiti allineati alla baseline 02A (errori schema biomi, sinergie mancanti, lint i18n stile trait).
+
 ## 2026-02-13 – Runbook 02A→03B pubblicato
 - Owner: Master DD (approvatore umano) con agente coordinator; supporto archivist/dev-tooling.
 - Azioni: pubblicato `docs/planning/REF_PATCHSET_02A_TO_03AB_RUNBOOK.md` con sequenza operativa 02A (report-only) → 03A/03B, includendo log/approvals, freeze fase 3→4 e requisiti di backup/rollback.

--- a/reports/temp/patch-03A-core-derived/schema_only.log
+++ b/reports/temp/patch-03A-core-derived/schema_only.log
@@ -1,0 +1,37 @@
+/workspace/Game/data/core/biomes.yaml: chiavi mancanti ['vc_adapt']
+/workspace/Game/data/core/biomes.yaml: biome 'vc_adapt' non è una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'aggro_high' manca 'diff_base'
+/workspace/Game/data/core/biomes.yaml: biome 'aggro_high' manca 'mod_biome'
+/workspace/Game/data/core/biomes.yaml: biome 'aggro_high' manca 'affixes'
+/workspace/Game/data/core/biomes.yaml: biome 'aggro_high' -> 'hazard' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'aggro_high' -> 'npc_archetypes' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'aggro_high' -> 'stresswave' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'aggro_high' -> 'narrative' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'cohesion_high' manca 'diff_base'
+/workspace/Game/data/core/biomes.yaml: biome 'cohesion_high' manca 'mod_biome'
+/workspace/Game/data/core/biomes.yaml: biome 'cohesion_high' manca 'affixes'
+/workspace/Game/data/core/biomes.yaml: biome 'cohesion_high' -> 'hazard' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'cohesion_high' -> 'npc_archetypes' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'cohesion_high' -> 'stresswave' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'cohesion_high' -> 'narrative' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'setup_high' manca 'diff_base'
+/workspace/Game/data/core/biomes.yaml: biome 'setup_high' manca 'mod_biome'
+/workspace/Game/data/core/biomes.yaml: biome 'setup_high' manca 'affixes'
+/workspace/Game/data/core/biomes.yaml: biome 'setup_high' -> 'hazard' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'setup_high' -> 'npc_archetypes' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'setup_high' -> 'stresswave' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'setup_high' -> 'narrative' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'explore_high' manca 'diff_base'
+/workspace/Game/data/core/biomes.yaml: biome 'explore_high' manca 'mod_biome'
+/workspace/Game/data/core/biomes.yaml: biome 'explore_high' manca 'affixes'
+/workspace/Game/data/core/biomes.yaml: biome 'explore_high' -> 'hazard' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'explore_high' -> 'npc_archetypes' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'explore_high' -> 'stresswave' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'explore_high' -> 'narrative' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'risk_high' manca 'diff_base'
+/workspace/Game/data/core/biomes.yaml: biome 'risk_high' manca 'mod_biome'
+/workspace/Game/data/core/biomes.yaml: biome 'risk_high' manca 'affixes'
+/workspace/Game/data/core/biomes.yaml: biome 'risk_high' -> 'hazard' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'risk_high' -> 'npc_archetypes' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'risk_high' -> 'stresswave' deve essere una mappa
+/workspace/Game/data/core/biomes.yaml: biome 'risk_high' -> 'narrative' deve essere una mappa

--- a/reports/temp/patch-03A-core-derived/trait_audit.log
+++ b/reports/temp/patch-03A-core-derived/trait_audit.log
@@ -1,0 +1,24 @@
+[BLOCCANTE] Tratto 'Coralli Sinaptici Fotofase' dichiara sinergia 'glare_control' non definita.
+[BLOCCANTE] Tratto 'Coralli Sinaptici Fotofase' dichiara sinergia 'buff_luminescente' non definita.
+[BLOCCANTE] Tratto 'Nodi Sinaptici Superficiali' dichiara sinergia 'buff_coordinamento' non definita.
+[BLOCCANTE] Tratto 'Impulsi Bioluminescenti' dichiara sinergia 'dazzle_chain' non definita.
+[BLOCCANTE] Tratto 'Sensori Planctonici' dichiara sinergia 'scan_memetico' non definita.
+[BLOCCANTE] Tratto 'Nebbia Mnesica' dichiara sinergia 'confusione_psionica' non definita.
+[BLOCCANTE] Tratto 'Lobi Risonanti Crepuscolo' dichiara sinergia 'resonant_chain' non definita.
+[BLOCCANTE] Tratto 'Placca di Diffusione Foschia' dichiara sinergia 'copertura_psionica' non definita.
+[BLOCCANTE] Tratto 'Spicole Canalizzatrici' dichiara sinergia 'reindirizzamento_buff' non definita.
+[BLOCCANTE] Tratto 'Organi Metacronici' dichiara sinergia 'furto_buff_chain' non definita.
+[BLOCCANTE] Tratto 'Ghiandole Mnemoniche' dichiara sinergia 'buff_replay' non definita.
+[BLOCCANTE] Tratto 'Camere di Risonanza Abyssal' dichiara sinergia 'waveguide_profondo' non definita.
+[BLOCCANTE] Tratto 'Corazze Ferro-Magnetico' dichiara sinergia 'riduzione_shear' non definita.
+[BLOCCANTE] Tratto 'Bioantenne Gravitiche' dichiara sinergia 'lettura_shear' non definita.
+[BLOCCANTE] Tratto 'Emettitori Voidsong' dichiara sinergia 'stabilizzazione_shear' non definita.
+[BLOCCANTE] Tratto 'Emolinfa Conducente' dichiara sinergia 'drain_energetico' non definita.
+[BLOCCANTE] Tratto 'Placche Pressioniche' dichiara sinergia 'riduzione_pressione' non definita.
+[BLOCCANTE] Tratto 'Filamenti Echo' dichiara sinergia 'relay_team' non definita.
+[BLOCCANTE] Tratto 'Scintilla Sinaptica' dichiara sinergia 'reazioni_rapide' non definita.
+[BLOCCANTE] Tratto 'Riverbero Memetico' dichiara sinergia 'duplica_buff' non definita.
+[BLOCCANTE] Tratto 'Pelle Piezo-Satura' dichiara sinergia 'riflesso_elettrico' non definita.
+[BLOCCANTE] Tratto 'Canto Risonante' dichiara sinergia 'stabilizzazione_team' non definita.
+[BLOCCANTE] Tratto 'Vortice Nera Flash' dichiara sinergia 'teletrasporto_breve' non definita.
+Report mancante (/workspace/Game/logs/trait_audit.md). Eseguire lo script senza --check per generarlo.

--- a/reports/temp/patch-03A-core-derived/trait_style.json
+++ b/reports/temp/patch-03A-core-derived/trait_style.json
@@ -1,0 +1,11 @@
+{
+  "generatedAt": "2025-11-25T11:47:54.341Z",
+  "totalTraits": 225,
+  "totalIssues": 465,
+  "counts": {
+    "info": 62,
+    "warning": 127,
+    "error": 276
+  },
+  "traitsWithIssues": 225
+}

--- a/reports/temp/patch-03A-core-derived/trait_style.log
+++ b/reports/temp/patch-03A-core-derived/trait_style.log
@@ -1,0 +1,7 @@
+Trait style: 465 suggerimenti (error=276, warning=127, info=62) su 225 file
+  - [ERROR] ali_fono_risonanti /debolezza :: Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.ali_fono_risonanti.debolezza).
+  - [ERROR] ali_fono_risonanti /fattore_mantenimento_energetico :: Allinea `fattore_mantenimento_energetico` al namespace i18n del tratto (i18n:traits.ali_fono_risonanti....).
+  - [ERROR] ali_fulminee /fattore_mantenimento_energetico :: Allinea `fattore_mantenimento_energetico` al namespace i18n del tratto (i18n:traits.ali_fulminee....).
+  - [ERROR] ali_ioniche /fattore_mantenimento_energetico :: Allinea `fattore_mantenimento_energetico` al namespace i18n del tratto (i18n:traits.ali_ioniche....).
+  - [ERROR] ali_membrana_sonica /fattore_mantenimento_energetico :: Allinea `fattore_mantenimento_energetico` al namespace i18n del tratto (i18n:traits.ali_membrana_sonica....).
+  … altri 460 suggerimenti


### PR DESCRIPTION
## Descrizione
- Riesecuzione dei validator 02A (schema-only, trait audit, trait style) sul branch patch/03A-core-derived con output salvati in `reports/temp/patch-03A-core-derived/`.
- Registrato in `logs/agent_activity.md` il nuovo step con ticket [TKT-02A-VALIDATOR] e link ai report generati.

## Checklist guida stile & QA
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [x] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato
- [ ] Documentazione/processi aggiornati ove necessario

## Testing
- [ ] `npm run style:check`
- [x] Altro: `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack`; `python scripts/trait_audit.py --check`; `node scripts/trait_style_check.js --output-json /tmp/trait_style.json --fail-on error`

## Note
- Report disponibili in `reports/temp/patch-03A-core-derived/`.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925949b129c8328915135c3c2ce5e46)