### PR TITLE
Rerun validator 02A logs for TKT-02A-VALIDATOR

### DIFF
--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,11 @@
 # Agent activity log
 
+## 2025-11-25 – Rerun validator 02A (report-only su patch/03A-core-derived)
+- Step ID: 02A-VALIDATOR-RERUN-2025-11-25; ticket: **[TKT-02A-VALIDATOR]**; owner: Master DD (approvatore umano) con agente dev-tooling in STRICT MODE.
+- Branch: `patch/03A-core-derived`; scopo: riesecuzione validator 02A senza modifiche ai workflow CI, con log temporanei dedicati.
+- Comandi: `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack` → PASS con 3 avvisi pack (log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25/schema_only.log`); `python scripts/trait_audit.py --check` → WARNING per report mancante `logs/trait_audit.md` (log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25/trait_audit.log`); `node scripts/trait_style_check.js --output-json reports/temp/patch-03A-core-derived/rerun-2025-11-25/trait_style.json --fail-on error` → PASS con 0 errori / 403 warning / 62 info (log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25/trait_style.log`, JSON: `.../trait_style.json`).
+- Note: output salvati in `reports/temp/patch-03A-core-derived/rerun-2025-11-25/` come artefatti temporanei; esiti allineati alla baseline di `docs/planning/02A_validator_report.md`.
+
 ## 2026-02-15 – Cleanup 03B con redirect + smoke 02A (report-only)
 - Step ID: 03B-INCOMING-CLEANUP-2026-02-15; owner: Master DD (approvatore umano) con agente dev-tooling/archivist.
 - Branch: `patch/03B-incoming-cleanup` (STRICT MODE); scope: spostamento bundle repo/devkit/inventari in `incoming/archive_cold/**` secondo manifesto 2025-11-25, senza toccare `data/core`/`data/derived`.

--- a/reports/temp/patch-03A-core-derived/rerun-2025-11-25/schema_only.log
+++ b/reports/temp/patch-03A-core-derived/rerun-2025-11-25/schema_only.log
@@ -1,0 +1,2 @@
+packs/evo_tactics_pack: 14 controlli eseguiti — 3 avvisi.
+Tutti i dataset YAML sono validi.

--- a/reports/temp/patch-03A-core-derived/rerun-2025-11-25/trait_audit.log
+++ b/reports/temp/patch-03A-core-derived/rerun-2025-11-25/trait_audit.log
@@ -1,0 +1,1 @@
+Report mancante (/workspace/Game/logs/trait_audit.md). Eseguire lo script senza --check per generarlo.

--- a/reports/temp/patch-03A-core-derived/rerun-2025-11-25/trait_style.json
+++ b/reports/temp/patch-03A-core-derived/rerun-2025-11-25/trait_style.json
@@ -1,0 +1,11 @@
+{
+  "generatedAt": "2025-11-25T14:48:46.263Z",
+  "totalTraits": 225,
+  "totalIssues": 465,
+  "counts": {
+    "info": 62,
+    "warning": 403,
+    "error": 0
+  },
+  "traitsWithIssues": 225
+}

--- a/reports/temp/patch-03A-core-derived/rerun-2025-11-25/trait_style.log
+++ b/reports/temp/patch-03A-core-derived/rerun-2025-11-25/trait_style.log
@@ -1,0 +1,7 @@
+Trait style: 465 suggerimenti (error=0, warning=403, info=62) su 225 file
+  - [WARNING] ali_fono_risonanti /debolezza :: Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.ali_fono_risonanti.debolezza).
+  - [WARNING] ali_fono_risonanti /fattore_mantenimento_energetico :: Allinea `fattore_mantenimento_energetico` al namespace i18n del tratto (i18n:traits.ali_fono_risonanti....).
+  - [WARNING] ali_fono_risonanti /slot_profile/complementare :: Compila il campo `complementare` in slot_profile (es. "metabolico").
+  - [WARNING] ali_fono_risonanti /slot_profile/core :: Compila il campo `core` in slot_profile (es. "metabolico").
+  - [WARNING] ali_fono_risonanti /usage_tags :: Popola almeno un usage tag dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank).
+  … altri 460 suggerimenti


### PR DESCRIPTION
## Summary
- reran the schema-only, trait audit, and trait style validators per the 02A baseline and captured fresh outputs under reports/temp/patch-03A-core-derived/rerun-2025-11-25
- recorded the rerun details and ticket association in logs/agent_activity.md

## Testing
- python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack
- python scripts/trait_audit.py --check
- node scripts/trait_style_check.js --output-json reports/temp/patch-03A-core-derived/rerun-2025-11-25/trait_style.json --fail-on error


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925c0f5e28c832885160b813bf95d9e)