### PR TITLE
Normalize trait style metadata for patch 03A

### DIFF
--- a/data/traits/alimentazione/fagocitosi_assorbente.json
+++ b/data/traits/alimentazione/fagocitosi_assorbente.json
@@ -47,5 +47,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_00000873"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "alimentazione",
+    "complementare": "digestione"
+  },
+  "usage_tags": [
+    "support"
+  ],
+  "debolezza": "i18n:traits.fagocitosi_assorbente.debolezza"
 }

--- a/data/traits/alimentazione/filtro_metallofago.json
+++ b/data/traits/alimentazione/filtro_metallofago.json
@@ -48,5 +48,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_00000873"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "alimentazione",
+    "complementare": "digestione"
+  },
+  "usage_tags": [
+    "support"
+  ],
+  "debolezza": "i18n:traits.filtro_metallofago.debolezza"
 }

--- a/data/traits/cognitivo/cervello_a_bassa_latenza.json
+++ b/data/traits/cognitivo/cervello_a_bassa_latenza.json
@@ -47,5 +47,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "cognitivo",
+    "complementare": "apprendimento"
+  },
+  "usage_tags": [
+    "controller"
+  ],
+  "debolezza": "i18n:traits.cervello_a_bassa_latenza.debolezza"
 }

--- a/data/traits/cognitivo/comunicazione_fotonica_coda_coda.json
+++ b/data/traits/cognitivo/comunicazione_fotonica_coda_coda.json
@@ -47,5 +47,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "cognitivo",
+    "complementare": "sociale"
+  },
+  "usage_tags": [
+    "controller"
+  ],
+  "debolezza": "i18n:traits.comunicazione_fotonica_coda_coda.debolezza"
 }

--- a/data/traits/cognitivo/corna_psico_conduttive.json
+++ b/data/traits/cognitivo/corna_psico_conduttive.json
@@ -50,5 +50,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "cognitivo",
+    "complementare": "sociale"
+  },
+  "usage_tags": [
+    "controller"
+  ],
+  "debolezza": "i18n:traits.corna_psico_conduttive.debolezza"
 }

--- a/data/traits/cognitivo/coscienza_d_alveare_diffusa.json
+++ b/data/traits/cognitivo/coscienza_d_alveare_diffusa.json
@@ -47,5 +47,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "cognitivo",
+    "complementare": "sociale"
+  },
+  "usage_tags": [
+    "controller"
+  ],
+  "debolezza": "i18n:traits.coscienza_d_alveare_diffusa.debolezza"
 }

--- a/data/traits/difensivo/bozzolo_magnetico.json
+++ b/data/traits/difensivo/bozzolo_magnetico.json
@@ -47,5 +47,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_00000873"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "difensivo",
+    "complementare": "resistenze"
+  },
+  "usage_tags": [
+    "tank"
+  ],
+  "debolezza": "i18n:traits.bozzolo_magnetico.debolezza"
 }

--- a/data/traits/difensivo/cisti_di_ibernazione_minerale.json
+++ b/data/traits/difensivo/cisti_di_ibernazione_minerale.json
@@ -48,5 +48,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_00000873"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "difensivo",
+    "complementare": "resistenze"
+  },
+  "usage_tags": [
+    "tank"
+  ],
+  "debolezza": "i18n:traits.cisti_di_ibernazione_minerale.debolezza"
 }

--- a/data/traits/difensivo/membrana_plastica_continua.json
+++ b/data/traits/difensivo/membrana_plastica_continua.json
@@ -49,5 +49,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_00000873"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "difensivo",
+    "complementare": "camuffamento"
+  },
+  "usage_tags": [
+    "tank"
+  ],
+  "debolezza": "i18n:traits.membrana_plastica_continua.debolezza"
 }

--- a/data/traits/difensivo/pelage_idrorepellente_avanzato.json
+++ b/data/traits/difensivo/pelage_idrorepellente_avanzato.json
@@ -49,5 +49,13 @@
       "http://purl.obolibrary.org/obo/ENVO_00000873",
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "difensivo",
+    "complementare": "termoregolazione"
+  },
+  "usage_tags": [
+    "tank"
+  ],
+  "debolezza": "i18n:traits.pelage_idrorepellente_avanzato.debolezza"
 }

--- a/data/traits/difensivo/scudo_gluteale_cheratinizzato.json
+++ b/data/traits/difensivo/scudo_gluteale_cheratinizzato.json
@@ -47,5 +47,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "difensivo",
+    "complementare": "corazza"
+  },
+  "usage_tags": [
+    "tank"
+  ],
+  "debolezza": "i18n:traits.scudo_gluteale_cheratinizzato.debolezza"
 }

--- a/data/traits/difensivo/vello_di_assorbimento_totale.json
+++ b/data/traits/difensivo/vello_di_assorbimento_totale.json
@@ -49,5 +49,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "difensivo",
+    "complementare": "camuffamento"
+  },
+  "usage_tags": [
+    "tank"
+  ],
+  "debolezza": "i18n:traits.vello_di_assorbimento_totale.debolezza"
 }

--- a/data/traits/digestivo/filamenti_digestivi_compattanti.json
+++ b/data/traits/digestivo/filamenti_digestivi_compattanti.json
@@ -16,7 +16,7 @@
       "meta": {
         "expansion": "controllo_psionico",
         "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
-        "tier": "T1"
+        "tier": "T2"
       }
     },
     {

--- a/data/traits/digestivo/ventriglio_gastroliti.json
+++ b/data/traits/digestivo/ventriglio_gastroliti.json
@@ -15,7 +15,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/escretorio/spore_psichiche_silenziate.json
+++ b/data/traits/escretorio/spore_psichiche_silenziate.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/fisiologico/ectotermia_dinamica.json
+++ b/data/traits/fisiologico/ectotermia_dinamica.json
@@ -54,5 +54,13 @@
     "created": "2025-11-04",
     "updated": "2025-11-23",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "termico"
+  },
+  "usage_tags": [
+    "sustain"
+  ],
+  "debolezza": "i18n:traits.ectotermia_dinamica.debolezza"
 }

--- a/data/traits/fisiologico/filtrazione_osmotica.json
+++ b/data/traits/fisiologico/filtrazione_osmotica.json
@@ -47,5 +47,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "idrico"
+  },
+  "usage_tags": [
+    "sustain"
+  ],
+  "debolezza": "i18n:traits.filtrazione_osmotica.debolezza"
 }

--- a/data/traits/fisiologico/ipertrofia_muscolare_massiva.json
+++ b/data/traits/fisiologico/ipertrofia_muscolare_massiva.json
@@ -56,5 +56,13 @@
     "created": "2025-11-04",
     "updated": "2025-11-23",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "metabolico"
+  },
+  "usage_tags": [
+    "sustain"
+  ],
+  "debolezza": "i18n:traits.ipertrofia_muscolare_massiva.debolezza"
 }

--- a/data/traits/fisiologico/metabolismo_di_condivisione_energetica.json
+++ b/data/traits/fisiologico/metabolismo_di_condivisione_energetica.json
@@ -47,5 +47,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "metabolico"
+  },
+  "usage_tags": [
+    "sustain"
+  ],
+  "debolezza": "i18n:traits.metabolismo_di_condivisione_energetica.debolezza"
 }

--- a/data/traits/fisiologico/motore_biologico_silenzioso.json
+++ b/data/traits/fisiologico/motore_biologico_silenzioso.json
@@ -48,5 +48,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "metabolico"
+  },
+  "usage_tags": [
+    "sustain"
+  ],
+  "debolezza": "i18n:traits.motore_biologico_silenzioso.debolezza"
 }

--- a/data/traits/fisiologico/rete_filtro_polmonare.json
+++ b/data/traits/fisiologico/rete_filtro_polmonare.json
@@ -47,5 +47,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "respiratorio"
+  },
+  "usage_tags": [
+    "sustain"
+  ],
+  "debolezza": "i18n:traits.rete_filtro_polmonare.debolezza"
 }

--- a/data/traits/fisiologico/siero_anti_gelo_naturale.json
+++ b/data/traits/fisiologico/siero_anti_gelo_naturale.json
@@ -47,5 +47,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "termico"
+  },
+  "usage_tags": [
+    "sustain"
+  ],
+  "debolezza": "i18n:traits.siero_anti_gelo_naturale.debolezza"
 }

--- a/data/traits/idrostatico/sacche_galleggianti_ascensoriali.json
+++ b/data/traits/idrostatico/sacche_galleggianti_ascensoriali.json
@@ -28,7 +28,7 @@
       "meta": {
         "expansion": "controllo_psionico",
         "notes": "Apex T3 su piattaforme orbitali a gravità invertita per ascese rapide.",
-        "tier": "T3"
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/locomotivo/articolazioni_a_leva_idraulica.json
+++ b/data/traits/locomotivo/articolazioni_a_leva_idraulica.json
@@ -48,13 +48,19 @@
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
   },
-  "usage_tags": [],
-  "slot_profile": {},
+  "usage_tags": [
+    "scout"
+  ],
+  "slot_profile": {
+    "core": "locomotivo",
+    "complementare": "terrestre"
+  },
   "species_affinity": [],
   "version": "1.0.0",
   "versioning": {
     "created": "2025-11-04",
     "updated": "2025-11-23",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "debolezza": "i18n:traits.articolazioni_a_leva_idraulica.debolezza"
 }

--- a/data/traits/locomotivo/articolazioni_multiassiali.json
+++ b/data/traits/locomotivo/articolazioni_multiassiali.json
@@ -48,13 +48,19 @@
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
   },
-  "usage_tags": [],
-  "slot_profile": {},
+  "usage_tags": [
+    "scout"
+  ],
+  "slot_profile": {
+    "core": "locomotivo",
+    "complementare": "terrestre"
+  },
   "species_affinity": [],
   "version": "1.0.0",
   "versioning": {
     "created": "2025-11-04",
     "updated": "2025-11-23",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "debolezza": "i18n:traits.articolazioni_multiassiali.debolezza"
 }

--- a/data/traits/locomotivo/cinghia_iper_ciliare.json
+++ b/data/traits/locomotivo/cinghia_iper_ciliare.json
@@ -48,13 +48,19 @@
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
   },
-  "usage_tags": [],
-  "slot_profile": {},
+  "usage_tags": [
+    "scout"
+  ],
+  "slot_profile": {
+    "core": "locomotivo",
+    "complementare": "terrestre"
+  },
   "species_affinity": [],
   "version": "1.0.0",
   "versioning": {
     "created": "2025-11-04",
     "updated": "2025-11-23",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "debolezza": "i18n:traits.cinghia_iper_ciliare.debolezza"
 }

--- a/data/traits/locomotivo/coda_prensile_muscolare.json
+++ b/data/traits/locomotivo/coda_prensile_muscolare.json
@@ -50,13 +50,19 @@
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
   },
-  "usage_tags": [],
-  "slot_profile": {},
+  "usage_tags": [
+    "scout"
+  ],
+  "slot_profile": {
+    "core": "locomotivo",
+    "complementare": "arboricolo"
+  },
   "species_affinity": [],
   "version": "1.0.0",
   "versioning": {
     "created": "2025-11-04",
     "updated": "2025-11-23",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "debolezza": "i18n:traits.coda_prensile_muscolare.debolezza"
 }

--- a/data/traits/locomotivo/flusso_ameboide_controllato.json
+++ b/data/traits/locomotivo/flusso_ameboide_controllato.json
@@ -48,13 +48,19 @@
       "http://purl.obolibrary.org/obo/ENVO_00000873"
     ]
   },
-  "usage_tags": [],
-  "slot_profile": {},
+  "usage_tags": [
+    "scout"
+  ],
+  "slot_profile": {
+    "core": "locomotivo",
+    "complementare": "terrestre"
+  },
   "species_affinity": [],
   "version": "1.0.0",
   "versioning": {
     "created": "2025-11-04",
     "updated": "2025-11-23",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "debolezza": "i18n:traits.flusso_ameboide_controllato.debolezza"
 }

--- a/data/traits/locomotivo/locomozione_miriapode_ibrida.json
+++ b/data/traits/locomotivo/locomozione_miriapode_ibrida.json
@@ -50,13 +50,19 @@
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
   },
-  "usage_tags": [],
-  "slot_profile": {},
+  "usage_tags": [
+    "scout"
+  ],
+  "slot_profile": {
+    "core": "locomotivo",
+    "complementare": "terrestre"
+  },
   "species_affinity": [],
   "version": "1.0.0",
   "versioning": {
     "created": "2025-11-04",
     "updated": "2025-11-23",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "debolezza": "i18n:traits.locomozione_miriapode_ibrida.debolezza"
 }

--- a/data/traits/locomotivo/scheletro_idraulico_a_pistoni.json
+++ b/data/traits/locomotivo/scheletro_idraulico_a_pistoni.json
@@ -55,7 +55,13 @@
     "updated": "2025-11-23",
     "author": "Master DD / GPT-5 Pro"
   },
-  "usage_tags": [],
-  "slot_profile": {},
-  "species_affinity": []
+  "usage_tags": [
+    "scout"
+  ],
+  "slot_profile": {
+    "core": "locomotivo",
+    "complementare": "balistico"
+  },
+  "species_affinity": [],
+  "debolezza": "i18n:traits.scheletro_idraulico_a_pistoni.debolezza"
 }

--- a/data/traits/locomotivo/scheletro_pneumatico_a_maglie.json
+++ b/data/traits/locomotivo/scheletro_pneumatico_a_maglie.json
@@ -51,13 +51,19 @@
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
   },
-  "usage_tags": [],
-  "slot_profile": {},
+  "usage_tags": [
+    "scout"
+  ],
+  "slot_profile": {
+    "core": "locomotivo",
+    "complementare": "terrestre"
+  },
   "species_affinity": [],
   "version": "1.0.0",
   "versioning": {
     "created": "2025-11-04",
     "updated": "2025-11-23",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "debolezza": "i18n:traits.scheletro_pneumatico_a_maglie.debolezza"
 }

--- a/data/traits/locomotivo/scivolamento_magnetico.json
+++ b/data/traits/locomotivo/scivolamento_magnetico.json
@@ -16,7 +16,7 @@
   "metrics": [
     {
       "name": "velocita_max",
-      "value": 4.0,
+      "value": 4,
       "unit": "m/s"
     }
   ],
@@ -48,13 +48,19 @@
       "http://purl.obolibrary.org/obo/ENVO_00000304"
     ]
   },
-  "usage_tags": [],
-  "slot_profile": {},
+  "usage_tags": [
+    "scout"
+  ],
+  "slot_profile": {
+    "core": "locomotivo",
+    "complementare": "terrestre"
+  },
   "species_affinity": [],
   "version": "1.0.0",
   "versioning": {
     "created": "2025-11-04",
     "updated": "2025-11-23",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "debolezza": "i18n:traits.scivolamento_magnetico.debolezza"
 }

--- a/data/traits/locomotivo/unghie_a_micro_adesione.json
+++ b/data/traits/locomotivo/unghie_a_micro_adesione.json
@@ -48,13 +48,19 @@
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
   },
-  "usage_tags": [],
-  "slot_profile": {},
+  "usage_tags": [
+    "scout"
+  ],
+  "slot_profile": {
+    "core": "locomotivo",
+    "complementare": "arboricolo"
+  },
   "species_affinity": [],
   "version": "1.0.0",
   "versioning": {
     "created": "2025-11-04",
     "updated": "2025-11-23",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "debolezza": "i18n:traits.unghie_a_micro_adesione.debolezza"
 }

--- a/data/traits/locomotorio/artigli_sette_vie.json
+++ b/data/traits/locomotorio/artigli_sette_vie.json
@@ -15,7 +15,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/locomotorio/artigli_sghiaccio_glaciale.json
+++ b/data/traits/locomotorio/artigli_sghiaccio_glaciale.json
@@ -15,7 +15,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Calotte di ghiaccio psionico che reagiscono alle vibrazioni e amplificano le lame criogeniche."
+        "notes": "Calotte di ghiaccio psionico che reagiscono alle vibrazioni e amplificano le lame criogeniche.",
+        "tier": "T2"
       }
     }
   ],

--- a/data/traits/locomotorio/cartilagine_flessotermica_venti.json
+++ b/data/traits/locomotorio/cartilagine_flessotermica_venti.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Canyon sospesi dove venti caldi e freddi si alternano in pattern ciclici."
+        "notes": "Canyon sospesi dove venti caldi e freddi si alternano in pattern ciclici.",
+        "tier": "T2"
       }
     }
   ],

--- a/data/traits/locomotorio/coda_frusta_cinetica.json
+++ b/data/traits/locomotorio/coda_frusta_cinetica.json
@@ -16,7 +16,7 @@
       "meta": {
         "expansion": "controllo_psionico",
         "notes": "Corridore T2 per intercettare campi magnetici psionici sulle dorsali.",
-        "tier": "T2"
+        "tier": "T1"
       }
     },
     {
@@ -28,7 +28,7 @@
       "meta": {
         "expansion": "controllo_psionico",
         "notes": "Variante T3 calibrata alle camere di gravità invertita e ai flussi orbitali.",
-        "tier": "T3"
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/locomotorio/zampe_a_molla.json
+++ b/data/traits/locomotorio/zampe_a_molla.json
@@ -14,7 +14,8 @@
       },
       "fonte": "env_to_traits",
       "meta": {
-        "expansion": "controllo_psionico"
+        "expansion": "controllo_psionico",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/locomotorio/zoccoli_risonanti_steppe.json
+++ b/data/traits/locomotorio/zoccoli_risonanti_steppe.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Praterie ventose dove il suolo amplifica vibrazioni utili alla comunicazione di branco."
+        "notes": "Praterie ventose dove il suolo amplifica vibrazioni utili alla comunicazione di branco.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/manipolativo/rostro_linguale_prensile.json
+++ b/data/traits/manipolativo/rostro_linguale_prensile.json
@@ -16,7 +16,7 @@
   "metrics": [
     {
       "name": "lunghezza_estensione",
-      "value": 2.0,
+      "value": 2,
       "unit": "m"
     }
   ],
@@ -47,5 +47,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "manipolativo",
+    "complementare": "alimentare"
+  },
+  "usage_tags": [
+    "controller"
+  ],
+  "debolezza": "i18n:traits.rostro_linguale_prensile.debolezza"
 }

--- a/data/traits/metabolico/circolazione_bifasica_palude.json
+++ b/data/traits/metabolico/circolazione_bifasica_palude.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Paludi bioluminescenti piene di gas nervini e batteri simbionti."
+        "notes": "Paludi bioluminescenti piene di gas nervini e batteri simbionti.",
+        "tier": "T2"
       }
     }
   ],

--- a/data/traits/metabolico/criostasi_adattiva.json
+++ b/data/traits/metabolico/criostasi_adattiva.json
@@ -31,7 +31,7 @@
       "meta": {
         "expansion": "controllo_psionico",
         "notes": "Variante apex T3 in camere orbitali a gravità invertita per stasi prolungate.",
-        "tier": "T3"
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/metabolico/cuticole_cerose.json
+++ b/data/traits/metabolico/cuticole_cerose.json
@@ -14,7 +14,8 @@
       },
       "fonte": "env_to_traits",
       "meta": {
-        "expansion": "controllo_psionico"
+        "expansion": "controllo_psionico",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/metabolico/enzimi_chelanti.json
+++ b/data/traits/metabolico/enzimi_chelanti.json
@@ -14,7 +14,8 @@
       },
       "fonte": "env_to_traits",
       "meta": {
-        "expansion": "controllo_psionico"
+        "expansion": "controllo_psionico",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/metabolico/grassi_termici.json
+++ b/data/traits/metabolico/grassi_termici.json
@@ -14,7 +14,8 @@
       },
       "fonte": "env_to_traits",
       "meta": {
-        "expansion": "controllo_psionico"
+        "expansion": "controllo_psionico",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/nervoso/sonno_emisferico_alternato.json
+++ b/data/traits/nervoso/sonno_emisferico_alternato.json
@@ -15,7 +15,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/offensivo/artigli_ipo_termici.json
+++ b/data/traits/offensivo/artigli_ipo_termici.json
@@ -47,5 +47,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "offensivo",
+    "complementare": "termico"
+  },
+  "usage_tags": [
+    "breaker"
+  ],
+  "debolezza": "i18n:traits.artigli_ipo_termici.debolezza"
 }

--- a/data/traits/offensivo/artiglio_cinetico_a_urto.json
+++ b/data/traits/offensivo/artiglio_cinetico_a_urto.json
@@ -48,5 +48,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "offensivo",
+    "complementare": "contusivo"
+  },
+  "usage_tags": [
+    "breaker"
+  ],
+  "debolezza": "i18n:traits.artiglio_cinetico_a_urto.debolezza"
 }

--- a/data/traits/offensivo/aura_di_dispersione_mentale.json
+++ b/data/traits/offensivo/aura_di_dispersione_mentale.json
@@ -47,5 +47,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "offensivo",
+    "complementare": "controllo"
+  },
+  "usage_tags": [
+    "breaker"
+  ],
+  "debolezza": "i18n:traits.aura_di_dispersione_mentale.debolezza"
 }

--- a/data/traits/offensivo/canto_infrasonico_tattico.json
+++ b/data/traits/offensivo/canto_infrasonico_tattico.json
@@ -47,5 +47,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000178"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "offensivo",
+    "complementare": "controllo"
+  },
+  "usage_tags": [
+    "breaker"
+  ],
+  "debolezza": "i18n:traits.canto_infrasonico_tattico.debolezza"
 }

--- a/data/traits/offensivo/elettromagnete_biologico.json
+++ b/data/traits/offensivo/elettromagnete_biologico.json
@@ -48,5 +48,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_00000873"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "offensivo",
+    "complementare": "elettrico"
+  },
+  "usage_tags": [
+    "breaker"
+  ],
+  "debolezza": "i18n:traits.elettromagnete_biologico.debolezza"
 }

--- a/data/traits/offensivo/estroflessione_gastrica_acida.json
+++ b/data/traits/offensivo/estroflessione_gastrica_acida.json
@@ -49,5 +49,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "offensivo",
+    "complementare": "chimico"
+  },
+  "usage_tags": [
+    "breaker"
+  ],
+  "debolezza": "i18n:traits.estroflessione_gastrica_acida.debolezza"
 }

--- a/data/traits/offensivo/ghiandola_caustica.json
+++ b/data/traits/offensivo/ghiandola_caustica.json
@@ -14,7 +14,8 @@
       },
       "fonte": "env_to_traits",
       "meta": {
-        "expansion": "controllo_psionico"
+        "expansion": "controllo_psionico",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/offensivo/rostro_emostatico_litico.json
+++ b/data/traits/offensivo/rostro_emostatico_litico.json
@@ -56,5 +56,13 @@
     "created": "2025-11-04",
     "updated": "2025-11-23",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "slot_profile": {
+    "core": "offensivo",
+    "complementare": "perforante"
+  },
+  "usage_tags": [
+    "breaker"
+  ],
+  "debolezza": "i18n:traits.rostro_emostatico_litico.debolezza"
 }

--- a/data/traits/offensivo/sangue_piroforico.json
+++ b/data/traits/offensivo/sangue_piroforico.json
@@ -18,7 +18,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/offensivo/seta_conduttiva_elettrica.json
+++ b/data/traits/offensivo/seta_conduttiva_elettrica.json
@@ -48,5 +48,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "offensivo",
+    "complementare": "elettrico"
+  },
+  "usage_tags": [
+    "breaker"
+  ],
+  "debolezza": "i18n:traits.seta_conduttiva_elettrica.debolezza"
 }

--- a/data/traits/offensivo/zanne_idracida.json
+++ b/data/traits/offensivo/zanne_idracida.json
@@ -49,5 +49,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "offensivo",
+    "complementare": "chimico"
+  },
+  "usage_tags": [
+    "breaker"
+  ],
+  "debolezza": "i18n:traits.zanne_idracida.debolezza"
 }

--- a/data/traits/respiratorio/branchie_osmotiche_salmastra.json
+++ b/data/traits/respiratorio/branchie_osmotiche_salmastra.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Estuari psionici dove l'acqua dolce e marina si mescolano creando gradienti forti."
+        "notes": "Estuari psionici dove l'acqua dolce e marina si mescolano creando gradienti forti.",
+        "tier": "T2"
       }
     }
   ],

--- a/data/traits/respiratorio/lamelle_termoforetiche.json
+++ b/data/traits/respiratorio/lamelle_termoforetiche.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Habitat idrotermali psionici dove il calore e la pressione variano rapidamente."
+        "notes": "Habitat idrotermali psionici dove il calore e la pressione variano rapidamente.",
+        "tier": "T2"
       }
     }
   ],

--- a/data/traits/respiratorio/membrane_eliofiltranti.json
+++ b/data/traits/respiratorio/membrane_eliofiltranti.json
@@ -15,7 +15,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Bacini alcalini sospesi dove la luce viene rifratta da vapori metallici."
+        "notes": "Bacini alcalini sospesi dove la luce viene rifratta da vapori metallici.",
+        "tier": "T2"
       }
     }
   ],

--- a/data/traits/respiratorio/polmoni_cristallini_alta_quota.json
+++ b/data/traits/respiratorio/polmoni_cristallini_alta_quota.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Catene montuose sospese dove i cristalli amplificano l'aria rarefatta."
+        "notes": "Catene montuose sospese dove i cristalli amplificano l'aria rarefatta.",
+        "tier": "T2"
       }
     }
   ],

--- a/data/traits/respiratorio/respiro_a_scoppio.json
+++ b/data/traits/respiratorio/respiro_a_scoppio.json
@@ -15,7 +15,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/riproduttivo/ermafroditismo_cronologico.json
+++ b/data/traits/riproduttivo/ermafroditismo_cronologico.json
@@ -48,5 +48,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "riproduttivo",
+    "complementare": "cicli"
+  },
+  "usage_tags": [
+    "support"
+  ],
+  "debolezza": "i18n:traits.ermafroditismo_cronologico.debolezza"
 }

--- a/data/traits/riproduttivo/moltiplicazione_per_fusione.json
+++ b/data/traits/riproduttivo/moltiplicazione_per_fusione.json
@@ -48,5 +48,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_00000873"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "riproduttivo",
+    "complementare": "cicli"
+  },
+  "usage_tags": [
+    "support"
+  ],
+  "debolezza": "i18n:traits.moltiplicazione_per_fusione.debolezza"
 }

--- a/data/traits/riproduttivo/nucleo_ovomotore_rotante.json
+++ b/data/traits/riproduttivo/nucleo_ovomotore_rotante.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/sensoriale/antenne_plasmatiche_tempesta.json
+++ b/data/traits/sensoriale/antenne_plasmatiche_tempesta.json
@@ -15,7 +15,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Occhi di tempesta permanenti che concentrano elettricità e onde psioniche."
+        "notes": "Occhi di tempesta permanenti che concentrano elettricità e onde psioniche.",
+        "tier": "T3"
       }
     }
   ],

--- a/data/traits/sensoriale/cavita_risonanti_tundra.json
+++ b/data/traits/sensoriale/cavita_risonanti_tundra.json
@@ -15,7 +15,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Steppe gelate che trasmettono vibrazioni psioniche a chilometri di distanza."
+        "notes": "Steppe gelate che trasmettono vibrazioni psioniche a chilometri di distanza.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/sensoriale/eco_interno_riflesso.json
+++ b/data/traits/sensoriale/eco_interno_riflesso.json
@@ -16,7 +16,7 @@
       "meta": {
         "expansion": "controllo_psionico",
         "notes": "Start T1 nelle canopie conduttrici per apprendere deformazioni controllate.",
-        "tier": "T1"
+        "tier": "T2"
       }
     },
     {

--- a/data/traits/sensoriale/integumento_bipolare.json
+++ b/data/traits/sensoriale/integumento_bipolare.json
@@ -18,7 +18,7 @@
   "metrics": [
     {
       "name": "sens_magnetica",
-      "value": 1e-06,
+      "value": 0.000001,
       "unit": "T"
     }
   ],
@@ -50,5 +50,13 @@
       "http://purl.obolibrary.org/obo/ENVO_00000304",
       "http://purl.obolibrary.org/obo/ENVO_00000873"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "sensoriale",
+    "complementare": "magnetoricettivo"
+  },
+  "usage_tags": [
+    "scout"
+  ],
+  "debolezza": "i18n:traits.integumento_bipolare.debolezza"
 }

--- a/data/traits/sensoriale/lingua_tattile_trama.json
+++ b/data/traits/sensoriale/lingua_tattile_trama.json
@@ -15,7 +15,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/sensoriale/occhi_analizzatori_di_tensione.json
+++ b/data/traits/sensoriale/occhi_analizzatori_di_tensione.json
@@ -48,5 +48,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "sensoriale",
+    "complementare": "visivo"
+  },
+  "usage_tags": [
+    "scout"
+  ],
+  "debolezza": "i18n:traits.occhi_analizzatori_di_tensione.debolezza"
 }

--- a/data/traits/sensoriale/occhi_cristallo_modulare.json
+++ b/data/traits/sensoriale/occhi_cristallo_modulare.json
@@ -15,5 +15,13 @@
     "has_biome": false,
     "has_species_link": false,
     "has_data_origin": true
-  }
+  },
+  "slot_profile": {
+    "core": "sensoriale",
+    "complementare": "visivo"
+  },
+  "usage_tags": [
+    "scout"
+  ],
+  "debolezza": "i18n:traits.occhi_cristallo_modulare.debolezza"
 }

--- a/data/traits/sensoriale/occhi_infrarosso_composti.json
+++ b/data/traits/sensoriale/occhi_infrarosso_composti.json
@@ -15,7 +15,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/sensoriale/olfatto_risonanza_magnetica.json
+++ b/data/traits/sensoriale/olfatto_risonanza_magnetica.json
@@ -28,7 +28,7 @@
       "meta": {
         "expansion": "controllo_psionico",
         "notes": "Variante T3 calibrata alle camere di gravità invertita e ai flussi orbitali.",
-        "tier": "T3"
+        "tier": "T2"
       }
     }
   ],

--- a/data/traits/sensoriale/organi_sismici_cutanei.json
+++ b/data/traits/sensoriale/organi_sismici_cutanei.json
@@ -55,5 +55,13 @@
     "created": "2025-11-04",
     "updated": "2025-11-23",
     "author": "Master DD / GPT-5 Pro"
-  }
+  },
+  "slot_profile": {
+    "core": "sensoriale",
+    "complementare": "tattovibro"
+  },
+  "usage_tags": [
+    "scout"
+  ],
+  "debolezza": "i18n:traits.organi_sismici_cutanei.debolezza"
 }

--- a/data/traits/sensoriale/sensori_geomagnetici.json
+++ b/data/traits/sensoriale/sensori_geomagnetici.json
@@ -15,7 +15,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Distese pianeggianti con vortici geomagnetici da sfruttare per la navigazione."
+        "notes": "Distese pianeggianti con vortici geomagnetici da sfruttare per la navigazione.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/sensoriale/sistemi_chimio_sonici.json
+++ b/data/traits/sensoriale/sistemi_chimio_sonici.json
@@ -50,5 +50,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "sensoriale",
+    "complementare": "uditivoolfattivo"
+  },
+  "usage_tags": [
+    "scout"
+  ],
+  "debolezza": "i18n:traits.sistemi_chimio_sonici.debolezza"
 }

--- a/data/traits/sensoriale/visione_multi_spettrale_amplificata.json
+++ b/data/traits/sensoriale/visione_multi_spettrale_amplificata.json
@@ -48,5 +48,13 @@
     "envo_terms": [
       "http://purl.obolibrary.org/obo/ENVO_01000228"
     ]
-  }
+  },
+  "slot_profile": {
+    "core": "sensoriale",
+    "complementare": "visivo"
+  },
+  "usage_tags": [
+    "scout"
+  ],
+  "debolezza": "i18n:traits.visione_multi_spettrale_amplificata.debolezza"
 }

--- a/data/traits/simbiotico/bulbi_radici_permafrost.json
+++ b/data/traits/simbiotico/bulbi_radici_permafrost.json
@@ -15,7 +15,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Suoli congelati con vene energetiche che alimentano radici coscienti."
+        "notes": "Suoli congelati con vene energetiche che alimentano radici coscienti.",
+        "tier": "T2"
       }
     }
   ],

--- a/data/traits/simbiotico/chioma_parassita_canopica.json
+++ b/data/traits/simbiotico/chioma_parassita_canopica.json
@@ -15,7 +15,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Foreste verticali multilivello con alberi levitanti e liane sensibili."
+        "notes": "Foreste verticali multilivello con alberi levitanti e liane sensibili.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/simbiotico/mucillagine_simbionte_mangrovie.json
+++ b/data/traits/simbiotico/mucillagine_simbionte_mangrovie.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Foreste di mangrovie ipersature dove le radici cantano frequenze psioniche."
+        "notes": "Foreste di mangrovie ipersature dove le radici cantano frequenze psioniche.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/simbiotico/nodi_micorrizici_oracolari.json
+++ b/data/traits/simbiotico/nodi_micorrizici_oracolari.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Sottoboschi viventi con reti fungine coscienti che emettono segnali premonitori."
+        "notes": "Sottoboschi viventi con reti fungine coscienti che emettono segnali premonitori.",
+        "tier": "T3"
       }
     }
   ],

--- a/data/traits/simbiotico/sacche_spore_stratosferiche.json
+++ b/data/traits/simbiotico/sacche_spore_stratosferiche.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Correnti ascendenti permanenti che trasportano semi e spore su larga scala."
+        "notes": "Correnti ascendenti permanenti che trasportano semi e spore su larga scala.",
+        "tier": "T3"
       }
     }
   ],

--- a/data/traits/simbiotico/sinapsi_coraline_polifoniche.json
+++ b/data/traits/simbiotico/sinapsi_coraline_polifoniche.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Scogliere viventi che rispondono a canti psionici e onde sonore."
+        "notes": "Scogliere viventi che rispondono a canti psionici e onde sonore.",
+        "tier": "T2"
       }
     }
   ],

--- a/data/traits/strategia/focus_frazionato.json
+++ b/data/traits/strategia/focus_frazionato.json
@@ -14,7 +14,8 @@
       },
       "fonte": "env_to_traits",
       "meta": {
-        "expansion": "controllo_psionico"
+        "expansion": "controllo_psionico",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/strategia/pathfinder.json
+++ b/data/traits/strategia/pathfinder.json
@@ -14,7 +14,8 @@
       },
       "fonte": "env_to_traits",
       "meta": {
-        "expansion": "controllo_psionico"
+        "expansion": "controllo_psionico",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/strategia/pianificatore.json
+++ b/data/traits/strategia/pianificatore.json
@@ -14,7 +14,8 @@
       },
       "fonte": "env_to_traits",
       "meta": {
-        "expansion": "controllo_psionico"
+        "expansion": "controllo_psionico",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/strategia/random.json
+++ b/data/traits/strategia/random.json
@@ -14,7 +14,8 @@
       },
       "fonte": "env_to_traits",
       "meta": {
-        "expansion": "controllo_psionico"
+        "expansion": "controllo_psionico",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/strategia/tattiche_di_branco.json
+++ b/data/traits/strategia/tattiche_di_branco.json
@@ -14,7 +14,8 @@
       },
       "fonte": "env_to_traits",
       "meta": {
-        "expansion": "controllo_psionico"
+        "expansion": "controllo_psionico",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/strutturale/carapace_fase_variabile.json
+++ b/data/traits/strutturale/carapace_fase_variabile.json
@@ -30,7 +30,7 @@
       "meta": {
         "expansion": "controllo_psionico",
         "notes": "Percorso T2 che aggiunge gradienti magnetici per pattern cromatici complessi.",
-        "tier": "T2"
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/strutturale/carapace_luminiscente_abissale.json
+++ b/data/traits/strutturale/carapace_luminiscente_abissale.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Gole oceaniche illuminate da coralli psionici e scariche elettrostatiche."
+        "notes": "Gole oceaniche illuminate da coralli psionici e scariche elettrostatiche.",
+        "tier": "T3"
       }
     }
   ],

--- a/data/traits/strutturale/scheletro_idro_regolante.json
+++ b/data/traits/strutturale/scheletro_idro_regolante.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/strutturale/struttura_elastica_amorfa.json
+++ b/data/traits/strutturale/struttura_elastica_amorfa.json
@@ -28,7 +28,7 @@
       "meta": {
         "expansion": "controllo_psionico",
         "notes": "Upgrade T2 sulle dorsali magnetiche per mantenere elasticità sotto stress.",
-        "tier": "T2"
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/supporto/empatia_coordinativa.json
+++ b/data/traits/supporto/empatia_coordinativa.json
@@ -14,7 +14,8 @@
       },
       "fonte": "env_to_traits",
       "meta": {
-        "expansion": "controllo_psionico"
+        "expansion": "controllo_psionico",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/supporto/risonanza_di_branco.json
+++ b/data/traits/supporto/risonanza_di_branco.json
@@ -14,7 +14,8 @@
       },
       "fonte": "env_to_traits",
       "meta": {
-        "expansion": "controllo_psionico"
+        "expansion": "controllo_psionico",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/tegumentario/mimetismo_cromatico_passivo.json
+++ b/data/traits/tegumentario/mimetismo_cromatico_passivo.json
@@ -28,7 +28,7 @@
       "meta": {
         "expansion": "controllo_psionico",
         "notes": "Percorso T2 che aggiunge gradienti magnetici per pattern cromatici complessi.",
-        "tier": "T2"
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/tegumentario/piume_solari_fotovoltaiche.json
+++ b/data/traits/tegumentario/piume_solari_fotovoltaiche.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Altipiani ad alta insolazione dove le correnti psioniche amplificano la luce."
+        "notes": "Altipiani ad alta insolazione dove le correnti psioniche amplificano la luce.",
+        "tier": "T2"
       }
     }
   ],

--- a/data/traits/tegumentario/secrezione_rallentante_palmi.json
+++ b/data/traits/tegumentario/secrezione_rallentante_palmi.json
@@ -18,7 +18,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+        "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+        "tier": "T1"
       }
     }
   ],

--- a/data/traits/tegumentario/squame_rifrangenti_deserto.json
+++ b/data/traits/tegumentario/squame_rifrangenti_deserto.json
@@ -17,7 +17,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Deserti di quarzo e vetro dove le tempeste solari vengono amplificate."
+        "notes": "Deserti di quarzo e vetro dove le tempeste solari vengono amplificate.",
+        "tier": "T2"
       }
     }
   ],

--- a/data/traits/tegumentario/vello_condensatore_nebbie.json
+++ b/data/traits/tegumentario/vello_condensatore_nebbie.json
@@ -15,7 +15,8 @@
       "fonte": "env_to_traits",
       "meta": {
         "expansion": "controllo_psionico",
-        "notes": "Canopie immerse in nebbia costante con risonanza umida e lampi bioluminescenti."
+        "notes": "Canopie immerse in nebbia costante con risonanza umida e lampi bioluminescenti.",
+        "tier": "T1"
       }
     }
   ],

--- a/reports/temp/patch-03A-core-derived/trait_style.json
+++ b/reports/temp/patch-03A-core-derived/trait_style.json
@@ -1,11 +1,11 @@
 {
-  "generatedAt": "2025-11-28T15:44:29.350Z",
+  "generatedAt": "2025-11-28T15:56:54.285Z",
   "totalTraits": 225,
-  "totalIssues": 230,
+  "totalIssues": 62,
   "counts": {
     "info": 62,
-    "warning": 168,
+    "warning": 0,
     "error": 0
   },
-  "traitsWithIssues": 104
+  "traitsWithIssues": 62
 }

--- a/reports/temp/patch-03A-core-derived/trait_style.log
+++ b/reports/temp/patch-03A-core-derived/trait_style.log
@@ -1,7 +1,7 @@
-Trait style: 230 suggerimenti (error=0, warning=168, info=62) su 225 file
-  - [WARNING] antenne_plasmatiche_tempesta /requisiti_ambientali/0/meta/tier :: Allinea meta.tier (—) al tier del tratto (T3).
-  - [WARNING] articolazioni_a_leva_idraulica /debolezza :: Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.articolazioni_a_leva_idraulica.debolezza).
-  - [WARNING] articolazioni_a_leva_idraulica /slot_profile/complementare :: Compila il campo `complementare` in slot_profile (es. "metabolico").
-  - [WARNING] articolazioni_a_leva_idraulica /slot_profile/core :: Compila il campo `core` in slot_profile (es. "metabolico").
-  - [WARNING] articolazioni_a_leva_idraulica /usage_tags :: Popola almeno un usage tag dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank).
-  … altri 225 suggerimenti
+Trait style: 62 suggerimenti (error=0, warning=0, info=62) su 225 file
+  - [INFO] ali_fono_risonanti /requisiti_ambientali/0/meta/notes :: Compila le note descrivendo perché il tratto si attiva in questo bioma.
+  - [INFO] articolazioni_a_leva_idraulica /requisiti_ambientali/0/meta/notes :: Compila le note descrivendo perché il tratto si attiva in questo bioma.
+  - [INFO] articolazioni_multiassiali /requisiti_ambientali/0/meta/notes :: Compila le note descrivendo perché il tratto si attiva in questo bioma.
+  - [INFO] artigli_ipo_termici /requisiti_ambientali/0/meta/notes :: Compila le note descrivendo perché il tratto si attiva in questo bioma.
+  - [INFO] artiglio_cinetico_a_urto /requisiti_ambientali/0/meta/notes :: Compila le note descrivendo perché il tratto si attiva in questo bioma.
+  … altri 57 suggerimenti

--- a/reports/temp/patch-03A-core-derived/trait_style.md
+++ b/reports/temp/patch-03A-core-derived/trait_style.md
@@ -1,74 +1,38 @@
 # Trait style guide report
 
-Generato: 2025-11-25T23:27:11.280Z
+Generato: 2025-11-28T15:56:43.498Z
 Totale trait analizzati: 225
-Totale suggerimenti: 230
-Breakdown: error=0, warning=168, info=62
-Trait con suggerimenti: 104
+Totale suggerimenti: 62
+Breakdown: error=0, warning=0, info=62
+Trait con suggerimenti: 62
 
 ## ali_fono_risonanti
 
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/locomotivo/ali_fono_risonanti.json → /requisiti_ambientali/0/meta/notes_ )
 
-## antenne_plasmatiche_tempesta
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T3). (_data/traits/sensoriale/antenne_plasmatiche_tempesta.json → /requisiti_ambientali/0/meta/tier_ )
-
 ## articolazioni_a_leva_idraulica
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.articolazioni_a_leva_idraulica.debolezza). (_data/traits/locomotivo/articolazioni_a_leva_idraulica.json → /debolezza_ )
-- **WARNING** — Compila il campo `complementare` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/articolazioni_a_leva_idraulica.json → /slot_profile/complementare_ )
-- **WARNING** — Compila il campo `core` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/articolazioni_a_leva_idraulica.json → /slot_profile/core_ )
-- **WARNING** — Popola almeno un usage tag dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/locomotivo/articolazioni_a_leva_idraulica.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/locomotivo/articolazioni_a_leva_idraulica.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## articolazioni_multiassiali
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.articolazioni_multiassiali.debolezza). (_data/traits/locomotivo/articolazioni_multiassiali.json → /debolezza_ )
-- **WARNING** — Compila il campo `complementare` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/articolazioni_multiassiali.json → /slot_profile/complementare_ )
-- **WARNING** — Compila il campo `core` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/articolazioni_multiassiali.json → /slot_profile/core_ )
-- **WARNING** — Popola almeno un usage tag dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/locomotivo/articolazioni_multiassiali.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/locomotivo/articolazioni_multiassiali.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## artigli_ipo_termici
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.artigli_ipo_termici.debolezza). (_data/traits/offensivo/artigli_ipo_termici.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/offensivo/artigli_ipo_termici.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/offensivo/artigli_ipo_termici.json → /requisiti_ambientali/0/meta/notes_ )
-
-## artigli_sette_vie
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/locomotorio/artigli_sette_vie.json → /requisiti_ambientali/0/meta/tier_ )
-
-## artigli_sghiaccio_glaciale
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T2). (_data/traits/locomotorio/artigli_sghiaccio_glaciale.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## artiglio_cinetico_a_urto
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.artiglio_cinetico_a_urto.debolezza). (_data/traits/offensivo/artiglio_cinetico_a_urto.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/offensivo/artiglio_cinetico_a_urto.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/offensivo/artiglio_cinetico_a_urto.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## aura_di_dispersione_mentale
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.aura_di_dispersione_mentale.debolezza). (_data/traits/offensivo/aura_di_dispersione_mentale.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/offensivo/aura_di_dispersione_mentale.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/offensivo/aura_di_dispersione_mentale.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## bozzolo_magnetico
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.bozzolo_magnetico.debolezza). (_data/traits/difensivo/bozzolo_magnetico.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/difensivo/bozzolo_magnetico.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/difensivo/bozzolo_magnetico.json → /requisiti_ambientali/0/meta/notes_ )
-
-## branchie_osmotiche_salmastra
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T2). (_data/traits/respiratorio/branchie_osmotiche_salmastra.json → /requisiti_ambientali/0/meta/tier_ )
-
-## bulbi_radici_permafrost
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T2). (_data/traits/simbiotico/bulbi_radici_permafrost.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## campo_di_interferenza_acustica
 
@@ -80,471 +44,213 @@ Trait con suggerimenti: 104
 
 ## canto_infrasonico_tattico
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.canto_infrasonico_tattico.debolezza). (_data/traits/offensivo/canto_infrasonico_tattico.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/offensivo/canto_infrasonico_tattico.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/offensivo/canto_infrasonico_tattico.json → /requisiti_ambientali/0/meta/notes_ )
-
-## carapace_fase_variabile
-
-- **WARNING** — Allinea meta.tier (T2) al tier del tratto (T1). (_data/traits/strutturale/carapace_fase_variabile.json → /requisiti_ambientali/1/meta/tier_ )
-
-## carapace_luminiscente_abissale
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T3). (_data/traits/strutturale/carapace_luminiscente_abissale.json → /requisiti_ambientali/0/meta/tier_ )
-
-## cartilagine_flessotermica_venti
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T2). (_data/traits/locomotorio/cartilagine_flessotermica_venti.json → /requisiti_ambientali/0/meta/tier_ )
-
-## cavita_risonanti_tundra
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/sensoriale/cavita_risonanti_tundra.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## cervello_a_bassa_latenza
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.cervello_a_bassa_latenza.debolezza). (_data/traits/cognitivo/cervello_a_bassa_latenza.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/cognitivo/cervello_a_bassa_latenza.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/cognitivo/cervello_a_bassa_latenza.json → /requisiti_ambientali/0/meta/notes_ )
-
-## chioma_parassita_canopica
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/simbiotico/chioma_parassita_canopica.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## cinghia_iper_ciliare
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.cinghia_iper_ciliare.debolezza). (_data/traits/locomotivo/cinghia_iper_ciliare.json → /debolezza_ )
-- **WARNING** — Compila il campo `complementare` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/cinghia_iper_ciliare.json → /slot_profile/complementare_ )
-- **WARNING** — Compila il campo `core` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/cinghia_iper_ciliare.json → /slot_profile/core_ )
-- **WARNING** — Popola almeno un usage tag dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/locomotivo/cinghia_iper_ciliare.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/locomotivo/cinghia_iper_ciliare.json → /requisiti_ambientali/0/meta/notes_ )
-
-## circolazione_bifasica_palude
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T2). (_data/traits/metabolico/circolazione_bifasica_palude.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## cisti_di_ibernazione_minerale
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.cisti_di_ibernazione_minerale.debolezza). (_data/traits/difensivo/cisti_di_ibernazione_minerale.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/difensivo/cisti_di_ibernazione_minerale.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/difensivo/cisti_di_ibernazione_minerale.json → /requisiti_ambientali/0/meta/notes_ )
-
-## coda_frusta_cinetica
-
-- **WARNING** — Allinea meta.tier (T2) al tier del tratto (T1). (_data/traits/locomotorio/coda_frusta_cinetica.json → /requisiti_ambientali/0/meta/tier_ )
-- **WARNING** — Allinea meta.tier (T3) al tier del tratto (T1). (_data/traits/locomotorio/coda_frusta_cinetica.json → /requisiti_ambientali/1/meta/tier_ )
 
 ## coda_prensile_muscolare
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.coda_prensile_muscolare.debolezza). (_data/traits/locomotivo/coda_prensile_muscolare.json → /debolezza_ )
-- **WARNING** — Compila il campo `complementare` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/coda_prensile_muscolare.json → /slot_profile/complementare_ )
-- **WARNING** — Compila il campo `core` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/coda_prensile_muscolare.json → /slot_profile/core_ )
-- **WARNING** — Popola almeno un usage tag dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/locomotivo/coda_prensile_muscolare.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/locomotivo/coda_prensile_muscolare.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## comunicazione_fotonica_coda_coda
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.comunicazione_fotonica_coda_coda.debolezza). (_data/traits/cognitivo/comunicazione_fotonica_coda_coda.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/cognitivo/comunicazione_fotonica_coda_coda.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/cognitivo/comunicazione_fotonica_coda_coda.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## corna_psico_conduttive
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.corna_psico_conduttive.debolezza). (_data/traits/cognitivo/corna_psico_conduttive.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/cognitivo/corna_psico_conduttive.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/cognitivo/corna_psico_conduttive.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## coscienza_d_alveare_diffusa
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.coscienza_d_alveare_diffusa.debolezza). (_data/traits/cognitivo/coscienza_d_alveare_diffusa.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/cognitivo/coscienza_d_alveare_diffusa.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/cognitivo/coscienza_d_alveare_diffusa.json → /requisiti_ambientali/0/meta/notes_ )
-
-## criostasi_adattiva
-
-- **WARNING** — Allinea meta.tier (T3) al tier del tratto (T1). (_data/traits/metabolico/criostasi_adattiva.json → /requisiti_ambientali/1/meta/tier_ )
 
 ## cuticole_cerose
 
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/metabolico/cuticole_cerose.json → /requisiti_ambientali/0/meta/tier_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/metabolico/cuticole_cerose.json → /requisiti_ambientali/0/meta/notes_ )
-
-## eco_interno_riflesso
-
-- **WARNING** — Allinea meta.tier (T1) al tier del tratto (T2). (_data/traits/sensoriale/eco_interno_riflesso.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## ectotermia_dinamica
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.ectotermia_dinamica.debolezza). (_data/traits/fisiologico/ectotermia_dinamica.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/fisiologico/ectotermia_dinamica.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/fisiologico/ectotermia_dinamica.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## elettromagnete_biologico
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.elettromagnete_biologico.debolezza). (_data/traits/offensivo/elettromagnete_biologico.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/offensivo/elettromagnete_biologico.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/offensivo/elettromagnete_biologico.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## empatia_coordinativa
 
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/supporto/empatia_coordinativa.json → /requisiti_ambientali/0/meta/tier_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/supporto/empatia_coordinativa.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## enzimi_chelanti
 
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/metabolico/enzimi_chelanti.json → /requisiti_ambientali/0/meta/tier_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/metabolico/enzimi_chelanti.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## ermafroditismo_cronologico
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.ermafroditismo_cronologico.debolezza). (_data/traits/riproduttivo/ermafroditismo_cronologico.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/riproduttivo/ermafroditismo_cronologico.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/riproduttivo/ermafroditismo_cronologico.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## estroflessione_gastrica_acida
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.estroflessione_gastrica_acida.debolezza). (_data/traits/offensivo/estroflessione_gastrica_acida.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/offensivo/estroflessione_gastrica_acida.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/offensivo/estroflessione_gastrica_acida.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## fagocitosi_assorbente
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.fagocitosi_assorbente.debolezza). (_data/traits/alimentazione/fagocitosi_assorbente.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/alimentazione/fagocitosi_assorbente.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/alimentazione/fagocitosi_assorbente.json → /requisiti_ambientali/0/meta/notes_ )
-
-## filamenti_digestivi_compattanti
-
-- **WARNING** — Allinea meta.tier (T1) al tier del tratto (T2). (_data/traits/digestivo/filamenti_digestivi_compattanti.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## filtrazione_osmotica
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.filtrazione_osmotica.debolezza). (_data/traits/fisiologico/filtrazione_osmotica.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/fisiologico/filtrazione_osmotica.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/fisiologico/filtrazione_osmotica.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## filtro_metallofago
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.filtro_metallofago.debolezza). (_data/traits/alimentazione/filtro_metallofago.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/alimentazione/filtro_metallofago.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/alimentazione/filtro_metallofago.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## flusso_ameboide_controllato
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.flusso_ameboide_controllato.debolezza). (_data/traits/locomotivo/flusso_ameboide_controllato.json → /debolezza_ )
-- **WARNING** — Compila il campo `complementare` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/flusso_ameboide_controllato.json → /slot_profile/complementare_ )
-- **WARNING** — Compila il campo `core` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/flusso_ameboide_controllato.json → /slot_profile/core_ )
-- **WARNING** — Popola almeno un usage tag dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/locomotivo/flusso_ameboide_controllato.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/locomotivo/flusso_ameboide_controllato.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## focus_frazionato
 
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/strategia/focus_frazionato.json → /requisiti_ambientali/0/meta/tier_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/strategia/focus_frazionato.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## ghiandola_caustica
 
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/offensivo/ghiandola_caustica.json → /requisiti_ambientali/0/meta/tier_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/offensivo/ghiandola_caustica.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## grassi_termici
 
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/metabolico/grassi_termici.json → /requisiti_ambientali/0/meta/tier_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/metabolico/grassi_termici.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## integumento_bipolare
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.integumento_bipolare.debolezza). (_data/traits/sensoriale/integumento_bipolare.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/sensoriale/integumento_bipolare.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/sensoriale/integumento_bipolare.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## ipertrofia_muscolare_massiva
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.ipertrofia_muscolare_massiva.debolezza). (_data/traits/fisiologico/ipertrofia_muscolare_massiva.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/fisiologico/ipertrofia_muscolare_massiva.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/fisiologico/ipertrofia_muscolare_massiva.json → /requisiti_ambientali/0/meta/notes_ )
-
-## lamelle_termoforetiche
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T2). (_data/traits/respiratorio/lamelle_termoforetiche.json → /requisiti_ambientali/0/meta/tier_ )
-
-## lingua_tattile_trama
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/sensoriale/lingua_tattile_trama.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## locomozione_miriapode_ibrida
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.locomozione_miriapode_ibrida.debolezza). (_data/traits/locomotivo/locomozione_miriapode_ibrida.json → /debolezza_ )
-- **WARNING** — Compila il campo `complementare` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/locomozione_miriapode_ibrida.json → /slot_profile/complementare_ )
-- **WARNING** — Compila il campo `core` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/locomozione_miriapode_ibrida.json → /slot_profile/core_ )
-- **WARNING** — Popola almeno un usage tag dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/locomotivo/locomozione_miriapode_ibrida.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/locomotivo/locomozione_miriapode_ibrida.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## membrana_plastica_continua
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.membrana_plastica_continua.debolezza). (_data/traits/difensivo/membrana_plastica_continua.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/difensivo/membrana_plastica_continua.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/difensivo/membrana_plastica_continua.json → /requisiti_ambientali/0/meta/notes_ )
-
-## membrane_eliofiltranti
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T2). (_data/traits/respiratorio/membrane_eliofiltranti.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## metabolismo_di_condivisione_energetica
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.metabolismo_di_condivisione_energetica.debolezza). (_data/traits/fisiologico/metabolismo_di_condivisione_energetica.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/fisiologico/metabolismo_di_condivisione_energetica.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/fisiologico/metabolismo_di_condivisione_energetica.json → /requisiti_ambientali/0/meta/notes_ )
-
-## mimetismo_cromatico_passivo
-
-- **WARNING** — Allinea meta.tier (T2) al tier del tratto (T1). (_data/traits/tegumentario/mimetismo_cromatico_passivo.json → /requisiti_ambientali/1/meta/tier_ )
 
 ## moltiplicazione_per_fusione
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.moltiplicazione_per_fusione.debolezza). (_data/traits/riproduttivo/moltiplicazione_per_fusione.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/riproduttivo/moltiplicazione_per_fusione.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/riproduttivo/moltiplicazione_per_fusione.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## motore_biologico_silenzioso
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.motore_biologico_silenzioso.debolezza). (_data/traits/fisiologico/motore_biologico_silenzioso.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/fisiologico/motore_biologico_silenzioso.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/fisiologico/motore_biologico_silenzioso.json → /requisiti_ambientali/0/meta/notes_ )
-
-## mucillagine_simbionte_mangrovie
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/simbiotico/mucillagine_simbionte_mangrovie.json → /requisiti_ambientali/0/meta/tier_ )
-
-## nodi_micorrizici_oracolari
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T3). (_data/traits/simbiotico/nodi_micorrizici_oracolari.json → /requisiti_ambientali/0/meta/tier_ )
-
-## nucleo_ovomotore_rotante
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/riproduttivo/nucleo_ovomotore_rotante.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## occhi_analizzatori_di_tensione
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.occhi_analizzatori_di_tensione.debolezza). (_data/traits/sensoriale/occhi_analizzatori_di_tensione.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/sensoriale/occhi_analizzatori_di_tensione.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/sensoriale/occhi_analizzatori_di_tensione.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## occhi_cinetici
 
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/sensoriale/occhi_cinetici.json → /requisiti_ambientali/0/meta/notes_ )
 
-## occhi_cristallo_modulare
-
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.occhi_cristallo_modulare.debolezza). (_data/traits/sensoriale/occhi_cristallo_modulare.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/sensoriale/occhi_cristallo_modulare.json → /usage_tags_ )
-
-## occhi_infrarosso_composti
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/sensoriale/occhi_infrarosso_composti.json → /requisiti_ambientali/0/meta/tier_ )
-
-## olfatto_risonanza_magnetica
-
-- **WARNING** — Allinea meta.tier (T3) al tier del tratto (T2). (_data/traits/sensoriale/olfatto_risonanza_magnetica.json → /requisiti_ambientali/1/meta/tier_ )
-
 ## organi_sismici_cutanei
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.organi_sismici_cutanei.debolezza). (_data/traits/sensoriale/organi_sismici_cutanei.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/sensoriale/organi_sismici_cutanei.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/sensoriale/organi_sismici_cutanei.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## pathfinder
 
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/strategia/pathfinder.json → /requisiti_ambientali/0/meta/tier_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/strategia/pathfinder.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## pelage_idrorepellente_avanzato
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.pelage_idrorepellente_avanzato.debolezza). (_data/traits/difensivo/pelage_idrorepellente_avanzato.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/difensivo/pelage_idrorepellente_avanzato.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/difensivo/pelage_idrorepellente_avanzato.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## pianificatore
 
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/strategia/pianificatore.json → /requisiti_ambientali/0/meta/tier_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/strategia/pianificatore.json → /requisiti_ambientali/0/meta/notes_ )
-
-## piume_solari_fotovoltaiche
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T2). (_data/traits/tegumentario/piume_solari_fotovoltaiche.json → /requisiti_ambientali/0/meta/tier_ )
-
-## polmoni_cristallini_alta_quota
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T2). (_data/traits/respiratorio/polmoni_cristallini_alta_quota.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## random
 
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/strategia/random.json → /requisiti_ambientali/0/meta/tier_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/strategia/random.json → /requisiti_ambientali/0/meta/notes_ )
-
-## respiro_a_scoppio
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/respiratorio/respiro_a_scoppio.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## rete_filtro_polmonare
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.rete_filtro_polmonare.debolezza). (_data/traits/fisiologico/rete_filtro_polmonare.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/fisiologico/rete_filtro_polmonare.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/fisiologico/rete_filtro_polmonare.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## risonanza_di_branco
 
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/supporto/risonanza_di_branco.json → /requisiti_ambientali/0/meta/tier_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/supporto/risonanza_di_branco.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## rostro_emostatico_litico
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.rostro_emostatico_litico.debolezza). (_data/traits/offensivo/rostro_emostatico_litico.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/offensivo/rostro_emostatico_litico.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/offensivo/rostro_emostatico_litico.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## rostro_linguale_prensile
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.rostro_linguale_prensile.debolezza). (_data/traits/manipolativo/rostro_linguale_prensile.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/manipolativo/rostro_linguale_prensile.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/manipolativo/rostro_linguale_prensile.json → /requisiti_ambientali/0/meta/notes_ )
-
-## sacche_galleggianti_ascensoriali
-
-- **WARNING** — Allinea meta.tier (T3) al tier del tratto (T1). (_data/traits/idrostatico/sacche_galleggianti_ascensoriali.json → /requisiti_ambientali/1/meta/tier_ )
-
-## sacche_spore_stratosferiche
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T3). (_data/traits/simbiotico/sacche_spore_stratosferiche.json → /requisiti_ambientali/0/meta/tier_ )
-
-## sangue_piroforico
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/offensivo/sangue_piroforico.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## scheletro_idraulico_a_pistoni
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.scheletro_idraulico_a_pistoni.debolezza). (_data/traits/locomotivo/scheletro_idraulico_a_pistoni.json → /debolezza_ )
-- **WARNING** — Compila il campo `complementare` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/scheletro_idraulico_a_pistoni.json → /slot_profile/complementare_ )
-- **WARNING** — Compila il campo `core` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/scheletro_idraulico_a_pistoni.json → /slot_profile/core_ )
-- **WARNING** — Popola almeno un usage tag dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/locomotivo/scheletro_idraulico_a_pistoni.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/locomotivo/scheletro_idraulico_a_pistoni.json → /requisiti_ambientali/0/meta/notes_ )
-
-## scheletro_idro_regolante
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/strutturale/scheletro_idro_regolante.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## scheletro_pneumatico_a_maglie
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.scheletro_pneumatico_a_maglie.debolezza). (_data/traits/locomotivo/scheletro_pneumatico_a_maglie.json → /debolezza_ )
-- **WARNING** — Compila il campo `complementare` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/scheletro_pneumatico_a_maglie.json → /slot_profile/complementare_ )
-- **WARNING** — Compila il campo `core` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/scheletro_pneumatico_a_maglie.json → /slot_profile/core_ )
-- **WARNING** — Popola almeno un usage tag dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/locomotivo/scheletro_pneumatico_a_maglie.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/locomotivo/scheletro_pneumatico_a_maglie.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## scivolamento_magnetico
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.scivolamento_magnetico.debolezza). (_data/traits/locomotivo/scivolamento_magnetico.json → /debolezza_ )
-- **WARNING** — Compila il campo `complementare` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/scivolamento_magnetico.json → /slot_profile/complementare_ )
-- **WARNING** — Compila il campo `core` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/scivolamento_magnetico.json → /slot_profile/core_ )
-- **WARNING** — Popola almeno un usage tag dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/locomotivo/scivolamento_magnetico.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/locomotivo/scivolamento_magnetico.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## scudo_gluteale_cheratinizzato
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.scudo_gluteale_cheratinizzato.debolezza). (_data/traits/difensivo/scudo_gluteale_cheratinizzato.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/difensivo/scudo_gluteale_cheratinizzato.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/difensivo/scudo_gluteale_cheratinizzato.json → /requisiti_ambientali/0/meta/notes_ )
-
-## secrezione_rallentante_palmi
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/tegumentario/secrezione_rallentante_palmi.json → /requisiti_ambientali/0/meta/tier_ )
-
-## sensori_geomagnetici
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/sensoriale/sensori_geomagnetici.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## seta_conduttiva_elettrica
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.seta_conduttiva_elettrica.debolezza). (_data/traits/offensivo/seta_conduttiva_elettrica.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/offensivo/seta_conduttiva_elettrica.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/offensivo/seta_conduttiva_elettrica.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## siero_anti_gelo_naturale
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.siero_anti_gelo_naturale.debolezza). (_data/traits/fisiologico/siero_anti_gelo_naturale.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/fisiologico/siero_anti_gelo_naturale.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/fisiologico/siero_anti_gelo_naturale.json → /requisiti_ambientali/0/meta/notes_ )
-
-## sinapsi_coraline_polifoniche
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T2). (_data/traits/simbiotico/sinapsi_coraline_polifoniche.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## sistemi_chimio_sonici
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.sistemi_chimio_sonici.debolezza). (_data/traits/sensoriale/sistemi_chimio_sonici.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/sensoriale/sistemi_chimio_sonici.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/sensoriale/sistemi_chimio_sonici.json → /requisiti_ambientali/0/meta/notes_ )
-
-## sonno_emisferico_alternato
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/nervoso/sonno_emisferico_alternato.json → /requisiti_ambientali/0/meta/tier_ )
-
-## spore_psichiche_silenziate
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/escretorio/spore_psichiche_silenziate.json → /requisiti_ambientali/0/meta/tier_ )
-
-## squame_rifrangenti_deserto
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T2). (_data/traits/tegumentario/squame_rifrangenti_deserto.json → /requisiti_ambientali/0/meta/tier_ )
-
-## struttura_elastica_amorfa
-
-- **WARNING** — Allinea meta.tier (T2) al tier del tratto (T1). (_data/traits/strutturale/struttura_elastica_amorfa.json → /requisiti_ambientali/1/meta/tier_ )
 
 ## tattiche_di_branco
 
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/strategia/tattiche_di_branco.json → /requisiti_ambientali/0/meta/tier_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/strategia/tattiche_di_branco.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## unghie_a_micro_adesione
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.unghie_a_micro_adesione.debolezza). (_data/traits/locomotivo/unghie_a_micro_adesione.json → /debolezza_ )
-- **WARNING** — Compila il campo `complementare` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/unghie_a_micro_adesione.json → /slot_profile/complementare_ )
-- **WARNING** — Compila il campo `core` in slot_profile (es. "metabolico"). (_data/traits/locomotivo/unghie_a_micro_adesione.json → /slot_profile/core_ )
-- **WARNING** — Popola almeno un usage tag dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/locomotivo/unghie_a_micro_adesione.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/locomotivo/unghie_a_micro_adesione.json → /requisiti_ambientali/0/meta/notes_ )
-
-## vello_condensatore_nebbie
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/tegumentario/vello_condensatore_nebbie.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## vello_di_assorbimento_totale
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.vello_di_assorbimento_totale.debolezza). (_data/traits/difensivo/vello_di_assorbimento_totale.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/difensivo/vello_di_assorbimento_totale.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/difensivo/vello_di_assorbimento_totale.json → /requisiti_ambientali/0/meta/notes_ )
-
-## ventriglio_gastroliti
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/digestivo/ventriglio_gastroliti.json → /requisiti_ambientali/0/meta/tier_ )
 
 ## visione_multi_spettrale_amplificata
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.visione_multi_spettrale_amplificata.debolezza). (_data/traits/sensoriale/visione_multi_spettrale_amplificata.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/sensoriale/visione_multi_spettrale_amplificata.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/sensoriale/visione_multi_spettrale_amplificata.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## zampe_a_molla
 
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/locomotorio/zampe_a_molla.json → /requisiti_ambientali/0/meta/tier_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/locomotorio/zampe_a_molla.json → /requisiti_ambientali/0/meta/notes_ )
 
 ## zanne_idracida
 
-- **WARNING** — Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.zanne_idracida.debolezza). (_data/traits/offensivo/zanne_idracida.json → /debolezza_ )
-- **WARNING** — Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank). (_data/traits/offensivo/zanne_idracida.json → /usage_tags_ )
 - **INFO** — Compila le note descrivendo perché il tratto si attiva in questo bioma. (_data/traits/offensivo/zanne_idracida.json → /requisiti_ambientali/0/meta/notes_ )
-
-## zoccoli_risonanti_steppe
-
-- **WARNING** — Allinea meta.tier (—) al tier del tratto (T1). (_data/traits/locomotorio/zoccoli_risonanti_steppe.json → /requisiti_ambientali/0/meta/tier_ )
 


### PR DESCRIPTION
## Summary
- populate missing `debolezza` i18n keys, slot profiles, and tactical usage tags across core trait files for patch 03A
- align environmental requirement tiers with trait tiers and refresh style reports

## Testing
- node scripts/trait_style_check.js --output-json reports/temp/patch-03A-core-derived/trait_style.json --fail-on error > reports/temp/patch-03A-core-derived/trait_style.log

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929c4dd43cc83289f4f6ccf31c627a6)