### PR TITLE
Log 02A validator rerun outputs

### DIFF
--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -29,6 +29,12 @@
 - Comandi: `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack` → PASS con 3 avvisi pack (log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25/schema_only.log`); `python scripts/trait_audit.py --check` → WARNING per report mancante `logs/trait_audit.md` (log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25/trait_audit.log`); `node scripts/trait_style_check.js --output-json reports/temp/patch-03A-core-derived/rerun-2025-11-25/trait_style.json --fail-on error` → PASS con 0 errori / 403 warning / 62 info (log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25/trait_style.log`, JSON: `.../trait_style.json`).
 - Note: output salvati in `reports/temp/patch-03A-core-derived/rerun-2025-11-25/` come artefatti temporanei; esiti allineati alla baseline di `docs/planning/02A_validator_report.md`.
 
+## 2025-11-25 – Checklist 02A in modalità report-only (schema-only, trait audit, trait style)
+- Step ID: 02A-VALIDATOR-RERUN-2025-11-25-02; ticket: **[TKT-02A-VALIDATOR]**; owner: Master DD (approvatore umano) con agente dev-tooling in STRICT MODE.
+- Branch: `patch/03A-core-derived`; scopo: riesecuzione checklist 02A in sola lettura con log temporanei condivisi prima del freeze.
+- Comandi: `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack` → PASS con 3 avvisi pack (log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/schema_only.log`); `python scripts/trait_audit.py --check` → WARNING (modulo jsonschema assente, audit senza regressioni; log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/trait_audit.log`); `node scripts/trait_style_check.js --output-json reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/trait_style.json --fail-on error` → PASS con 0 errori / 403 warning / 62 info (log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/trait_style.log`, JSON nella stessa cartella).
+- Note: artefatti temporanei salvati in `reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/`; nessuna modifica ai workflow CI o ai dataset, esecuzione preparatoria al freeze.
+
 ## 2026-02-15 – Cleanup 03B con redirect + smoke 02A (report-only)
 - Step ID: 03B-INCOMING-CLEANUP-2026-02-15; owner: Master DD (approvatore umano) con agente dev-tooling/archivist.
 - Branch: `patch/03B-incoming-cleanup` (STRICT MODE); scope: spostamento bundle repo/devkit/inventari in `incoming/archive_cold/**` secondo manifesto 2025-11-25, senza toccare `data/core`/`data/derived`.

--- a/reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/schema_only.log
+++ b/reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/schema_only.log
@@ -1,0 +1,2 @@
+packs/evo_tactics_pack: 14 controlli eseguiti — 3 avvisi.
+Tutti i dataset YAML sono validi.

--- a/reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/trait_audit.log
+++ b/reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/trait_audit.log
@@ -1,0 +1,1 @@
+Audit dei tratti: nessuna regressione rilevata.

--- a/reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/trait_style.json
+++ b/reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/trait_style.json
@@ -1,0 +1,11 @@
+{
+  "generatedAt": "2025-11-25T17:20:32.866Z",
+  "totalTraits": 225,
+  "totalIssues": 465,
+  "counts": {
+    "info": 62,
+    "warning": 403,
+    "error": 0
+  },
+  "traitsWithIssues": 225
+}

--- a/reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/trait_style.log
+++ b/reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/trait_style.log
@@ -1,0 +1,7 @@
+Trait style: 465 suggerimenti (error=0, warning=403, info=62) su 225 file
+  - [WARNING] ali_fono_risonanti /debolezza :: Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.ali_fono_risonanti.debolezza).
+  - [WARNING] ali_fono_risonanti /fattore_mantenimento_energetico :: Allinea `fattore_mantenimento_energetico` al namespace i18n del tratto (i18n:traits.ali_fono_risonanti....).
+  - [WARNING] ali_fono_risonanti /slot_profile/complementare :: Compila il campo `complementare` in slot_profile (es. "metabolico").
+  - [WARNING] ali_fono_risonanti /slot_profile/core :: Compila il campo `core` in slot_profile (es. "metabolico").
+  - [WARNING] ali_fono_risonanti /usage_tags :: Popola almeno un usage tag dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank).
+  … altri 460 suggerimenti


### PR DESCRIPTION
## Summary
- add a report-only 02A validator rerun entry linked to [TKT-02A-VALIDATOR]
- store schema-only, trait audit, and trait style logs for the rerun under patch/03A-core-derived temp reports

## Testing
- python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack
- python scripts/trait_audit.py --check
- node scripts/trait_style_check.js --output-json reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/trait_style.json --fail-on error

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e43302b4832899abdfee5e28f985)