### PR TITLE
Add incoming segmentation table and log entry

### DIFF
--- a/docs/planning/REF_INCOMING_CATALOG.md
+++ b/docs/planning/REF_INCOMING_CATALOG.md
@@ -45,6 +45,21 @@ Stato: PATCHSET-01A – inventario aggiornato
 
 ---
 
+## Segmentazione buffer/legacy/archive_cold (REF_REPO_SCOPE)
+
+| Percorso                                | Segmento                   | Stato        | Owner umano | Ticket/Patchset                          | Fase |
+| --------------------------------------- | -------------------------- | ------------ | ----------- | ---------------------------------------- | ---- |
+| `incoming/` (pack e dataset attivi)     | buffer backlog             | DA_INTEGRARE | Master DD   | **[TKT-01B-001]** (matrice core/derived) | 01B  |
+| `incoming/lavoro_da_classificare/`      | buffer backlog             | DA_INTEGRARE | Master DD   | **[TKT-01A-001]** (gap list)             | 01B  |
+| `incoming/archive/`                     | legacy (warm archive)      | STORICO      | Master DD   | —                                        | 02A  |
+| `incoming/archive_cold/`                | archive_cold (immutabile)  | STORICO      | Master DD   | —                                        | 02A  |
+| `docs/incoming/` (linee guida e mappe)  | buffer documentale         | DA_INTEGRARE | Master DD   | **[TKT-01A-005]** (piani integrazione)   | 01B  |
+| `docs/incoming/lavoro_da_classificare/` | buffer documentale         | DA_INTEGRARE | Master DD   | **[TKT-01A-005]**                        | 01B  |
+| `docs/incoming/decompressed/`           | legacy (derivati estratti) | STORICO      | Master DD   | —                                        | 02A  |
+| `docs/incoming/archive/`                | archive_cold documentale   | STORICO      | Master DD   | —                                        | 02A  |
+
+Le etichette di stato seguono la convenzione **INTEGRATO / DA_INTEGRARE / STORICO** e riprendono la segmentazione `buffer → legacy → archive_cold` di `REF_REPO_SCOPE`; ogni riga è allineata ai gate 01B (handoff verso species/trait curators) o 02A (validator/report-only) per il collegamento ai ticket esistenti.
+
 ## Inventario `incoming/`
 
 <!-- prettier-ignore -->

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,8 @@
 # Agent activity log
 
+## 2026-05-05 – Segmentazione incoming 01B/02A (archivist)
+- Step: `[REF-INCOMING-CATALOG-TABLE-2026-05-05] owner=archivist (approvatore Master DD); files=docs/planning/REF_INCOMING_CATALOG.md, logs/agent_activity.md; rischio=basso (documentazione/catalogo); note=aggiunta tabella di stato con segmentazione buffer/legacy/archive_cold per `incoming/**` e `docs/incoming/**`, collegata ai gate 01B/02A e ai ticket **[TKT-01A-001]**, **[TKT-01A-005]**, **[TKT-01B-001]** senza spostamenti di file.`
+
 ## 2026-05-03 – Registrazione finestra freeze 03AB (archivist)
 - Step: `[TKT-03AB-FREEZE-WINDOW-2026-05-03] owner=archivist (approvatore Master DD); files=docs/planning/TKT-03AB-FREEZE.md, PULL_REQUEST_TEMPLATE.md, docs/incoming/decompressed/evo_sentience_branch_layout_v0_1/.github/pull_request_template.md, logs/agent_activity.md; rischio=basso (documentazione/freeze); note=Registrata nel canale operativo la finestra 2025-11-25T12:05Z→2025-11-27T12:05Z con blocco su data/core/**, data/derived/**, incoming/**, docs/incoming/**; checklist PR/branch aggiornate per ricordare il divieto salvo rollback autorizzati; nessuna eccezione richiesta a Master DD.`
 


### PR DESCRIPTION
## Summary
- add a segmentation table for incoming and docs/incoming aligning buffer/legacy/archive_cold with 01B/02A gates and ticket owners
- log the catalog update with Master DD approval and ticket references in agent activity log

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929fa7ff5c08328b327fe881b13cf64)