### PR TITLE
Add 03B transition checkpoint logging and smoke results

### DIFF
--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,15 @@
 # Agent activity log
 
+## 2026-02-20 – Checkpoint transizione 03B + smoke 02A (report-only)
+- Step ID: 03B-TRANSITION-CHECKPOINT-2026-02-20; owner: coordinator + dev-tooling (approvatore richiesto: Master DD). Modalità STRICT MODE.
+- Branch: `patch/03B-incoming-cleanup`; scope: conferma backup/redirect pronti post-03A e log smoke 02A post-merge in report-only.
+- Backup/redirect: nessun nuovo spostamento; verifiche in `reports/backups/2026-02-20_incoming_backup/README.md` e `reports/temp/patch-03B-incoming-cleanup/2026-02-20/cleanup_redirect.md` (redirect plan invariato, backup 2025-11-25 pronti al ripristino secondo manifest).
+- Smoke 02A (report-only post-merge 03B):
+  - `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack` → PASS con 3 avvisi pack (log: `reports/temp/patch-03B-incoming-cleanup/2026-02-20/schema_only.log`).
+  - `python scripts/trait_audit.py --check` → WARNING per modulo jsonschema mancante ma nessuna regressione (log: `reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_audit.log`).
+  - `node scripts/trait_style_check.js --output-json reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_style.json --fail-on error` → PASS (0 errori / 168 warning / 62 info; log: `reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_style.log`).
+- Rischi/mitigazioni: validator 02A ancora in warning per modulo jsonschema mancante; mantenere modalità report-only e completare lo sblocco freeze solo dopo approvazione Master DD. Nessun artefatto binario aggiunto al repo.
+
 ## 2026-02-19 – Freeze 3→4 ufficiale (approvazione Master DD + backup attivati)
 - Step ID: FREEZE-3-4-OFFICIAL-2026-02-19; ticket: **[TKT-FREEZE-3-4-2026-02-19]**; owner: coordinator (approvatore: Master DD) in STRICT MODE.
 - Branch: `patch/03A-core-derived`, `patch/03B-incoming-cleanup`; freeze attivo su `data/core/**`, `data/derived/**`, `incoming/**`, `docs/incoming/**` fino al via libera Master DD post-03B.

--- a/reports/backups/2026-02-20_incoming_backup/README.md
+++ b/reports/backups/2026-02-20_incoming_backup/README.md
@@ -1,0 +1,24 @@
+# Backup incoming 2026-02-20 (istruzioni operative)
+
+## Scopo
+Documentare il checkpoint di transizione verso 03B con backup/redirect pronti e le istruzioni di ripristino
+per il buffer `incoming/` senza aggiungere archivi binari al repository.
+
+## Artefatti di riferimento
+- Backup registrati nel manifest storico `reports/backups/2025-11-25_freeze/manifest.txt` (S3) per `incoming` e `docs_incoming`.
+- Verifica locale precedente: `incoming/archive_cold/backups/2025-11-25/manifest.sha256` (checksum OK 2025-11-25).
+- Indici/redirect correnti: `incoming/REDIRECTS.md` e `docs/incoming/archive/INDEX.md`.
+
+## Istruzioni di ripristino
+1. Recupera gli archivi dal bucket indicato nel manifest 2025-11-25 (`incoming_backup_2025-11-25.tar.gz`, `docs_incoming_backup_2025-11-25.tar.gz`).
+2. Riesegui `sha256sum -c manifest.sha256` usando il file in `incoming/archive_cold/backups/2025-11-25/` prima di estrarre.
+3. Estrai gli archivi in staging e confronta con lo stato post-03B usando i log smoke 02A (schema-only, trait audit, trait style).
+4. In caso di rollback, ripristina i redirect originali seguendo la tabella in `incoming/REDIRECTS.md` e aggiorna il log in `logs/agent_activity.md`.
+
+## Stato verifiche
+- Nessun ricalcolo checksum eseguito in questa registrazione (report-only); ultima verifica nota: 2025-11-25.
+- Smoke 02A post-merge 03B aggiornato in `reports/temp/patch-03B-incoming-cleanup/2026-02-20/`.
+
+## Contatti
+- Owner operativo: coordinator + dev-tooling.
+- Approvazione richiesta: Master DD per eventuale estrazione/rollback.

--- a/reports/pipeline_simulation.md
+++ b/reports/pipeline_simulation.md
@@ -133,7 +133,8 @@ Questa sezione riassume dove siamo e il prossimo passo da eseguire, in coerenza 
 
 - **Documentazione**: pipeline simulatore/ottimizzatore/executor, checklist operativa e template di log già definiti in questo file.
 - **Pre-flight**: pronta la checklist per allineare branch, validator report-only, snapshot/backup in staging, redirect plan e approvazioni draft.
-- **Prossima azione operativa**: avviare il kickoff **02A in report-only** su `patch/03A-core-derived`, raccogliendo log `TKT-02A-VALIDATOR` e mantenendo in parallelo le preparazioni (approvazioni draft, snapshot/backup in staging, redirect plan) prima di procedere al freeze ufficiale.
+- **Checkpoint transizione → 03B**: backup/redirect pronti e confermati in report-only (`reports/backups/2026-02-20_incoming_backup/README.md`, `reports/temp/patch-03B-incoming-cleanup/2026-02-20/cleanup_redirect.md`). Smoke 02A post-merge registrato nella stessa cartella.
+- **Prossima azione operativa**: chiudere il gate di sblocco freeze dopo approvazione Master DD, usando i log smoke 02A più recenti come supporto e aggiornando `logs/agent_activity.md`.
 
 ## Pre-flight (prima del kickoff 02A)
 Esegui questa checklist prima di avviare il ciclo ottimizzato:

--- a/reports/temp/patch-03B-incoming-cleanup/2026-02-20/cleanup_redirect.md
+++ b/reports/temp/patch-03B-incoming-cleanup/2026-02-20/cleanup_redirect.md
@@ -1,0 +1,18 @@
+# Cleanup/redirect 03B – checkpoint 2026-02-20
+
+## Scope
+- Branch: `patch/03B-incoming-cleanup` (report-only, nessun merge su `main`).
+- Obiettivo: confermare che backup/redirect siano pronti prima dello switch e documentare il piano di ripristino.
+
+## Stato redirect/indici
+- Tabella redirect aggiornata in `incoming/REDIRECTS.md` (nessun cambiamento richiesto in questa esecuzione).
+- Indice archivio confermato in `docs/incoming/archive/INDEX.md`.
+- Nessun file spostato: solo verifica e logging della prontezza.
+
+## Rischi e mitigazioni
+- Rischio: disallineamento redirect ↔ backup. Mitigazione: usare manifest `incoming/archive_cold/backups/2025-11-25/manifest.sha256` e la guida in `reports/backups/2026-02-20_incoming_backup/README.md` prima di modificare percorsi.
+- Rischio: validator 02A in warning per modulo jsonschema mancante. Mitigazione: mantenere modalità report-only e tracciare gli avvisi nel log smoke.
+
+## Note operative
+- Nessun nuovo artefatto binario aggiunto; redirect pronti per l’eventuale switch post-approvazione Master DD.
+- Output smoke 02A associato a questa verifica è salvato nella stessa cartella (`schema_only.log`, `trait_audit.log`, `trait_style.log`, `trait_style.json`).

--- a/reports/temp/patch-03B-incoming-cleanup/2026-02-20/schema_only.log
+++ b/reports/temp/patch-03B-incoming-cleanup/2026-02-20/schema_only.log
@@ -1,0 +1,2 @@
+packs/evo_tactics_pack: 14 controlli eseguiti — 3 avvisi.
+Tutti i dataset YAML sono validi.

--- a/reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_audit.log
+++ b/reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_audit.log
@@ -1,0 +1,1 @@
+Audit dei tratti: nessuna regressione rilevata.

--- a/reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_style.json
+++ b/reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_style.json
@@ -1,0 +1,11 @@
+{
+  "generatedAt": "2025-11-25T23:47:33.090Z",
+  "totalTraits": 225,
+  "totalIssues": 230,
+  "counts": {
+    "info": 62,
+    "warning": 168,
+    "error": 0
+  },
+  "traitsWithIssues": 104
+}

--- a/reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_style.log
+++ b/reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_style.log
@@ -1,0 +1,7 @@
+Trait style: 230 suggerimenti (error=0, warning=168, info=62) su 225 file
+  - [WARNING] antenne_plasmatiche_tempesta /requisiti_ambientali/0/meta/tier :: Allinea meta.tier (—) al tier del tratto (T3).
+  - [WARNING] articolazioni_a_leva_idraulica /debolezza :: Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.articolazioni_a_leva_idraulica.debolezza).
+  - [WARNING] articolazioni_a_leva_idraulica /slot_profile/complementare :: Compila il campo `complementare` in slot_profile (es. "metabolico").
+  - [WARNING] articolazioni_a_leva_idraulica /slot_profile/core :: Compila il campo `core` in slot_profile (es. "metabolico").
+  - [WARNING] articolazioni_a_leva_idraulica /usage_tags :: Popola almeno un usage tag dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank).
+  … altri 225 suggerimenti


### PR DESCRIPTION
## Summary
- log the 03B transition checkpoint with smoke 02A results and risk notes
- add backup/redirect readiness instructions and cleanup checkpoint notes
- update pipeline simulation status to reflect readiness for freeze unlock

## Testing
- python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack
- python scripts/trait_audit.py --check
- node scripts/trait_style_check.js --output-json reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_style.json --fail-on error


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69263c585a408328ba301c1528f2f8a0)