### PR TITLE
Add freeze phase procedure and log template

### DIFF
--- a/docs/planning/REF_PATCHSET_02A_TO_03AB_RUNBOOK.md
+++ b/docs/planning/REF_PATCHSET_02A_TO_03AB_RUNBOOK.md
@@ -20,8 +20,13 @@ Stato: PIANO ESECUTIVO – sequenza operativa dal baseline 02A al rollout 03A/03
 
 2. **Aprire/riconfermare freeze fase 3→4**
    - Scope: blocco merge non urgenti su `core/**`, `derived/**`, `incoming/**`, `docs/incoming/**` durante 03A/03B.
-   - Prerequisiti: approvazione Master DD, snapshot core/derived + backup incoming etichettato.
-   - Deliverable: entry log con finestra freeze, percorso snapshot/backup e responsabili rollback.
+   - Prerequisiti: approvazione Master DD pre-freeze, snapshot core/derived + backup incoming etichettato.
+   - Procedura standard:
+     1. Registrare finestra freeze e owner (coordinator + archivist) in `logs/agent_activity.md` con timestamp UTC.
+     2. Allegare percorsi snapshot `data/core/**` e `data/derived/**`, branch `patch/03A-core-derived`, checksum e storage.
+     3. Allegare backup `incoming/**` e `docs/incoming/**` con manifest e branch `patch/03B-incoming-cleanup` associato.
+     4. Indicare responsabile rollback (coordinator) e verifica archivist sul ripristino.
+   - Deliverable: entry log con finestra freeze, percorsi snapshot/backup e responsabili rollback.
 
 3. **Esecuzione 03A – patch core/derived**
    - Branch: `patch/03A-core-derived`; owner coordinator con species/trait-curator + balancer.
@@ -39,7 +44,12 @@ Stato: PIANO ESECUTIVO – sequenza operativa dal baseline 02A al rollout 03A/03
 
 6. **Chiusura e sblocco freeze**
    - Condizioni: validator 02A (smoke) ok, redirect/link verificati, log completato.
-   - Aggiornare `logs/agent_activity.md` con via libera Master DD e stato freeze chiuso.
+   - Checklist di chiusura (dry-run rollback):
+     - Eseguire dry-run di rollback 03A su copia snapshot core/derived e loggare esito.
+     - Eseguire dry-run di ripristino backup incoming/redirect e loggare esito.
+     - Validare che i branch `patch/03A-core-derived` e `patch/03B-incoming-cleanup` siano puliti da change locali non loggati.
+   - Aggiornare `logs/agent_activity.md` con via libera Master DD e stato freeze chiuso, includendo timestamp e owner.
+   - Registrare l’approvazione finale di Master DD (firma) come gate di uscita del freeze fase 3→4.
 
 ## Checklist operative per ogni passo
 

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,15 @@
 # Agent activity log
 
+## Template freeze fase 3→4
+- Step: `[FREEZE-03A03B-<YYYY-MM-DDThhmmZ>] owner=<coordinator|archivist> (approvatore Master DD); branch=patch/03A-core-derived, patch/03B-incoming-cleanup;
+  snapshot=<path data/core/** + data/derived/**> (checksum+storage); backup_incoming=<path incoming/** + docs/incoming/**> (manifest+checksum);
+  freeze_window=<start→end UTC>; rollback=<responsabile + link dry-run>; note=<esiti validator/report-only, redirect, approvazioni>`
+- Loggare sempre:
+  - timestamp UTC e owner (coordinator per rollback, archivist per verifica documentale).
+  - Percorsi snapshot core/derived e backup incoming con checksum/manifest.
+  - Esito dry-run rollback (core/derived) e dry-run ripristino backup/redirect prima della chiusura.
+  - Riferimento alla firma finale Master DD che chiude il freeze 3→4.
+
 ## 2026-05-06 – Allineamento fonti core/pack (archivist)
 - Step: `[REF-SOURCES-PACKS-2026-05-06] owner=archivist (approvatore Master DD); files=docs/planning/REF_REPO_SOURCES_OF_TRUTH.md, docs/planning/REF_PACKS_AND_DERIVED.md, logs/agent_activity.md; rischio=basso (documentazione/cataloghi); note=Aggiornata tabella canonica per trait/specie/biomi/telemetria con link a schemi ALIENA/UCUM e cross-link reciproco a REF_PACKS_AND_DERIVED; mappati generatori pack/derived con requisiti di checksum/log e verificata assenza di percorsi duplicati in data/core/**, packs/**, data/derived/**.`
 


### PR DESCRIPTION
## Summary
- document standard procedure to open/close freeze phase 3→4 with snapshots, backups, and branch references
- add dry-run rollback checklist and Master DD approval gate for freeze closure
- provide a logging template for freeze entries in logs/agent_activity.md with timestamp, owner, and backup details

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a5cf467e08328b63ce612056f6c89)