### PR TITLE
Apply sonic trait i18n fixes and rerun 02A validators

### DIFF
--- a/data/traits/difensivo/campo_di_interferenza_acustica.json
+++ b/data/traits/difensivo/campo_di_interferenza_acustica.json
@@ -3,11 +3,13 @@
   "label": "i18n:traits.campo_di_interferenza_acustica.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Difensivo/Camuffamento",
-  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+  "fattore_mantenimento_energetico": "i18n:traits.campo_di_interferenza_acustica.fattore_mantenimento_energetico",
   "tier": "T3",
   "slot": [],
   "sinergie": [
-    "ali_fono_risonanti"
+    "ali_fono_risonanti",
+    "occhi_cinetici",
+    "cannone_sonico_a_raggio"
   ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.campo_di_interferenza_acustica.mutazione_indotta",
@@ -47,5 +49,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
+  },
+  "usage_tags": [
+    "controller",
+    "support"
+  ],
+  "slot_profile": {
+    "core": "difensivo",
+    "complementare": "controllo"
   }
 }

--- a/data/traits/index.csv
+++ b/data/traits/index.csv
@@ -200,7 +200,7 @@ scheletro_idraulico_a_pistoni,Scheletro Idraulico a Pistoni,Locomotivo/Balistico
 ipertrofia_muscolare_massiva,i18n:traits.ipertrofia_muscolare_massiva.label,Fisiologico/Metabolico,Metabolico,data/traits/fisiologico/ipertrofia_muscolare_massiva.json,,incoming_tr1100_pack,terrestre,,true,false
 ectotermia_dinamica,i18n:traits.ectotermia_dinamica.label,Fisiologico/Termico,Termico,data/traits/fisiologico/ectotermia_dinamica.json,,incoming_tr1100_pack,terrestre,,true,false
 organi_sismici_cutanei,i18n:traits.organi_sismici_cutanei.label,Sensoriale/Tatto-Vibro,Tatto-Vibro,data/traits/sensoriale/organi_sismici_cutanei.json,,incoming_tr1100_pack,terrestre,,true,false
-ali_fono_risonanti,Ali Fono-Risonanti,Locomotivo/Aereo,Aereo,data/traits/locomotivo/ali_fono_risonanti.json,,coverage_q4_2025,terrestre,,true,false
+ali_fono_risonanti,Ali Fono-Risonanti,Locomotivo/Aereo,Aereo,data/traits/locomotivo/ali_fono_risonanti.json,,coverage_q4_2025,terrestre,scout;controller,true,false
 articolazioni_a_leva_idraulica,Articolazioni a Leva Idraulica,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/articolazioni_a_leva_idraulica.json,,coverage_q4_2025,terrestre,,true,false
 articolazioni_multiassiali,Articolazioni Multiassiali,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/articolazioni_multiassiali.json,,coverage_q4_2025,terrestre,,true,false
 cinghia_iper_ciliare,Cinghia Iper-Ciliare,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/cinghia_iper_ciliare.json,,coverage_q4_2025,terrestre,,true,false

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -12228,11 +12228,11 @@
         "has_biome": true,
         "has_data_origin": true,
         "has_species_link": false,
-        "has_usage_tags": false
+        "has_usage_tags": true
       },
       "data_origin": "coverage_q4_2025",
       "famiglia_tipologia": "Locomotivo/Aereo",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "fattore_mantenimento_energetico": "i18n:traits.ali_fono_risonanti.fattore_mantenimento_energetico",
       "id": "ali_fono_risonanti",
       "label": "Ali Fono-Risonanti",
       "mutazione_indotta": "Venature come corde vibranti controllate.",
@@ -12252,12 +12252,20 @@
       "sinergie": [
         "cannone_sonico_a_raggio",
         "campo_di_interferenza_acustica",
-        "cervello_a_bassa_latenza"
+        "cervello_a_bassa_latenza",
+        "occhi_cinetici"
       ],
       "slot": [],
+      "slot_profile": {
+        "core": "locomotivo",
+        "complementare": "sensoriale"
+      },
       "spinta_selettiva": "Mappatura ambiente e segnalazione.",
       "tier": "T3",
-      "usage_tags": [],
+      "usage_tags": [
+        "scout",
+        "controller"
+      ],
       "uso_funzione": "Generare ampia banda sonora in volo.",
       "metrics": [
         {
@@ -12638,12 +12646,13 @@
       "label": "Campo di Interferenza Acustica",
       "data_origin": "coverage_q4_2025",
       "famiglia_tipologia": "Difensivo/Camuffamento",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "fattore_mantenimento_energetico": "i18n:traits.campo_di_interferenza_acustica.fattore_mantenimento_energetico",
       "tier": "T3",
       "slot": [],
       "sinergie": [
         "ali_fono_risonanti",
-        "occhi_cinetici"
+        "occhi_cinetici",
+        "cannone_sonico_a_raggio"
       ],
       "conflitti": [],
       "mutazione_indotta": "Rumore bianco caotico a fase variabile.",
@@ -12689,7 +12698,15 @@
         "has_biome": true,
         "has_data_origin": true,
         "has_species_link": false,
-        "has_usage_tags": false
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "controller",
+        "support"
+      ],
+      "slot_profile": {
+        "core": "difensivo",
+        "complementare": "controllo"
       }
     },
     "cannone_sonico_a_raggio": {
@@ -12697,12 +12714,13 @@
       "label": "Cannone Sonico a Raggio",
       "data_origin": "coverage_q4_2025",
       "famiglia_tipologia": "Offensivo/Controllo",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "fattore_mantenimento_energetico": "i18n:traits.cannone_sonico_a_raggio.fattore_mantenimento_energetico",
       "tier": "T4",
       "slot": [],
       "sinergie": [
         "ali_fono_risonanti",
-        "occhi_cinetici"
+        "occhi_cinetici",
+        "campo_di_interferenza_acustica"
       ],
       "conflitti": [],
       "mutazione_indotta": "Risonanza focale su membrana alare.",
@@ -12748,7 +12766,15 @@
         "has_biome": true,
         "has_data_origin": true,
         "has_species_link": false,
-        "has_usage_tags": false
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "breaker",
+        "controller"
+      ],
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "controllo"
       }
     },
     "canto_infrasonico_tattico": {
@@ -14053,12 +14079,13 @@
       "label": "Occhi Cinetici",
       "data_origin": "coverage_q4_2025",
       "famiglia_tipologia": "Sensoriale/Visivo",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "fattore_mantenimento_energetico": "i18n:traits.occhi_cinetici.fattore_mantenimento_energetico",
       "tier": "T2",
       "slot": [],
       "sinergie": [
         "cannone_sonico_a_raggio",
-        "campo_di_interferenza_acustica"
+        "campo_di_interferenza_acustica",
+        "ali_fono_risonanti"
       ],
       "conflitti": [],
       "mutazione_indotta": "Retina sensibile a distorsioni da vibrazione.",
@@ -14104,7 +14131,15 @@
         "has_biome": true,
         "has_data_origin": true,
         "has_species_link": false,
-        "has_usage_tags": false
+        "has_usage_tags": true
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "slot_profile": {
+        "core": "sensoriale",
+        "complementare": "supporto"
       }
     },
     "pelage_idrorepellente_avanzato": {

--- a/data/traits/locomotivo/ali_fono_risonanti.json
+++ b/data/traits/locomotivo/ali_fono_risonanti.json
@@ -3,13 +3,14 @@
   "label": "i18n:traits.ali_fono_risonanti.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Locomotivo/Aereo",
-  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+  "fattore_mantenimento_energetico": "i18n:traits.ali_fono_risonanti.fattore_mantenimento_energetico",
   "tier": "T3",
   "slot": [],
   "sinergie": [
     "cannone_sonico_a_raggio",
     "campo_di_interferenza_acustica",
-    "cervello_a_bassa_latenza"
+    "cervello_a_bassa_latenza",
+    "occhi_cinetici"
   ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.ali_fono_risonanti.mutazione_indotta",
@@ -50,8 +51,14 @@
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
   },
-  "usage_tags": [],
-  "slot_profile": {},
+  "usage_tags": [
+    "scout",
+    "controller"
+  ],
+  "slot_profile": {
+    "core": "locomotivo",
+    "complementare": "sensoriale"
+  },
   "species_affinity": [],
   "version": "1.0.0",
   "versioning": {

--- a/data/traits/offensivo/cannone_sonico_a_raggio.json
+++ b/data/traits/offensivo/cannone_sonico_a_raggio.json
@@ -3,12 +3,13 @@
   "label": "i18n:traits.cannone_sonico_a_raggio.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Offensivo/Controllo",
-  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+  "fattore_mantenimento_energetico": "i18n:traits.cannone_sonico_a_raggio.fattore_mantenimento_energetico",
   "tier": "T4",
   "slot": [],
   "sinergie": [
     "ali_fono_risonanti",
-    "occhi_cinetici"
+    "occhi_cinetici",
+    "campo_di_interferenza_acustica"
   ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.cannone_sonico_a_raggio.mutazione_indotta",
@@ -48,5 +49,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
+  },
+  "usage_tags": [
+    "breaker",
+    "controller"
+  ],
+  "slot_profile": {
+    "core": "offensivo",
+    "complementare": "controllo"
   }
 }

--- a/data/traits/sensoriale/occhi_cinetici.json
+++ b/data/traits/sensoriale/occhi_cinetici.json
@@ -3,12 +3,13 @@
   "label": "i18n:traits.occhi_cinetici.label",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Sensoriale/Visivo",
-  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+  "fattore_mantenimento_energetico": "i18n:traits.occhi_cinetici.fattore_mantenimento_energetico",
   "tier": "T2",
   "slot": [],
   "sinergie": [
     "cannone_sonico_a_raggio",
-    "campo_di_interferenza_acustica"
+    "campo_di_interferenza_acustica",
+    "ali_fono_risonanti"
   ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.occhi_cinetici.mutazione_indotta",
@@ -48,5 +49,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
+  },
+  "usage_tags": [
+    "scout",
+    "support"
+  ],
+  "slot_profile": {
+    "core": "sensoriale",
+    "complementare": "supporto"
   }
 }

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -202,3 +202,9 @@
 - Stato ticket: le sigle **[TKT-01A-*]** sono placeholder proposti; apertura e tracciamento ufficiale richiedono conferma Master DD prima di passare a 01B/01C.
 - README sincronizzati (`incoming/README.md`, `docs/incoming/README.md`) con nota sui ticket 01A proposti e sull'assenza di batch in `_holding`.
 - Chiusura “RIAPERTURA-2026-01” registrata e passaggio operativo verso pipeline 01A in STRICT MODE, mantenendo freeze inattivo finché non arriva nuova approvazione.
+
+## 2026-02-18 – Patchset 03A (cluster sonoro + validator 02A report-only)
+- Step ID: 03A-SONIC-VALIDATOR-2026-02-18; branch: `patch/03A-core-derived`; owner: Master DD (approvatore umano) con agente coordinator in STRICT MODE.
+- Azioni: corretti i trait sonori (`ali_fono_risonanti`, `cannone_sonico_a_raggio`, `campo_di_interferenza_acustica`, `occhi_cinetici`) aggiungendo chiavi i18n su `fattore_mantenimento_energetico`, usage tags e slot_profile coerenti; sinergie rese reciproche in JSON e index.
+- Validator 02A (report-only): `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack` → PASS (3 avvisi pack); `python scripts/trait_audit.py --check` → PASS (solo warning modulo jsonschema); `node scripts/trait_style_check.js --output-json reports/temp/patch-03A-core-derived/trait_style.json --fail-on error` → PASS (0 errori / 393 warning / 62 info). Log aggiornati in `reports/temp/patch-03A-core-derived/{schema_only.log,trait_audit.log,trait_style.log}`.
+- Documentazione: changelog `reports/temp/patch-03A-core-derived/changelog.md` e rollback `reports/temp/patch-03A-core-derived/rollback.md` aggiornati (snapshot di riferimento 2025-11-25). Merge subordinato ad approvazione finale di Master DD.

--- a/reports/temp/patch-03A-core-derived/changelog.md
+++ b/reports/temp/patch-03A-core-derived/changelog.md
@@ -6,14 +6,14 @@
 - Validator 02A rieseguiti in modalità report-only (schema-only, trait audit, trait style).
 
 ## Modifiche applicate
-1. **Sinergie trait** – rese reciproche tutte le sinergie bloccanti del `trait_audit` (es. `ectotermia_dinamica` ↔ `ipertrofia_muscolare_massiva`, `artigli_ipo_termici` ↔ `visione_multi_spettrale_amplificata`, catena `locomozione_miriapode_ibrida` ↔ `ermafroditismo_cronologico`/`sistemi_chimio_sonici`).
-2. **Copertura i18n frattura_abissale_sinaptica** – aggiunti i campi descrittivi (`mutazione_indotta`, `uso_funzione`, `spinta_selettiva`) ai trait catalogati solo in `index.json` per eliminare i warning di completezza.
-3. **Allineamento index** – `data/traits/index.json` sincronizzato con i dataset sorgente per sinergie e metadati, mantenendo lo schema invariato.
+1. **Schema biomi** – riesecuzione validator schema-only su `data/core/biomes.yaml` (nessun errore, 3 avvisi pack) per chiudere i rilievi 02A.
+2. **Sinergie trait cluster sonoro** – sinergie rese pienamente reciproche per `ali_fono_risonanti`, `cannone_sonico_a_raggio`, `campo_di_interferenza_acustica`, `occhi_cinetici` sia nei payload JSON sia in `data/traits/index.json`.
+3. **i18n/stile** – applicate chiavi i18n a `fattore_mantenimento_energetico`, popolati `usage_tags` e `slot_profile` coerenti (controller/scout/support) nel cluster sonoro; `data/traits/index.csv` allineato.
 
 ## Validator 02A (report-only)
 - `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack` → **OK** (3 avvisi pack). Log: `reports/temp/patch-03A-core-derived/schema_only.log`.
 - `python scripts/trait_audit.py` → **OK** (nessun blocco, solo warning sul modulo jsonschema mancante). Log: `reports/temp/patch-03A-core-derived/trait_audit.log`.
-- `node scripts/trait_style_check.js --output-json reports/temp/patch-03A-core-derived/trait_style.json --fail-on error` → **OK** (0 errori; 403 warning residui). Log: `reports/temp/patch-03A-core-derived/trait_style.log`.
+- `node scripts/trait_style_check.js --output-json reports/temp/patch-03A-core-derived/trait_style.json --fail-on error` → **OK** (0 errori; 393 warning, 62 info). Log: `reports/temp/patch-03A-core-derived/trait_style.log`.
 
 ## Note operative
 - Nessun artefatto generato fuori da `reports/temp/patch-03A-core-derived/`.

--- a/reports/temp/patch-03A-core-derived/rollback.md
+++ b/reports/temp/patch-03A-core-derived/rollback.md
@@ -12,7 +12,12 @@
    ```bash
    tar -xzf /path/to/core_snapshot_2025-11-25.tar.gz -C /workspace/Game --overwrite
    tar -xzf /path/to/derived_snapshot_2025-11-25.tar.gz -C /workspace/Game --overwrite
-   git checkout -- data/core/biomes.yaml data/traits/index.json apps/backend/services/traitStyleGuide.js
+   git checkout -- data/core/biomes.yaml data/traits/index.json data/traits/index.csv \
+     data/traits/locomotivo/ali_fono_risonanti.json \
+     data/traits/offensivo/cannone_sonico_a_raggio.json \
+     data/traits/difensivo/campo_di_interferenza_acustica.json \
+     data/traits/sensoriale/occhi_cinetici.json \
+     apps/backend/services/traitStyleGuide.js
    ```
 2. **Ripristino incoming/docs** (se necessario)
    ```bash

--- a/reports/temp/patch-03A-core-derived/trait_audit.log
+++ b/reports/temp/patch-03A-core-derived/trait_audit.log
@@ -1,1 +1,1 @@
-Report scritto in /workspace/Game/logs/trait_audit.md
+Audit dei tratti: nessuna regressione rilevata.

--- a/reports/temp/patch-03A-core-derived/trait_style.json
+++ b/reports/temp/patch-03A-core-derived/trait_style.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2025-11-25T16:57:45.250Z",
+  "generatedAt": "2025-11-25T17:36:54.798Z",
   "totalTraits": 225,
-  "totalIssues": 465,
+  "totalIssues": 455,
   "counts": {
     "info": 62,
-    "warning": 403,
+    "warning": 393,
     "error": 0
   },
   "traitsWithIssues": 225

--- a/reports/temp/patch-03A-core-derived/trait_style.log
+++ b/reports/temp/patch-03A-core-derived/trait_style.log
@@ -1,7 +1,7 @@
-Trait style: 465 suggerimenti (error=0, warning=403, info=62) su 225 file
+Trait style: 455 suggerimenti (error=0, warning=393, info=62) su 225 file
   - [WARNING] ali_fono_risonanti /debolezza :: Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.ali_fono_risonanti.debolezza).
-  - [WARNING] ali_fono_risonanti /fattore_mantenimento_energetico :: Allinea `fattore_mantenimento_energetico` al namespace i18n del tratto (i18n:traits.ali_fono_risonanti....).
-  - [WARNING] ali_fono_risonanti /slot_profile/complementare :: Compila il campo `complementare` in slot_profile (es. "metabolico").
-  - [WARNING] ali_fono_risonanti /slot_profile/core :: Compila il campo `core` in slot_profile (es. "metabolico").
-  - [WARNING] ali_fono_risonanti /usage_tags :: Popola almeno un usage tag dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank).
-  … altri 460 suggerimenti
+  - [WARNING] ali_fulminee /fattore_mantenimento_energetico :: Allinea `fattore_mantenimento_energetico` al namespace i18n del tratto (i18n:traits.ali_fulminee....).
+  - [WARNING] ali_ioniche /fattore_mantenimento_energetico :: Allinea `fattore_mantenimento_energetico` al namespace i18n del tratto (i18n:traits.ali_ioniche....).
+  - [WARNING] ali_membrana_sonica /fattore_mantenimento_energetico :: Allinea `fattore_mantenimento_energetico` al namespace i18n del tratto (i18n:traits.ali_membrana_sonica....).
+  - [WARNING] antenne_dustsense /fattore_mantenimento_energetico :: Allinea `fattore_mantenimento_energetico` al namespace i18n del tratto (i18n:traits.antenne_dustsense....).
+  … altri 450 suggerimenti


### PR DESCRIPTION
## Summary
- align the sonic trait cluster with reciprocal synergies, i18n energy factors, usage tags, and slot profiles, updating the catalog indices accordingly
- refresh changelog and rollback instructions tied to the 2025-11-25 snapshot
- rerun validator 02A in report-only mode and store the latest logs for schema-only, trait audit, and trait style checks

## Testing
- python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack
- python scripts/trait_audit.py --check
- node scripts/trait_style_check.js --output-json reports/temp/patch-03A-core-derived/trait_style.json --fail-on error


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e6ff5f9c8328ba2570c469d71568)