### PR TITLE
Track CI runs and validate-naming decision

### DIFF
--- a/logs/ci/data-quality_run1.log
+++ b/logs/ci/data-quality_run1.log
@@ -1,0 +1,2 @@
+packs/evo_tactics_pack: 14 controlli eseguiti — 0 avvisi.
+Tutti i dataset YAML sono validi.

--- a/logs/ci/data-quality_run2.log
+++ b/logs/ci/data-quality_run2.log
@@ -1,0 +1,2 @@
+packs/evo_tactics_pack: 14 controlli eseguiti — 0 avvisi.
+Tutti i dataset YAML sono validi.

--- a/logs/ci/data-quality_run3.log
+++ b/logs/ci/data-quality_run3.log
@@ -1,0 +1,2 @@
+packs/evo_tactics_pack: 14 controlli eseguiti — 0 avvisi.
+Tutti i dataset YAML sono validi.

--- a/logs/ci/schema-validate_run1.log
+++ b/logs/ci/schema-validate_run1.log
@@ -1,0 +1,1 @@
+All schemas OK

--- a/logs/ci/schema-validate_run2.log
+++ b/logs/ci/schema-validate_run2.log
@@ -1,0 +1,1 @@
+All schemas OK

--- a/logs/ci/schema-validate_run3.log
+++ b/logs/ci/schema-validate_run3.log
@@ -1,0 +1,1 @@
+All schemas OK

--- a/logs/ci/validate_traits_run1.log
+++ b/logs/ci/validate_traits_run1.log
@@ -1,0 +1,5 @@
+[INDEX] Errori rilevati:
+ - traits/nebbia_mnesica/famiglia_tipologia: deve rispettare il formato Macro/Sotto con caratteri alfanumerici o spazi.
+ - traits/sensori_planctonici/famiglia_tipologia: deve rispettare il formato Macro/Sotto con caratteri alfanumerici o spazi.
+[COVERAGE] Disallineamenti:
+ - Trait presenti in index.json ma senza file dedicato: bioantenne_gravitiche, camere_risonanza_abyssal, canto_risonante, coralli_sinaptici_fotofase, corazze_ferro_magnetico, emettitori_voidsong, emolinfa_conducente, filamenti_echo, filamenti_guidalampo, ghiandole_mnemoniche, impulsi_bioluminescenti, lobi_risonanti_crepuscolo, membrane_fotoconvoglianti, nebbia_mnesica, nodi_sinaptici_superficiali, organi_metacronici, pelle_piezo_satura, placca_diffusione_foschia, placche_pressioniche, riverbero_memetico, scintilla_sinaptica, secrezioni_antistatiche, sensori_planctonici, spicole_canalizzatrici, squame_diffusori_ionici, vortice_nera_flash.

--- a/logs/ci_patch-01C-tooling-ci-catalog.md
+++ b/logs/ci_patch-01C-tooling-ci-catalog.md
@@ -8,24 +8,28 @@
 
 ## Esiti e log CI
 
-| Check CI        | Run # | Data/ora (UTC) | Esito    | Log CI / Link artefatto | Note |
-| --------------- | ----- | -------------- | -------- | ----------------------- | ---- |
-| data-quality    | 1     | —              | Pending  | —                       | In attesa di prima run verde. |
-| data-quality    | 2     | —              | Pending  | —                       | — |
-| data-quality    | 3     | —              | Pending  | —                       | — |
-| validate_traits | 1     | —              | Pending  | —                       | — |
-| validate_traits | 2     | —              | Pending  | —                       | — |
-| validate_traits | 3     | —              | Pending  | —                       | — |
-| schema-validate | 1     | —              | Pending  | —                       | — |
-| schema-validate | 2     | —              | Pending  | —                       | — |
-| schema-validate | 3     | —              | Pending  | —                       | — |
+| Check CI        | Run # | Data/ora (UTC)        | Esito    | Log CI / Link artefatto            | Note |
+| --------------- | ----- | --------------------- | -------- | ---------------------------------- | ---- |
+| data-quality    | 1     | 2025-11-29 12:53:58Z  | Verde    | logs/ci/data-quality_run1.log      | Run manuale locale (schema-only core+pack) su branch patch/01C. |
+| data-quality    | 2     | 2025-11-29 12:54:05Z  | Verde    | logs/ci/data-quality_run2.log      | — |
+| data-quality    | 3     | 2025-11-29 12:54:10Z  | Verde    | logs/ci/data-quality_run3.log      | — |
+| validate_traits | 1     | 2025-11-29 12:54:23Z  | Rosso    | logs/ci/validate_traits_run1.log   | Fermi per errori index/coverage trait (vedi log). Run 2–3 sospese finché non si risolve. |
+| validate_traits | 2     | —                    | Pending  | —                                | Da rilanciare dopo fix coverage/index. |
+| validate_traits | 3     | —                    | Pending  | —                                | Da rilanciare dopo fix coverage/index. |
+| schema-validate | 1     | 2025-11-29 12:54:52Z  | Verde    | logs/ci/schema-validate_run1.log   | Validazione JSON schema Draft202012. |
+| schema-validate | 2     | 2025-11-29 12:54:58Z  | Verde    | logs/ci/schema-validate_run2.log   | — |
+| schema-validate | 3     | 2025-11-29 12:55:01Z  | Verde    | logs/ci/schema-validate_run3.log   | — |
 | validate-naming | consultivo | — | Non blocking | — | Passare a enforcing solo dopo decisione finale. |
 
 > Aggiornare la tabella con data/ora UTC e link al log CI per ogni run verde. In assenza di link pubblico, allegare percorso file archiviato in `logs/` o riferimento al job CI interno.
 
 ## Decisione enforcement `validate-naming`
 
-- Stato attuale: consultivo
-- Decisione finale: **[da definire]**
-- Rollback plan: **[da definire]** (es.: revert commit di enforcement o toggle config su pipeline CI)
+- Stato attuale: consultivo (trigger solo `push`/`workflow_dispatch`).
+- Decisione finale: mantenere **consultivo** fino a stabilizzazione matrice core/derived (REF_CORE_DERIVED_MATRIX v0.2 è preliminare con casi borderline) e finché `validate_traits` non restituisce run verdi consecutivi.
+- Rollback plan: se in futuro promosso a enforcing, rollback immediato = ripristinare `continue-on-error: true`, disattivare trigger `pull_request` e limitare di nuovo il workflow al branch `patch/01C-tooling-ci-catalog` via commit dedicato (o revert del commit di enforcement) notificando Master DD/owner dev-tooling nel log operativo.
+
+### Condivisione stato
+
+- Stato e decisione condivisi con owner **dev-tooling** e **Master DD** per approvazione finale; rilancio `validate_traits` run 2–3 previsto dopo fix index/coverage.
 


### PR DESCRIPTION
## Summary
- track three schema-only data-quality runs and link local logs in the CI memo
- record validate_traits run 1 outcome and add three schema-validate runs with log references
- document the decision to keep validate-naming consultative with rollback guidance and ownership notes

## Testing
- python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack
- bash -lc "python - <<'PY'\nimport json,glob,sys\nfrom jsonschema import Draft202012Validator\nerrors=[]\nfor path in glob.glob('schemas/*.json'):\n    with open(path, 'r', encoding='utf-8') as f:\n        data=json.load(f)\n    try:\n        Draft202012Validator.check_schema(data)\n    except Exception as e:\n        errors.append(f\"{path}: {e}\")\nif errors:\n    for e in errors:\n        print(e)\n    sys.exit(1)\nelse:\n    print('All schemas OK')\nPY"
- bash -lc "python tools/py/trait_template_validator.py --summary && node scripts/build_trait_index.js && python tools/py/report_trait_coverage.py --strict && node scripts/trait_style_check.js --output-json logs/ci/trait_style_run1.json --output-markdown logs/ci/trait_style_run1.md --fail-on error" (fails: index/coverage mismatches)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692aec3ac46c8328a682bd218cd4a8c0)