### PR TITLE
Normalize backup manifests for rollback and log audit

### DIFF
--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -473,3 +473,8 @@
   - `python scripts/trait_audit.py --check` → PASS (schema skip per jsonschema mancante; nessuna regressione).
   - `node scripts/trait_style_check.js --output-json reports/temp/patch-03B-incoming-cleanup/trait_style.json --fail-on error` → PASS (0 errori; 172 warning, 62 info; solo suggerimenti stilistici preesistenti).
 - Esito: redirect e manifest 03B validati; via libera Master DD per chiudere il freeze soft su `incoming/**`/`docs/incoming/**` dopo merge.
+
+## 2025-11-28 – Audit manifest backup rollback 03A/03B (archivist)
+- Verificate le cartelle `reports/backups/2025-11-25T1500Z_freeze`, `.../2025-11-25T1724Z_masterdd_freeze`, `.../2025-11-25T2028Z_masterdd_freeze` e confermati i checksum presenti (revisionati i manifest *.sha256 senza ricalcolo).
+- Normalizzati i `manifest.txt` con campi Location/On-call/Last verified e nota sull'uso per rollback 03A/03B per i bundle `incoming` e `docs_incoming` in S3 `evo-backups`.
+- Nessun binario aggiunto; verifica documentata come review dei manifest (checksum non ricalcolati).

--- a/reports/backups/2025-11-25T1500Z_freeze/manifest.txt
+++ b/reports/backups/2025-11-25T1500Z_freeze/manifest.txt
@@ -1,4 +1,23 @@
-ca398fe09b2761c0b6354921e5491d24aa75d16640fb21f0736fa424694c834e  reports/backups/2025-11-25T1500Z_freeze/core_snapshot_2025-11-25T1500Z.tar.gz
-b75661be3c2216844d38d3de9412cc8bc7a03eed16ec01ab1288723147000068  reports/backups/2025-11-25T1500Z_freeze/derived_snapshot_2025-11-25T1500Z.tar.gz
-967eba521fe915f0c0bf18c633ffcfed3423ad3204d1a199cfe52a2850573ccb  reports/backups/2025-11-25T1500Z_freeze/docs_incoming_backup_2025-11-25T1500Z.tar.gz
-4905044b6be251b85ba9026c4668728bafae2bafe3b5d716e155e5013288d64d  reports/backups/2025-11-25T1500Z_freeze/incoming_backup_2025-11-25T1500Z.tar.gz
+Archive: core_snapshot_2025-11-25T1500Z.tar.gz
+SHA256: ca398fe09b2761c0b6354921e5491d24aa75d16640fb21f0736fa424694c834e
+Location: s3://evo-backups/game/2025-11-25T1500Z_freeze/core_snapshot_2025-11-25T1500Z.tar.gz
+On-call: backups-oncall@game.internal (pager 4242)
+Last verified: 2025-11-28 (manifest review; checksum from original run, not recomputed)
+
+Archive: derived_snapshot_2025-11-25T1500Z.tar.gz
+SHA256: b75661be3c2216844d38d3de9412cc8bc7a03eed16ec01ab1288723147000068
+Location: s3://evo-backups/game/2025-11-25T1500Z_freeze/derived_snapshot_2025-11-25T1500Z.tar.gz
+On-call: backups-oncall@game.internal (pager 4242)
+Last verified: 2025-11-28 (manifest review; checksum from original run, not recomputed)
+
+Archive: docs_incoming_backup_2025-11-25T1500Z.tar.gz
+SHA256: 967eba521fe915f0c0bf18c633ffcfed3423ad3204d1a199cfe52a2850573ccb
+Location: s3://evo-backups/game/2025-11-25T1500Z_freeze/docs_incoming_backup_2025-11-25T1500Z.tar.gz
+On-call: backups-oncall@game.internal (pager 4242)
+Last verified: 2025-11-28 (manifest review; checksum from original run, not recomputed; required for rollback 03A/03B)
+
+Archive: incoming_backup_2025-11-25T1500Z.tar.gz
+SHA256: 4905044b6be251b85ba9026c4668728bafae2bafe3b5d716e155e5013288d64d
+Location: s3://evo-backups/game/2025-11-25T1500Z_freeze/incoming_backup_2025-11-25T1500Z.tar.gz
+On-call: backups-oncall@game.internal (pager 4242)
+Last verified: 2025-11-28 (manifest review; checksum from original run, not recomputed; required for rollback 03A/03B)

--- a/reports/backups/2025-11-25T1724Z_masterdd_freeze/manifest.txt
+++ b/reports/backups/2025-11-25T1724Z_masterdd_freeze/manifest.txt
@@ -1,0 +1,23 @@
+Archive: core_snapshot_2025-11-25T1724Z.tar.gz
+SHA256: a20b73d3eed4556b4a4a1b9025789493f882adf0ffd9916e733c3482f85a885f
+Location: s3://evo-backups/game/2025-11-25T1724Z_masterdd_freeze/core_snapshot_2025-11-25T1724Z.tar.gz
+On-call: backups-oncall@game.internal (pager 4242)
+Last verified: 2025-11-28 (manifest review of manifest.sha256; checksum from original run, not recomputed)
+
+Archive: derived_snapshot_2025-11-25T1724Z.tar.gz
+SHA256: e8d5f747952f42677619f08f1810f62f4a2b0f21a2a19766c9367f1d7cd61d3d
+Location: s3://evo-backups/game/2025-11-25T1724Z_masterdd_freeze/derived_snapshot_2025-11-25T1724Z.tar.gz
+On-call: backups-oncall@game.internal (pager 4242)
+Last verified: 2025-11-28 (manifest review of manifest.sha256; checksum from original run, not recomputed)
+
+Archive: docs_incoming_backup_2025-11-25T1724Z.tar.gz
+SHA256: b40e4cc9945d180a4a440a9f3c2386ec622fde121a601424ec2bded3f9520d5a
+Location: s3://evo-backups/game/2025-11-25T1724Z_masterdd_freeze/docs_incoming_backup_2025-11-25T1724Z.tar.gz
+On-call: backups-oncall@game.internal (pager 4242)
+Last verified: 2025-11-28 (manifest review of manifest.sha256; checksum from original run, not recomputed; required for rollback 03A/03B)
+
+Archive: incoming_backup_2025-11-25T1724Z.tar.gz
+SHA256: 034c6d4a4e4ada80cbc46def215eb70fa7070115ea289bb8974d4a29ba67f69f
+Location: s3://evo-backups/game/2025-11-25T1724Z_masterdd_freeze/incoming_backup_2025-11-25T1724Z.tar.gz
+On-call: backups-oncall@game.internal (pager 4242)
+Last verified: 2025-11-28 (manifest review of manifest.sha256; checksum from original run, not recomputed; required for rollback 03A/03B)

--- a/reports/backups/2025-11-25T2028Z_masterdd_freeze/manifest.txt
+++ b/reports/backups/2025-11-25T2028Z_masterdd_freeze/manifest.txt
@@ -1,0 +1,23 @@
+Archive: core_snapshot_2025-11-25T2028Z.tar.gz
+SHA256: 77b3e95abc1e5c2376251c8aa59670d6dd52aa4b52ce36e110e3954262c141f2
+Location: s3://evo-backups/game/2025-11-25T2028Z_masterdd_freeze/core_snapshot_2025-11-25T2028Z.tar.gz
+On-call: backups-oncall@game.internal (pager 4242)
+Last verified: 2025-11-28 (manifest review of manifest.sha256; checksum from original run, not recomputed)
+
+Archive: derived_snapshot_2025-11-25T2028Z.tar.gz
+SHA256: 1caee01ccc871cd7daf1a585456d1d0f8a89b2669ab312668dec6d196768e03a
+Location: s3://evo-backups/game/2025-11-25T2028Z_masterdd_freeze/derived_snapshot_2025-11-25T2028Z.tar.gz
+On-call: backups-oncall@game.internal (pager 4242)
+Last verified: 2025-11-28 (manifest review of manifest.sha256; checksum from original run, not recomputed)
+
+Archive: docs_incoming_backup_2025-11-25T2028Z.tar.gz
+SHA256: 4154ad3326340203052a0f6b770ae71549859525856a1affe98ea36b8d0a9236
+Location: s3://evo-backups/game/2025-11-25T2028Z_masterdd_freeze/docs_incoming_backup_2025-11-25T2028Z.tar.gz
+On-call: backups-oncall@game.internal (pager 4242)
+Last verified: 2025-11-28 (manifest review of manifest.sha256; checksum from original run, not recomputed; required for rollback 03A/03B)
+
+Archive: incoming_backup_2025-11-25T2028Z.tar.gz
+SHA256: aa0bdcce913fd31e5caf6caa189327770f31ba135ab7a0e614b3ae632e8f2268
+Location: s3://evo-backups/game/2025-11-25T2028Z_masterdd_freeze/incoming_backup_2025-11-25T2028Z.tar.gz
+On-call: backups-oncall@game.internal (pager 4242)
+Last verified: 2025-11-28 (manifest review of manifest.sha256; checksum from original run, not recomputed; required for rollback 03A/03B)


### PR DESCRIPTION
## Summary
- normalize the timestamped 2025-11-25 backup manifests with standard fields, locations, and rollback 03A/03B notes
- document the manifest review in logs/agent_activity.md

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929942ea2448328b200d56280826559)