### PR TITLE
Improve backlog setup validation and guidance

### DIFF
--- a/docs/incoming/lavoro_da_classificare/TASKS_BREAKDOWN.md
+++ b/docs/incoming/lavoro_da_classificare/TASKS_BREAKDOWN.md
@@ -145,7 +145,7 @@ chiudere il batch corrispondente.
       _Output_: board popolata con `setup_backlog.py` usando `backlog_tasks_example.yaml`.
       _Passi_: esportare template dall'archivio, impostare variabili `REPO`/`GITHUB_TOKEN`/`BACKLOG_FILE`, eseguire script.
       _Bloccanti_: richiede `GITHUB_TOKEN` con permessi project/issue.
-      _Note_: template copiato in `incoming/lavoro_da_classificare/backlog_tasks_example.yaml`; esecuzione sospesa finché non vengono forniti i segreti.
+      _Note_: template copiato in `incoming/lavoro_da_classificare/backlog_tasks_example.yaml`; script aggiornato con preflight per verificare REPO e token prima di creare Projects/issue. Necessario PAT repo+project valido per la run finale sul repository target.
 
 ---
 

--- a/incoming/lavoro_da_classificare/tasks.yml
+++ b/incoming/lavoro_da_classificare/tasks.yml
@@ -427,8 +427,8 @@ tasks:
       - python incoming/scripts/setup_backlog.py
     notes: |
       Template backlog convertito nel formato atteso dallo script (project_name, columns, issues).
-      Tentata esecuzione con REPO=MasterDD-L34D/Game e BACKLOG_FILE impostato al nuovo template ma la GitHub API ha restituito 404 (token placeholder, project non creato).
-      Richiesto rerun con GITHUB_TOKEN valido e repository accessibile; la pipeline resta attiva in attesa del token corretto.
+      Script rafforzato con preflight che verifica accesso al repository e alle Projects prima di creare board e issue.
+      Run richiede ancora un GITHUB_TOKEN valido (scope repo+project) per finalizzare la popolazione sul repository target.
 
   - id: ROL-08
     batch: rollout

--- a/incoming/scripts/setup_backlog.py
+++ b/incoming/scripts/setup_backlog.py
@@ -51,24 +51,44 @@ Nota: Questo script non gestisce la deduplicazione di issue esistenti.  Utilizza
 
 import os
 import sys
+from pathlib import Path
 from typing import Any, Dict, List, Tuple
+
 import requests
 import yaml
+
+
+class BacklogConfigError(Exception):
+    """Raised when local configuration is invalid."""
 
 
 def github_request(method: str, url: str, **kwargs) -> Any:
     token = os.environ.get("GITHUB_TOKEN")
     if not token:
-        raise RuntimeError("GITHUB_TOKEN non impostato")
+        raise BacklogConfigError("GITHUB_TOKEN non impostato: servono permessi repo+project.")
     headers = kwargs.pop("headers", {})
-    headers.update({
-        "Authorization": f"token {token}",
-        "Accept": "application/vnd.github+json",
-    })
-    response = requests.request(method, url, headers=headers, **kwargs)
+    headers.update(
+        {
+            "Authorization": f"token {token}",
+            "Accept": "application/vnd.github+json, application/vnd.github.inertia-preview+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+    )
+    try:
+        response = requests.request(method, url, headers=headers, timeout=30, **kwargs)
+    except requests.exceptions.RequestException as exc:  # pragma: no cover - network guardrail
+        raise RuntimeError(f"Errore di rete verso GitHub: {exc}") from exc
+
     if not response.ok:
+        if response.status_code == 404:
+            raise RuntimeError(
+                "GitHub API error 404: repository o Projects non accessibili. "
+                "Verifica REPO e che il token abbia scope repo+project con accesso al repository."
+            )
         raise RuntimeError(f"GitHub API error {response.status_code}: {response.text}")
-    return response.json()
+    if response.text:
+        return response.json()
+    return None
 
 
 def create_project(repo_full_name: str, project_name: str) -> int:
@@ -106,26 +126,48 @@ def add_issue_to_column(column_id: int, issue_id: int) -> None:
 
 
 def main() -> None:
-    repo = os.environ.get("REPO")
-    backlog_file = os.environ.get("BACKLOG_FILE")
-    if not repo or not backlog_file:
-        print("Errore: REPO e BACKLOG_FILE devono essere impostate.")
+    try:
+        repo = os.environ.get("REPO")
+        backlog_file = os.environ.get("BACKLOG_FILE")
+        if not repo or not backlog_file:
+            raise BacklogConfigError("REPO e BACKLOG_FILE devono essere impostate.")
+        if "/" not in repo:
+            raise BacklogConfigError("REPO deve avere il formato <owner>/<repo> (es. MasterDD-L34D/Game).")
+        backlog_path = Path(backlog_file)
+        if not backlog_path.is_file():
+            raise BacklogConfigError(f"BACKLOG_FILE non trovato: {backlog_path}")
+
+        # Preflight: verificare che il token abbia accesso al repository e ai progetti
+        github_request("GET", f"https://api.github.com/repos/{repo}")
+
+        with backlog_path.open("r", encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+
+        if "project_name" not in config or "columns" not in config or "issues" not in config:
+            raise BacklogConfigError("BACKLOG_FILE mancante di una delle chiavi richieste: project_name, columns, issues.")
+
+        project_id = create_project(repo, config["project_name"])
+        # Creazione colonne
+        column_ids = {}
+        for col_name in config.get("columns", []):
+            col_id = create_column(project_id, col_name)
+            column_ids[col_name] = col_id
+        # Creazione issue e assegnazione a colonna
+        for item in config.get("issues", []):
+            issue_id, _issue_number = create_issue(
+                repo, item["title"], item.get("body", ""), item.get("labels", [])
+            )
+            column_name = item.get("column") or config["columns"][0]
+            col_id = column_ids[column_name]
+            add_issue_to_column(col_id, issue_id)
+            print(f"Creata issue '{item['title']}' in colonna {column_name}")
+        print("Setup backlog completato.")
+    except BacklogConfigError as cfg_error:
+        print(f"Errore di configurazione: {cfg_error}")
         sys.exit(1)
-    with open(backlog_file, "r", encoding="utf-8") as f:
-        config = yaml.safe_load(f)
-    project_id = create_project(repo, config["project_name"])
-    # Creazione colonne
-    column_ids = {}
-    for col_name in config.get("columns", []):
-        col_id = create_column(project_id, col_name)
-        column_ids[col_name] = col_id
-    # Creazione issue e assegnazione a colonna
-    for item in config.get("issues", []):
-        issue_id, _issue_number = create_issue(repo, item["title"], item.get("body", ""), item.get("labels", []))
-        column_name = item.get("column") or config["columns"][0]
-        col_id = column_ids[column_name]
-        add_issue_to_column(col_id, issue_id)
-        print(f"Creata issue '{item['title']}' in colonna {column_name}")
+    except RuntimeError as runtime_error:
+        print(runtime_error)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Descrizione
- Rafforza `incoming/scripts/setup_backlog.py` con preflight su REPO/BACKLOG_FILE/token, header Projects e messaggi d'errore più chiari in caso di 404 o assenza permessi.
- Aggiorna le note di ROL-07 in `tasks.yml` e in `docs/incoming/lavoro_da_classificare/TASKS_BREAKDOWN.md` per riflettere le nuove verifiche e la necessità di un PAT repo+project.

## Checklist guida stile & QA
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate (N/A)
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa (N/A)
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati (N/A)
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact) (N/A)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti) (N/A)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown) (N/A)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato (N/A)
- [ ] Documentazione/processi aggiornati ove necessario

## Testing
- [ ] Altro: `REPO=MasterDD-L34D/Game BACKLOG_FILE=incoming/lavoro_da_classificare/backlog_tasks_example.yaml python incoming/scripts/setup_backlog.py` (fallito: GITHUB_TOKEN mancante, preflight attivo)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692854f0ad8883289948ceb56c4759a4)