### PR TITLE
Add audit bundle verification log entry

### DIFF
--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,10 @@
 # Agent activity log
 
+## 2026-02-22 – Verifica bundle audit 02A→03A/03B (archivist)
+- Step ID: AUDIT-BUNDLE-VERIFICATION-2026-02-22; owner: archivist in STRICT MODE (approvazione Master DD già registrata nel log di sblocco 2026-02-21).
+- Azioni: controllati i riferimenti in `reports/audit/2026-02-20_audit_bundle.md` seguendo l’indice; confermata presenza dei log freeze/sblocco (`logs/agent_activity.md`), dei report 02A baseline/post-merge (`reports/temp/patch-03A-core-derived/…`, `reports/temp/patch-03B-incoming-cleanup/2026-02-20/`), del changelog/rollback 03A e delle istruzioni backup/redirect 03B (`reports/backups/2026-02-20_incoming_backup/README.md`, `.../cleanup_redirect.md`).
+- Esito: nessun riferimento mancante o path divergente rilevato; nessun artefatto nuovo aggiunto.
+
 ## 2025-11-26 – Pipeline cycle 02A→03A→03B completato (dev-tooling)
 - Step ID: PIPELINE-CYCLE-02A-03B-2025-11-26; owner: agente dev-tooling in STRICT MODE con approvatore Master DD.
 - Prerequisiti: installato il modulo Python `jsonschema` (pip) dopo errore di dipendenza durante l'avvio della pipeline.


### PR DESCRIPTION
## Summary
- add archivist log entry documenting verification of the 2026-02-20 audit bundle paths and assets

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926ffcba98c8328ad939680304fae9d)