### PR TITLE
Add RIAPERTURA-2026-01 availability note and README links

### DIFF
--- a/docs/incoming/README.md
+++ b/docs/incoming/README.md
@@ -20,6 +20,7 @@ Linee guida minime:
 Note:
 
 - 2026-03-19: log **RIAPERTURA-2026-01** (micro-step archivist) riconferma soft freeze su `incoming/**` e `docs/incoming/**`, gap list 01A allineata a `docs/planning/REF_INCOMING_CATALOG.md` e ticket **[TKT-01A-001]** … **[TKT-01A-005]** (alias **[TKT-01A-DOCS]** per la voce documentazione) registrati in `logs/agent_activity.md`; nessuno spostamento file autorizzato.
+- 2026-03-20: nota **RIAPERTURA-2026-01** aggiornata con disponibilità species-curator/trait-curator (01B) e dev-tooling (01C) in modalità report-only, con ticket **[TKT-01B-001]**, **[TKT-01B-002]**, **[TKT-01C-001]**, **[TKT-01C-002]** e riferimenti in `logs/RIAPERTURA-2026-01-note.md` e `reports/audit/readiness-01c-ci-inventory.md`.
 - Spostamento eseguito per i duplicati DevKit e inventari (freeze 2025-11-25) verso `incoming/archive_cold/**` con riferimento a `reports/backups/2025-11-25_freeze/manifest.txt`.
 - Tenere la tabella sincronizzata con `incoming/README.md` e il catalogo di pianificazione.
 - 2026-03-13: kickoff 01B con species-curator per matrice core/derived su ticket **[TKT-01A-001]** … **[TKT-01A-005]**; dev-tooling incaricato di inventariare workflow CI/script incoming senza eseguire pipeline. Aggiornamento README dopo approvazione Master DD (vedi `logs/agent_activity.md`).

--- a/incoming/README.md
+++ b/incoming/README.md
@@ -36,6 +36,7 @@ Linee guida minime:
 Note:
 
 - 2026-03-19: log **RIAPERTURA-2026-01** (micro-step archivist) riconferma soft freeze su `incoming/**` e `docs/incoming/**`, con gap list 01A allineata a `docs/planning/REF_INCOMING_CATALOG.md` e ticket **[TKT-01A-001]** … **[TKT-01A-005]** (alias **[TKT-01A-DOCS]** per la voce documentazione) tracciati in `logs/agent_activity.md`; nessuno spostamento file autorizzato.
+- 2026-03-20: nota **RIAPERTURA-2026-01** aggiornata con disponibilità species-curator/trait-curator per 01B e dev-tooling per 01C in modalità report-only; ticket **[TKT-01B-001]**, **[TKT-01B-002]**, **[TKT-01C-001]**, **[TKT-01C-002]** confermati e riferimenti in `logs/RIAPERTURA-2026-01-note.md` e `reports/audit/readiness-01c-ci-inventory.md`.
 - Redirect/indici del cleanup 03B riepilogati in `incoming/REDIRECTS.md`.
 - Spostamento effettuato (freeze 2025-11-25) verso `incoming/archive_cold/**` per bundle repo, script DevKit duplicati e inventari storici; riferimenti e checksum in `reports/backups/2025-11-25_freeze/manifest.txt`.
 - Usare lo stesso stato sia qui sia in `docs/incoming/README.md` per tenere sincronizzato il triage.

--- a/logs/RIAPERTURA-2026-01-note.md
+++ b/logs/RIAPERTURA-2026-01-note.md
@@ -1,0 +1,18 @@
+# RIAPERTURA-2026-01 – Nota disponibilità 01B/01C (coordinator)
+
+## Sintesi
+- Obiettivo: riepilogo disponibilità e ticket in carico per 01B (matrice core/derived) e 01C (inventario workflow CI/script) in modalità report-only.
+- Scope: aggiornamento richiesto dal gate RIAPERTURA-2026-01; nessuna esecuzione di validator o pipeline.
+
+## Disponibilità e ticket
+### Species-curator / Trait-curator – 01B (matrice core/derived)
+- Disponibilità confermata in modalità report-only per 01B; kickoff registrato con supporto trait-curator/balancer e uso dei ticket di gap list come input.
+- Ticket attivi: **[TKT-01B-001]** (matrice core/derived), **[TKT-01B-002]** (trait sentience/enneagramma). Collegati ai ticket di gap list **[TKT-01A-001]** … **[TKT-01A-005]** per i casi borderline.
+
+### Dev-tooling – 01C (inventario workflow CI/script)
+- Disponibilità confermata in modalità report-only; incarico di raccogliere l’inventario dei workflow CI/script senza attivare validatori.
+- Ticket attivi: **[TKT-01C-001]** (validator parametri), **[TKT-01C-002]** (hook/script engine). Base informativa: `reports/audit/readiness-01c-ci-inventory.md` (workflow e script con I/O e stato report-only).
+
+## Note operative
+- Nessuna esecuzione di pipeline o validatori autorizzata: output limitato a documentazione e aggiornamento log/README.
+- Gli aggiornamenti devono rimanere allineati ai README `incoming/` e `docs/incoming/` e al log RIAPERTURA-2026-01.

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,8 @@
 # Agent activity log
 
+## 2026-03-20 – RIAPERTURA-2026-01 – Disponibilità 01B/01C (coordinator)
+- Step: `[RIAPERTURA-2026-01-AVAIL-01B01C-2026-03-20] owner=coordinator (approvatore Master DD); files=logs/RIAPERTURA-2026-01-note.md, logs/agent_activity.md, incoming/README.md, docs/incoming/README.md, reports/audit/readiness-01c-ci-inventory.md; rischio=basso (documentazione/ricognizione); note=Registrata nota di disponibilità 01B/01C in modalità report-only per species-curator/trait-curator (matrice core/derived, ticket TKT-01B-001/002) e dev-tooling (inventario workflow CI/script, ticket TKT-01C-001/002) con riferimento all’inventario readiness 01C e senza esecuzione di validator. README incoming/docs_incoming allineati al log RIAPERTURA-2026-01.`
+
 # 2026-03-19 – RIAPERTURA-2026-01 micro-step log (archivist)
 - Step: `[RIAPERTURA-2026-01-INIT-2026-03-19] owner=Master DD (agente archivist); files=logs/agent_activity.md; rischio=medio (riapertura gate 01A–03B); note=Registrata riapertura con scope 01A–03B e rischio stimato condiviso con Master DD; confermato routing archivist/coordinator per la tracciatura del gate.`
 - Step: `[RIAPERTURA-2026-01-KICKOFF-2026-03-19] owner=archivist (approvatore Master DD); files=logs/agent_activity.md; rischio=basso (brief/documentazione); note=Kickoff completato con checklist micro-step (freeze, gap list, readiness, README) e conferma che tutti gli aggiornamenti restano in STRICT MODE su branch/log dedicati.`


### PR DESCRIPTION
## Descrizione
- Aggiunta una nota dedicata alla disponibilità 01B/01C per species-curator, trait-curator e dev-tooling in modalità report-only.
- Registrato il micro-step nel log RIAPERTURA-2026-01 con riferimenti a ticket e inventario CI.
- Allineati i README incoming/docs_incoming con i riferimenti alla nota e all’inventario readiness 01C.

## Checklist guida stile & QA
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato
- [x] Documentazione/processi aggiornati ove necessario

## Testing
- [ ] `npm run style:check`
- [ ] Altro: N/D (aggiornamento documentazione)

## Note
- Collegamenti principali: `logs/RIAPERTURA-2026-01-note.md`, `reports/audit/readiness-01c-ci-inventory.md`, log `logs/agent_activity.md`.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69278e4ab5e48328b53f4c401765268e)