### PR TITLE
Record 02A rerun status with logs

### DIFF
--- a/docs/migration_targeted_workplan.md
+++ b/docs/migration_targeted_workplan.md
@@ -16,6 +16,29 @@ Questo piano elenca le attività operative a "lavori mirati" per avviare subito 
    - Eseguire in report-only: `validate_datasets.py --schemas-only`, `trait_audit --check`, `trait_style_check` e archiviare gli output in `logs/`.
    - Uscita: log firmato e richiesta di approvazione a Master DD per chiudere il gate 02A.
 
+### Riesecuzione 02A – check operativo
+
+- Owner raccomandati: dev-tooling (correzioni e validazione) + trait-curator (i18n e stile trait).
+- Frequenza: ripetere l'intero ciclo fino a ottenere un pass verde su tutti i validator.
+- Checklist di esecuzione:
+  - [ ] Correzione schema applicata (tracce in diff e note su sinergie/affinità completate).
+  - [ ] Allineamento i18n/trait eseguito (stile e localizzazione uniformati).
+  - [ ] `validate_datasets.py --schemas-only` eseguito.
+  - [ ] `trait_audit --check` eseguito.
+  - [ ] `trait_style_check` eseguito.
+  - [ ] Log allegati (percorso obbligatorio in `logs/`): [incolla link/file in `logs/`]
+  - [ ] Firma Master DD: [firma/autorizzazione Master DD]
+
+#### Stato ultima riesecuzione (2025-11-29 01:30 UTC)
+
+- [ ] Correzione schema applicata → **da completare** (validator schema-only ancora con 3 avvisi pack).
+- [ ] Allineamento i18n/trait eseguito → **parziale**: `trait_style_check` segnala 62 suggerimenti informativi su note bioma.
+- [x] `validate_datasets.py --schemas-only` eseguito → log: `logs/validate_datasets_20251129013037.log`.
+- [x] `trait_audit --check` eseguito → log: `logs/trait_audit_20251129013044.log` (schema skip per `jsonschema` mancante).
+- [x] `trait_style_check` eseguito → log: `logs/trait_style_check_20251129013047.log`.
+- [x] Log allegati → vedi percorsi sopra in `logs/`.
+- [ ] Firma Master DD → in attesa della tua autorizzazione.
+
 2. **Preparazione freeze e snapshot per 03A/03B** (owner: coordinator + archivist)
    - Creare snapshot di core/derived e backup di incoming; predisporre script di rollback già elencati nel piano di fase 3.
    - Annotare in `logs/agent_activity.md` l'apertura del freeze fase 3→4, con riferimenti ai branch `patch/03A-core-derived` e `patch/03B-incoming-cleanup`.


### PR DESCRIPTION
## Summary
- document the latest 02A rerun status with log paths and open items for schema and trait alignment
- capture executed validation steps and outstanding i18n/trait notes flagged by style checks
- keep Master DD sign-off explicit and pending

## Testing
- python tools/py/validate_datasets.py --schemas-only
- python scripts/trait_audit.py --check
- node scripts/trait_style_check.js
- npx prettier --check docs/migration_targeted_workplan.md

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a4b26695c8328ac5dc23cfd66e1a0)