### PR TITLE
Document backup runbook and block binaries under reports/backups

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,3 +4,5 @@ set -e
 
 git diff --cached --name-only --diff-filter=ACMR -z \
   | xargs -0 npx prettier --check --ignore-unknown
+
+node tools/check_backups_binary.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,22 @@ Per eseguire uno script in un workspace specifico puoi usare `npm run <script>
 - Per script specifici (CLI, QA report, esportazioni) consulta le directory
   `tools/ts`, `tools/py` e `scripts/` oppure la documentazione dedicata.
 
+## Backup, manifest e rollback
+
+Segui queste regole quando lavori con snapshot o backup:
+
+1. **Non committare archivi binari** in `reports/backups/**`: caricali in storage
+   esterno mantenendo il percorso logico `reports/backups/<label>/` e registra il
+   checksum (`sha256sum`) e l'URL nel manifest.
+2. **Aggiorna il manifest** testuale (`reports/backups/<label>/manifest.txt`):
+   per ogni archivio compila i campi `Archive`, `SHA256`, `Location`, `On-call`,
+   `Last verified` e logga l'attività in `logs/agent_activity.md`.
+3. **Rollback**: recupera gli URL dal manifest, verifica i checksum in una
+   workspace temporanea (`sha256sum -c manifest.txt`), applica il ripristino in
+   sandbox/staging senza committare artefatti e aggiorna `Last verified` + log.
+4. Consulta il runbook `docs/planning/REF_BACKUP_AND_ROLLBACK.md` per i dettagli
+   e le note operative aggiornate.
+
 ## Flusso PR e collegamento con la CI
 
 1. Crea una branch descrittiva e collega eventuali issue.

--- a/docs/planning/REF_BACKUP_AND_ROLLBACK.md
+++ b/docs/planning/REF_BACKUP_AND_ROLLBACK.md
@@ -1,0 +1,33 @@
+# REF_BACKUP_AND_ROLLBACK – Runbook archivi, manifest e rollback
+
+Versione: 0.1
+Data: 2026-02-10
+Owner: dev-tooling (con supporto archivist)
+Stato: operativo
+
+## Dove caricare gli archivi
+
+1. Genera gli snapshot/backup fuori repo (es. export core/pack) e **non copiarli** in `reports/backups/**`.
+2. Carica gli archivi nel bucket esterno mantenendo la struttura logica `reports/backups/<label>/` (es. `s3://evo-backups/game/<label>/...`).
+3. Per ogni upload annota subito il percorso completo e il checksum (usando `sha256sum <file>`).
+4. Evita di committare file binari: in repo va solo la traccia testuale.
+
+## Come registrare i manifest
+
+1. Crea/aggiorna `reports/backups/<label>/manifest.txt` con un blocco per archivio includendo i campi:
+   - `Archive`, `SHA256`, `Location`, `On-call`, `Last verified`.
+2. Mantieni l'ordine degli artefatti coerente con il planning corrispondente.
+3. Riporta note e verifiche incrociate anche in `logs/agent_activity.md` o nel ticket associato.
+4. Se il manifest vive in una nuova cartella `reports/backups/<label>/`, aggiungi un breve README (testuale) che rimandi a questo runbook.
+
+## Cosa fare per un rollback
+
+1. Individua il manifest della finestra temporale corretta in `reports/backups/<label>/` e recupera gli URL dal campo `Location`.
+2. Scarica gli archivi in workspace temporaneo e verifica il checksum (`sha256sum -c manifest.txt`).
+3. Applica il restore solo in sandbox/staging, seguendo le note operative collegate (es. ripristino pack o dataset) e senza committare gli artefatti.
+4. Dopo il ripristino aggiorna `Last verified` nel manifest, registra l'azione in `logs/agent_activity.md` e allega l'esito (pass/fail) nel ticket di incidente.
+
+## Controlli automatici
+
+- Il pre-commit blocca nuovi binari sotto `reports/backups/**` e suggerisce di spostarli off-repo e committare solo il manifest.
+- In caso di necessità di commit temporanei, richiedere un'eccezione documentata al maintainer e allegare il piano di ripulitura.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:backend": "npm run test:api",
     "test:stack": "bash scripts/test-stack.sh",
     "lint:stack": "node scripts/lint-stack.mjs",
+    "lint:backups": "node tools/check_backups_binary.js",
     "lint:lighthouse": "lhci autorun --config=./config/lighthouse/evo.lighthouserc.json",
     "schema:lint": "python tools/automation/evo_schema_lint.py schemas/evo",
     "ci:stack": "npm run lint:stack && npm run test:backend && npm run test --workspace apps/dashboard && VITE_BASE_PATH=./ npm run build --workspace apps/dashboard",

--- a/tools/check_backups_binary.js
+++ b/tools/check_backups_binary.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('child_process');
+
+function listAddedBackups() {
+  const result = spawnSync(
+    'git',
+    ['diff', '--cached', '--name-only', '--diff-filter=A', '--', 'reports/backups'],
+    { encoding: 'utf8' },
+  );
+
+  if (result.status !== 0) {
+    console.error('[check-backups] Impossibile leggere i file in staging.', result.stderr);
+    process.exit(result.status || 1);
+  }
+
+  return result.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function readBlob(path) {
+  const result = spawnSync('git', ['show', `:${path}`], { encoding: null });
+  if (result.status !== 0) {
+    return null;
+  }
+  return result.stdout;
+}
+
+function isLikelyBinary(buffer) {
+  if (!buffer || buffer.length === 0) return false;
+  const maxBytes = Math.min(buffer.length, 8000);
+  let suspicious = 0;
+
+  for (let i = 0; i < maxBytes; i += 1) {
+    const byte = buffer[i];
+    if (byte === 0) {
+      return true;
+    }
+    if (byte < 7 || (byte > 13 && byte < 32) || byte > 126) {
+      suspicious += 1;
+    }
+  }
+
+  return suspicious / maxBytes > 0.3;
+}
+
+function main() {
+  const added = listAddedBackups();
+  if (added.length === 0) {
+    process.exit(0);
+  }
+
+  const violations = [];
+
+  added.forEach((path) => {
+    const blob = readBlob(path);
+    if (blob && isLikelyBinary(blob)) {
+      violations.push(path);
+    }
+  });
+
+  if (violations.length > 0) {
+    console.error(
+      '[check-backups] Rilevati nuovi file binari in reports/backups:** che non sono ammessi nel repo:',
+    );
+    violations.forEach((v) => console.error(` - ${v}`));
+    console.error(
+      '\nSposta gli archivi su storage esterno (es. s3://.../reports/backups/<label>/) e committa solo manifest/README testuali.',
+    );
+    console.error('Consulta docs/planning/REF_BACKUP_AND_ROLLBACK.md per la procedura completa.');
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add runbook for backups, manifest registration, and rollback steps under docs/planning
- extend contributing guide with backup rules and references
- add pre-commit binary guard for reports/backups and expose it via npm script

## Testing
- node tools/check_backups_binary.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925aa03da7883288c082cd82fef4bfd)