### PR TITLE
Clarify Master DD approval freeze notes

### DIFF
--- a/docs/incoming/README.md
+++ b/docs/incoming/README.md
@@ -21,6 +21,7 @@ Note:
 
 - Spostamento eseguito per i duplicati DevKit e inventari (freeze 2025-11-25) verso `incoming/archive_cold/**` con riferimento a `reports/backups/2025-11-25_freeze/manifest.txt`.
 - Tenere la tabella sincronizzata con `incoming/README.md` e il catalogo di pianificazione.
+- 2026-03-05: approvazione Master DD registrata per log 01A e aggiornamento README (ticket **[TKT-01A-DOCS]**); soft freeze ancora attivo su `incoming/**`/`docs/incoming/**` con sblocco pianificato **2026-03-08 09:00 UTC** (nessun `_holding`, nessun drop nuovo; autorizzato solo l’update documentale).
 - 2026-02-07: gap list 01A aggiornata con ticket proposti **[TKT-01A-*]** sulle voci aperte (placeholder da aprire e loggare con approvazione Master DD); `incoming/_holding` non presente (nessun batch attivo) e ogni nuovo drop va loggato prima di eventuale ingestione.
 - Handoff 01A → 01B: gap list e ticket sono specchiati in `incoming/README.md` e `docs/planning/REF_INCOMING_CATALOG.md`; species-curator è on-call per 01B con supporto trait-curator/balancer per i casi borderline core/derived.
 - 2026-02-12: checkpoint **RIAPERTURA-2026-02** per patchset 03A/03B registrato in `logs/agent_activity.md` dopo gate 02A (report-only); freeze soft ancora da confermare con Master DD e nessuna riapertura automatica dei validator CI.

--- a/incoming/README.md
+++ b/incoming/README.md
@@ -38,6 +38,7 @@ Note:
 - Redirect/indici del cleanup 03B riepilogati in `incoming/REDIRECTS.md`.
 - Spostamento effettuato (freeze 2025-11-25) verso `incoming/archive_cold/**` per bundle repo, script DevKit duplicati e inventari storici; riferimenti e checksum in `reports/backups/2025-11-25_freeze/manifest.txt`.
 - Usare lo stesso stato sia qui sia in `docs/incoming/README.md` per tenere sincronizzato il triage.
+- 2026-03-05: approvazione Master DD registrata per log 01A e aggiornamento README (ticket **[TKT-01A-DOCS]**); soft freeze ancora attivo su `incoming/**`/`docs/incoming/**` con sblocco pianificato **2026-03-08 09:00 UTC** (nessun `_holding` presente, nessun drop nuovo; autorizzato solo l’update documentale).
 - 2026-02-07: gap list 01A aggiornata con ticket proposti **[TKT-01A-*]** per ogni voce aperta (placeholder da aprire e loggare con approvazione Master DD); `incoming/_holding` risulta assente (nessun batch da integrare/archiviare) e va loggato qualunque nuovo drop prima dell’ingestione.
 - Handoff 01A → 01B: le voci della gap list sono tracciate anche in `docs/planning/REF_INCOMING_CATALOG.md` e `docs/incoming/README.md`; species-curator è on-call per 01B (matrice core/derived) usando i ticket **[TKT-01A-*]** come input di kickoff.
 - 2026-02-12: aperto checkpoint **RIAPERTURA-2026-02** (patchset 03A/03B) dopo baseline 02A in modalità report-only; freeze soft su `incoming/**`/`docs/incoming/**` ancora in attesa di approvazione Master DD. README sincronizzati col catalogo e ticket/gate tracciati in log.

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,11 @@
 # Agent activity log
 
+## 2026-03-05 – Approvazione Master DD su log 01A + note README (archivist)
+- Step ID: LOG-01A-APPROVAL-2026-03-05; owner: Master DD (approvatore umano) con agente archivist in STRICT MODE.
+- Azioni: rieseguito check freeze su `incoming/**` e `docs/incoming/**` (nessun `_holding`, nessun nuovo drop) e confermato che il soft freeze resta attivo; autorizzato l’aggiornamento delle note README + log 01A con finestra di sblocco pianificata **2026-03-08 09:00 UTC**.
+- Ticket: **[TKT-01A-DOCS]** (riferimento per gap list e allineamento README); nessun file spostato/ingestito.
+- Esito: README `incoming/` e `docs/incoming/` aggiornati con la conferma di approvazione Master DD e la data di sblocco pianificata; log 01A riallineato al ticket di tracciamento.
+
 ## 2026-03-01 – Richiamo log 01A verso bundle audit (archivist)
 - Step ID: LOG-01A-AUDIT-2026-03-01; owner: archivist in STRICT MODE.
 - Azioni: registrato collegamento esplicito al bundle audit 02A→03A/03B per tracciamento 01A senza eseguire nuove pipeline o modifiche di freeze.


### PR DESCRIPTION
## Summary
- clarify the 2026-03-05 log entry with explicit freeze status, approval scope, and planned unfreeze window
- align incoming README notes to stress the soft freeze remains active and only documentation updates were authorized

## Testing
- Not run (docs-only changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927745272dc8328bb31b4bf0deefef1)