### PR TITLE
Documenta attivazione CI approvata da Master DD

### DIFF
--- a/docs/planning/REF_TOOLING_AND_CI.md
+++ b/docs/planning/REF_TOOLING_AND_CI.md
@@ -49,6 +49,16 @@ Stato: PATCHSET-00 PROPOSTA – allineare tooling/CI al nuovo assetto (nessuna m
 4. Identificare fixture `data/derived/**` critiche per i test e pianificare la loro sostituzione con versioni rigenerate dai core.
 5. Proporre aggiornamenti incrementali ai workflow CI, allineandoli con i patchset definiti nel piano di migrazione.
 
+## Ordine di abilitazione CI (Master DD – 2026-04-12)
+
+- Branch operativo: `patch/01C-tooling-ci-catalog` (strict-mode, nessun artefatto commit).
+- Sequenza approvata:
+  1. Abilitare **enforcing** su `data-quality.yml` (audit core/pack) e `validate_traits.yml` (catalogo trait, lint, coverage) come gate PR.
+  2. Portare **schema-validate.yml** in enforcing su variazioni schema/lint (core + config/schemas) prima dei merge.
+  3. Mantenere **validate-naming.yml** in **report-only** finché la matrice core/derived non è stabile; convergere a enforcing solo dopo l’allineamento delle registrazioni pack.
+  4. Lasciare **incoming-smoke.yml** **disattivato/solo dispatch manuale** (nessun trigger PR) fino a quando non vengono definiti i check automatici su nuovi drop.
+- Reminder check mancanti: drift `data/derived/**` vs sorgenti non ancora monitorato (proposta step opzionale in `validate_traits.yml`), gating incoming ancora limitato a uso manuale di `scripts/report_incoming.sh`.
+
 ## Inventario workflow/script (modalità report-only – 2026-02-07)
 
 | Voce                 | Percorso                                                      | Stato       | Note                                                                                                                                                                        |

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,8 @@
 # Agent activity log
 
+## 2026-04-12 – Attivazione CI 01C (dev-tooling)
+- Step: `[01C-CI-ACTIVATION-2026-04-12] owner=dev-tooling (approvatore Master DD); files=reports/audit/2026-04-10_ci-script-report.md, logs/agent_activity.md, docs/planning/REF_TOOLING_AND_CI.md; rischio=medio (attivazione gating CI); note=Master DD approva il passaggio di `data-quality.yml`, `validate_traits.yml` e `schema-validate.yml` da report-only a enforcing con branch `patch/01C-tooling-ci-catalog`; `validate-naming.yml` resta consultivo, `incoming-smoke.yml` resta disattivato/dispatch manuale. Ordine di abilitazione documentato in REF_TOOLING_AND_CI con reminder su derived drift e incoming gating ancora mancanti.`
+
 ## 2026-04-11 – Via libera Master DD gate uscita 01B (archivist)
 - Step: `[01B-GATE-EXIT-2026-04-09] owner=archivist (approvatore Master DD); files=docs/planning/REF_CORE_DERIVED_MATRIX.md, logs/agent_activity.md, incoming/README.md, docs/incoming/README.md; rischio=basso (documentazione/chiusura gate); note=Master DD approva la matrice core/derived v0.2 e autorizza la chiusura del gate 01B su branch `patch/01B-core-derived-matrix` con handoff verso fase 02A. README incoming/docs_incoming aggiornati per segnalare chiusura gate 01B e avvio 02A.`
 

--- a/reports/audit/2026-04-10_ci-script-report.md
+++ b/reports/audit/2026-04-10_ci-script-report.md
@@ -1,14 +1,21 @@
-# Inventario CI e script locali – 2026-04-10 (dev-tooling, report-only)
+# Inventario CI e script locali – 2026-04-10 (dev-tooling, approved by Master DD)
+
+Stato approvazione: **approved by Master DD** (branch di roll-out `patch/01C-tooling-ci-catalog`).
+
+Transizioni di modalità:
+- Passano da report-only a **enforcing (gating PR)**: `data-quality.yml`, `validate_traits.yml`, `schema-validate.yml`.
+- Restano **report-only** (consultivi): `validate-naming.yml`.
+- Restano **disattivati/solo dispatch manuale**: `incoming-smoke.yml` (non schedulato sulle PR).
 
 ## Workflow CI attivi (focus pack/incoming/derived)
 
 | Nome | Percorso | Trigger/Input | Output/Artefatti | Owner | Impatto pack |
 | ---- | -------- | ------------- | ---------------- | ----- | ------------ |
-| Data audit e validation | .github/workflows/data-quality.yml | PR su data/**, packs/**, tool di audit | Valida dataset YAML/JSON, esegue trait audit e genera coverage/metriche con upload artefatti (reports/**, data/derived/analysis, logs/trait_audit) | dev-tooling | Controllo dati core/pack e derived; non modifica pack ma blocca PR se audit fallisce |
-| Validate Trait Catalog | .github/workflows/validate_traits.yml | Push/PR su data/traits, schema trait, tools/py | Costruisce indice e coverage trait, esegue lint stile e carica report (reports/**, data/derived/analysis) | dev-tooling | Garantisce coerenza trait e derived; gating PR su regressioni trait |
-| Validate registry naming | .github/workflows/validate-naming.yml | Push/PR su registri pack e scanner correlati | Esegue scanner naming Python per slug/registri del pack | dev-tooling | Protegge naming pack/registri; nessun artefatto |
-| Schema validate | .github/workflows/schema-validate.yml | Push/PR su schemas/**, dispatch manuale | Verifica struttura JSON Schema con jsonschema Draft2020-12 | dev-tooling | Riduce rischio schema invalido usato da CLI/validator |
-| Incoming CLI smoke | .github/workflows/incoming-smoke.yml | Dispatch manuale con input opzionali data-root/pack-root | Esegue profile CLI `staging_incoming` e carica `incoming-smoke-logs` da logs/incoming_smoke | dev-tooling | Smoke non bloccante su pacchetti incoming decompressi; non attivo su PR |
+| Data audit e validation | .github/workflows/data-quality.yml | PR su data/**, packs/**, tool di audit | Valida dataset YAML/JS ON, esegue trait audit e genera coverage/metriche con upload artefatti (reports/**, data/derived/analysis, logs/trait_audit) | dev-tooling | **Enforcing** su core/pack (blocca PR se audit fallisce); derived solo report |
+| Validate Trait Catalog | .github/workflows/validate_traits.yml | Push/PR su data/traits, schema trait, tools/py | Costruisce indice e coverage trait, esegue lint stile e carica report (reports/**, data/derived/analysis) | dev-tooling | **Enforcing** su regressioni trait/core; derived come artefatti |
+| Validate registry naming | .github/workflows/validate-naming.yml | Push/PR su registri pack e scanner correlati | Esegue scanner naming Python per slug/registri del pack | dev-tooling | **Report-only** (consultivo su registri pack/slug) |
+| Schema validate | .github/workflows/schema-validate.yml | Push/PR su schemas/**, dispatch manuale | Verifica struttura JSON Schema con jsonschema Draft2020-12 | dev-tooling | **Enforcing** su regressioni schema/lint |
+| Incoming CLI smoke | .github/workflows/incoming-smoke.yml | Dispatch manuale con input opzionali data-root/pack-root | Esegue profile CLI `staging_incoming` e carica `incoming-smoke-logs` da logs/incoming_smoke | dev-tooling | **Disattivato** (solo dispatch manuale, nessun gating PR) |
 
 ## Script locali con I/O (report-only)
 


### PR DESCRIPTION
## Summary
- aggiornato il report CI 2026-04-10 con stato "approved by Master DD" e dettaglio dei workflow passati a enforcing vs report-only/disattivi
- registrato in `logs/agent_activity.md` lo step [01C-CI-ACTIVATION-2026-04-12] con owner, rischi e branch `patch/01C-tooling-ci-catalog`
- aggiunto in `docs/planning/REF_TOOLING_AND_CI.md` l’ordine di abilitazione approvato e i reminder su derived drift e gating incoming ancora mancanti

## Testing
- Not run (documentazione)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69297c2ff3b08328b9993c0a69b38add)