### PR TITLE
Archive playbook snapshots for rollout ROL-03

### DIFF
--- a/docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_security_ops.md
+++ b/docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_security_ops.md
@@ -1,0 +1,73 @@
+---
+title: Evo-Tactics · Security & Ops Playbook
+description: Linee guida operative per audit, rotazione credenziali e response collegati al pacchetto Evo-Tactics.
+tags:
+  - evo-tactics
+  - security
+  - operations
+updated: 2025-12-19
+---
+
+# Security & Ops Playbook — Evo-Tactics
+
+Questa guida consolida i controlli di sicurezza e le procedure operative dedicate al
+pacchetto Evo-Tactics. Le indicazioni estendono la visione tattica descritta in
+[`playbook_visione_struttura.md`](playbook_visione_struttura.md) e sostituiscono il precedente
+placeholder generale.
+
+## 1. Scope & Responsabilità
+
+| Squadra                  | Ruolo                                       | Artefatti collegati                                                                                        |
+| ------------------------ | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Design Ops**           | Garantire coerenza dei deliverable.         | `docs/evo-tactics/README.md`, `docs/evo-tactics-pack/README.md`.                                           |
+| **Security Engineering** | Esegue auditing e secret scanning.          | `incoming/lavoro_da_classificare/security.yml`, `incoming/lavoro_da_classificare/init_security_checks.sh`. |
+| **Support/QA Bridge**    | Gestisce rotazione token e validazioni CLI. | `config/cli/support.yaml`, `docs/support/token-rotation.md`.                                               |
+
+## 2. Workflow di validazione
+
+1. **Pipeline CI** — la configurazione GitHub Actions in
+   `incoming/lavoro_da_classificare/security.yml` esegue `bandit`, `npm audit` e
+   `gitleaks` su `main` e `develop`. I report vengono salvati come artefatti.
+2. **Audit locale** — `incoming/lavoro_da_classificare/init_security_checks.sh`
+   produce report HTML/JSON in `reports/security/` replicando la pipeline CI.
+3. **Allineamento telemetry** — eseguire `scripts/api/telemetry_alerts.py` in
+   modalità lint (funzione `validate_alert_context`) sulle nuove missioni per
+   assicurare soglie coerenti con `reports/trait_balance_summary.md`.
+4. **Rotazione credenziali** — seguire la checklist documentata in
+   `docs/support/token-rotation.md`, aggiornando `config/cli/support.yaml` con
+   `last_completed` e `next_window`.
+
+## 3. Controlli applicativi
+
+| Controllo                | Obiettivo                                     | Script/Documento                                                                                            |
+| ------------------------ | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Static Analysis**      | Individuare regressioni Python/Node.          | `incoming/lavoro_da_classificare/security.yml`, `reports/trait_balance_summary.md` (per correlare impatti). |
+| **Trait Drift Alerting** | Normalizzare soglie e payload.                | `scripts/api/telemetry_alerts.py`, `reports/daily_tracker_summary.json`.                                    |
+| **Vault & Token Ops**    | Assicurare rotazione settimanale dei segreti. | `docs/support/token-rotation.md`, `config/cli/support.yaml`.                                                |
+| **Dataset Integrity**    | Validare YAML/JSON condivisi.                 | `incoming/docs/yaml_validator.py`, `reports/pathfinder_trait_gap.csv`.                                      |
+
+## 4. Incident Response
+
+- Aprire ticket con label `SEC-EVO` nel tracker e registrarlo in
+  `reports/qa-changelog.md`.
+- Collegare i log prodotti dagli script (`reports/security/*.json`) agli spazi
+  condivisi, indicando riferimenti commit.
+- Aggiornare il registro [`docs/archive/evo-tactics/integration-log.md`](../../../archive/evo-tactics/integration-log.md)
+  con il numero attività (DOC-XX) e le follow-up note.
+
+## 5. Checklist di rilascio
+
+- [ ] Verificare che `incoming/lavoro_da_classificare/security.yml` sia stato
+      rieseguito con esito positivo (Bandit, npm audit, gitleaks).
+- [ ] Aggiornare `reports/daily_tracker_summary.json` con l'esito degli alert
+      drift/adozione.
+- [ ] Documentare il turno di rotazione su `docs/support/token-rotation.md`.
+- [ ] Archiviare eventuali placeholder rimossi in `docs/archive/evo-tactics/` con
+      nota motivazionale.
+
+## Changelog
+
+- 2025-12-19: Snapshot archiviato dal file `docs/evo-tactics/guides/security-ops.md`,
+  ripristinando il frontmatter e aggiungendo cronologia per l'inventory cleanup 2025-12-19.
+
+**[END · Security & Ops Playbook]**

--- a/docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_template_ptpf.md
+++ b/docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_template_ptpf.md
@@ -1,0 +1,132 @@
+---
+title: Template PTPF Evo-Tactics
+description: Struttura PTPF per mantenere coerenza tattica, drift lock e telemetria nel progetto Evo-Tactics.
+tags:
+  - evo-tactics
+  - template
+  - ptpf
+updated: 2025-12-19
+---
+
+# Template — Game Design Structure (PTPF)
+
+Questo template fornisce i campi minimi da compilare quando si introdurrà un nuovo
+modulo Evo-Tactics (missione, specie, rituale di telemetria). Ogni sezione include
+esempi concreti, note di completamento e riferimenti diretti agli asset del pack.
+
+> **Come usarlo**: duplica il file, sostituisci le parti in corsivo e conserva le
+> checklist per assicurare la qualità del deliverable. Gli esempi riportati derivano
+> dagli asset attivi (`docs/evo-tactics-pack/`) e possono essere copiati come base.
+
+## 1. Vision & Tone
+
+| Campo                 | Descrizione                                                | Esempio                                      |
+| --------------------- | ---------------------------------------------------------- | -------------------------------------------- |
+| **Tag**               | Identificatore univoco (`@VISION_CORE`, `@MISSION_ARC_X`). | `@VISION_CORE`                               |
+| **Setting**           | Contesto narrativo/ambientale.                             | "Recupero di biosfere sintetiche orbitanti"  |
+| **Esperienza target** | Sensazioni ricercate dal team.                             | "Pressione costante, collaborazione tattica" |
+| **Tone guardrail**    | Elementi da evitare.                                       | "No elementi fantasy, no comic relief"       |
+
+**Checklist**
+
+- [ ] Allineare il tono con `docs/02-PILASTRI.md`.
+- [ ] Collegare la missione a un arco esistente nel catalogo (`catalog_data.json`).
+
+## 2. Tactical System
+
+| Campo                 | Descrizione                           | Esempio Evo-Tactics                                                                                                        |
+| --------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Dashboard anchors** | Widget o viste UI da aggiornare.      | `Encounter Timeline`, `VC Alert Panel`, `Loadout Slots`.                                                                   |
+| **Outcome attesi**    | Risultati misurabili.                 | "Ridurre drift medio < 0.16" (ref `reports/trait_balance_summary.md`).                                                     |
+| **Vincoli**           | Limiti hard (slot PI, rarità, timer). | "Max 2 trait `@VC_ALERT` per missione", timer 12' (coordinato con `docs/mission-console/data/flow/validators/biome.json`). |
+| **Rehydration**       | Processo per reiniettare i dati.      | Pipeline `incoming/docs/bioma_encounters.yaml` → aggiornamento `packs/evo_tactics_pack/data/species.yaml`.                 |
+
+**Checklist**
+
+- [ ] Aggiornare `docs/evo-tactics-pack/ui/elements.ts` con eventuali nuovi componenti o parametri.
+- [ ] Documentare i vincoli in `docs/mission-console/data/flow/validators/biome.json` e sincronizzarli con `docs/process/traits_checklist.md`.
+
+## 3. Form & Mutation Management
+
+| Campo             | Descrizione                                     | Esempio Evo-Tactics                                                                                                 |
+| ----------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Packet Types**  | Gruppi di mutazioni coinvolte.                  | `Mutation Pack C` (sinergia Support/Analyst) definito in `packs/evo_tactics_pack/data/species.yaml`.                |
+| **Shape Biasing** | Regole per distribuzione delle forme per bioma. | Matrice `biomes/terraforming_bands.yaml` con pesi 0.2/0.35/0.45.                                                    |
+| **Visibility**    | Come i giocatori percepiscono i limiti.         | Dashboard `docs/mission-console/index.html` + diagnostica `docs/mission-console/data/flow/traits/diagnostics.json`. |
+| **DriftLock**     | Condizioni che invalidano la missione.          | Drift cumulativo > 0.18 → fallback `scripts/drift_check.js`.                                                        |
+
+**Checklist**
+
+- [ ] Inserire i nuovi trait in `packs/evo_tactics_pack/data/species.yaml` e aggiornarne i metadata.
+- [ ] Aggiornare la tabella di compatibilità in `docs/evo-tactics-pack/env-traits.json` e validare con `npm run docs:lint`.
+
+## 4. Telemetry & VC Tracking
+
+| Campo                | Descrizione                | Esempio Evo-Tactics                                                                                                              |
+| -------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Input**            | Fonti dati operative.      | Export `reports/trait_progress.md`, dataset `reports/pathfinder_trait_gap.csv`.                                                  |
+| **Output**           | Report o trigger generati. | Ticket `QA-VC-214` + diff `reports/daily_tracker_summary.json`.                                                                  |
+| **Alert Thresholds** | Valori soglia e azioni.    | Drift > 0.18 → attivare `scripts/api/telemetry_alerts.py`; adozione trait < 55% → aggiornare `reports/trait_balance_summary.md`. |
+| **Review Mode**      | Strumenti di analisi.      | Dashboard `analytics/dashboards/campaignProgress.vue`, CLI `incoming/docs/yaml_validator.py`.                                    |
+
+**Checklist**
+
+- [ ] Validare i dataset con `incoming/docs/yaml_validator.py` e registrare l'esito in `docs/playtest/`.
+- [ ] Aggiornare gli script di analisi in `analytics/` e sincronizzare i report in `reports/trait_progress.md`.
+
+## 5. Encounter & Biome Engine
+
+| Campo                  | Descrizione                              | Esempio Evo-Tactics                                                                                     |
+| ---------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Generator**          | Algoritmo o script usato.                | `docs/mission-console/data/flow/generation/species.json` (seed `mission-helix-023`).                    |
+| **Spotlight**          | Focus meccanico.                         | Scontro "Cavitation Rift" che premia mutazioni Aquatic Support.                                         |
+| **Compatibilità MBTI** | Mappatura missione ↔ profili giocatore. | Vanguard → ENTJ, Support → INFJ (ref `docs/evo-tactics-pack/species-index.json`).                       |
+| **Load**               | Come vengono caricati gli encounter.     | Precompilati via `docs/mission-console/data/flow/generation/species-preview.json` con fallback runtime. |
+
+**Checklist**
+
+- [ ] Sincronizzare `incoming/docs/bioma_encounters.yaml` con gli aggiornamenti e rigenerare `catalog_data.json`.
+- [ ] Verificare la difficoltà con due run QA registrate in `docs/playtest/SESSION-*/`.
+
+## 6. Playtest Loop
+
+| Campo                 | Descrizione                          | Esempio Evo-Tactics                                                                                                                 |
+| --------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Iteration Tracker** | Parametri registrati.                | Loop `PT-EVO-019`, `stress_level: 0.63`, `mutation_stability: 0.78`.                                                                |
+| **Routine**           | Sequenza di test automatici/manuali. | `npm run docs:lint`, `scripts/run_playtest_ci.sh`, sessione manuale 30'.                                                            |
+| **Entry Criteria**    | Requisiti iniziali.                  | Catalogo sincronizzato (`docs/evo-tactics-pack/catalog_data.json`) e seed `docs/mission-console/data/flow/generation/species.json`. |
+| **Exit Criteria**     | Condizioni di chiusura.              | Zero blocker, drift < 0.18, esiti QA caricati in `docs/playtest/SESSION-2025-11-12/feedback/README.md`.                             |
+
+**Checklist**
+
+- [ ] Registrare gli esiti in `docs/playtest/` seguendo la guida dedicata e allegare i log telemetrici pertinenti.
+- [ ] Aggiornare il tracker `docs/qa-checklist.md` con i risultati del ciclo.
+
+## 7. Linking & Traceability
+
+- **Anchor Map**: elenca le relazioni principali (`@VISION_CORE ↔ @TACTICS_CORE`) citando gli ID missione da `catalog_data.json`.
+- **Receipts**: link a commit, issue tracker o report QA e registra il riferimento in `docs/archive/evo-tactics/integration-log.md` con tag `DOC-XX`.
+- **Altre note**: strumenti usati, esperimenti non adottati, follow-up (es. link a `incoming/lavoro_da_classificare/security.yml`).
+
+## 8. Drift Guards
+
+| Guardrail      | Descrizione                                              | Azione correttiva                               |
+| -------------- | -------------------------------------------------------- | ----------------------------------------------- |
+| Tone Lock      | Evitare deviazioni da techno-biologico.                  | Rieseguire sessione di review con narrativa.    |
+| Structure Lock | Garantire moduli packetizzati (no freeform).             | Applicare `scripts/drift_check.js`.             |
+| Telemetry Lock | Ogni variazione deve essere YAML-valid e receipt-tagged. | Bloccare merge finché la validazione non passa. |
+
+## 9. Repo Tools & Extensions
+
+- `/tools/obsidian-template.md` — per vault locale condiviso.
+- `/scripts/yaml_validator.py` — validatore di dataset.
+- `/hooks/drift_check.js` — pre-commit check per delta drift.
+- `/docs/structure_overview.md` — mappa generale per cross-repo linking.
+- `/docs/evo-tactics-pack/README.md` — riepilogo degli asset sincronizzati.
+- `/incoming/lavoro_da_classificare/init_security_checks.sh` — audit sicurezza per i deploy Evo-Tactics.
+
+## Changelog
+
+- 2025-12-19: Snapshot archiviato dal file `docs/evo-tactics/guides/template-ptpf.md` e portato nell'archivio storico con meta aggiornati per l'inventory cleanup.
+
+**[END TEMPLATE — Evo-Tactics PTPF Seed · v1.1]**

--- a/docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_visione_struttura.md
+++ b/docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_visione_struttura.md
@@ -1,0 +1,105 @@
+---
+title: Visione & Struttura Concettuale Evo-Tactics
+description: Guida alla mappa concettuale drift-locked e alle raccomandazioni PrimeTalk per Evo-Tactics.
+tags:
+  - evo-tactics
+  - visione
+  - struttura
+updated: 2025-12-19
+---
+
+# Evo-Tactics · Visione & Struttura Concettuale
+
+Questa guida descrive la visione condivisa del progetto Evo-Tactics e la struttura
+che governa i flussi di gioco, dalla generazione delle missioni fino alla
+telemetria di ritorno. I contenuti sostituiscono il precedente schema
+"placeholder" con indicazioni concrete basate sul catalogo pack e sugli obiettivi
+PTPF.
+
+## 1. Visione di prodotto
+
+| Elemento                 | Descrizione                                                                                                            |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| **Premessa**             | Squadre ibride di esploratori bio-tecnologici recuperano ecosistemi instabili attraverso missioni rapide e ripetibili. |
+| **Esperienza giocatore** | Decisioni tattiche veloci, feedback leggibili sulle mutazioni equipaggiate e senso di progressione condivisa del team. |
+| **Tone guide**           | Techno-biologico, tensione scientifica, linguaggio operativo (evitare elementi fantasy o tono comico).                 |
+| **Deliverable chiave**   | Catalogo missioni, registri trait, dashboard telemetria, kit di onboarding per nuovi designer.                         |
+
+## 2. Pilastri tattici
+
+1. **Adattamento progressivo** — ogni missione aggiorna il profilo mutazione del
+   team. Le carte specie disponibili dipendono dal drift cumulativo registrato in
+   `catalog_data.json`.
+2. **Leggibilità delle scelte** — dashboard UI (vedi `docs/evo-tactics-pack/ui/`)
+   mostra sempre rarià, costo e compatibilità VC delle forme selezionate.
+3. **Sinergia di squadra** — ruoli complementari (Support, Vanguard, Analyst)
+   condividono pool di risorse. I pacchetti loadout definiscono trigger combinati
+   e condizioni di fallimento.
+4. **Telemetria attuabile** — il sistema VC genera alert quando il tasso di
+   utilizzo di un trait scende sotto soglia o quando il drift supera 0.18;
+   l'alert produce ticket nel registro playtest.
+
+## 3. Struttura ad anello (loop principali)
+
+| Loop               | Input                                | Output                                          | Note                                                             |
+| ------------------ | ------------------------------------ | ----------------------------------------------- | ---------------------------------------------------------------- |
+| **Strategic Loop** | Briefing missione + stato ecosistema | Obiettivi dinamici e vincoli PI                 | Aggiorna `docs/mission-console/data/flow/validators/biome.json`. |
+| **Mutation Loop**  | Trait equipaggiati + log telemetria  | Nuove forme/limitazioni                         | Sincronizzato con `packs/evo_tactics_pack/traits/`.              |
+| **Encounter Loop** | Seed bioma + modulatore difficoltà   | Sequenza incontri adattiva                      | Basato su `incoming/docs/bioma_encounters.yaml`.                 |
+| **Review Loop**    | Dati post-missione                   | Report delta drift + suggerimenti bilanciamento | Alimenta il canale QA e `reports/` del pack.                     |
+
+## 4. Trasversalità team
+
+- **Design ↔ Data**: ogni nuova missione deve includere ID e tag per l'estrazione
+  automatica (`mission_id`, `biome_id`, `mutation_focus`).
+- **Design ↔ Engineering**: utilizzare `scripts/update_evo_pack_catalog.js` per
+  rigenerare gli asset quando vengono introdotte specie o hazard.
+- **Design ↔ QA**: registrare nel Playtest Loop (vedi sezione successiva) le
+  condizioni riprodotte e gli esiti, allegando gli hash delle versioni esportate.
+
+## 5. Playtest & Metriche
+
+- **Playtest Loop**
+  - Identificatore: `PT-EVO-021` con link a [`docs/playtest/SESSION-2025-11-12.md`](../../../playtest/SESSION-2025-11-12.md).
+  - Parametri da tracciare: `stress_level`, `mutation_stability`, `encounter_delta`.
+  - Checklist: replicare almeno due missioni per livello di difficoltà, verificare
+    la presenza di tutorial inline per nuove specie.
+- **Metriche operative**
+  - `Drift Index`: media ponderata delle mutazioni adottate, target 0.12 ±0.03.
+  - `Engagement Session`: durata mediana di 22 minuti per missione completa.
+  - `Trait Adoption`: almeno 65% di varianti utilizzate entro tre sessioni.
+
+## 6. Workflow suggerito
+
+1. **Ingestione** — importare nuovi materiali in `incoming/docs/` e registrarli in
+   `incoming/lavoro_da_classificare/tasks.yml`.
+2. **Normalizzazione** — convertire i file con `pandoc`, applicare il frontmatter
+   e verificare i link con `npm run docs:lint`.
+3. **Validazione** — aggiornare il catalogo tramite gli script in `scripts/` e
+   verificare le metriche con i tool in `analytics/`.
+4. **Pubblicazione** — sincronizzare gli asset statici (`scripts/sync_evo_pack_assets.js`) e
+   aggiornare l'indice generale (`docs/INDEX.md`).
+
+## 7. Risorse di supporto
+
+- `docs/evo-tactics-pack/README.md` — panoramica degli asset distribuiti con il pack.
+- `docs/playtest-log-guidelines.md` — formato unico per i log di playtest.
+- `tools/drift-check/` — utilità per calcolare rapidamente il drift index su file JSON.
+
+## 8. Security & Ops Alignment
+
+| Ambito                    | Artefatto                                                    | Note operative                                                                        |
+| ------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| **Automazione sicurezza** | `incoming/lavoro_da_classificare/security.yml`               | Definisce job Bandit, npm audit e gitleaks per le branch `main`/`develop`.            |
+| **Script locali**         | `incoming/lavoro_da_classificare/init_security_checks.sh`    | Esegue bandit, semgrep, npm audit e gitleaks generando report in `reports/security/`. |
+| **Rotazione credenziali** | `config/cli/support.yaml` & `docs/support/token-rotation.md` | Coordina finestra settimanale (lunedì) con notifiche `#support-ops`.                  |
+| **Alert telemetrici**     | `scripts/api/telemetry_alerts.py`                            | Normalizza i payload `telemetry.alert_context` per il controllo drift/adozione trait. |
+
+- Annotare gli esiti delle rotazioni in `reports/qa-changelog.md` per garantire tracciabilità.
+- In caso di incident response, collegare i ticket Ops al registro `reports/daily_tracker_summary.json` con tag `SEC-EVO`.
+
+## Changelog
+
+- 2025-12-19: Snapshot archiviato dal file `docs/evo-tactics/guides/visione-struttura.md` e registrato nell'archivio storico con meta aggiornati per l'inventory cleanup.
+
+**[END: Visione & Struttura · Evo-Tactics]**

--- a/docs/reports/evo/rollout/documentation_gap.md
+++ b/docs/reports/evo/rollout/documentation_gap.md
@@ -21,6 +21,9 @@ updated: 2025-12-19
 | `../archive/documents/Guida Ai tratti 3 Evo tact.docx` | `docs/evo-tactics/guida-ai-tratti-3-evo-tactics.md` | Conversione DOCX → Markdown normalizzato |
 | `../archive/documents/Guida Ai tratti 3 database.docx` | `docs/evo-tactics/guida-ai-tratti-3-database.md` | Conversione DOCX → Markdown normalizzato |
 | `../archive/documents/Integrazioni V2.docx` | `docs/evo-tactics/integrazioni-v2.md` | Conversione DOCX → Markdown normalizzato |
+| `docs/evo-tactics/guides/security-ops.md` | `docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_security_ops.md` | Snapshot archivio con frontmatter e changelog (inventory cleanup 19/12/2025). |
+| `docs/evo-tactics/guides/template-ptpf.md` | `docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_template_ptpf.md` | Snapshot archivio con frontmatter e changelog (inventory cleanup 19/12/2025). |
+| `docs/evo-tactics/guides/visione-struttura.md` | `docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_visione_struttura.md` | Snapshot archivio con frontmatter e changelog (inventory cleanup 19/12/2025). |
 
 L’elenco completo degli asset inventariati con le rispettive destinazioni è stato serializzato in `reports/evo/rollout/documentation_diff.json` per consentire filtri aggiuntivi e correlazioni future con i batch di rollout.【F:incoming/lavoro_da_classificare/inventario.yml†L216-L260】【F:reports/evo/rollout/documentation_diff.json†L1094-L1149】
 
@@ -30,13 +33,13 @@ L’automazione `scripts/evo_tactics_metadata_diff.py` confronta le copie consol
 
 - Le versioni archiviate in `docs/incoming/archive/2025-12-19_inventory_cleanup/` non contengono frontmatter YAML (`title`, `description`, `tags`, `updated`), mentre le copie consolidate sì.【F:reports/evo/rollout/documentation_diff.json†L1096-L1118】
 - Le guide consolidate hanno introdotto ancore semantiche esplicite (`{#...}`) per tutte le sezioni e sottosezioni, assenti nelle controparti archiviate. Il diff registra oltre 20 nuove ancore per ciascuna guida principale, facilitando i deep-link nelle wiki interne.【F:reports/evo/rollout/documentation_diff.json†L1119-L1149】
-- Tre documenti operativi (`guides/security-ops.md`, `guides/template-ptpf.md`, `guides/visione-struttura.md`) non hanno ancora un match nell’archivio storicizzato: il dato emerge nella sezione `unmatched` del report JSON, indicando che non esiste una copia legacy con cui confrontare metadati e ancore.【F:reports/evo/rollout/documentation_diff.json†L1366-L1369】
+- Le snapshot archivio per i playbook operativi (`security-ops`, `template-ptpf`, `visione-struttura`) sono state aggiunte in `docs/incoming/archive/2025-12-19_inventory_cleanup/`, chiudendo il gap precedentemente rilevato nella sezione `unmatched` del diff.【F:docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_security_ops.md†L1-L73】【F:docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_template_ptpf.md†L1-L73】【F:docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_visione_struttura.md†L1-L73】
 
 ## Gap e impatti sui consumer
 
 1. **Ricerca e indicizzazione** – L’assenza di frontmatter nei documenti storici impedisce ai motori di ricerca interni (docs hub, wiki, Obsidian) di esporre i contenuti Evo-Tactics via filtri per tag o date. I team che ancora consultano gli archivi rischiano di utilizzare versioni non aggiornate o di non trovare il documento corretto.
 2. **Deep-link e navigazione** – Senza ancore stabili, i link da dashboard Notion/wiki puntano a sezioni non deterministiche, causando errori 404 in strumenti di documentazione che generano slug automaticamente. I consumer (design, QA, telemetria) non possono condividere riferimenti precisi alle checklist operative.
-3. **Copertura incompleta** – L’assenza di controparti archiviate per i playbook (Security & Ops, Template PTPF, Visione) lascia un buco di conformità: i team di sicurezza e PMO non hanno uno storico da confrontare per audit o regressioni di processo.
+3. **Copertura incompleta (risolta)** – Le nuove snapshot archivio dei playbook (Security & Ops, Template PTPF, Visione) chiudono il buco di conformità fornendo uno storico consultabile per audit e regressioni di processo.
 
 ## Priorità di rollout
 

--- a/incoming/lavoro_da_classificare/tasks.yml
+++ b/incoming/lavoro_da_classificare/tasks.yml
@@ -321,7 +321,7 @@ tasks:
     batch: rollout
     title: Snapshot playbook Evo mancanti
     description: 'Produrre versioni archivio per i playbook senza controparte legacy.'
-    status: in-progress
+    status: done
     owner: security-pmo
     depends_on:
       - ROL-01
@@ -332,16 +332,16 @@ tasks:
     notes: 'Estrarre le copie consolidate dei playbook security/PMO e versionarle nell’archivio storico con changelog.'
 
     telemetry:
-      last_sync: 2025-10-29T14:20:44+00:00
-      progress: 99
+      last_sync: 2025-12-19T00:00:00+00:00
+      progress: 100
       metric:
         label: Playbook da archiviare
-        open_items: 3
+        open_items: 0
         total_items: 218
       samples:
-        - docs/evo-tactics/guides/security-ops.md
-        - docs/evo-tactics/guides/template-ptpf.md
-        - docs/evo-tactics/guides/visione-struttura.md
+        - docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_security_ops.md
+        - docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_template_ptpf.md
+        - docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_visione_struttura.md
 
   - id: ROL-04
     batch: rollout


### PR DESCRIPTION
## Summary
- archived the Security & Ops, PTPF template, and visione/struttura playbooks under docs/incoming/archive/2025-12-19_inventory_cleanup with frontmatter and changelog entries
- updated the rollout documentation gap report with the new archived destinations and notes that the playbook gap is closed
- marked ROL-03 as complete in incoming/lavoro_da_classificare/tasks.yml and refreshed telemetry/samples for the archived playbooks

## Testing
- npx prettier --write docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_security_ops.md docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_template_ptpf.md docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_visione_struttura.md


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928421c365483288f8988617db9ef1a)