### PR TITLE
Add CI promotion tracking for patch 01C

### DIFF
--- a/docs/migration_targeted_workplan.md
+++ b/docs/migration_targeted_workplan.md
@@ -72,6 +72,17 @@ Questo piano elenca le attività operative a "lavori mirati" per avviare subito 
    - Mantenere `validate-naming` consultivo finché non è stabile la matrice core/derived; poi proporre passaggio a enforcing con rollback plan.
    - Uscita: memo con stato gate CI e decisione su enforcement.
 
+   | Check CI        | Branch                       | Esito atteso | Run/Log CI                                               | Note                                 |
+   | --------------- | ---------------------------- | ------------ | -------------------------------------------------------- | ------------------------------------ |
+   | data-quality    | patch/01C-tooling-ci-catalog | Verde        | Vedi log in `logs/ci_patch-01C-tooling-ci-catalog.md`    | Tracking run 1–3 e link CI esterni.  |
+   | validate_traits | patch/01C-tooling-ci-catalog | Verde        | Vedi log in `logs/ci_patch-01C-tooling-ci-catalog.md`    | Run allineata ai dati core/derived.  |
+   | schema-validate | patch/01C-tooling-ci-catalog | Verde        | Vedi log in `logs/ci_patch-01C-tooling-ci-catalog.md`    | Run completa su catalogo CI tooling. |
+   | validate-naming | patch/01C-tooling-ci-catalog | Consultivo   | Documentato in `logs/ci_patch-01C-tooling-ci-catalog.md` | Enforcing solo dopo matrice stabile. |
+   - Nota enforcement `validate-naming`:
+     - Stato attuale: **consultivo** (mantenere fino a stabilizzazione matrice core/derived).
+     - Decisione finale: **[da compilare]**.
+     - Rollback plan: **[da compilare]** (includere comando/commit per disabilitare enforcement e ripristinare configurazione attuale).
+
 6. **Allineamento trait/biomi post-migrazione** (owner: trait-curator + balancer)
    - Applicare pipeline trait (conversione, coverage, locale sync) e migrazione v1→v2 secondo il piano operativo trait.
    - Eseguire QA finale (validator, link checker) e aggiornare documentazione/indici.

--- a/logs/ci_patch-01C-tooling-ci-catalog.md
+++ b/logs/ci_patch-01C-tooling-ci-catalog.md
@@ -1,0 +1,31 @@
+# CI patch/01C-tooling-ci-catalog – tracking run verdi
+
+## Run attese
+
+- Branch: `patch/01C-tooling-ci-catalog`
+- Validatori da tracciare (3 run verdi): `data-quality`, `validate_traits`, `schema-validate`.
+- Stato `validate-naming`: **consultivo** finché la matrice core/derived non è stabile.
+
+## Esiti e log CI
+
+| Check CI        | Run # | Data/ora (UTC) | Esito    | Log CI / Link artefatto | Note |
+| --------------- | ----- | -------------- | -------- | ----------------------- | ---- |
+| data-quality    | 1     | —              | Pending  | —                       | In attesa di prima run verde. |
+| data-quality    | 2     | —              | Pending  | —                       | — |
+| data-quality    | 3     | —              | Pending  | —                       | — |
+| validate_traits | 1     | —              | Pending  | —                       | — |
+| validate_traits | 2     | —              | Pending  | —                       | — |
+| validate_traits | 3     | —              | Pending  | —                       | — |
+| schema-validate | 1     | —              | Pending  | —                       | — |
+| schema-validate | 2     | —              | Pending  | —                       | — |
+| schema-validate | 3     | —              | Pending  | —                       | — |
+| validate-naming | consultivo | — | Non blocking | — | Passare a enforcing solo dopo decisione finale. |
+
+> Aggiornare la tabella con data/ora UTC e link al log CI per ogni run verde. In assenza di link pubblico, allegare percorso file archiviato in `logs/` o riferimento al job CI interno.
+
+## Decisione enforcement `validate-naming`
+
+- Stato attuale: consultivo
+- Decisione finale: **[da definire]**
+- Rollback plan: **[da definire]** (es.: revert commit di enforcement o toggle config su pipeline CI)
+


### PR DESCRIPTION
## Summary
- extend the progressive CI promotion section with a tracking table and enforcement note for validate-naming
- add a logs entry to capture CI outcomes and links for patch/01C-tooling-ci-catalog

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a61803e9c8328ad2554707df2177c)