### PR TITLE
Regenerate trait external export and rollout notes

### DIFF
--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2025-11-23T02:12:53+00:00",
+  "updated_at": "2025-11-27T12:52:56.066604+00:00",
   "sources": {
     "trait_reference": "data/traits/index.json"
   },
@@ -1510,6 +1510,12 @@
       "label_en": "Black Vortex Flash",
       "description_it": "Implosione luminosa seguita da vuoto e teletrasporto breve (temp).",
       "description_en": "Luminous implosion followed by void and short teleport (temp)."
+    },
+    "coscienza_dalveare_diffusa": {
+      "label_it": "Coscienza d’Alveare Diffusa",
+      "label_en": "Coscienza d’Alveare Diffusa",
+      "description_it": "Fondere decisioni e memoria a breve termine.",
+      "description_en": "Fondere decisioni e memoria a breve termine."
     }
   }
 }

--- a/incoming/lavoro_da_classificare/tasks.yml
+++ b/incoming/lavoro_da_classificare/tasks.yml
@@ -380,15 +380,19 @@ tasks:
     deliverables:
       - reports/evo/rollout/traits_external_sync.csv
       - reports/evo/rollout/traits_gap.csv
-    notes: 'Deriva dall’analisi `missing_in_external` e fornisce export normalizzato per partner tooling.'
+    notes: |
+      Deriva dall’analisi `missing_in_external` e fornisce export normalizzato per partner tooling.
+      - Export rigenerato dopo la chiusura di ROL-04: CSV UTF-8 con intestazione `slug,label_it,label_en,tier,external_code,status` (RFC4180, separatore `,`, newline LF) e 204 righe totali.
+      - `traits_gap.csv` aggiornato per i `missing_in_external` (202 occorrenze; `missing_in_index`: 2) a partire dal dataset normalizzato.
+      - Output condiviso con il team partner-success per validazione finale.
 
     telemetry:
-      last_sync: 2025-10-29T14:20:44+00:00
-      progress: 23
+      last_sync: 2025-11-27T00:00:00+00:00
+      progress: 20
       metric:
         label: Trait missing_in_external
-        open_items: 174
-        total_items: 225
+        open_items: 202
+        total_items: 253
       samples:
         - ali_fulminee
         - ali_ioniche

--- a/reports/evo/rollout/traits_external_sync.csv
+++ b/reports/evo/rollout/traits_external_sync.csv
@@ -1,0 +1,205 @@
+slug,label_it,label_en,tier,external_code,status
+ali_fulminee,Ali Fulminee,Ali Fulminee,T1,,missing_in_external
+ali_ioniche,Ali Ioniche,Ionic Wings,T1,,missing_in_external
+ali_membrana_sonica,Ali a Membrana Sonica,Sonic Membrane Wings,T1,,missing_in_external
+antenne_dustsense,Antenne Dustsense,Dustsense Antennae,T1,,missing_in_external
+antenne_eco_turbina,Antenne Eco Turbina,Antenne Eco Turbina,T1,,missing_in_external
+antenne_flusso_mareale,Antenne Flusso Mareale,Antenne Flusso Mareale,T1,,missing_in_external
+antenne_microonde_cavernose,Antenne Microonde Cavernose,Antenne Microonde Cavernose,T1,,missing_in_external
+antenne_plasmatiche_tempesta,Antenne Plasmatiche di Tempesta,Storm Plasma Antennae,T3,,missing_in_external
+antenne_reagenti,Antenne Reagenti,Antenne Reagenti,T1,,missing_in_external
+antenne_tesla,Antenne Tesla,Antenne Tesla,T1,,missing_in_external
+antenne_waveguide,Antenne Waveguide,Antenne Waveguide,T1,,missing_in_external
+antenne_wideband,Antenne Wideband,Antenne Wideband,T1,,missing_in_external
+appendici_risonanti_marea,Appendici Risonanti Marea,Appendici Risonanti Marea,T1,,missing_in_external
+appendici_thermotattiche,Appendici Thermotattiche,Appendici Thermotattiche,T1,,missing_in_external
+armatura_pietra_planare,Armatura di Pietra Planare,Planar Stone Plating,T2,,missing_in_external
+artigli_acidofagi,Artigli Acidofagi,Artigli Acidofagi,T1,,missing_in_external
+artigli_induzione,Artigli Induzione,Artigli Induzione,T1,,missing_in_external
+artigli_radice,Artigli Radice,Artigli Radice,T1,,missing_in_external
+artigli_scivolo_silente,Artigli Scivolo Silente,Artigli Scivolo Silente,T1,,missing_in_external
+artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,T1,,missing_in_external
+artigli_sghiaccio_glaciale,Artigli Sghiaccio Glaciale,Artigli Sghiaccio Glaciale,T2,,missing_in_external
+artigli_vetrificati,Artigli Vetrificati,Artigli Vetrificati,T1,,missing_in_external
+aura_scudo_radianza,Aura Scudo di Radianza,Radiant Shield Aura,T3,,missing_in_external
+baffi_mareomotori,Baffi Mareomotori,Baffi Mareomotori,T1,,missing_in_external
+barbigli_sensori_plasma,Barbigli Sensori Plasma,Barbigli Sensori Plasma,T1,,missing_in_external
+barriere_miasma_glaciale,Barriere Miasma Glaciale,Barriere Miasma Glaciale,T1,,missing_in_external
+batteri_endosimbionti_chemio,Batteri Endosimbionti Chemio,Batteri Endosimbionti Chemio,T1,,missing_in_external
+batteri_termofili_endosimbiosi,Batteri Termofili Endosimbiosi,Batteri Termofili Endosimbiosi,T1,,missing_in_external
+bioantenne_gravitiche,Bioantenne Gravitiche,Gravitic Bio-Antennae,,,missing_in_external
+biochip_memoria,Biochip Memoria,Biochip Memoria,T1,,missing_in_external
+biofilm_glow,Biofilm Glow,Biofilm Glow,T1,,missing_in_external
+biofilm_iperarido,Biofilm Iperarido,Biofilm Iperarido,T1,,missing_in_external
+branchie_dual_mode,Branchie Dual Mode,Branchie Dual Mode,T1,,missing_in_external
+branchie_eoliche,Branchie Eoliche,Branchie Eoliche,T1,,missing_in_external
+branchie_metalloidi,Branchie Metalloidi,Branchie Metalloidi,T1,,missing_in_external
+branchie_microfiltri,Branchie Microfiltri,Branchie Microfiltri,T1,,missing_in_external
+branchie_osmotiche_salmastra,Branchie Osmotiche Salmastre,Branchie Osmotiche Salmastre,T2,,missing_in_external
+branchie_solfatiche,Branchie Solfatiche,Branchie Solfatiche,T1,,missing_in_external
+branchie_turbina,Branchie Turbina,Branchie Turbina,T1,,missing_in_external
+bulbi_radici_permafrost,Bulbi Radici del Permafrost,Bulbi Radici del Permafrost,T2,,missing_in_external
+camere_anticorrosione,Camere Anticorrosione,Camere Anticorrosione,T1,,missing_in_external
+camere_mirage,Camere Mirage,Camere Mirage,T1,,missing_in_external
+camere_nutrienti_vent,Camere Nutrienti Vent,Camere Nutrienti Vent,T1,,missing_in_external
+camere_risonanza_abyssal,Camere di Risonanza Abyssal,Abyssal Resonance Chambers,,,missing_in_external
+canto_risonante,Canto Risonante,Resonant Chant,,,missing_in_external
+capillari_criogenici,Capillari Criogenici,Capillari Criogenici,T1,,missing_in_external
+capillari_fluoridici,Capillari Fluoridici,Capillari Fluoridici,T1,,missing_in_external
+capillari_fotovoltaici,Capillari Fotovoltaici,Capillari Fotovoltaici,T1,,missing_in_external
+capsule_paracadute,Capsule Paracadute,Capsule Paracadute,T1,,missing_in_external
+carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,T1,,missing_in_external
+carapace_luminiscente_abissale,Carapace Luminiscente Abissale,Carapace Luminiscente Abissale,T3,,missing_in_external
+carapace_segmenti_logici,Carapace Segmenti Logici,Carapace Segmenti Logici,T1,,missing_in_external
+carapaci_ferruginosi,Carapaci Ferruginosi,Carapaci Ferruginosi,T1,,missing_in_external
+cartilagine_flessotermica_venti,Cartilagine Flessotermica dei Venti,Cartilagine Flessotermica dei Venti,T2,,missing_in_external
+cartilagini_biofibre,Cartilagini Biofibre,Cartilagini Biofibre,T1,,missing_in_external
+cartilagini_desertiche,Cartilagini Desertiche,Cartilagini Desertiche,T1,,missing_in_external
+cartilagini_flessoacustiche,Cartilagini Flessoacustiche,Cartilagini Flessoacustiche,T1,,missing_in_external
+cartilagini_pseudometalliche,Cartilagini Pseudometalliche,Cartilagini Pseudometalliche,T1,,missing_in_external
+cavita_risonanti_tundra,Cavità Risonanti della Tundra,Cavità Risonanti della Tundra,T1,,missing_in_external
+cervelletto_equilibrio_statico,Cervelletto Equilibrio Statico,Cervelletto Equilibrio Statico,T1,,missing_in_external
+chemiorecettori_bromuro,Chemiorecettori Bromuro,Chemiorecettori Bromuro,T1,,missing_in_external
+chioma_parassita_canopica,Chioma Parassita Canopica,Chioma Parassita Canopica,T1,,missing_in_external
+circolazione_bifasica,Circolazione Bifasica,Circolazione Bifasica,T1,,missing_in_external
+circolazione_bifasica_palude,Circolazione Bifasica di Palude,Swamp Biphase Circulation,T2,,missing_in_external
+circolazione_cooling_loop,Circolazione Cooling Loop,Circolazione Cooling Loop,T1,,missing_in_external
+circolazione_doppia,Circolazione Doppia,Circolazione Doppia,T1,,missing_in_external
+circolazione_supercritica,Circolazione Supercritica,Circolazione Supercritica,T1,,missing_in_external
+ciste_riduttive,Ciste Riduttive,Ciste Riduttive,T1,,missing_in_external
+ciste_salmastre,Ciste Salmastre,Ciste Salmastre,T1,,missing_in_external
+cisti_iperbariche,Cisti Iperbariche,Cisti Iperbariche,T1,,missing_in_external
+coda_balanciere,Coda Balanciere,Coda Balanciere,T1,,missing_in_external
+coda_contrappeso,Coda Contrappeso,Coda Contrappeso,T1,,missing_in_external
+coda_coppia_retroattiva,Coda Coppia Retroattiva,Coda Coppia Retroattiva,T1,,missing_in_external
+coda_frusta_cinetica,Coda a Frusta Cinetica,Kinetic Lash Tail,T1,,missing_in_external
+coda_stabilizzatrice_filo,Coda Stabilizzatrice Filo,Coda Stabilizzatrice Filo,T1,,missing_in_external
+coda_stabilizzatrice_geiser,Coda Stabilizzatrice Geiser,Coda Stabilizzatrice Geiser,T1,,missing_in_external
+coda_stabilizzatrice_vortex,Coda Stabilizzatrice Vortex,Coda Stabilizzatrice Vortex,T1,,missing_in_external
+colonne_vibromagnetiche,Colonne Vibromagnetiche,Colonne Vibromagnetiche,T1,,missing_in_external
+coralli_partner,Coralli Partner,Coralli Partner,T1,,missing_in_external
+coralli_sinaptici_fotofase,Coralli Sinaptici Fotofase,Photophase Synaptic Corals,,,missing_in_external
+corazze_ferro_magnetico,Corazze Ferro-Magnetico,Ferro-Magnetic Carapace,,,missing_in_external
+coscienza_d_alveare_diffusa,Coscienza d’Alveare Diffusa,Diffuse Hive Consciousness,T4,,missing_in_external
+coscienza_dalveare_diffusa,Coscienza d’Alveare Diffusa,Coscienza d’Alveare Diffusa,T4,TR-2002,missing_in_index
+criostasi_adattiva,Criostasi,Adaptive Cryostasis,T1,,missing_in_external
+cromofori_alert_acido,Cromofori Alert Acido,Cromofori Alert Acido,T1,,missing_in_external
+cuore_multicamera_bassa_pressione,Cuore Multicamera Bassa Pressione,Cuore Multicamera Bassa Pressione,T1,,missing_in_external
+cuscinetti_elettrostatici,Cuscinetti Elettrostatici,Cuscinetti Elettrostatici,T1,,missing_in_external
+cute_resistente_sali,Cute Resistente Sali,Cute Resistente Sali,T2,,missing_in_external
+cuticole_cerose,Cuticole Cerose,Cuticole Cerose,T1,,missing_in_external
+cuticole_neutralizzanti,Cuticole Neutralizzanti,Cuticole Neutralizzanti,T1,,missing_in_external
+denti_chelatanti,Denti Chelatanti,Denti Chelatanti,T1,,missing_in_external
+denti_ossidoferro,Denti Ossidoferro,Denti Ossidoferro,T1,,missing_in_external
+denti_silice_termici,Denti Silice Termici,Denti Silice Termici,T1,,missing_in_external
+denti_tuning_fork,Denti Tuning Fork,Denti Tuning Fork,T1,,missing_in_external
+echi_risonanti,Echi Risonanti,Echi Risonanti,T1,,missing_in_external
+eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,T2,,missing_in_external
+emettitori_voidsong,Emettitori Voidsong,Voidsong Emitters,,,missing_in_external
+emolinfa_conducente,Emolinfa Conducente,Conductive Hemolymph,,,missing_in_external
+empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,T1,,missing_in_external
+enzimi_antifase_termica,Enzimi Antifase Termica,Enzimi Antifase Termica,T1,,missing_in_external
+enzimi_antipredatori_algali,Enzimi Antipredatori Algali,Enzimi Antipredatori Algali,T1,,missing_in_external
+enzimi_chelanti,Enzimi Chelanti,Enzimi Chelanti,T1,,missing_in_external
+enzimi_chelatori_rapidi,Enzimi Chelatori Rapidi,Enzimi Chelatori Rapidi,T1,,missing_in_external
+enzimi_metanoossidanti,Enzimi Metanoossidanti,Enzimi Metanoossidanti,T1,,missing_in_external
+epidermide_dielettrica,Epidermide Dielettrica,Epidermide Dielettrica,T1,,missing_in_external
+epitelio_fosforescente,Epitelio Fosforescente,Epitelio Fosforescente,T1,,missing_in_external
+filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,T2,,missing_in_external
+filamenti_echo,Filamenti Echo,Echo Filaments,,,missing_in_external
+filamenti_guidalampo,Filamenti Guidalampo,Lightning Guide Filaments,,,missing_in_external
+filamenti_magnetotrofi,Filamenti Magnetotrofi,Filamenti Magnetotrofi,T1,,missing_in_external
+filamenti_superconduttivi,Filamenti Superconduttivi,Filamenti Superconduttivi,T1,,missing_in_external
+filamenti_termoconduzione,Filamenti Termoconduzione,Filamenti Termoconduzione,T1,,missing_in_external
+filtri_planctonici,Filtri Planctonici,Filtri Planctonici,T1,,missing_in_external
+flagelli_ancoranti,Flagelli Ancoranti,Flagelli Ancoranti,T1,,missing_in_external
+focus_frazionato,Focus Frazionato,Fractional Focus,T1,,missing_in_external
+foliage_fotocatodico,Foliage Fotocatodico,Foliage Fotocatodico,T1,,missing_in_external
+foliaggio_spugna,Foliaggio Spugna,Foliaggio Spugna,T1,,missing_in_external
+frusta_fiammeggiante,Frusta Fiammeggiante,Flame Lash,T2,,missing_in_external
+ghiaccio_piezoelettrico,Ghiaccio Piezoelettrico,Ghiaccio Piezoelettrico,T1,,missing_in_external
+ghiandola_caustica,Ghiandola Caustica,Caustic Gland,T1,,missing_in_external
+ghiandole_cambio_salino,Ghiandole Cambio Salino,Ghiandole Cambio Salino,T1,,missing_in_external
+ghiandole_condensa_ozono,Ghiandole Condensa Ozono,Ghiandole Condensa Ozono,T1,,missing_in_external
+ghiandole_eco_mappanti,Ghiandole Eco Mappanti,Ghiandole Eco Mappanti,T1,,missing_in_external
+ghiandole_fango_calde,Ghiandole Fango Calde,Ghiandole Fango Calde,T1,,missing_in_external
+ghiandole_fango_coesivo,Ghiandole Fango Coesivo,Ghiandole Fango Coesivo,T1,,missing_in_external
+ghiandole_grafene,Ghiandole Grafene,Ghiandole Grafene,T1,,missing_in_external
+ghiandole_inchiostro_luce,Ghiandole Inchiostro Luce,Ghiandole Inchiostro Luce,T1,,missing_in_external
+ghiandole_iodoattive,Ghiandole Iodoattive,Ghiandole Iodoattive,T1,,missing_in_external
+ghiandole_minerali,Ghiandole Minerali,Ghiandole Minerali,T1,,missing_in_external
+ghiandole_mnemoniche,Ghiandole Mnemoniche,Mnemonic Glands,,,missing_in_external
+ghiandole_nebbia_acida,Ghiandole Nebbia Acida,Ghiandole Nebbia Acida,T1,,missing_in_external
+ghiandole_nebbia_ionica,Ghiandole Nebbia Ionica,Ghiandole Nebbia Ionica,T1,,missing_in_external
+ghiandole_resina_conduttiva,Ghiandole Resina Conduttiva,Ghiandole Resina Conduttiva,T1,,missing_in_external
+ghiandole_ventosa,Ghiandole Ventosa,Ghiandole Ventosa,T1,,missing_in_external
+giunti_antitorsione,Giunti Antitorsione,Giunti Antitorsione,T1,,missing_in_external
+grassi_termici,Grassi Termici,Grassi Termici,T1,,missing_in_external
+gusci_criovetro,Gusci Criovetro,Gusci Criovetro,T1,,missing_in_external
+gusci_magnesio,Gusci Magnesio,Gusci Magnesio,T1,,missing_in_external
+impulsi_bioluminescenti,Impulsi Bioluminescenti,Bioluminescent Pulses,,,missing_in_external
+lamelle_shear,Lamelle Shear,Lamelle Shear,T1,,missing_in_external
+lamelle_sincroniche,Lamelle Sincroniche,Lamelle Sincroniche,T1,,missing_in_external
+lamelle_termoforetiche,Lamelle Termoforetiche,Thermophoretic Lamellae,T2,,missing_in_external
+lamine_filtranti_aeree,Lamine Filtranti Aeree,Lamine Filtranti Aeree,T1,,missing_in_external
+lamine_scudo_silice,Lamine Scudo Silice,Lamine Scudo Silice,T1,,missing_in_external
+linfa_tampone,Linfa Tampone,Linfa Tampone,T1,,missing_in_external
+lingua_cristallina,Lingua Cristallina,Lingua Cristallina,T1,,missing_in_external
+lingua_tattile_trama,Lingua Tattile Trama-Sensibile,Texture-Sensing Tongue,T1,,missing_in_external
+lobi_risonanti_crepuscolo,Lobi Risonanti Crepuscolo,Twilight Resonant Lobes,,,missing_in_external
+luminescenza_aurorale,Luminescenza Aurorale,Luminescenza Aurorale,T1,,missing_in_external
+luminescenza_hydrotermica,Luminescenza Hydrotermica,Luminescenza Hydrotermica,T1,,missing_in_external
+mantelli_geotermici,Mantelli Geotermici,Mantelli Geotermici,T1,,missing_in_external
+mantello_meteoritico,Mantello Meteoritico,Meteoric Mantle,T3,,missing_in_external
+membrane_captura_rugiada,Membrane Captura Rugiada,Membrane Captura Rugiada,T1,,missing_in_external
+membrane_eliofiltranti,Membrane Eliofiltranti,Membrane Eliofiltranti,T2,,missing_in_external
+membrane_fotoconvoglianti,Membrane Fotoconvoglianti,Photoconductive Membranes,,,missing_in_external
+membrane_planata_vectored,Membrane Planata Vectored,Membrane Planata Vectored,T1,,missing_in_external
+membrane_pneumatofori,Membrane Pneumatofori,Membrane Pneumatofori,T1,,missing_in_external
+midollo_antivibrazione,Midollo Antivibrazione,Midollo Antivibrazione,T1,,missing_in_external
+mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,T1,,missing_in_external
+mucillagine_simbionte_mangrovie,Mucillagine Simbionte delle Mangrovie,Mucillagine Simbionte delle Mangrovie,T1,,missing_in_external
+mucose_aderenza_sonica,Mucose Aderenza Sonica,Mucose Aderenza Sonica,T1,,missing_in_external
+mucose_barofile,Mucose Barofile,Mucose Barofile,T1,,missing_in_external
+nebbia_mnesica,Nebbia Mnesica,Mnesic Fog,,,missing_in_external
+nodi_micorrizici_oracolari,Nodi Micorrizici Oracolari,Nodi Micorrizici Oracolari,T3,,missing_in_external
+nodi_sinaptici_superficiali,Nodi Sinaptici Superficiali,Surface Synaptic Nodes,,,missing_in_external
+nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,T1,,missing_in_external
+occhi_cristallo_modulare,Occhi di Cristallo Modulare,Occhi di Cristallo Modulare,T2,,missing_in_external
+occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Infrared Compound Eyes,T1,,missing_in_external
+olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,T2,,missing_in_external
+organi_metacronici,Organi Metacronici,Metachronic Organs,,,missing_in_external
+pathfinder,Pathfinder,Pathfinder,T1,,missing_in_external
+pelle_piezo_satura,Pelle Piezo-Satura,Piezo-Saturated Skin,,,missing_in_external
+pianificatore,Pianificatore,Strategic Planner,T1,,missing_in_external
+piume_solari_fotovoltaiche,Piume Solari Fotovoltaiche,Piume Solari Fotovoltaiche,T2,,missing_in_external
+placca_diffusione_foschia,Placca di Diffusione Foschia,Fog Diffusion Plate,,,missing_in_external
+placche_pressioniche,Placche Pressioniche,Pressure Plates,,,missing_in_external
+polmoni_cristallini_alta_quota,Polmoni Cristallini d'Alta Quota,Polmoni Cristallini d'Alta Quota,T2,,missing_in_external
+random,Trait Random,Trait Random,T1,,missing_in_external
+respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,T1,,missing_in_external
+risonanza_di_branco,Risonanza di Branco,Pack Resonance,T1,,missing_in_external
+riverbero_memetico,Riverbero Memetico,Memetic Reverb,,,missing_in_external
+sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,T1,,missing_in_external
+sacche_spore_stratosferiche,Sacche di Spore Stratosferiche,Sacche di Spore Stratosferiche,T3,,missing_in_external
+sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,T1,,missing_in_external
+scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,T1,,missing_in_external
+scintilla_sinaptica,Scintilla Sinaptica,Synaptic Spark,,,missing_in_external
+secrezione_rallentante_palmi,Mani secernano liquido rallentante,Retarding Palm Secretions,T1,,missing_in_external
+secrezioni_antistatiche,Secrezioni Antistatiche,Antistatic Secretions,,,missing_in_external
+sensori_geomagnetici,Sensori a Risonanza Geomagnetica,Geomagnetic Resonance Sensors,T1,,missing_in_external
+sensori_planctonici,Sensori Planctonici,Planctonic Sensors,,,missing_in_external
+sinapsi_coraline_polifoniche,Sinapsi Coraline Polifoniche,Sinapsi Coraline Polifoniche,T2,,missing_in_external
+sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,T1,,missing_in_external
+spicole_canalizzatrici,Spicole Canalizzatrici,Channeling Spicules,,,missing_in_external
+spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,T1,,missing_in_external
+squame_diffusori_ionici,Squame Diffusori Ionici,Ionic Diffuser Scales,,,missing_in_external
+squame_rifrangenti_deserto,Squame Rifrangenti del Deserto,Squame Rifrangenti del Deserto,T2,,missing_in_external
+struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,T1,,missing_in_external
+tattiche_di_branco,Tattiche di Branco,Pack Tactics,T1,,missing_in_external
+traits_aggregate,traits_aggregate,traits_aggregate,,traits_aggregate,missing_in_index
+vello_condensatore_nebbie,Vello Condensatore di Nebbie,Vello Condensatore di Nebbie,T1,,missing_in_external
+ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,T1,,missing_in_external
+vortice_nera_flash,Vortice Nera Flash,Black Vortex Flash,,,missing_in_external
+zampe_a_molla,Zampe a Molla,Spring-Loaded Limbs,T1,,missing_in_external
+zoccoli_risonanti_steppe,Zoccoli Risonanti delle Steppe,Zoccoli Risonanti delle Steppe,T1,,missing_in_external

--- a/reports/evo/rollout/traits_gap.svg
+++ b/reports/evo/rollout/traits_gap.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2025-11-27T12:41:06.608231</dc:date>
+    <dc:date>2025-11-27T12:52:42.566700</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,7 +43,7 @@ L 140.604737 288.095888
 L 140.604737 255.094716 
 L 68.091818 255.094716 
 z
-" clip-path="url(#p1e97a3f39d)" style="fill: #005f73"/>
+" clip-path="url(#p066e80989a)" style="fill: #005f73"/>
    </g>
    <g id="patch_4">
     <path d="M 158.732967 288.095888 
@@ -51,7 +51,7 @@ L 231.245885 288.095888
 L 231.245885 79.775995 
 L 158.732967 79.775995 
 z
-" clip-path="url(#p1e97a3f39d)" style="fill: #005f73"/>
+" clip-path="url(#p066e80989a)" style="fill: #005f73"/>
    </g>
    <g id="patch_5">
     <path d="M 249.374115 288.095888 
@@ -59,7 +59,7 @@ L 321.887033 288.095888
 L 321.887033 270.564015 
 L 249.374115 270.564015 
 z
-" clip-path="url(#p1e97a3f39d)" style="fill: #005f73"/>
+" clip-path="url(#p066e80989a)" style="fill: #005f73"/>
    </g>
    <g id="patch_6">
     <path d="M 340.015263 288.095888 
@@ -67,18 +67,18 @@ L 412.528182 288.095888
 L 412.528182 286.033314 
 L 340.015263 286.033314 
 z
-" clip-path="url(#p1e97a3f39d)" style="fill: #005f73"/>
+" clip-path="url(#p066e80989a)" style="fill: #005f73"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mdb7d8af248" d="M 0 0 
+       <path id="mb3f7a8e2f9" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdb7d8af248" x="104.348278" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3f7a8e2f9" x="104.348278" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -268,7 +268,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mdb7d8af248" x="194.989426" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3f7a8e2f9" x="194.989426" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -425,7 +425,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mdb7d8af248" x="285.630574" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3f7a8e2f9" x="285.630574" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -442,7 +442,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mdb7d8af248" x="376.271722" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3f7a8e2f9" x="376.271722" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -500,12 +500,12 @@ z
     <g id="ytick_1">
      <g id="line2d_5">
       <defs>
-       <path id="mfd001e6806" d="M 0 0 
+       <path id="md6ed16256a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfd001e6806" x="50.87" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="50.87" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -541,7 +541,7 @@ z
     <g id="ytick_2">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mfd001e6806" x="50.87" y="262.313723" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="50.87" y="262.313723" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -606,7 +606,7 @@ z
     <g id="ytick_3">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mfd001e6806" x="50.87" y="236.531558" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="50.87" y="236.531558" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -620,7 +620,7 @@ z
     <g id="ytick_4">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mfd001e6806" x="50.87" y="210.749393" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="50.87" y="210.749393" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -646,7 +646,7 @@ z
     <g id="ytick_5">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mfd001e6806" x="50.87" y="184.967228" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="50.87" y="184.967228" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -677,7 +677,7 @@ z
     <g id="ytick_6">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mfd001e6806" x="50.87" y="159.185063" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="50.87" y="159.185063" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -692,7 +692,7 @@ z
     <g id="ytick_7">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mfd001e6806" x="50.87" y="133.402898" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="50.87" y="133.402898" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -707,7 +707,7 @@ z
     <g id="ytick_8">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mfd001e6806" x="50.87" y="107.620733" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="50.87" y="107.620733" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -722,7 +722,7 @@ z
     <g id="ytick_9">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mfd001e6806" x="50.87" y="81.838568" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="50.87" y="81.838568" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -927,7 +927,7 @@ L 548.947879 288.095888
 L 548.947879 288.095888 
 L 491.541818 288.095888 
 z
-" clip-path="url(#pea2d8fcb36)" style="fill: #ee9b00"/>
+" clip-path="url(#p2da45234fe)" style="fill: #ee9b00"/>
    </g>
    <g id="patch_13">
     <path d="M 563.299394 288.095888 
@@ -935,7 +935,7 @@ L 620.705455 288.095888
 L 620.705455 288.095888 
 L 563.299394 288.095888 
 z
-" clip-path="url(#pea2d8fcb36)" style="fill: #ee9b00"/>
+" clip-path="url(#p2da45234fe)" style="fill: #ee9b00"/>
    </g>
    <g id="patch_14">
     <path d="M 635.05697 288.095888 
@@ -943,7 +943,7 @@ L 692.46303 288.095888
 L 692.46303 79.775995 
 L 635.05697 79.775995 
 z
-" clip-path="url(#pea2d8fcb36)" style="fill: #ee9b00"/>
+" clip-path="url(#p2da45234fe)" style="fill: #ee9b00"/>
    </g>
    <g id="patch_15">
     <path d="M 706.814545 288.095888 
@@ -951,7 +951,7 @@ L 764.220606 288.095888
 L 764.220606 288.095888 
 L 706.814545 288.095888 
 z
-" clip-path="url(#pea2d8fcb36)" style="fill: #ee9b00"/>
+" clip-path="url(#p2da45234fe)" style="fill: #ee9b00"/>
    </g>
    <g id="patch_16">
     <path d="M 778.572121 288.095888 
@@ -959,13 +959,13 @@ L 835.978182 288.095888
 L 835.978182 288.095888 
 L 778.572121 288.095888 
 z
-" clip-path="url(#pea2d8fcb36)" style="fill: #ee9b00"/>
+" clip-path="url(#p2da45234fe)" style="fill: #ee9b00"/>
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_5">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mdb7d8af248" x="520.244848" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3f7a8e2f9" x="520.244848" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -992,7 +992,7 @@ z
     <g id="xtick_6">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mdb7d8af248" x="592.002424" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3f7a8e2f9" x="592.002424" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1019,7 +1019,7 @@ z
     <g id="xtick_7">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mdb7d8af248" x="663.76" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3f7a8e2f9" x="663.76" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1068,7 +1068,7 @@ z
     <g id="xtick_8">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mdb7d8af248" x="735.517576" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3f7a8e2f9" x="735.517576" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1106,7 +1106,7 @@ z
     <g id="xtick_9">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mdb7d8af248" x="807.275152" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3f7a8e2f9" x="807.275152" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1144,7 +1144,7 @@ z
     <g id="ytick_10">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mfd001e6806" x="474.32" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="474.32" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
@@ -1157,7 +1157,7 @@ z
     <g id="ytick_11">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mfd001e6806" x="474.32" y="255.545904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="474.32" y="255.545904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
@@ -1170,7 +1170,7 @@ z
     <g id="ytick_12">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mfd001e6806" x="474.32" y="222.995921" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="474.32" y="222.995921" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
@@ -1184,7 +1184,7 @@ z
     <g id="ytick_13">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mfd001e6806" x="474.32" y="190.445938" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="474.32" y="190.445938" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
@@ -1198,7 +1198,7 @@ z
     <g id="ytick_14">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mfd001e6806" x="474.32" y="157.895954" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="474.32" y="157.895954" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_25">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mfd001e6806" x="474.32" y="125.345971" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="474.32" y="125.345971" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_26">
@@ -1226,7 +1226,7 @@ z
     <g id="ytick_16">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mfd001e6806" x="474.32" y="92.795988" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md6ed16256a" x="474.32" y="92.795988" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_27">
@@ -1504,10 +1504,10 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p1e97a3f39d">
+  <clipPath id="p066e80989a">
    <rect x="50.87" y="69.36" width="378.88" height="218.735888"/>
   </clipPath>
-  <clipPath id="pea2d8fcb36">
+  <clipPath id="p2da45234fe">
    <rect x="474.32" y="69.36" width="378.88" height="218.735888"/>
   </clipPath>
  </defs>


### PR DESCRIPTION
## Summary
- regenerate the trait gap artifacts and produce an updated partner export after the ROL-04 closure
- add the missing coscienza_dalveare_diffusa entry to the legacy trait glossary with metadata from the external dataset
- refresh ROL-05 rollout notes/telemetry with CSV format guidance, counts, and partner handoff details

## Testing
- python tools/audit/evo_trait_diff.py
- python tools/traits/sync_missing_index.py --source reports/evo/rollout/traits_gap.csv --dest data/core/traits/glossary.json --trait-dir data/external/evo/traits --update-glossary --export reports/evo/rollout/traits_external_sync.csv

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692848e5654083288961548e29a66066)