### PR TITLE
Handle 03AB backups off-repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,10 @@ reports/trait_balance/*.png
 reports/trait_style/
 logs/monthly_trait_maintenance/trait_style_*.json
 logs/monthly_trait_maintenance/trait_style_*.md
+# Backup archives (tracked off-repo)
+reports/backups/**/*.tar.gz
+reports/backups/**/*.tgz
+reports/backups/**/*.zip
+!reports/backups/**/README.md
 .local/
 .docker-prisma-bootstrapped

--- a/docs/planning/TKT-03AB-FREEZE.md
+++ b/docs/planning/TKT-03AB-FREEZE.md
@@ -1,0 +1,35 @@
+# TKT-03AB-FREEZE — Freeze core/derived/incoming
+
+## Contesto
+
+Freeze straordinario richiesto per proteggere `core/**`, `derived/**`, `incoming/**` e `docs/incoming/**` durante la fase 03A/03B.
+
+## Approvals
+
+- Master DD (approvatore umano) – 2025-11-25T12:05Z
+- Agente: coordinator (esecuzione in STRICT MODE)
+
+## Finestra di freeze
+
+- Start: 2025-11-25T12:05Z
+- End: 2025-11-27T12:05Z
+- Scope: blocco merge/patch su `data/core/**`, `data/derived/**`, `incoming/**`, `docs/incoming/**`, salvo interventi di rollback autorizzati.
+
+## Artefatti di snapshot/backup
+
+- Archivi custoditi off-repo (policy anti-binary in PR). Percorso logico: `reports/backups/2025-11-25_freeze/`.
+- Manifests:
+  - `core_snapshot_2025-11-25.tar.gz` — sha256 `f42ac8a30fffafa4a6178602cf578474fe2c0c03b6c26a664fec5dc04aeabe17`
+  - `derived_snapshot_2025-11-25.tar.gz` — sha256 `e9552e270b16af35731156dc04888df4d590f6677624fc9a9232e0e3c43b675b`
+  - `incoming_backup_2025-11-25.tar.gz` — sha256 `44fca4ef9f02871394f3b57fa665998aa748a169f32fb3baac93ef97f373a626`
+  - `docs_incoming_backup_2025-11-25.tar.gz` — sha256 `c6f6cf435f7ce22326e8cbfbb34f0ee8029daae5f4ff55b6ee41a468f904840c`
+
+## Rollback
+
+- Owner rollback: Master DD (approvatore umano)
+- Ripristino: estrarre l’archivio pertinente nella root del repository e ripristinare i permessi di default.
+
+## Note operative
+
+- Validare eventuali patch future contro la finestra di freeze prima di procedere.
+- Loggare in `logs/agent_activity.md` ogni eccezione o rollback.

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -77,6 +77,19 @@
 - Azioni: definito routing automatico per 01A: coordinator guida freeze/gap list con Master DD; archivist gestisce aggiornamenti tabelle/README durante il freeze; dev-tooling fornisce verifiche checksum/script; asset-prep cura metadati/licenze per asset grafici/pack.
 - Prossimi passi immediati: loggare ogni batch approvato (freeze, gap list, aggiornamento README) in `logs/agent_activity.md` con ticket/patchset collegati prima dello sblocco 01B/01C.
 
+## 2025-11-25 – Freeze 03AB approvato con snapshot/backup
+- Owner: Master DD (approvatore umano) con agente coordinator in STRICT MODE.
+- Ticket: **[TKT-03AB-FREEZE]** aperto in `docs/planning/TKT-03AB-FREEZE.md`.
+- Finestra freeze: 2025-11-25T12:05Z → 2025-11-27T12:05Z su `data/core/**`, `data/derived/**`, `incoming/**`, `docs/incoming/**`; sblocco solo previa autorizzazione Master DD o rollback.
+- Snapshot/backup etichettati 2025-11-25:
+  - `reports/backups/2025-11-25_freeze/core_snapshot_2025-11-25.tar.gz` — sha256 `f42ac8a30fffafa4a6178602cf578474fe2c0c03b6c26a664fec5dc04aeabe17`
+  - `reports/backups/2025-11-25_freeze/derived_snapshot_2025-11-25.tar.gz` — sha256 `e9552e270b16af35731156dc04888df4d590f6677624fc9a9232e0e3c43b675b`
+  - `reports/backups/2025-11-25_freeze/incoming_backup_2025-11-25.tar.gz` — sha256 `44fca4ef9f02871394f3b57fa665998aa748a169f32fb3baac93ef97f373a626`
+  - `reports/backups/2025-11-25_freeze/docs_incoming_backup_2025-11-25.tar.gz` — sha256 `c6f6cf435f7ce22326e8cbfbb34f0ee8029daae5f4ff55b6ee41a468f904840c`
+- Owner rollback: Master DD; ripristino consentito tramite estrazione degli archivi sopra elencati.
+
+  Nota: gli archivi sono custoditi off-repo (policy anti-binary PR); in git restano solo manifest/checksum e il percorso logico.
+
 ## 2025-11-26 – kickoff operativo 01A (freeze + gap list)
 - Owner: Master DD (approvatore umano) con agente coordinator.
 - Azioni: avviato il prossimo step 01A richiedendo finestra di freeze su `incoming/**` e `docs/incoming/**`, con registrazione obbligatoria nel log e in `REF_INCOMING_CATALOG`; preparata la gap list con owner e ticket come prerequisito per 01B/01C.

--- a/reports/backups/README.md
+++ b/reports/backups/README.md
@@ -1,0 +1,8 @@
+# Backups and snapshots (off-repo)
+
+Per policy CI/PR, gli archivi binari non vengono versionati nel repository. Conservare snapshot/backup
+in storage esterno mantenendo il percorso logico `reports/backups/<label>/` e registrando checksum e
+metadati in `docs/planning/` e `logs/agent_activity.md`.
+
+Al bisogno, depositare solo file testuali (es. manifest, note operative) per documentare dove sono
+archiviati gli artefatti.


### PR DESCRIPTION
## Summary
- remove committed 03AB backup archives and add ignores so binaries stay out of the repo
- document the off-repo storage policy in the 03AB freeze planning note and backups README
- log the off-repo archival note alongside the existing 03AB freeze entry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69259848b78c8328a562953676080407)