### PR TITLE
Update 02A checklist log references

### DIFF
--- a/docs/migration_targeted_workplan.md
+++ b/docs/migration_targeted_workplan.md
@@ -26,17 +26,17 @@ Questo piano elenca le attività operative a "lavori mirati" per avviare subito 
   - [x] `validate_datasets.py --schemas-only` eseguito.
   - [x] `trait_audit --check` eseguito.
   - [x] `trait_style_check` eseguito.
-  - [x] Log allegati (percorso obbligatorio in `logs/`): `reports/temp/patch-03A-core-derived/schema_only_2026-05-02.log`, `reports/temp/patch-03A-core-derived/trait_audit.log`, `reports/temp/patch-03A-core-derived/trait_style.log`, `logs/TKT-02A-VALIDATOR.rerun.log`.
+  - [x] Log allegati (percorso obbligatorio in `logs/`): `logs/schema_only_2026-05-02.log`, `logs/trait_audit_2026-05-02.log`, `logs/trait_style_2026-05-02.log`, `logs/TKT-02A-VALIDATOR.rerun.log`.
   - [x] Firma Master DD: Master DD
 
 #### Stato ultima riesecuzione (2026-05-02 00:00 UTC)
 
 - [x] Correzione schema applicata → **OK** (validator schema-only in pass, solo 3 avvisi pack attesi).
 - [x] Allineamento i18n/trait eseguito → **OK** (stile uniforme, solo 62 suggerimenti informativi su note bioma).
-- [x] `validate_datasets.py --schemas-only` eseguito → log: `reports/temp/patch-03A-core-derived/schema_only_2026-05-02.log`.
-- [x] `trait_audit --check` eseguito → log: `reports/temp/patch-03A-core-derived/trait_audit.log`.
-- [x] `trait_style_check` eseguito → log: `reports/temp/patch-03A-core-derived/trait_style.log`.
-- [x] Log allegati → `logs/TKT-02A-VALIDATOR.rerun.log` + log canonici in `reports/temp/patch-03A-core-derived/`.
+- [x] `validate_datasets.py --schemas-only` eseguito → log: `logs/schema_only_2026-05-02.log` (copia corrente in `logs/`, fonte in `reports/temp/patch-03A-core-derived/`).
+- [x] `trait_audit --check` eseguito → log: `logs/trait_audit_2026-05-02.log` (copia corrente in `logs/`, fonte in `reports/temp/patch-03A-core-derived/`).
+- [x] `trait_style_check` eseguito → log: `logs/trait_style_2026-05-02.log` (copia corrente in `logs/`, fonte in `reports/temp/patch-03A-core-derived/`).
+- [x] Log allegati → `logs/TKT-02A-VALIDATOR.rerun.log` + log correnti in `logs/` e copie canoniche in `reports/temp/patch-03A-core-derived/`.
 - [x] Firma Master DD → Master DD
 
 2. **Preparazione freeze e snapshot per 03A/03B** (owner: coordinator + archivist)


### PR DESCRIPTION
## Summary
- update the 02A operational checklist to point to current validator logs stored under logs/
- keep Master DD approval state and execution items marked completed

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a5b8b3cdc8328a51dc3f05abd61b0)