### PR TITLE
Document consultative validate-naming mode and limit workflow triggers

### DIFF
--- a/.github/workflows/validate-naming.yml
+++ b/.github/workflows/validate-naming.yml
@@ -2,6 +2,8 @@ name: Validate registry naming
 
 on:
   push:
+    branches:
+      - patch/01C-tooling-ci-catalog
     paths:
       - 'config/project_index.json'
       - 'data/core/traits/glossary.json'
@@ -13,23 +15,11 @@ on:
       - 'tools/py/game_utils/env_traits_scanner.py'
       - 'tools/py/scan_env_traits.py'
       - '.github/workflows/validate-naming.yml'
-  pull_request:
-    paths:
-      - 'config/project_index.json'
-      - 'data/core/traits/glossary.json'
-      - 'data/traits/index.json'
-      - 'packs/evo_tactics_pack/data/species/**'
-      - 'docs/evo-tactics-pack/trait-reference.json'
-      - 'packs/evo_tactics_pack/tools/config/registries/**'
-      - 'tools/py/validate_registry_naming.py'
-      - 'tools/py/game_utils/env_traits_scanner.py'
-      - 'tools/py/scan_env_traits.py'
-      - '.github/workflows/validate-naming.yml'
+  workflow_dispatch:
 
 jobs:
   naming:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -39,3 +29,6 @@ jobs:
         run: pip install -r tools/py/requirements.txt
       - name: Validate registry naming
         run: python tools/py/validate_registry_naming.py
+        continue-on-error: true
+      - name: Consultivo
+        run: echo "Validate registry naming eseguito in modalità consultiva (no gate PR); usare il log per monitorare falsi positivi/negativi."

--- a/docs/planning/REF_TOOLING_AND_CI.md
+++ b/docs/planning/REF_TOOLING_AND_CI.md
@@ -3,7 +3,7 @@
 Versione: 0.5
 Data: 2025-12-30
 Owner: agente **dev-tooling** (supporto: archivist, coordinator)
-Stato: PATCHSET-00 PROPOSTA – allineare tooling/CI al nuovo assetto (nessuna modifica a dati/tooling prevista in questo stadio)
+Stato: PATCHSET-00 CONSULTIVO – allineare tooling/CI al nuovo assetto (nessuna modifica a dati/tooling prevista in questo stadio; `validate-naming.yml` mantenuto report-only finché la matrice core/derived non è stabilizzata)
 
 ---
 
@@ -52,10 +52,16 @@ Stato: PATCHSET-00 PROPOSTA – allineare tooling/CI al nuovo assetto (nessuna m
 ## Ordine di abilitazione CI (Master DD – 2026-04-12)
 
 - Branch operativo: `patch/01C-tooling-ci-catalog` (strict-mode, nessun artefatto commit).
+- **Decisione 2026-04-20**: `validate-naming.yml` resta in modalità consultiva per raccogliere metriche di stabilità finché la matrice core/derived non è stabilizzata. La pipeline gira su `push` del branch `patch/01C-tooling-ci-catalog` e via `workflow_dispatch` per run controllati; il trigger PR è disattivato per evitare blocchi.
+- **Condizioni per promuovere a enforcing**:
+  - matrice core/derived stabilizzata e allineata con gli scope 03A/03B;
+  - almeno **3 run consecutivi verdi** su `patch/01C-tooling-ci-catalog` con falsi positivi/negativi monitorati;
+  - approvazione esplicita Master DD e log operativo aggiornato con piano di rollback (ripristino consultivo o disattivazione trigger PR in caso di regressioni);
+  - conferma che glossari/registri pack puntino alle fonti core aggiornate senza drift.
 - Nota decisionale (report-only vs enforcing):
-  - **Report-only**: mantenere `validate-naming.yml` e gli step dei workflow in modalità consultiva su trigger `pull_request` + `push` per raccogliere metriche di stabilità (matrice core/derived) senza bloccare merge; validazione glossari/registi limitata ai registri trait/species core e ai registri pack (`packs/evo_tactics_pack/tools/config/registries/**`) per misurare falsi positivi.
-  - **Enforcing**: passaggio vincolante sui medesimi trigger `pull_request` + `push` quando (i) la matrice core/derived è stabile, (ii) esistono **3 run verdi consecutivi** su `patch/01C-tooling-ci-catalog`, (iii) è stato monitorato e documentato il tasso di falsi positivi/negativi nei log operativi; includere i glossari core e pack come source-of-truth nei job di naming/schema.
-  - Impatti attesi sui trigger: nessun trigger aggiuntivo, ma il passaggio a enforcing rende bloccanti i gate PR; su `push` restano consultivi finché il branch di prova non viene promosso.
+  - **Report-only**: mantenere `validate-naming.yml` consultivo su `push` del branch `patch/01C-tooling-ci-catalog` e tramite `workflow_dispatch` per raccolta metriche, con step non bloccanti e senza gate PR; validazione glossari/registi limitata ai registri trait/species core e ai registri pack (`packs/evo_tactics_pack/tools/config/registries/**`) per misurare falsi positivi.
+  - **Enforcing**: passaggio vincolante (riattivando il trigger `pull_request` e rimuovendo continue-on-error) quando (i) la matrice core/derived è stabile, (ii) esistono **3 run verdi consecutivi** su `patch/01C-tooling-ci-catalog`, (iii) è stato monitorato e documentato il tasso di falsi positivi/negativi nei log operativi; includere i glossari core e pack come source-of-truth nei job di naming/schema.
+  - Impatti attesi sui trigger: nessun trigger aggiuntivo; il passaggio a enforcing rende bloccanti i gate PR e può essere revocato tornando a trigger solo `push`/`workflow_dispatch` in caso di regressioni.
 - Sequenza approvata:
   1. Abilitare **enforcing** su `data-quality.yml` (audit core/pack) e `validate_traits.yml` (catalogo trait, lint, coverage) come gate PR.
   2. Portare **schema-validate.yml** in enforcing su variazioni schema/lint (core + config/schemas) prima dei merge.

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,8 @@
 # Agent activity log
 
+## 2026-04-20 – Stato consultivo validate-naming 01C (dev-tooling)
+- Step: `[01C-NAMING-CONSULTIVE-2026-04-20] owner=dev-tooling (approvatore Master DD); files=docs/planning/REF_TOOLING_AND_CI.md, .github/workflows/validate-naming.yml, logs/agent_activity.md; rischio=basso (config CI); note=Aggiornato stato `validate-naming.yml`: precedente=trigger push+pull_request (potenziale gate PR), nuovo=consultivo su push `patch/01C-tooling-ci-catalog` + `workflow_dispatch` con step `continue-on-error` e nota consultiva. Evidenze CI: matrice core/derived non ancora stabilizzata e nessuna serie di 3 run verdi consecutivi su branch 01C → mantenuto consultivo. Prossima verifica programmata dopo raccolta run su branch 01C (target entro 2026-04-27) o alla stabilizzazione della matrice core/derived.`
+
 ## 2026-04-19 – Stato freeze mirato 03A/03B (archivist)
 - Step: `[03A03B-FREEZE-STATUS-2026-04-19] owner=archivist (approvatore richiesto: Master DD); files=logs/agent_activity.md, logs/TKT-02A-VALIDATOR.rerun.log, reports/audit/2026-02-20_audit_bundle.md; rischio=basso (documentazione/freeze); note=Firma Master DD registrata per questo checkpoint: freeze ora in modalità mirata (aperto solo a log/report) sui branch 'patch/03A-core-derived' e 'patch/03B-incoming-cleanup'. Condizioni di merge ribadite: ultimo rerun validator 02A in pass (log TKT-02A-VALIDATOR.rerun), changelog/rollback pronti all'uso, backup/redirect confermati dai manifest storici. Riferimento audit testuale: reports/audit/2026-02-20_audit_bundle.md; archiviazione tar opzionale da rigenerare solo su richiesta. Finestra operativa: 03A avviabile dopo conferma slot Master DD, 03B successivo al checkpoint post-03A mantenendo redirect/backup attivi.`
 


### PR DESCRIPTION
## Summary
- document the consultative status of validate-naming with promotion criteria and rollback conditions
- log the status change, approver, evidence gap, and next verification window in the agent activity log
- scope validate-naming workflow to branch push/dispatch only with consultative, non-blocking execution

## Testing
- not run (documentation and CI configuration changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69299fd069cc8328a5d7a11bfb7711ec)