### PR TITLE
Update 01B core-derived matrix and log gate exit

### DIFF
--- a/docs/planning/REF_CORE_DERIVED_MATRIX.md
+++ b/docs/planning/REF_CORE_DERIVED_MATRIX.md
@@ -1,7 +1,7 @@
-# REF_CORE_DERIVED_MATRIX – Matrice preliminare 01B (core vs derived)
+# REF_CORE_DERIVED_MATRIX – Matrice 01B (core vs derived)
 
-Versione: 0.1
-Data: 2026-02-07
+Versione: 0.2
+Data: 2026-04-09
 Scope: specie e trait legati alla gap list 01A aggiornata
 Owner operativo: species-curator (lead 01B) con trait-curator per nomenclatura/mapping trait
 
@@ -19,13 +19,13 @@ Owner operativo: species-curator (lead 01B) con trait-curator per nomenclatura/m
 ## Matrice core/derived (preliminare)
 
 <!-- prettier-ignore -->
-| Fonte (gap 01A) | Dominio | Proposta core/derived | Rationale + rischio/fixture | Owner & ticket | Validazione specie-curator | Validazione trait-curator |
-| --- | --- | --- | --- | --- | --- | --- |
-| `incoming/ancestors_*` CSV / `Ancestors_Neurons_*` | Specie (dataset esperimentale) | **Derived** (no patch ai pack core finché schema non stabilizzato) | Dataset non allineato a `data/core/species`; schema e sensitività dati da sanificare. Borderline su etichettamento etico → richiesta sanitizzazione e versioning prima di eventuale promozione. | species-curator (lead) + dev-tooling; **[TKT-01A-ANC]** | ✅ Revisione preliminare: mantiene derived fino a verifica schema contro core e privacy. | ⚠️ Non applicabile (nessun trait diretto), ma richiesto check nomenclatura se emergono tratti implicitamente modellati. |
-| `incoming/evo_tactics_validator-pack_v1.5.zip`, `evo_tactics_param_synergy_v8_3.zip` | Trait / parametri | **Derived** (tooling/fixture, non fonte core) | Tabelle di parametri legacy usate per validazione; rischio di divergenza dai trait core correnti. Da usare solo come riferimento di confronto. | balancer + dev-tooling; **[TKT-01A-PARAM]** | ⚠️ Non applicabile lato specie. | ✅ Validazione preliminare: classificati come derived/fixture; richiede sync con trait canonici prima di qualsiasi import. |
-| `incoming/lavoro_da_classificare/*` | Misto (specie/trait/asset) | **Pending** → default derived finché non assegnato dominio | Contenuto eterogeneo senza mapping; rischio alto di portare materiale fuori roadmap. Necessario triage per separare specie vs trait vs asset. | coordinator + owner dominio da nominare; **[TKT-01A-LDC]** | ✅ Ha richiesto trattare tutto come derived/pending e bloccare uso fino a triage completato. | ✅ Concorda sul flag derived/pending; richiede review nomenclature per eventuali trait estratti. |
-| `incoming/hook_bindings.ts`, `engine_events.schema.json`, `scan_engine_idents.py` | Engine (supporto trait/trigger) | **Derived** (consultivo, niente patch) | Bindings non allineati agli ID engine correnti; usabili solo come reference storico finché non riallineati. | dev-tooling; **[TKT-01A-ENGINE]** | ⚠️ Non applicabile lato specie. | ⚠️ Non applicabile lato trait diretto; nota: eventuali trigger trait vanno rimappati dopo revisioning. |
-| `docs/incoming/lavoro_da_classificare/INTEGRATION_PLAN.md` | Processo (note su specie/trait) | **Derived** (documentazione di lavorazione) | Piano privo di legame a patchset/ticket; usarlo solo come storico finché non riallineato a 01B. | coordinator + archivist; **[TKT-01A-DOCS]** | ✅ Segnala che riferimenti a specie restano consultivi, nessuna promozione ai core. | ✅ Conferma che eventuali checklist trait sono da rivedere prima di applicarle. |
+| Asset (gap 01A + ticket) | Proposta core/derived | Rationale + fixture (rif. REF_REPO_SOURCES_OF_TRUTH) | Co-triage / owner (flag borderline) |
+| --- | --- | --- | --- |
+| `incoming/ancestors_*` CSV / `Ancestors_Neurons_*` (**[TKT-01A-002]**) | **Derived** (nessuna patch ai core specie) | Non allineato ai core canonici `data/core/species.yaml`/`data/core/species/aliases.json`; schema e dati sensibili da sanificare prima di qualsiasi promozione. Fixture richiesta: dump versionato post-sanitizzazione con checksum e log comando. | species-curator (lead) + archivist/dev-tooling per verifica schema/privacy (**borderline** etico); escalation a Master DD per uso esteso. |
+| `incoming/evo_tactics_validator-pack_v1.5.zip`, `evo_tactics_param_synergy_v8_3.zip`, `evo_tactics_tables_v8_3.xlsx` (**[TKT-01A-003]**) | **Derived/fixture** (tooling parametri) | Tabelle legacy da usare solo come confronto contro i trait canonici `data/core/traits/glossary.json` e pool `data/core/traits/biome_pools.json`; nessun dato core nuovo. Fixture: esecuzione controllata dei validatori con log e checksum. | dev-tooling + balancer (co-triage su coerenza parametri); trait-curator in supporto se emergono rename trait. |
+| `incoming/lavoro_da_classificare/*` (**[TKT-01A-001]**) | **Derived/Pending** (blocco all’uso) | Materiale eterogeneo senza mapping verso core `data/core/**`; rischio di import di asset fuori roadmap. Richiede triage per separare specie/trait/asset prima di qualsiasi derivazione. | coordinator + species-curator/trait-curator per triage; Master DD deve nominare owner di dominio (**borderline** per rischio scope). |
+| `incoming/hook_bindings.ts`, `engine_events.schema.json`, `scan_engine_idents.py` (**[TKT-01A-004]**) | **Derived** (consultivo, no patch) | Binding non riallineati alle sorgenti di verità engine `data/core/game_functions.yaml` / `data/core/telemetry.yaml`; usare solo come reference storico finché non verificati. Fixture: diff degli ID engine rispetto ai core prima di ogni riuso. | dev-tooling owner; co-triage con balancer/species-curator se i trigger toccano trait/specie (**borderline** per compatibilità eventi). |
+| `docs/incoming/lavoro_da_classificare/INTEGRATION_PLAN.md` (**[TKT-01A-005]**) | **Derived** (documentazione di lavorazione) | Piano senza legame a patchset/ticket; non sostituisce i riferimenti canonici su specie/trait (`data/core/traits/**`, `data/core/species.yaml`). Fixture: checklist aggiornata solo dopo approvazione Master DD. | coordinator + archivist; trait-curator in review se riemergono checklist trait (nessun flag borderline attivo). |
 
 ---
 
@@ -35,3 +35,4 @@ Owner operativo: species-curator (lead 01B) con trait-curator per nomenclatura/m
 - Ogni variazione o nuova voce derivata dal triage deve aggiornare questo file insieme a `incoming/README.md` e `docs/incoming/README.md`, seguendo il log in `logs/agent_activity.md`.
 - I casi contrassegnati `Pending` richiedono triage dedicato: bloccare l’uso di materiale finché species-curator/trait-curator non chiudono la classificazione.
 - Quando un asset passa da derived/pending a core, registrare la decisione (owner, ticket) e includere nota su fixture critiche e compatibilità con validator.
+- Borderline = richiede co-triage (trait-curator/balancer/archivist) e validazione Master DD prima di promozione.

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,8 @@
 # Agent activity log
 
+## 2026-04-09 – Gate uscita 01B matrice core/derived (species-curator)
+- Step: `[01B-GATE-EXIT-2026-04-09] owner=species-curator (approvatore richiesto: Master DD); files=docs/planning/REF_CORE_DERIVED_MATRIX.md, logs/agent_activity.md; rischio=basso (documentazione/triage); note=Matrice 01B aggiornata a v0.2 usando REF_REPO_SOURCES_OF_TRUTH e catalogo stabile per le fonti gap list **[TKT-01A-001]** … **[TKT-01A-005]**: proposta core/derived con fixture richieste, flag borderline con co-triage trait-curator/balancer/archivist e blocco Pending su `incoming/lavoro_da_classificare/*`. Bozza pubblicata sul branch `patch/01B-core-derived-matrix`; richiesta via libera Master DD per chiudere il gate 01B e procedere agli step successivi. Ticket 01B collegati: **[TKT-01B-001]**/**[TKT-01B-002]**.`
+
 ## 2026-04-08 – Freeze 01A: etichettatura tabelle + owner gap list (archivist)
 - Step: `[FREEZE-01A-TRIAGE-2026-04-08] owner=archivist (approvatore Master DD); files=incoming/README.md, docs/incoming/README.md, logs/agent_activity.md; rischio=basso (documentazione/triage); note=Riesaminate tabelle incoming in STRICT MODE durante freeze: etichette **DA_INTEGRARE/LEGACY/STORICO** confermate senza spostamenti file; `_holding` ancora assente. Gap list 01A aggiornata con owner proposti e ticket collegati alle fonti (Laura B per catalogo 01A; species-curator per dataset ancestors; dev-tooling per validator/engine; archivist+Master DD per documento 01A-DOCS). Soft freeze documentale su `incoming/**` e `docs/incoming/**` invariato.`
 


### PR DESCRIPTION
## Summary
- align the core/derived matrix v0.2 with gap list 01A sources, co-triage flags, and references to sources of truth
- log the 01B gate exit with branch link and Master DD approval request for the updated matrix

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928cba33c2c8328ad97fb18a85d6e46)