### PR TITLE
Log 02A validator rerun artifacts (2025-11-25-03)

### DIFF
--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -57,6 +57,12 @@
 - Comandi: `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack` → PASS con 3 avvisi pack (log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/schema_only.log`); `python scripts/trait_audit.py --check` → WARNING (modulo jsonschema assente, audit senza regressioni; log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/trait_audit.log`); `node scripts/trait_style_check.js --output-json reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/trait_style.json --fail-on error` → PASS con 0 errori / 403 warning / 62 info (log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/trait_style.log`, JSON nella stessa cartella).
 - Note: artefatti temporanei salvati in `reports/temp/patch-03A-core-derived/rerun-2025-11-25-02/`; nessuna modifica ai workflow CI o ai dataset, esecuzione preparatoria al freeze.
 
+## 2025-11-25 – Checklist 02A (report-only) – rerun 03
+- Step ID: 02A-VALIDATOR-RERUN-2025-11-25-03; ticket: **[TKT-02A-VALIDATOR]**; owner: Master DD (approvatore umano) con agente dev-tooling in STRICT MODE.
+- Branch: `patch/03A-core-derived`; scopo: riesecuzione checklist 02A in sola lettura con artefatti temporanei condivisi.
+- Comandi: `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack` → PASS con 3 avvisi pack (log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/schema_only.log`); `python scripts/trait_audit.py --check` → WARNING per modulo jsonschema mancante, nessuna regressione (log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/trait_audit.log`); `node scripts/trait_style_check.js --output-json reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/trait_style.json --fail-on error` → PASS con 0 errori / 176 warning / 66 info su 225 file (log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/trait_style.log`, JSON nella stessa cartella).
+- Note: artefatti temporanei salvati in `reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/`; nessuna modifica ai workflow CI o ai dataset.
+
 ## 2026-02-15 – Cleanup 03B con redirect + smoke 02A (report-only)
 - Step ID: 03B-INCOMING-CLEANUP-2026-02-15; owner: Master DD (approvatore umano) con agente dev-tooling/archivist.
 - Branch: `patch/03B-incoming-cleanup` (STRICT MODE); scope: spostamento bundle repo/devkit/inventari in `incoming/archive_cold/**` secondo manifesto 2025-11-25, senza toccare `data/core`/`data/derived`.

--- a/reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/schema_only.log
+++ b/reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/schema_only.log
@@ -1,0 +1,2 @@
+packs/evo_tactics_pack: 14 controlli eseguiti — 3 avvisi.
+Tutti i dataset YAML sono validi.

--- a/reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/trait_audit.log
+++ b/reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/trait_audit.log
@@ -1,0 +1,1 @@
+Audit dei tratti: nessuna regressione rilevata.

--- a/reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/trait_style.json
+++ b/reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/trait_style.json
@@ -1,0 +1,11 @@
+{
+  "generatedAt": "2025-11-25T20:22:22.892Z",
+  "totalTraits": 225,
+  "totalIssues": 242,
+  "counts": {
+    "info": 66,
+    "warning": 176,
+    "error": 0
+  },
+  "traitsWithIssues": 104
+}

--- a/reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/trait_style.log
+++ b/reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/trait_style.log
@@ -1,0 +1,7 @@
+Trait style: 242 suggerimenti (error=0, warning=176, info=66) su 225 file
+  - [WARNING] ali_fono_risonanti /debolezza :: Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.ali_fono_risonanti.debolezza).
+  - [WARNING] ali_fono_risonanti /fattore_mantenimento_energetico :: `fattore_mantenimento_energetico` è nella whitelist NON_LOCALISED_FIELDS: usa il testo inline invece di una chiave i18n.
+  - [WARNING] antenne_plasmatiche_tempesta /requisiti_ambientali/0/meta/tier :: Allinea meta.tier (—) al tier del tratto (T3).
+  - [WARNING] articolazioni_a_leva_idraulica /debolezza :: Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.articolazioni_a_leva_idraulica.debolezza).
+  - [WARNING] articolazioni_a_leva_idraulica /slot_profile/complementare :: Compila il campo `complementare` in slot_profile (es. "metabolico").
+  … altri 237 suggerimenti


### PR DESCRIPTION
## Descrizione
- Archiviata una nuova esecuzione report-only della checklist 02A su `patch/03A-core-derived` con log in `reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/`.
- Registrato in `logs/agent_activity.md` lo step **02A-VALIDATOR-RERUN-2025-11-25-03** collegato al ticket **TKT-02A-VALIDATOR** con riepilogo dei tre comandi eseguiti.

## Checklist guida stile & QA
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [x] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato
- [ ] Documentazione/processi aggiornati ove necessario

## Testing
- [x] `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack`
- [x] `python scripts/trait_audit.py --check`
- [x] `node scripts/trait_style_check.js --output-json reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/trait_style.json --fail-on error`

## Note
- Log: `reports/temp/patch-03A-core-derived/rerun-2025-11-25-03/` (schema_only.log, trait_audit.log, trait_style.log, trait_style.json).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69260f5edf1883289a2dfecde9348870)