### PR TITLE
Add rerun appendix for April 2026

### DIFF
--- a/reports/audit/2026-02-20_audit_bundle.md
+++ b/reports/audit/2026-02-20_audit_bundle.md
@@ -39,3 +39,24 @@ Raccogliere in un unico punto i riferimenti operativi per chiudere il ciclo 02A�
 - [x] Changelog + rollback 03A
 - [x] Istruzioni backup/redirect 03B
 - [x] Trigger riavvio eseguito
+
+## Appendice rerun 2026-04-XX (solo testuale)
+- Log operativi: sblocco registrato in [`logs/agent_activity.md` (entry UNFREEZE-02A-APPROVED-2026-02-21)](../../logs/agent_activity.md#2026-02-21--sblocco-freeze--trigger-pipeline_simulator-coordinator) e rerun 02A (report-only) in [`logs/agent_activity.md` (03A sonic cluster debolezze + rerun 02A)](../../logs/agent_activity.md#2026-02-20--03a-sonic-cluster-debolezze--rerun-02a-report-only).
+- Log rerun schema/trait/style 03A (report-only) in `reports/temp/patch-03A-core-derived/`:
+  - `schema_only.log` — sha256 `805d6a88ae39f76fc1ad9dd9a7f26cbe26a91019c63c9bdf32aba74390cb59ec`.
+  - `trait_audit.log` — sha256 `a4bfc3b7ac4d77dc4998c88930383fc49c4939d1093298323653643eb5d89277`.
+  - `trait_style.log` — sha256 `1ac8496f3f4a1fb340026a93b6608a3d713c9edbacf715dc3e7e91ac19460c6d`.
+  - `trait_style.json` — sha256 `bfea3a033eb43e86c0368af196e0803df17270c937350ae26f13b1dd053e3d4e`.
+- Log rerun schema/trait/style 03B (smoke post-merge) in `reports/temp/patch-03B-incoming-cleanup/2026-02-20/` (stessa serie di checksum della baseline 03A):
+  - `schema_only.log` — sha256 `805d6a88ae39f76fc1ad9dd9a7f26cbe26a91019c63c9bdf32aba74390cb59ec`.
+  - `trait_audit.log` — sha256 `a4bfc3b7ac4d77dc4998c88930383fc49c4939d1093298323653643eb5d89277`.
+  - `trait_style.log` — sha256 `1ac8496f3f4a1fb340026a93b6608a3d713c9edbacf715dc3e7e91ac19460c6d`.
+  - `trait_style.json` — sha256 `bfea3a033eb43e86c0368af196e0803df17270c937350ae26f13b1dd053e3d4e`.
+- Nessun tarball o artefatto binario aggiunto: i checksum sono testuali e i log restano nei percorsi già indicizzati.
+
+### Mini-checklist rerun 2026-04-XX
+- [x] Log freeze/sblocco
+- [x] Report 02A baseline
+- [x] Report 02A post-merge
+- [x] Changelog/rollback 03A
+- [x] Backup/redirect 03B


### PR DESCRIPTION
## Summary
- add an appendix for the April 2026 rerun to the 2026-02-20 audit bundle
- list schema/trait/style log checksums for 03A and 03B rerun outputs
- link the appendix back to the relevant entries in logs/agent_activity.md and include a completion checklist

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929903baac48328943904de4b327762)