### PR TITLE
Add audit bundle references for 02A-03B cycle

### DIFF
--- a/docs/planning/REF_PATCHSET_02A_TO_03AB_RUNBOOK.md
+++ b/docs/planning/REF_PATCHSET_02A_TO_03AB_RUNBOOK.md
@@ -49,6 +49,11 @@ Stato: PIANO ESECUTIVO – sequenza operativa dal baseline 02A al rollout 03A/03
 - **Validator:** mantenere modalità report-only fino al via libera per rollout; allegare output sintetico nel log e collegare ai comandi usati.
 - **Rollback:** indicare script/percorso di rollback per 03A; per 03B, percorso backup incoming + istruzioni di ripristino redirect.
 
+## Audit bundle e riavvio
+
+- Conservare il pacchetto di audit in `reports/audit/2026-02-20_audit_bundle.md`, che aggrega log freeze/sblocco, report 02A (baseline e smoke post-merge), changelog/rollback 03A e istruzioni backup/redirect 03B.
+- Usare il bundle come checkpoint per il ciclo successivo: completare il log di sblocco, rieseguire PIPELINE_SIMULATOR sulla sequenza 02A→freeze→03A→03B e aggiornare eventuali whitelist 02A prima di nuovi patchset.
+
 ## Rischi e mitigazioni rapide
 
 - **Freeze non formalizzato:** rischio ingressi non tracciati → non avviare patch senza log di freeze approvato.

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,10 @@
 # Agent activity log
 
+## 2026-02-21 – Audit bundle 02A→03A/03B archiviato (archivist)
+- Step ID: AUDIT-BUNDLE-02A-03B-2026-02-21; owner: archivist con approvazione Master DD richiesta per l’uso in produzione.
+- Azioni: raccolti log freeze/sblocco, report 02A (baseline e smoke post-merge), changelog/rollback 03A e istruzioni backup/redirect 03B nel pacchetto testuale `reports/audit/2026-02-20_audit_bundle.md`.
+- Esito: bundle pronto per il riavvio del ciclo 02A→freeze→03A→03B; da collegare al trigger PIPELINE_SIMULATOR dopo il log di sblocco definitivo.
+
 ## 2026-02-21 – Sblocco freeze + trigger PIPELINE_SIMULATOR (coordinator)
 - Step ID: UNFREEZE-02A-APPROVED-2026-02-21; owner: Master DD (approvatore umano) con agente coordinator in STRICT MODE; branch coinvolti `patch/03A-core-derived` e `patch/03B-incoming-cleanup`.
 - Prerequisiti verificati: smoke 02A più recente in pass (report-only) e approvazione finale Master DD registrata; nessun delta aperto su validator schema/trait/style.

--- a/reports/audit/2026-02-20_audit_bundle.md
+++ b/reports/audit/2026-02-20_audit_bundle.md
@@ -1,0 +1,36 @@
+# Audit bundle 02A → 03A/03B (ciclo 2026-02-20)
+
+## Scopo
+Raccogliere in un unico punto i riferimenti operativi per chiudere il ciclo 02A→03A→03B e preparare il riavvio successivo. Il bundle è testuale e punta agli artefatti già versionati (log, changelog, rollback, istruzioni backup/redirect) senza introdurre binari.
+
+## Indice artefatti
+- **Log freeze/sblocco**
+  - Freeze 03AB (2025-11-25) registrato in `logs/agent_activity.md` con snapshot/core/derived/incoming e owner Master DD.
+  - Sblocco finale ancora da registrare: usare lo stesso log (`logs/agent_activity.md`) per documentare approvazione Master DD e ripristino del ciclo.
+- **Report 02A – baseline (pre-03A)**
+  - Validatori 02A in report-only per `patch/03A-core-derived`: `reports/temp/patch-03A-core-derived/{schema_only.log,trait_audit.log,trait_style.log,trait_style.json}` e appendici `trait_style.md`/`changelog.md`.
+  - Rerun dedicati (report-only) per TKT-02A con copie in `reports/temp/patch-03A-core-derived/rerun-2025-11-25-04/` e `.../rerun-2025-11-25T23-27-06Z/`.
+- **Report 02A – post-merge (smoke 03B)**
+  - Output smoke 02A in `reports/temp/patch-03B-incoming-cleanup/2026-02-20/` (`schema_only.log`, `trait_audit.log`, `trait_style.log`, `trait_style.json`).
+- **Changelog + rollback 03A**
+  - Changelog: `reports/temp/patch-03A-core-derived/changelog.md`.
+  - Pacchetto rollback: `reports/temp/patch-03A-core-derived/rollback.md` (agganciato allo snapshot 2025-11-25).
+- **Backup/redirect 03B**
+  - Istruzioni di backup/restore incoming: `reports/backups/2026-02-20_incoming_backup/README.md`.
+  - Piano redirect e rischi: `reports/temp/patch-03B-incoming-cleanup/2026-02-20/cleanup_redirect.md`.
+
+## Uso pratico (riavvio ciclo)
+1. **Verifica log** – Aggiorna `logs/agent_activity.md` con la chiusura freeze/sblocco citando approvazione Master DD e l’esito smoke 02A post-merge.
+2. **Conferma baseline** – Riesamina i log 02A baseline e le whitelist 02A presenti nei rerun 2025-11-25 per allineare i validator al nuovo ciclo.
+3. **Validazione post-merge** – Conserva gli output smoke 02A del 2026-02-20 come riferimento iniziale per il prossimo ciclo; riesegui se cambiano gli input core/pack.
+4. **Ripristino rapido** – In caso di regressione, applica il rollback 03A seguendo `reports/temp/patch-03A-core-derived/rollback.md` e, per incoming, le istruzioni di `reports/backups/2026-02-20_incoming_backup/README.md`.
+5. **Trigger riavvio** – Dopo lo sblocco e il log finale, rilancia la sequenza 02A→freeze→03A→03B tramite PIPELINE_SIMULATOR/GOLDEN_PATH con i riferimenti sopra come baseline.
+
+## Checklist di copertura
+- [x] Log freeze referenziati
+- [ ] Log sblocco registrato
+- [x] Report 02A iniziale
+- [x] Report 02A post-merge (smoke)
+- [x] Changelog + rollback 03A
+- [x] Istruzioni backup/redirect 03B
+- [ ] Trigger riavvio eseguito


### PR DESCRIPTION
## Summary
- add an audit bundle README that aggregates freeze/sblocco logs, 02A reports, 03A changelog/rollback, and 03B backup/redirect notes
- log the audit bundle creation in agent_activity
- reference the bundle in the 02A→03A/03B runbook for reuse in the next cycle

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69264626bedc8328ae5ec6dec61bb2ca)