### PR TITLE
Document PATCHSET-00 01A approval and branch controls

### DIFF
--- a/docs/planning/REF_REPO_PATCH_PROPOSTA.md
+++ b/docs/planning/REF_REPO_PATCH_PROPOSTA.md
@@ -11,6 +11,8 @@ Stato: PATCHSET-00 PROPOSTA – patch da validare
 
 Tradurre `REF_REPO_SCOPE` in **PATCHSET-00**: una proposta neutrale che non altera i dati core ma prepara la struttura di documentazione e cataloghi per i refactor successivi.
 
+Lo scope è confermato neutrale: limita le attività a documentazione/cataloghi senza modificare `data/core/**`, `packs/**` o tooling esistente.
+
 La numerazione delle uscite successive resta agganciata alla sequenza 01A–03B per il rollout graduale dopo approvazione.
 
 ## Numerazione e riferimenti
@@ -25,6 +27,7 @@ La numerazione delle uscite successive resta agganciata alla sequenza 01A–03B 
 - Deliverable proposti sono limitati a documentazione e mappature, senza toccare `data/core/**`, `packs/**` o tooling.
 - Gli stub richiesti in §6.1 di `REF_REPO_SCOPE` esistono ma vanno completati con sezioni operative.
 - Le cartelle `incoming/` e `docs/incoming/` sono solo censite; manca una tabella di stato condivisa.
+- **01A approvata il 2025-11-28 da Master DD (owner umano)** con ambito neutrale confermato e blocco dei merge diretti su `main` fino al superamento del gate previsto.
 
 ## Rischi
 
@@ -42,6 +45,7 @@ La numerazione delle uscite successive resta agganciata alla sequenza 01A–03B 
 ## Prerequisiti generali
 
 - Ogni PATCHSET applicativa deve partire da un branch dedicato per garantire tracciabilità e rollback controllato.
+- Per PATCHSET-00 è attivo il branch dedicato `patch/PATCHSET-00` (originato da `work`) e il merge diretto su `main` è bloccato fino al superamento del gate 01A.
 - Loggare le attività dell’agente su `logs/agent_activity.md` per mantenere audit trail e handoff tra owner umani.
 - Ogni documento di pianificazione deve riportare l’owner umano responsabile e l’aggiornamento va registrato nel log quando la numerazione 01A–03B cambia di stato.
 - Master DD agisce come approvatore umano per 01A–01C (strict mode), valida i freeze, gap list e assegnazioni prima di propagare modifiche ad altri reference.
@@ -60,4 +64,5 @@ La numerazione delle uscite successive resta agganciata alla sequenza 01A–03B 
 
 - 2025-12-30: versione 0.5 – allineamento al report v0.5 con intestazione aggiornata e conferma del ruolo di PATCHSET-00 come proposta neutrale per la sequenza 01A–03B.
 - 2025-12-17: versione 0.3 – design completato confermato, perimetro documentazione fissato, numerazione 01A–03B bloccata con richiamo alle fasi GOLDEN_PATH; prerequisiti di governance ribaditi (owner umano, branch dedicati, logging in `logs/agent_activity.md`).
+- 2025-11-28: approvazione 01A (Master DD) su PATCHSET-00 con conferma di scope neutrale e blocco dei merge diretti su `main` fino al gate superato; creato branch dedicato `patch/PATCHSET-00` da `work`.
 - 2025-11-23: prima proposta di patch basata su `REF_REPO_SCOPE` (archivist).

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -156,7 +156,12 @@
 - Stato corrente: soft freeze ancora attivo su `incoming/**` e `docs/incoming/**` in attesa di nuova approvazione Master DD; gate “RIAPERTURA-2026-01” già marcato come chiuso e non riaperto.
 - README `incoming/` e `docs/incoming/` confermano assenza di nuovi drop (`_holding` non presente) e freeze soft in sospeso; readiness: trait-curator/species-curator on-call per 01B, dev-tooling on-call per 01C; ticket **[TKT-01A-*]**, **[TKT-01B-*]**, **[TKT-01C-*]** da aprire con approvazione Master DD.
 
-# 2025-11-26 – Tabella gap 01A consolidata (archivist)
+## 2025-11-28 – Approvazione 01A PATCHSET-00 (archivist)
+- Step ID: PATCHSET-00-01A-APPROVED-2025-11-28; owner: archivist in STRICT MODE con approvazione umana Master DD.
+- Azioni: confermato che PATCHSET-00 resta neutrale (solo documentazione/cataloghi) e registrata l’approvazione 01A con data/owner nel reference; creato il branch dedicato `patch/PATCHSET-00` da `work` e annotato il blocco dei merge diretti su `main` fino al superamento del gate.
+- Riferimenti: `docs/planning/REF_REPO_PATCH_PROPOSTA.md`, `logs/agent_activity.md`.
+
+## 2025-11-26 – Tabella gap 01A consolidata (archivist)
 - Step ID: 01A-GAP-TABLE-2025-11-26; owner: archivist in STRICT MODE.
 - Azione: tabella unica con sezioni **DA_INTEGRARE/LEGACY/STORICO** aggiornata su gap list 01A (nessuno spostamento di pack: solo etichettatura/report). Fonti allineate a `docs/planning/REF_INCOMING_CATALOG.md` e README incoming.
 - Tabella gap 01A (ID, fonte, pack, versione, stato, rischio, next step):


### PR DESCRIPTION
## Summary
- Confirmed PATCHSET-00 remains a neutral documentation/catalog scope and recorded the 01A approval with date/owner in the proposal reference.
- Documented the dedicated `patch/PATCHSET-00` branch and merge block on `main` until the 01A gate is cleared.
- Logged the 01A approval actions in `logs/agent_activity.md` for audit traceability.

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929f911d0a08328897c30df786cb2e5)