### PR TITLE
Log kickoff 01B and CI workflow inventory

### DIFF
--- a/docs/incoming/README.md
+++ b/docs/incoming/README.md
@@ -21,6 +21,7 @@ Note:
 
 - Spostamento eseguito per i duplicati DevKit e inventari (freeze 2025-11-25) verso `incoming/archive_cold/**` con riferimento a `reports/backups/2025-11-25_freeze/manifest.txt`.
 - Tenere la tabella sincronizzata con `incoming/README.md` e il catalogo di pianificazione.
+- 2026-03-13: kickoff 01B con species-curator per matrice core/derived su ticket **[TKT-01A-001]** … **[TKT-01A-005]**; dev-tooling incaricato di inventariare workflow CI/script incoming senza eseguire pipeline. Aggiornamento README dopo approvazione Master DD (vedi `logs/agent_activity.md`).
 - 2026-03-10: riesame gate **RIAPERTURA-2026-01** con Master DD (ticket **[TKT-01A-DOCS]**): soft freeze su `incoming/**`/`docs/incoming/**` confermato e finestra di sblocco rinviata a **2026-03-12 09:00 UTC**. Nessun `_holding` o drop nuovo; restano consentiti solo update documentali finché non arriva via libera sull’ingest.
 - 2026-02-07: gap list 01A aggiornata con ticket proposti **[TKT-01A-*]** sulle voci aperte (placeholder da aprire e loggare con approvazione Master DD); `incoming/_holding` non presente (nessun batch attivo) e ogni nuovo drop va loggato prima di eventuale ingestione.
 - Handoff 01A → 01B: gap list e ticket sono specchiati in `incoming/README.md` e `docs/planning/REF_INCOMING_CATALOG.md`; species-curator è on-call per 01B con supporto trait-curator/balancer per i casi borderline core/derived.

--- a/incoming/README.md
+++ b/incoming/README.md
@@ -38,6 +38,7 @@ Note:
 - Redirect/indici del cleanup 03B riepilogati in `incoming/REDIRECTS.md`.
 - Spostamento effettuato (freeze 2025-11-25) verso `incoming/archive_cold/**` per bundle repo, script DevKit duplicati e inventari storici; riferimenti e checksum in `reports/backups/2025-11-25_freeze/manifest.txt`.
 - Usare lo stesso stato sia qui sia in `docs/incoming/README.md` per tenere sincronizzato il triage.
+- 2026-03-13: kickoff 01B con species-curator per matrice core/derived usando ticket **[TKT-01A-001]** … **[TKT-01A-005]**; dev-tooling incaricato di inventariare workflow CI/script incoming senza eseguire pipeline. Aggiornamento README dopo approvazione Master DD (vedi `logs/agent_activity.md`).
 - 2026-03-10: riesame gate **RIAPERTURA-2026-01** con Master DD (ticket **[TKT-01A-005]**): soft freeze su `incoming/**`/`docs/incoming/**` confermato e rinvio dello sblocco a **2026-03-12 09:00 UTC**. Nessun `_holding` o drop nuovo; restano consentiti solo update documentali finché non arriva via libera sull’ingest.
 - 2026-02-07: gap list 01A aggiornata con ticket aperti **[TKT-01A-001]** … **[TKT-01A-005]** (registrati con approvazione Master DD); `incoming/_holding` risulta assente (nessun batch da integrare/archiviare) e va loggato qualunque nuovo drop prima dell’ingestione.
 - Handoff 01A → 01B: le voci della gap list sono tracciate anche in `docs/planning/REF_INCOMING_CATALOG.md` e `docs/incoming/README.md`; species-curator è on-call per 01B (matrice core/derived) usando i ticket **[TKT-01A-001]** … **[TKT-01A-005]** come input di kickoff.

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,10 @@
 # Agent activity log
 
+## 2026-03-13 – Kickoff 01B core/derived + mandato inventario workflow CI (coordinator)
+- Step: `[01B-KICKOFF-MATRIX-2026-03-13] owner=coordinator (approvatore Master DD); files=logs/agent_activity.md, incoming/README.md, docs/incoming/README.md; rischio=medio (documentazione/processo); note=Kickoff rapido con species-curator usando i ticket **[TKT-01A-001]** … **[TKT-01A-005]** come input per costruire la matrice core/derived (fase 01B) e definire blocchi derived borderline con trait-curator/balancer in supporto.`
+- Step: `[01C-WF-INVENTORY-2026-03-13] owner=dev-tooling (approvatore Master DD); files=logs/agent_activity.md; rischio=basso (ricognizione/script); note=Incaricato dev-tooling di raccogliere inventario di workflow CI e script legati ai pack incoming senza eseguire pipeline o validatori.`
+- Note: README `incoming/` e `docs/incoming/` da aggiornare dopo approvazione Master DD con esito del kickoff e dell’inventario (nessun cambio di freeze o pipeline attivata).
+
 ## 2026-03-12 – Apertura ticket reali gap list 01A + shortlist kickoff (archivist)
 - Step: `[TICKETS-01A-OPEN-2026-03-12] owner=archivist (approvatore Master DD); files=docs/planning/REF_INCOMING_CATALOG.md, incoming/README.md, logs/agent_activity.md; rischio=medio (documentazione/ownership); note=Aperti i ticket **[TKT-01A-001]** … **[TKT-01A-005]** per tutte le voci della gap list 01A e sincronizzati i riferimenti nei README; registrata shortlist kickoff 01B/01C (ticket **[TKT-01B-001]**, **[TKT-01B-002]**, **[TKT-01C-001]**, **[TKT-01C-002]**) con rischi/dipendenze. Fase=01A→01B/01C.`
 


### PR DESCRIPTION
## Summary
- log kickoff 01B for the core/derived matrix using TKT-01A inputs
- record the dev-tooling inventory mandate for CI workflows/scripts on incoming packs
- sync incoming README notes with the new kickoff and inventory reminders

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69277db32e84832894d297123704e38e)