### PR TITLE
Refactor Evo validation tooling paths

### DIFF
--- a/.github/workflows/evo-batch.yml
+++ b/.github/workflows/evo-batch.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       batch:
-        description: "Batch da eseguire"
+        description: 'Batch da eseguire'
         required: true
         type: choice
         options:
@@ -16,12 +16,12 @@ on:
           - ops_ci
           - frontend
       execute:
-        description: "Eseguire i comandi (false = dry-run)"
+        description: 'Eseguire i comandi (false = dry-run)'
         required: false
         type: boolean
         default: false
       ignore_errors:
-        description: "Ignora errori dei comandi"
+        description: 'Ignora errori dei comandi'
         required: false
         type: boolean
         default: false
@@ -45,15 +45,18 @@ jobs:
         run: pip install -r requirements-dev.txt
 
       - name: Plan batch
+        working-directory: ${{ github.workspace }}
         run: |
           python tools/automation/evo_batch_runner.py plan --batch "$BATCH"
 
       - name: Execute batch
         if: ${{ inputs.execute == true }}
+        working-directory: ${{ github.workspace }}
         run: |
           python tools/automation/evo_batch_runner.py run --batch "$BATCH" --execute $IGNORE_ERRORS_FLAG
 
       - name: Dry-run summary
         if: ${{ inputs.execute == false }}
+        working-directory: ${{ github.workspace }}
         run: |
           python tools/automation/evo_batch_runner.py run --batch "$BATCH" $IGNORE_ERRORS_FLAG

--- a/docs/tooling/evo.md
+++ b/docs/tooling/evo.md
@@ -79,20 +79,15 @@ Il comando è disponibile anche tramite `make evo-lint` (variabili opzionali
 
 ## Validazione dei pacchetti incoming
 
-- Script: `incoming/scripts/validate.sh`
+- Script: `incoming/scripts/validate_evo_pack.sh`
 - Obiettivo: eseguire la validazione AJV dei trait e delle specie provenienti
-  dai drop `incoming/`.
-- Variabili supportate:
-  - `AJV` o `EVO_VALIDATE_AJV`: comando AJV da utilizzare (default `ajv`).
-  - `EVO_TEMPLATES_DIR`: directory degli schemi (default
-    `incoming/templates`).
-  - `EVO_TRAITS_DIR`: directory dei trait JSON (default `incoming/traits`).
-  - `EVO_SPECIES_DIR`: directory delle specie JSON (default `incoming/species`).
-- Output: messaggi di stato su stdout/stderr; interruzione immediata in caso di
-  errori di validazione. File mancanti producono un warning non bloccante.
-- Target Makefile: `make evo-validate` propaga automaticamente le variabili di
-  default, consentendo override (ad esempio
-  `make evo-validate EVO_TRAITS_DIR=data/external/evo/traits`).
+  dai drop `incoming/` o dal pacchetto Evo esterno.
+- Parametri: richiede `--dataset` (cartella con i JSON) e `--schema`
+  (percorso allo schema), risolvendo automaticamente i percorsi relativi al
+  repository.
+- Target Makefile: `make evo-validate` lancia due passaggi (specie e trait)
+  usando `EVO_VALIDATE_SPECIES` e `EVO_VALIDATE_TRAITS` come cartelle sorgente
+  e salta automaticamente quelli mancanti.
 
 ## Automazione backlog GitHub
 
@@ -121,7 +116,8 @@ EVO_BACKLOG_FILE=backlog.yaml` che reindirizza le variabili richieste allo
 - Target Makefile: `make traits-review` esegue la modalità legacy
   (`TRAITS_REVIEW_GLOSSARY`, `TRAITS_REVIEW_OUTDIR` sovrascrivibili). Passando
   `TRAITS_REVIEW_INPUT=/path TRAITS_REVIEW_OUT=report.csv` il target commuta
-  automaticamente in modalità confronto.
+  automaticamente in modalità confronto e genera inoltre un CSV di riepilogo
+  specie tramite `SPECIES_SUMMARY_ROOT`/`SPECIES_SUMMARY_OUT`.
 
 ## Make target di supporto
 

--- a/incoming/lavoro_da_classificare/tasks.yml
+++ b/incoming/lavoro_da_classificare/tasks.yml
@@ -100,7 +100,7 @@ tasks:
     deliverables:
       - reports/incoming/species_validation.log
     commands:
-      - ./scripts/validate.sh --dataset evo-species --schema schemas/evo/species.schema.json
+      - ./incoming/scripts/validate_evo_pack.sh --dataset evo-species --schema schemas/evo/species.schema.json
     notes: 'Log SPEC-01 aggiornato; QA `reports/evo/qa/dataset.log` rigenerato con `make evo-validate` (AJV=tools/ajv-wrapper.sh) su 5 trait; directory species attualmente vuota.'
 
   - id: SPEC-02
@@ -114,7 +114,7 @@ tasks:
     deliverables:
       - reports/evo/species_summary.md
     commands:
-      - python incoming/lavoro_da_classificare/species_summary_script.py --input data/external/evo/species/ --output reports/evo/species_summary.md
+      - python incoming/scripts/species_summary_script.py --root data/external/evo/species/ --output reports/evo/species_summary.csv
     notes: 'Report Markdown con conteggi specie/ecotipi e dettaglio biome; confronto con baseline `reports/evo/species_summary.md` senza differenze.'
 
   - id: SPEC-03
@@ -140,7 +140,7 @@ tasks:
     deliverables:
       - reports/evo/traits_anomalies.csv
     commands:
-      - python incoming/lavoro_da_classificare/scripts/trait_review.py
+      - python incoming/scripts/trait_review.py
     notes: 'Script esteso con modalità `--input/--baseline/--out`; CSV rigenerato e righe segnate come `action=add`, invariato rispetto a `reports/evo/traits_anomalies.csv`.'
 
   - id: TRT-02


### PR DESCRIPTION
## Summary
- move the Evo validation helper into incoming/scripts/validate_evo_pack.sh and update Makefile defaults
- run trait review together with species summary generation and refresh tracker commands
- harden the Evo batch runner/workflow to resolve repository paths from the workspace root

## Testing
- bash incoming/scripts/validate_evo_pack.sh --help
- python -m py_compile tools/automation/evo_batch_runner.py incoming/scripts/species_summary_script.py incoming/scripts/trait_review.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69279be36cac83288a5d50d5909a82f6)