### PR TITLE
Normalize famiglia tipologia for abyss traits

### DIFF
--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -15188,7 +15188,7 @@
     "sensori_planctonici": {
       "id": "sensori_planctonici",
       "label": "Sensori Planctonici",
-      "famiglia_tipologia": "Analisi",
+      "famiglia_tipologia": "Analisi/Sensori Planctonici",
       "data_origin": "frattura_abissale_sinaptica",
       "completion_flags": {
         "has_biome": true,
@@ -15242,7 +15242,7 @@
     "nebbia_mnesica": {
       "id": "nebbia_mnesica",
       "label": "Nebbia Mnesica",
-      "famiglia_tipologia": "Controllo",
+      "famiglia_tipologia": "Controllo/Mnesica",
       "data_origin": "frattura_abissale_sinaptica",
       "completion_flags": {
         "has_biome": true,


### PR DESCRIPTION
## Summary
- normalize `famiglia_tipologia` for `sensori_planctonici` and `nebbia_mnesica` to the Macro/Sotto format with alphanumeric-friendly labels
- keep trait metadata aligned with their analytical and mnesic-control roles

## Testing
- python tools/py/trait_template_validator.py --summary


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692af17efa6883288cab0c91935094d6)