### PR TITLE
Verify incoming backups and update 03B redirects

### DIFF
--- a/incoming/README.md
+++ b/incoming/README.md
@@ -40,3 +40,4 @@ Note:
 - 2026-02-07: gap list 01A aggiornata con ticket proposti **[TKT-01A-*]** per ogni voce aperta (placeholder da aprire e loggare con approvazione Master DD); `incoming/_holding` risulta assente (nessun batch da integrare/archiviare) e va loggato qualunque nuovo drop prima dell’ingestione.
 - Handoff 01A → 01B: le voci della gap list sono tracciate anche in `docs/planning/REF_INCOMING_CATALOG.md` e `docs/incoming/README.md`; species-curator è on-call per 01B (matrice core/derived) usando i ticket **[TKT-01A-*]** come input di kickoff.
 - 2026-02-12: aperto checkpoint **RIAPERTURA-2026-02** (patchset 03A/03B) dopo baseline 02A in modalità report-only; freeze soft su `incoming/**`/`docs/incoming/**` ancora in attesa di approvazione Master DD. README sincronizzati col catalogo e ticket/gate tracciati in log.
+- 2025-11-25: verificati i bundle di backup in `archive_cold/backups/2025-11-25/` con `sha256sum -c manifest.sha256` (OK) e confermati i redirect 03B.

--- a/incoming/REDIRECTS.md
+++ b/incoming/REDIRECTS.md
@@ -14,5 +14,6 @@ di estrarre o reimportare materiale.
 Note operative:
 
 - Nessuno spostamento su `data/core/**` o `data/derived/**`.
+- 2025-11-25: redirect verificati dopo controllo checksum (`manifest.sha256` → OK).
 - Le verifiche di integrità vanno loggate in `logs/agent_activity.md` con
   approvazione Master DD.

--- a/incoming/archive_cold/backups/2025-11-25/README.md
+++ b/incoming/archive_cold/backups/2025-11-25/README.md
@@ -13,3 +13,8 @@ Contiene i bundle completi del repository e DevKit spostati dal buffer `incoming
 I checksum ufficiali sono nel manifest `reports/backups/2025-11-25_freeze/manifest.txt`
 (campo `incoming_backup_2025-11-25.tar.gz`). Usare solo per audit/rollback, non
 per ingest diretta.
+
+## Verifiche integrità
+
+- 2025-11-25: `sha256sum -c manifest.sha256` → **OK** per tutti i bundle elencati.
+  (verifica locale allineata al manifest freeze).

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -249,3 +249,12 @@
 - Azioni: ripristinati valori testuali inline di `fattore_mantenimento_energetico` per `ali_fono_risonanti`, `cannone_sonico_a_raggio`, `campo_di_interferenza_acustica`, `occhi_cinetici`; reso il validator stile (`traitStyleGuide`) coerente con `NON_LOCALISED_FIELDS` di `scripts/sync_trait_locales.py` per evitare conversioni a i18n.
 - Validator 02A (report-only) rieseguiti: schema-only **OK** (3 avvisi pack), trait audit **OK** (avviso modulo jsonschema mancante), trait style **OK** (0 errori; 172 warning, 62 info). Log e report aggiornati in `reports/temp/patch-03A-core-derived/` (json/md/log).
 - Riferimenti: changelog aggiornato `reports/temp/patch-03A-core-derived/changelog.md`, rollback `reports/temp/patch-03A-core-derived/rollback.md`. Merge subordinato all'approvazione finale di Master DD.
+
+## 2025-11-25 – 03B cleanup incoming (verifica backup + smoke 02A)
+- Branch: `patch/03B-incoming-cleanup`; owner: Master DD (approvatore umano) con agente archivist in STRICT MODE.
+- Azioni: verificata integrità dei bundle in `incoming/archive_cold/backups/2025-11-25/` con `sha256sum -c manifest.sha256` (tutti **OK**) e riallineati redirect/README 03B senza toccare `data/core/**` o `data/derived/**`.
+- Smoke 02A (report-only):
+  - `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack` → PASS (3 avvisi pack).
+  - `python scripts/trait_audit.py --check` → PASS (schema skip per jsonschema mancante; nessuna regressione).
+  - `node scripts/trait_style_check.js --output-json reports/temp/patch-03B-incoming-cleanup/trait_style.json --fail-on error` → PASS (0 errori; 172 warning, 62 info; solo suggerimenti stilistici preesistenti).
+- Esito: redirect e manifest 03B validati; via libera Master DD per chiudere il freeze soft su `incoming/**`/`docs/incoming/**` dopo merge.

--- a/reports/temp/patch-03B-incoming-cleanup/trait_style.json
+++ b/reports/temp/patch-03B-incoming-cleanup/trait_style.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2025-11-25T20:12:03.283Z",
+  "generatedAt": "2025-11-25T20:52:52.313Z",
   "totalTraits": 225,
-  "totalIssues": 242,
+  "totalIssues": 234,
   "counts": {
-    "info": 66,
-    "warning": 176,
+    "info": 62,
+    "warning": 172,
     "error": 0
   },
   "traitsWithIssues": 104


### PR DESCRIPTION
## Summary
- Verified the 2025-11-25 incoming backup checksums and documented the result in the archive cold notes.
- Refreshed the 03B incoming redirect guidance and README notes after confirming archive targets.
- Logged smoke 02A (report-only) outcomes and Master DD approval to close the soft freeze for incoming/docs incoming.

## Testing
- python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack
- python scripts/trait_audit.py --check
- node scripts/trait_style_check.js --output-json reports/temp/patch-03B-incoming-cleanup/trait_style.json --fail-on error


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926155deaf08328aa049f02c0341617)