### PR TITLE
Handle 03AB backups off-repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ logs/monthly_trait_maintenance/trait_style_*.md
 reports/backups/**/*.tar.gz
 reports/backups/**/*.tgz
 reports/backups/**/*.zip
+reports/backups/**/*.tar
 !reports/backups/**/README.md
+!reports/backups/**/MANIFEST.md
 .local/
 .docker-prisma-bootstrapped

--- a/docs/planning/TKT-03AB-FREEZE.md
+++ b/docs/planning/TKT-03AB-FREEZE.md
@@ -18,7 +18,8 @@ Freeze straordinario richiesto per proteggere `core/**`, `derived/**`, `incoming
 ## Artefatti di snapshot/backup
 
 - Archivi custoditi off-repo (policy anti-binary in PR). Percorso logico: `reports/backups/2025-11-25_freeze/`.
-- Manifests:
+- Manifest versionato: `reports/backups/2025-11-25_freeze/MANIFEST.md`.
+- Archivi rimossi dal repository git e conservati solo off-repo con i checksum seguenti:
   - `core_snapshot_2025-11-25.tar.gz` — sha256 `f42ac8a30fffafa4a6178602cf578474fe2c0c03b6c26a664fec5dc04aeabe17`
   - `derived_snapshot_2025-11-25.tar.gz` — sha256 `e9552e270b16af35731156dc04888df4d590f6677624fc9a9232e0e3c43b675b`
   - `incoming_backup_2025-11-25.tar.gz` — sha256 `44fca4ef9f02871394f3b57fa665998aa748a169f32fb3baac93ef97f373a626`

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -88,7 +88,8 @@
   - `reports/backups/2025-11-25_freeze/docs_incoming_backup_2025-11-25.tar.gz` — sha256 `c6f6cf435f7ce22326e8cbfbb34f0ee8029daae5f4ff55b6ee41a468f904840c`
 - Owner rollback: Master DD; ripristino consentito tramite estrazione degli archivi sopra elencati.
 
-  Nota: gli archivi sono custoditi off-repo (policy anti-binary PR); in git restano solo manifest/checksum e il percorso logico.
+  Nota: gli archivi sono custoditi off-repo (policy anti-binary PR); in git restano solo manifest/checksum e il percorso logico
+  documentato in `reports/backups/2025-11-25_freeze/MANIFEST.md` dopo la rimozione delle copie binarie dal repository.
 
 ## 2025-11-26 – kickoff operativo 01A (freeze + gap list)
 - Owner: Master DD (approvatore umano) con agente coordinator.

--- a/reports/backups/2025-11-25_freeze/MANIFEST.md
+++ b/reports/backups/2025-11-25_freeze/MANIFEST.md
@@ -1,0 +1,16 @@
+# Manifesto backup freeze 03AB (2025-11-25)
+
+## Artefatti custoditi off-repo
+
+Gli archivi binari del freeze 03AB sono stati rimossi dal repository e conservati in storage esterno.
+Sono accessibili solo come riferimento tramite questo manifest e il log operativo.
+
+- `core_snapshot_2025-11-25.tar.gz` — sha256 `f42ac8a30fffafa4a6178602cf578474fe2c0c03b6c26a664fec5dc04aeabe17`
+- `derived_snapshot_2025-11-25.tar.gz` — sha256 `e9552e270b16af35731156dc04888df4d590f6677624fc9a9232e0e3c43b675b`
+- `incoming_backup_2025-11-25.tar.gz` — sha256 `44fca4ef9f02871394f3b57fa665998aa748a169f32fb3baac93ef97f373a626`
+- `docs_incoming_backup_2025-11-25.tar.gz` — sha256 `c6f6cf435f7ce22326e8cbfbb34f0ee8029daae5f4ff55b6ee41a468f904840c`
+
+## Politica di conservazione
+
+- Nessun archivio binario resta tracciato in git; eventuali copie temporanee vanno eliminate prima del commit.
+- I manifest rimangono versionati per garantire tracciabilità e verifica dei checksum.

--- a/reports/backups/README.md
+++ b/reports/backups/README.md
@@ -6,3 +6,10 @@ metadati in `docs/planning/` e `logs/agent_activity.md`.
 
 Al bisogno, depositare solo file testuali (es. manifest, note operative) per documentare dove sono
 archiviati gli artefatti.
+
+## Convenzioni per i manifest
+
+- Ogni blocco di backup deve avere una cartella dedicata (es. `reports/backups/2025-11-25_freeze/`).
+- Versionare solo file di testo (es. `MANIFEST.md`) con percorso logico e checksum; rimuovere
+  qualsiasi archivio (`*.tar`, `*.tar.gz`, `*.tgz`, `*.zip`) prima del commit.
+- Collegare il manifest ai log operativi e alle note di pianificazione pertinenti.


### PR DESCRIPTION
## Summary
- block backup archive formats in git while keeping manifests tracked, and add the 2025-11-25 freeze manifest with checksums stored off-repo
- update the 03AB freeze note and backups README to highlight the manifest location and off-repo storage policy
- log the 03AB backup cleanup and manifest path in the agent activity log

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6925be15e120832a919352e58209358d)