### PR TITLE
Confirm validate-naming remains consultative

### DIFF
--- a/docs/planning/REF_TOOLING_AND_CI.md
+++ b/docs/planning/REF_TOOLING_AND_CI.md
@@ -3,7 +3,7 @@
 Versione: 0.5
 Data: 2025-12-30
 Owner: agente **dev-tooling** (supporto: archivist, coordinator)
-Stato: PATCHSET-00 CONSULTIVO – allineare tooling/CI al nuovo assetto (nessuna modifica a dati/tooling prevista in questo stadio; `validate-naming.yml` mantenuto report-only finché la matrice core/derived non è stabilizzata)
+Stato: PATCHSET-00 CONSULTIVO – allineare tooling/CI al nuovo assetto (nessuna modifica a dati/tooling prevista in questo stadio; `validate-naming.yml` confermato report-only con trigger `push`/`workflow_dispatch` e gate PR disattivato finché la matrice core/derived non è stabilizzata)
 
 ---
 
@@ -53,6 +53,7 @@ Stato: PATCHSET-00 CONSULTIVO – allineare tooling/CI al nuovo assetto (nessuna
 
 - Branch operativo: `patch/01C-tooling-ci-catalog` (strict-mode, nessun artefatto commit).
 - **Decisione 2026-04-20**: `validate-naming.yml` resta in modalità consultiva per raccogliere metriche di stabilità finché la matrice core/derived non è stabilizzata. La pipeline gira su `push` del branch `patch/01C-tooling-ci-catalog` e via `workflow_dispatch` per run controllati; il trigger PR è disattivato per evitare blocchi.
+- **Verifica 2026-04-26**: confermata la modalità consultiva e il gate PR disattivato su `patch/01C-tooling-ci-catalog`; nessuna sequenza di 3 run verdi consecutivi disponibile, monitoraggio continuo finché la matrice core/derived non è stabile.
 - **Condizioni per promuovere a enforcing**:
   - matrice core/derived stabilizzata e allineata con gli scope 03A/03B;
   - almeno **3 run consecutivi verdi** su `patch/01C-tooling-ci-catalog` con falsi positivi/negativi monitorati;

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,8 @@
 # Agent activity log
 
+## 2026-04-26 – Conferma consultivo validate-naming 01C (dev-tooling)
+- Step: `[01C-NAMING-CONSULTIVE-2026-04-26] owner=dev-tooling (approvatore Master DD); files=docs/planning/REF_TOOLING_AND_CI.md, .github/workflows/validate-naming.yml, logs/agent_activity.md; rischio=basso (config CI); note=Confermato stato consultivo di `validate-naming.yml`: precedente=consultivo (report-only), nuovo=consultivo (report-only) con gate PR disattivato e trigger limitati a push su `patch/01C-tooling-ci-catalog` + `workflow_dispatch`. Evidenze CI: nessuna sequenza di **3 run verdi consecutivi** disponibile sul branch 01C, matrice core/derived ancora instabile; mantenuto monitoraggio continuo e pronto rollback (riattivazione consultiva già attiva) in caso di falsi positivi/negativi.
+
 ## 2026-04-25 – Firma Master DD e verifica manifest freeze 03AB (archivist)
 - Step: `[03A-UNLOCK-CHECKPOINT-2026-04-25] owner=archivist (approvatore Master DD); files=docs/planning/TKT-03AB-FREEZE.md, reports/audit/2026-02-20_audit_bundle.md, reports/backups/2025-11-25_freeze/manifest.txt, reports/backups/2025-11-25T1500Z_freeze/manifest.txt, reports/backups/2025-11-25T1724Z_masterdd_freeze/manifest.txt, reports/backups/2025-11-25T2028Z_masterdd_freeze/manifest.txt, logs/agent_activity.md; rischio=basso (documentazione/freeze); note=Registrata la firma Master DD per avviare la patch 03A con checkpoint intermedio pianificato prima della fase 03B. Verificati i manifest richiamati da TKT-03AB-FREEZE: checksum e percorsi s3 combaciano con il ticket e con l’indice dell’audit bundle; nessun drift rilevato. Il runbook 02A→03A/03B resta la fonte di sequenza, con i log 02A già legati ai percorsi 03A/03B e pronti per il checkpoint post-03A pre-03B.`
 


### PR DESCRIPTION
## Descrizione
- documentata la conferma dello stato consultivo di `validate-naming.yml` con gate PR disattivato e trigger limitati a push/workflow_dispatch su `patch/01C-tooling-ci-catalog`.
- registrato nel log operativo lo stato precedente/nuovo, l’approvatore richiesto e le evidenze di monitoraggio (assenza di 3 run verdi consecutivi e matrice core/derived ancora instabile).

## Checklist guida stile & QA
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate (N/A documentazione)
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa (N/A)
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati (N/A)
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact) (N/A)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti) (N/A)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown) (N/A)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato (N/A)
- [x] Documentazione/processi aggiornati ove necessario

## Testing
- [ ] `npm run style:check` (non eseguito, cambio solo documentazione)
- [ ] Altro: <!-- specificare -->

## Note
- Aggiornamento solo documentazione/log; nessun run CI aggiuntivo disponibile per soddisfare il requisito di 3 run verdi consecutivi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929a3811cb08328abb16ac9a183fac1)