### PR TITLE
Adjust validate-naming workflow triggers and gating

### DIFF
--- a/.github/workflows/validate-naming.yml
+++ b/.github/workflows/validate-naming.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - 'config/project_index.json'
+      - 'data/core/traits/glossary.json'
+      - 'data/traits/index.json'
+      - 'packs/evo_tactics_pack/data/species/**'
       - 'docs/evo-tactics-pack/trait-reference.json'
       - 'packs/evo_tactics_pack/tools/config/registries/**'
       - 'tools/py/validate_registry_naming.py'
@@ -13,6 +16,9 @@ on:
   pull_request:
     paths:
       - 'config/project_index.json'
+      - 'data/core/traits/glossary.json'
+      - 'data/traits/index.json'
+      - 'packs/evo_tactics_pack/data/species/**'
       - 'docs/evo-tactics-pack/trait-reference.json'
       - 'packs/evo_tactics_pack/tools/config/registries/**'
       - 'tools/py/validate_registry_naming.py'
@@ -23,6 +29,7 @@ on:
 jobs:
   naming:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- expand the validate-naming workflow paths to monitor core glossary, trait index, and pack species registries alongside existing registries
- mark the naming job as continue-on-error to keep the workflow consultative while gathering signal on push and PR updates

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69299c5c899083288ade0341736581f2)